### PR TITLE
Cleanup development environment

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -174,27 +174,22 @@ macro( setupOpenMPI )
     message( FATAL_ERROR "OpenMPI version < 1.4 found." )
   endif()
 
-  # Setting mpi_paffinity_alone to 0 allows parallel ctest to
-  # work correctly.  MPIEXEC_POSTFLAGS only affects MPI-only
-  # tests (and not MPI+OpenMP tests).
+  # Setting mpi_paffinity_alone to 0 allows parallel ctest to work correctly.
+  # MPIEXEC_POSTFLAGS only affects MPI-only tests (and not MPI+OpenMP tests).
   if( "$ENV{GITLAB_CI}" STREQUAL "true" )
     set(runasroot "--allow-run-as-root")
   endif()
 
-  # This flag also shows up in
-  # jayenne/pkg_tools/run_milagro_test.py and regress_funcs.py.
+  # This flag also shows up in jayenne/pkg_tools/run_milagro_test.py and
+  # regress_funcs.py.
   if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.7 )
     set( MPIEXEC_POSTFLAGS "--mca mpi_paffinity_alone 0 ${runasroot}" CACHE
       STRING "extra mpirun flags (list)." FORCE)
   else()
-    # (2015-04-08) Flags provided by Sam Gutierrez:
-    # "-mca hwloc_base_binding_policy none"
-
-    # (2016-12-14) Replace the above with a new set of flags that are used by
-    # MCATK and EAP code projects. These options appear to work correctly for
-    # running concurrent unit tests on a node.
-    set( MPIEXEC_POSTFLAGS "-mca btl self,vader -bind-to none ${runasroot}" CACHE
-      STRING "extra mpirun flags (list)." FORCE)
+    # (2017-01-13) Bugs in openmpi-1.10.x are mostly fixed. Remove flags used
+    # to work around bugs: '-mca btl self,vader -mca timer_require_monotonic 0'
+    set( MPIEXEC_POSTFLAGS "-bind-to none ${runasroot}" CACHE STRING
+      "extra mpirun flags (list)." FORCE)
   endif()
 
   # Find cores/cpu, cpu/node, hyperthreading

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -39,6 +39,9 @@ case ${-} in
    shopt -s checkwinsize # autocorrect window size
    #shopt -s cdspell # autocorrect spelling errors on cd command line.
 
+   # Prevent creation of core files (ulimit -a to see all limits).
+   ulimit -c 0
+
    ##------------------------------------------------------------------------##
    ## Common aliases
    ##------------------------------------------------------------------------##

--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -332,3 +332,60 @@ function rdde ()
   unset DRACO_BASHRC_DONE
   source ${DRACO_ENV_DIR}/bashrc/.bashrc
 }
+
+#------------------------------------------------------------------------------#
+# Quick remove: instead of 'rm -rf', mv the directory to .../trash/tmpname
+#
+# Use: qrm dir1 dir2 ...
+#------------------------------------------------------------------------------#
+function qrm ()
+{
+  # must provide at least one directory
+  if [[ ! $1 ]]; then
+    echo "You must provide a single argument to this function that is the name of the directory to delete."
+    return
+  fi
+
+  for dir in "$@"; do
+
+    # fully qualified directory name
+    fqd=`cd $dir && pwd`
+
+    if [[ ! -d $dir ]]; then
+      echo "$dir doesn't look like a directory. aborting."
+      return
+    fi
+
+    if [[ `echo $fqd | grep -c scratch` == 0 ]]; then
+      echo "This command should only be used for scratch directories."
+      return
+    fi
+
+    # Identify the scratch system
+    target=`uname -n`
+    case $target in
+      sn* | fi* | ic* | ml* | pi* | wf* | lu* )
+        if [[ `echo $fqd | grep -c scratch2` == 1 ]]; then
+          trashdir=/lustre/scratch2/yellow/$USER/trash
+        elif [[ `echo $fqd | grep -c scratch3` == 1 ]]; then
+          trashdir=/lustre/scratch3/yellow/$USER/trash
+        fi
+        ;;
+      tt* )
+        trashdir=/lustre/ttscratch1/$USER/trash ;;
+      tr* )
+        trashdir=/lustre/trscratch/$USER/trash ;;
+    esac
+
+    # ensure trash folder exists.
+    mkdir -p $trashdir
+
+    # We rename/move the old directory to a random name
+    TMPDIR=$(mktemp -d $trashdir/XXXXXXXXXX) || { echo \
+      "Failed to create temporary directory"; return; }
+
+    # do it
+    mv $dir $TMPDIR/.
+
+  done
+}


### PR DESCRIPTION
+ Revert flags passed to mpirun for OpenMPI 1.10.  Recent fixes found in openmpi/1.10.5 make these flags unnecessary.
+ Change developer environment to prevent the creation of core files.
+ Add a new bash function, `qrm` (quick remove).  On Lustre scratch filesystems, use this function to move directories to a _trash_ folder instead of using `rm -rf`.  The recursive remove operation is very slow on Lustre, the new function is very fast and it let's the system's garbage collection system complete the remove operation.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
