### PR TITLE
Update options provided to aprun on Cray machines.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -26,9 +26,7 @@
 # DRACO_C4                   MPI|SCALAR
 # C4_SCALAR                  BOOL
 # C4_MPI                     BOOL
-#
 #------------------------------------------------------------------------------#
-
 include( FeatureSummary )
 
 ##---------------------------------------------------------------------------##
@@ -262,32 +260,36 @@ macro( setupCrayMPI )
     endif()
   endif()
 
-  # According to email from Mike McKay (2013/04/18), we might
-  # need to set the the mpirun command to something like:
-  #
-  # setenv OMP_NUM_THREADS ${MPI_CORES_PER_CPU}
-  # aprun ... -d ${MPI_CORES_PER_CPU} -n [0-9]+
-
   query_topology()
 
+  # -b        Bypass transfer of application executable to the compute node.
+  # -cc none  Do not bind threads to a CPU within the assigned NUMA node.
+  # -q        Quiet
+  # -m 1400m  Reserve 1.4 GB of RAM per PE. Trinitite/Trinity has 4GB/core for
+  #           haswells, 1.4GB/core for KNL
+  # -F shared enabled shared mode to allow multiple applications to run on a
+  #           single node.
+  set( MPIEXEC_POSTFLAGS "-q -F shared -b -m 1400m" CACHE STRING
+    "extra mpirun flags (list)." FORCE)
+
   # Extra flags for OpenMP + MPI
-  # -m 1400m reserves 1.4 GB per core when running with MAPN.
-  # Trinitite/Trinity has 4GB/node for haswells
   if( DEFINED ENV{OMP_NUM_THREADS} )
-    set( MPIEXEC_OMP_POSTFLAGS "-q -b -m 1400m -d $ENV{OMP_NUM_THREADS}" CACHE
-      STRING "extra mpirun flags (list)." FORCE)
+    # Consider using 'aprun -n # -N # -S # -d # -T -cc depth ...'
+    # -n #  number of processes
+    # -N #  number of processes per node
+    # -S #  number of processes per numa node
+    # -d #  cpus-per-pe
+    # -T    sync-output
+    # -cc depth PEs are constrained to CPUs with a distance of depth between
+    #       them so each PE's threads can be constrained to the CPUs closest to
+    #       the PE's CPU.
+    set( MPIEXEC_OMP_POSTFLAGS "-q -b -d $ENV{OMP_NUM_THREADS}"
+      CACHE STRING "extra mpirun flags (list)." FORCE)
   else()
     message( STATUS "
 WARNING: ENV{OMP_NUM_THREADS} is not set in your environment,
          all OMP tests will be disabled." )
   endif()
-
-  # -b        Bypass transfer of application executable to the compute node.
-  # -cc none  Do not bind threads to a CPU within the assigned NUMA node.
-  # -q        Quiet
-  # -m 1400m     Reserve 1.4 GB of RAM per PE.
-  set( MPIEXEC_POSTFLAGS "-q -b -m 1400m" CACHE STRING
-    "extra mpirun flags (list)." FORCE)
 
 endmacro()
 


### PR DESCRIPTION
+ For our testing system, begin using the `-F shared` option for aprun. Recent changes to aprun require this new flag to continue allowing multiple concurrent jobs to run on a shared node.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
+ Notes from HPC email:
  + Ticket Link: https://itsm.sandia.gov/arsys/servlet/ViewFormServlet?form=HPD%3aHelp%20Desk&server=itsm-ars-prod&eid=INC000001311624
  + Rob Cunningham: _I believe the workaround was to grab two nodes and then it worked.  Led to the MAPN assumption; lots of things started working when going from 1 node to 2 (leaving the second unused):  CCM, thread placement, rank placement, apps crashing, etc.  Anyone remember this one, the Ptag issue, is there a ticket number?_
  + Mike Berry:
> We finally got the patch that reverts the default behavior of a MAPN enabled system to run in exclusive mode.
> I'm testing the ALPS patch on gadget now.  It should also already be on tr2.   Triniite and trinity haven't been changed yet.
> This change restores the original behavior of exclusive mode, where only one application will run at a time on a node, and the aprun default of -j 1, where only one rank or process is assigned per core.  With this patch, MAPN is off by default, but users will still have access to the MAPN (shared mode) thru the -F shared (or -Fs) option to aprun.
> If you're enjoying the MAPN capability now, after the patch has been applied, you'll probably need to add -Fs (turning on shared mode) to your apruns to retain the MAPN  capability and features. Adding -Fs now (prior to the patch) shouldn't change the MAPN behavior.  You'll just be asking for shared mode, when that's the default already.
> Also, the previously noted problem where small jobs were being squeezed onto a single node (when they fit) in a multi-node allocation, should now behave as they did originally with the implied -j 1.  Using aprun -Fs will enable an effective -j 0 with MAPN, where ranks/processes will be squeezed onto cores using hyper-threads (2 on Haswell, and 4 on KNL), and allow multiple invocations of aprun run in the background to run simultaneously on a node.
> Just a reminder, you'll probably still need to use the -m <MB memory/job> option with aprun, to prevent the 1st submitted job from grabbing all the memory, blocking subsequent apruns from launching on your otherwise shared node.  No change with the patch to the current 
MAPN use requirements wrt -m and memory mgt.
> The patch should also fix the memory allocation issue seen on trinity and restore the ability to use -F.  Trinity testing TBA.
> Hopefully for you MAPN savvy users, this should all make sense and be clear.  If it's not, please let me know.
