### PR TITLE
One more attempt at fixing fpe_trap on KNL (optimized) and Travis.

### DIFF
--- a/.travis-install-dependencies.sh
+++ b/.travis-install-dependencies.sh
@@ -14,7 +14,7 @@
 set -e
 source regression/scripts/common.sh
 
-topdir=`pwd` # /home/travis/build/losalamos/Draco
+topdir=`pwd` # /home/travis/build/lanl/Draco
 # HOME = /home/travis
 # USER = travis
 # GROUP = travis
@@ -70,7 +70,7 @@ else
   echo "Random123"
   cd $HOME
   run "wget http://www.deshawresearch.com/downloads/download_random123.cgi/Random123-${RANDOM123_VER}.tar.gz"
-  run "tar -xvf Random123-${RANDOM123_VER}.tar.gz"
+  run "tar -xvf Random123-${RANDOM123_VER}.tar.gz &> build-r123.log"
   echo "Please set RANDOM123_INC_DIR=$HOME/Random123-${RANDOM123_VER}/include"
   run "ls $HOME/Random123-${RANDOM123_VER}/include"
 
@@ -79,16 +79,16 @@ else
   echo "CMake"
   run "cd $HOME"
   run "wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz"
-  run "tar -xzf cmake-${CMAKE_VERSION}.tar.gz"
+  run "tar -xzf cmake-${CMAKE_VERSION}.tar.gz &> build-cmake.log"
   run "cd $topdir"
 
   # Numdiff
   echo " "
   echo "Numdiff"
   run "wget http://mirror.lihnidos.org/GNU/savannah/numdiff/numdiff-${NUMDIFF_VER}.tar.gz"
-  run "tar -xvf numdiff-${NUMDIFF_VER}.tar.gz"
+  run "tar -xvf numdiff-${NUMDIFF_VER}.tar.gz >& build-numdiff.log"
   run "cd numdiff-${NUMDIFF_VER}"
-  run "./configure --prefix=/usr && make"
+  run "./configure --prefix=/usr && make >> build-numdiff.log 2>&1"
   run "sudo make install"
   run "cd $topdir"
 
@@ -96,10 +96,10 @@ else
   echo " "
   echo "OpenMPI"
   run "wget --no-check-certificate https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-${OPENMPI_VER}.tar.gz"
-  run "tar -zxf openmpi-${OPENMPI_VER}.tar.gz"
+  run "tar -zxf openmpi-${OPENMPI_VER}.tar.gz > build-openmpi.log"
   run "cd openmpi-${OPENMPI_VER}"
-  run "./configure --enable-mpi-thread-multiple --quiet > build-openmpi.log"
-  run "make >> build-openmpi.log"
+  run "./configure --enable-mpi-thread-multiple --quiet >> build-openmpi.log 2>&1"
+  run "make >> build-openmpi.log 2>&1"
   run "sudo make install"
   run "sudo sh -c 'echo \"/usr/local/lib\n/usr/local/lib/openmpi\" > /etc/ld.so.conf.d/openmpi.conf'"
   run "sudo ldconfig"

--- a/.travis-run-tests.sh
+++ b/.travis-run-tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+##---------------------------------------------------------------------------##
+## File  : ./travis-run-tests.sh
+## Date  : Tuesday, Jan 17, 2017, 15:55 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
+
+# .travis.yml calls this script to build draco and run the tests.
+
+# preliminaries and environment
+set -e
+source regression/scripts/common.sh
+
+topdir=`pwd` # /home/travis/build/lanl/Draco
+# HOME = /home/travis
+# USER = travis
+# GROUP = travis
+RANDOM123_VER=1.09
+CMAKE_VERSION=3.6.2-Linux-x86_64
+NUMDIFF_VER=5.8.1
+CLANG_FORMAT_VER=3.9
+OPENMPI_VER=1.10.3
+
+if [[ ${STYLE} ]]; then
+  regression/check_style.sh -t
+else
+  mkdir -p build
+  cd build
+  # configure
+  # -Wl,--no-as-needed is a workaround for bugs.debian.org/457284 .
+  echo " "
+  echo "${CMAKE} -DCMAKE_EXE_LINKER_FLAGS=\"-Wl,--no-as-needed\" .."
+  ${CMAKE} -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" ..
+  error_code=$?
+  # if configure was successful, the start the build, otherwise abort.
+  if [[ $error_code -eq 0 ]]; then
+    echo " "
+    echo "make -j 2 VERBOSE=1"
+    make -j 2 VERBOSE=1
+    error_code=$?
+  else
+    echo "configure failed, errorcode=$error_code"
+    exit $error_code
+  fi
+  # if the build was successful, then run the tests, otherwise abort.
+  if [[ $error_code -eq 0 ]]; then
+    echo " "
+    echo "${CTEST} -VV -E \(c4_tstOMP_2\)"
+    ${CTEST} -VV -E \(c4_tstOMP_2\)
+    error_code=$?
+  else
+    echo "build failed, errorcode=$error_code"
+    exit $error_code
+  fi
+  # if some of the tests failed, rerun them with full verbosity to provide more
+  # information in the output log.
+  # if ! [[ $error_code -eq 0 ]]; then
+  #   echo "some tests failed, errorcode=$error_code, trying again with more verbosity."
+  #   echo " "
+  #   echo "${CTEST} --rerun-failed -VV -E \(c4_tstOMP_2\)"
+  #   ${CTEST} --rerun-failed -VV -E \(c4_tstOMP_2\)
+  #   exit $error_code
+  #   echo "error_code=$error_code"
+  # fi
+  echo " "
+  echo "make install DESTDIR=${HOME}"
+  make install DESTDIR="${HOME}"
+  cd -
+fi
+
+# Finish up and report

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 # Notes:
 # $HOME -> /home/travis
-# code checked out to (this is $PWD for the script) -> /home/travis/build/losalamos/Draco
+# code checked out to (this is $PWD for the script) -> /home/travis/build/lanl/Draco
 # travis will not install numdiff -> use ./.travis-install-dependencies.sh.
 
 env:
@@ -49,12 +49,7 @@ before_script:
   - if [[ ${COVERAGE} ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} --coverage\"; done; fi
 
 script:
-    # -Wl,--no-as-needed is a workaround for bugs.debian.org/457284 .
-  - if [[ ${STYLE} ]]; then regression/check_style.sh -t; else mkdir -p build && cd build &&
-    ${CMAKE} -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" .. &&
-    make -j 2 VERBOSE=1 &&
-    ${CTEST} -j 2 -E \(c4_tstOMP_2\) &&
-    make install DESTDIR="${HOME}" && cd - ; fi
+  - ./.travis-run-tests.sh
 
 after_success:
   - if [[ ${COVERAGE} ]]; then codecov --gcov-exec gcov-5; fi

--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -41,7 +41,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_C_FLAGS_DEBUG
     "-g -O0 -inline-level=0 -ftrapuv -check=uninit -fp-model precise -fp-speculation safe -DDEBUG")
   set( CMAKE_C_FLAGS_RELEASE
-    "-O3 -fp-speculation fast -fp-model fast -pthread -DNDEBUG" )
+    "-O3 -fp-speculation fast -fp-model precise -pthread -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL
     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO

--- a/src/ds++/test/test_fpe_trap.py
+++ b/src/ds++/test/test_fpe_trap.py
@@ -73,7 +73,13 @@ try:
     if( string_found ):
       tFpeTrap.passmsg("Caught SIGFPE (Floating point divide by zero)")
     else:
-      tFpeTrap.failmsg("Failed to catch SIGFPE (Floating point divide by zero)")
+      # 2nd chance: try the error stream
+      string_found = tFpeTrap.error_contains("Floating point divide by zero")
+      if( string_found):
+        tFpeTrap.passmsg("Caught SIGFPE (Floating point divide by zero)")
+      else:
+        tFpeTrap.failmsg("Failed to catch SIGFPE (Floating point divide by zero)")
+
 
       print "Standard out:"
       with open(tFpeTrap.outfile) as f:


### PR DESCRIPTION
+ For Intel compilers, revert fp-model to precise instead of fast. There will be a small performance hit, but this makes the KNL's behave more like the Haswell chipset.
+ For the CI on Travis, if ctest returns non-zero (if one or more tests failes), rerun the failed tests with full verbosity (`-VV`).
+ refs #835
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
