### PR TITLE
Revert to '-fp-model fast' for Release builds that use Intel C++.

### DIFF
--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -42,6 +42,13 @@ if( NOT CXX_FLAGS_INITIALIZED )
     "-g -O0 -inline-level=0 -ftrapuv -check=uninit -fp-model precise -fp-speculation safe -DDEBUG")
   set( CMAKE_C_FLAGS_RELEASE
     "-O3 -fp-speculation fast -fp-model precise -pthread -DNDEBUG" )
+  # [KT 2017-01-19] On KNL, -fp-model fast changes behavior significantly for
+  # IMC. Revert to -fp-model precise.
+  if( "$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl" )
+    string( REPLACE "-fp-model fast" "-fp-model precise" CMAKE_C_FLAGS_RELEASE
+      ${CMAKE_C_FLAGS_RELEASE} )
+  endif()
+
   set( CMAKE_C_FLAGS_MINSIZEREL
     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO


### PR DESCRIPTION
+ Except for KNL, where we use `-fp-model precise` to preserve numerical behavior that produces consistent results with Haswell.
+ refs #835
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
