### PR TITLE
Add missing header for DBC check.

### DIFF
--- a/src/roots/fdjac.hh
+++ b/src/roots/fdjac.hh
@@ -19,10 +19,12 @@
 #include <limits>
 #include <vector>
 
+#include "ds++/Assert.hh"
+
 namespace rtt_roots {
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  * \brief Calculate the Jacobian of a nonlinear system of equations.
  *
  * This procedure computes the Jacobian using a forward-difference
@@ -30,14 +32,14 @@ namespace rtt_roots {
  *
  * \arg \a Field A field type
  * \arg \a Function_N_to_N A function representing a set of N functions of N
- * variables. 
- * 
+ * variables.
+ *
  * \param x Point at which the Jacobian is to be evaluated.
  * \param fvec Residuals of the equations at x.
  * \param df On return, contains the Jacobian. The ordering is that df[i+n*j]
  * contains the jth derivative of the ith residual.
  * \param vecfunc Multifunctor returning the residuals of the nonlinear
- * equations. 
+ * equations.
  *
  * \pre \c x.size()==fvec.size()
  *


### PR DESCRIPTION
The fdjac function template has a Require check, but the ds++/Assert.hh header is not included in the file.

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
