### PR TITLE
[WIP] First real attempt to prevent CI scripts from clobbering each other.

### DIFF
--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -41,14 +41,13 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_C_FLAGS_DEBUG
     "-g -O0 -inline-level=0 -ftrapuv -check=uninit -fp-model precise -fp-speculation safe -DDEBUG")
   set( CMAKE_C_FLAGS_RELEASE
-    "-O3 -fp-speculation fast -fp-model precise -pthread -DNDEBUG" )
+    "-O3 -fp-speculation fast -fp-model fast -pthread -DNDEBUG" )
   # [KT 2017-01-19] On KNL, -fp-model fast changes behavior significantly for
   # IMC. Revert to -fp-model precise.
   if( "$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl" )
     string( REPLACE "-fp-model fast" "-fp-model precise" CMAKE_C_FLAGS_RELEASE
       ${CMAKE_C_FLAGS_RELEASE} )
   endif()
-
   set( CMAKE_C_FLAGS_MINSIZEREL
     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO

--- a/environment/bashrc/.bashrc_rfta
+++ b/environment/bashrc/.bashrc_rfta
@@ -42,8 +42,15 @@ if [[ ! ${modcmd} ]]; then
    echo "ERROR: The module command was not found. No modules will be loaded."
 else
 
-  module use --append /usr/projects/packages/user_contrib/modulefiles/fta
-  module load hsi psi
+  # If modulefiles is located at $HOME, assume that the current developer wants
+  # to use his/her own checkout of user_contrib modulefiles.
+  if test -d $HOME/modulefiles; then
+    export ucmf=$HOME/modulefiles
+    module use --append $ucmf/fta
+  else
+    module load user_contrib
+  fi
+  export dracomodules='hsi psi svn'
 
 fi
 

--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -1,10 +1,10 @@
 # crontab for ccscs7
 
 # Keep vendor installations in sync between ccs-net servers.
-45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh &> /scratch/regress/logs/sync_vendors_ccscs7.log
+45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh
 
 # Update the regression scripts.
-01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh &> /scratch/regress/logs/update_regression_scripts.log
+01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh
 
 # Send a copy of our repositories to the Red.
 00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /scratch/regress/logs/push_repositories_xf.log

--- a/regression/darwin-crontab
+++ b/regression/darwin-crontab
@@ -1,8 +1,8 @@
 # crontab for darwin-fe
 
-01 22 * * 0-6 /usr/projects/draco/regress/draco/regression/update_regression_scripts.sh &> /usr/projects/draco/regress/logs/update_regression_scripts.log
+01 22 * * 0-6 /usr/projects/draco/regress/draco/regression/update_regression_scripts.sh
 
-01 23 * * 0-6 /usr/projects/draco/regress/draco/regression/sync_repository.sh &> /usr/projects/draco/regress/logs/sync_repository.log
+01 23 * * 0-6 /usr/projects/draco/regress/draco/regression/sync_repository.sh
 
 01 01 * * 0-6 /usr/projects/draco/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/draco/regress/logs/darwin-Debug-master.log
 

--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -1,10 +1,10 @@
 # crontab for ml-fey
 
 # Sync git repositories to local FS and run CI tests
-*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh &> /usr/projects/jayenne/regress/logs/sync_repository.ml.log
+*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
 
 # Update the run scripts in the regression directory
-01 23 * * 0-6 /usr/projects/jayenne/regress/draco/regression/update_regression_scripts.sh &> /usr/projects/jayenne/regress/logs/update_regression_scripts.log
+01 23 * * 0-6 /usr/projects/jayenne/regress/draco/regression/update_regression_scripts.sh
 
 #------------------------------------------------------------------------------#
 # Regressions options:

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -1,10 +1,7 @@
 # crontab for sn-fey
 
 # Sync git repositories to local FS and run CI tests
-# */15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh &> /usr/projects/jayenne/regress/logs/sync_repository.sn.log
-
-# Update the run scripts in the regression directory (currently, only do this from ml)
-# 01 23 * * 0-6 /usr/projects/jayenne/regress/draco/regression/update_regression_scripts.sh &> /usr/projects/jayenne/regress/logs/update_regression_scripts.log
+*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
 
 #------------------------------------------------------------------------------#
 # Regressions options:
@@ -21,20 +18,12 @@
 #------------------------------------------------------------------------------#
 
 #------------------------------------------------------------------------------#
-# Intel/16.0.3 and OpenMPI/1.10.3
+# Intel/17.0.1 and OpenMPI/1.10.5
 #------------------------------------------------------------------------------#
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/sn-Debug-master.log
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/sn-Release-master.log
-
-#------------------------------------------------------------------------------#
-# Periodic usage reports
-#------------------------------------------------------------------------------#
-
-# 01 00 1 * * /usr/projects/packages/user_contrib/usage_logs/bin/user_contrib_monthly_report.sh
-
-# 01 01 * * 4 /users/kellyt/bin/weekly_report.sh
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/sn-job-launch.sh
+++ b/regression/sn-job-launch.sh
@@ -3,7 +3,7 @@
 ## File  : regression/sn-job-launch.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -67,15 +67,12 @@ if test $subproj == draco || test $subproj == jayenne; then
   fi
 fi
 
-# What queue should we use
-#access_queue=""
-#if test -x /opt/MOAB/bin/drmgroups; then
-#   avail_queues=`/opt/MOAB/bin/drmgroups`
+# What queue should we use ('-A access' or '-A dev')?
 avail_queues=`mdiag -u $LOGNAME | grep ALIST | sed -e 's/.*ALIST=//' | sed -e 's/,/ /g'`
 case $avail_queues in
 *access*) access_queue="-A access" ;;
+*dev*) access_queue="-A dev" ;;
 esac
-#fi
 
 # Banner
 echo "==========================================================================="

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -3,7 +3,7 @@
 ## File  : regression/sn-regression.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -25,15 +25,17 @@
 
 target="`uname -n | sed -e s/[.].*//`"
 
-# Prevent multiple copies of this script from running at the same time:
-[ "${FLOCKER}" != "${0}-$target" ] && exec env FLOCKER="${0}-$target" flock -en "${0}-$target" "${0}" "$@" || :
-
 # Locate the directory that this script is located in:
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Redirect all output to a log file.
+# All output will be saved to this log file.  This is also the lockfile for flock.
 logdir="$( cd $scriptdir/../../logs && pwd )"
 logfile=$logdir/sync_repository_$target.log
+
+# Prevent multiple copies of this script from running at the same time:
+[ "${FLOCKER}" != "${logfile}" ] && exec env FLOCKER="${logfile}" flock -en "${logfile}" "${0}" "$@" || :
+
+# Redirect all future output to the logfile.
 exec > $logfile
 exec 2>&1
 

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -23,10 +23,18 @@
 #    the compute node to access the latest git repository. This also copies down
 #    all pull requests.
 
-target="`uname -n | sed -e s/[.].*//`"
+# Prevent multiple copies of this script from running at the same time:
+[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -en "$0" "$0" "$@" || :
 
 # Locate the directory that this script is located in:
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Redirect all output to a log file.
+target="`uname -n | sed -e s/[.].*//`"
+logdir="$( cd $scriptdir/../../logs && pwd )"
+logfile=$logdir/sync_repository_$target.log
+exec > $logfile
+exec 2>&1
 
 #
 # MODULES
@@ -36,23 +44,55 @@ modcmd=`declare -f module`
 # If not found, look for it in /usr/share/Modules (ML)
 if [[ ! ${modcmd} ]]; then
   case ${target} in
-    tt-fey*) module_init_dir=/opt/cray/pe/modules/3.2.10.4/init ;;
+    tt-fey*) module_init_dir=/opt/cray/pe/modules/3.2.10.4/init/bash ;;
     # snow (Toss3)
-    sn-fey*) module_init_dir=/usr/share/lmod/lmod/init ;;
+    sn-fey*) module_init_dir=/usr/share/lmod/lmod/init/profile ;;
     # ccs-net, darwin, ml
-    *)       module_init_dir=/usr/share/Modules/init ;;
+    *)       module_init_dir=/usr/share/Modules/init/bash ;;
   esac
-  if test -f ${module_init_dir}/bash; then
-    source ${module_init_dir}/bash
+  if test -f ${module_init_dir}; then
+    source ${module_init_dir}
   else
     echo "ERROR: The module command was not found. No modules will be loaded."
   fi
   modcmd=`declare -f module`
+  if [[ ! ${modcmd} ]]; then
+    echo "ERROR: the module command was not found (even after sourcing $module_init_dir"
+    exit 1
+  fi
 fi
 
 #
 # Environment
 #
+
+##----------------------------------------------------------------------------##
+# Pause until the 'last modified' timestamp of file $1 to be $2 seconds old.
+function allow_file_to_age
+{
+  if [[ ! $2 ]]; then
+    echo "ERROR: This function requires two arguments: a filename and an age value (sec)."
+    exit 1
+  fi
+
+  # If file does not exist, no need to wait.
+  if [[ ! -f $1 ]]; then
+    return
+  fi
+
+  # assume file was last modified 0 seconds ago.
+  timediff=0
+
+  # If no changes for $2 seconds, continue
+  # else, wait until until file, $1, hasn't been touched for $2 seconds.
+  while [[ $timediff -lt $2 ]]; do
+    eval "$(date +'now=%s')"
+    pr_last_check=$(date +%s -r $1)
+    timediff=$(expr $now - $pr_last_check)
+    echo "$now, $pr_last_check, $timediff"
+    sleep 30s
+  done
+}
 
 # import some bash functions
 source $scriptdir/scripts/common.sh
@@ -82,6 +122,11 @@ case ${target} in
     keychain=keychain-2.7.1
     ;;
   sn-fey*)
+    run "module use --append /usr/projects/hpcsoft/toss3/modulefiles/snow/compiler"
+    run "module use --append /usr/projects/hpcsoft/toss3/modulefiles/snow/libraries"
+    run "module use --append /usr/projects/hpcsoft/toss3/modulefiles/snow/misc"
+    run "module use --append /usr/projects/hpcsoft/toss3/modulefiles/snow/mpi"
+    run "module use --append /usr/projects/hpcsoft/toss3/modulefiles/snow/tools"
     run "module load user_contrib subversion git"
     regdir=/usr/projects/jayenne/regress
     gitroot=$regdir/git.sn
@@ -149,6 +194,9 @@ else
   run "mkdir -p $gitroot"
   run "cd $gitroot"
   run "git clone --bare git@github.com:lanl/Draco.git Draco.git"
+  run "Draco.git"
+  run "git fetch origin +refs/heads/*:refs/heads/*"
+  run "git fetch origin +refs/pull/*:refs/pull/*"
 fi
 case ${target} in
   ccscs7*)
@@ -186,6 +234,9 @@ if test -d $gitroot/jayenne.git; then
 else
   run "mkdir -p $gitroot; cd $gitroot"
   run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git"
+  run "cd jayenne.git"
+  run "git fetch origin +refs/heads/*:refs/heads/*"
+  run "git fetch origin +refs/merge-requests/*:refs/merge-requests/*"
 fi
 case ${target} in
   ccscs7*)
@@ -222,6 +273,9 @@ if test -d $gitroot/capsaicin.git; then
 else
   run "mkdir -p $gitroot; cd $gitroot"
   run "git clone --bare git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin.git"
+  run "cd capsaicin.git"
+  run "git fetch origin +refs/heads/*:refs/heads/*"
+  run "git fetch origin +refs/merge-requests/*:refs/merge-requests/*"
 fi
 case ${target} in
   ccscs7*)
@@ -265,11 +319,13 @@ for prline in $draco_prs; do
       # Coverage (Debug) & Valgrind (Debug)
       pr=`echo $prline |  sed -r 's/^[^0-9]*([0-9]+).*/\1/'`
       logfile=$regdir/logs/ccscs-draco-Debug-coverage-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (coverage) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug -e coverage \
         -p draco -f pr${pr} &> $logfile &
       logfile=$regdir/logs/ccscs-draco-Debug-valgrind-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (valgrind) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug -e valgrind \
@@ -280,6 +336,7 @@ for prline in $draco_prs; do
     ml-fey*)
       pr=`echo $prline |  sed -r 's/^[^0-9]*([0-9]+).*/\1/'`
       logfile=$regdir/logs/ml-draco-Debug-fulldiagnostics-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (fulldiagnostics) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug \
@@ -288,13 +345,20 @@ for prline in $draco_prs; do
 
     # Snow ----------------------------------------
     sn-fe*)
-      # No CI
+      pr=`echo $prline |  sed -r 's/^[^0-9]*([0-9]+).*/\1/'`
+      logfile=$regdir/logs/sn-draco-Debug-fulldiagnostics-master-pr${pr}.log
+      allow_file_to_age $logfile 600
+      echo "- Starting regression (fulldiagnostics) for pr${pr}."
+      echo "  Log: $logfile"
+      $regdir/draco/regression/regression-master.sh -r -b Debug \
+        -p draco -f pr${pr} &> $logfile &
       ;;
 
     # Trinitite: Release
     tt-fey*)
       pr=`echo $prline |  sed -r 's/^[^0-9]*([0-9]+).*/\1/'`
       logfile=$regdir/logs/tt-draco-Release-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (Release) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Release -p draco \
@@ -354,12 +418,14 @@ for prline in $jayenne_prs $capsaicin_prs; do
       # CCS-NET: Coverage (Debug) & Valgrind (Debug)
       ccscs*)
         logfile=$regdir/logs/ccscs-draco-Debug-coverage-master-develop.log
+        allow_file_to_age $logfile 600
         echo "- Starting regression (coverage) for develop."
         echo "  Log: $logfile"
         $regdir/draco/regression/regression-master.sh -r -b Debug -e coverage \
           -p "${projects}" &> $logfile &
 
         logfile=$regdir/logs/ccscs-draco-Debug-valgrind-master-develop.log
+        allow_file_to_age $logfile 600
         echo "- Starting regression (valgrind) for develop."
         echo "  Log: $logfile"
         $regdir/draco/regression/regression-master.sh -r -b Debug -e valgrind \
@@ -371,6 +437,7 @@ for prline in $jayenne_prs $capsaicin_prs; do
       # Moonlight: Fulldiagnostics (Debug)
       ml-fey*)
         logfile=$regdir/logs/ml-draco-Debug-fulldiagnostics-master-develop.log
+        allow_file_to_age $logfile 600
         echo "- Starting regression (fulldiagnostics) for develop."
         echo "  Log: $logfile"
         $regdir/draco/regression/regression-master.sh -r -b Debug \
@@ -381,12 +448,20 @@ for prline in $jayenne_prs $capsaicin_prs; do
 
       # Snow ----------------------------------------
       sn-fe*)
-        # No CI
+        logfile=$regdir/logs/sn-draco-Debug-master-develop.log
+        allow_file_to_age $logfile 600
+        echo "- Starting regression for develop."
+        echo "  Log: $logfile"
+        $regdir/draco/regression/regression-master.sh -r -b Debug \
+          -p draco &> $logfile
+        # Do not put the above command into the background! It must finish
+        # before jayenne is started.
         ;;
 
       # Trinitite: Release
       tt-fey*)
         logfile=$regdir/logs/tt-draco-Release-master-develop.log
+        allow_file_to_age $logfile 600
         echo "- Starting regression (Release) for develop."
         echo "  Log: $logfile"
         $regdir/draco/regression/regression-master.sh -r -b Release -p draco \
@@ -422,12 +497,14 @@ for prline in $jayenne_prs; do
     # CCS-NET: Coverage (Debug) & Valgrind (Debug)
     ccscs*)
       logfile=$regdir/logs/ccscs-jayenne-Debug-coverage-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (coverage) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug -e coverage \
         -p "${projects}" -f "${featurebranches}" &> $logfile &
 
       logfile=$regdir/logs/ccscs-jayenne-Debug-valgrind-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (valgrind) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug -e valgrind \
@@ -437,6 +514,7 @@ for prline in $jayenne_prs; do
     # Moonlight: Fulldiagnostics (Debug)
     ml-fey*)
       logfile=$regdir/logs/ml-jayenne-Debug-fulldiagnostics-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (fulldiagnostics) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug \
@@ -446,12 +524,19 @@ for prline in $jayenne_prs; do
 
     # Snow ----------------------------------------
     sn-fe*)
-      # No CI
+      logfile=$regdir/logs/sn-jayenne-Debug-master-pr${pr}.log
+      allow_file_to_age $logfile 600
+      echo "- Starting regression for pr${pr}."
+      echo "  Log: $logfile"
+      $regdir/draco/regression/regression-master.sh -r -b Debug \
+        -p "${projects}" -f "${featurebranches}" \
+        &> $logfile &
       ;;
 
     # Trinitite: Release
     tt-fey*)
       logfile=$regdir/logs/tt-jayenne-Release-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (Release) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Release \
@@ -483,12 +568,14 @@ for prline in $capsaicin_prs; do
     # CCS-NET: Coverage (Debug) & Valgrind (Debug)
     ccscs*)
       logfile=$regdir/logs/ccscs-capsaicin-Debug-coverage-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (coverage) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug -e coverage \
         -p "${projects}" -f "${featurebranches}" &> $logfile &
 
       logfile=$regdir/logs/ccscs-capsaicin-Debug-valgrind-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (valgrind) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug -e valgrind \
@@ -498,6 +585,7 @@ for prline in $capsaicin_prs; do
     # Moonlight: Fulldiagnostics (Debug)
     ml-fey*)
       logfile=$regdir/logs/ml-capsaicin-Debug-fulldiagnostics-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (fulldiagnostics) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug \
@@ -507,12 +595,19 @@ for prline in $capsaicin_prs; do
 
     # Snow ----------------------------------------
     sn-fe*)
-      # No CI
+      logfile=$regdir/logs/sn-capsaicin-Debug-master-pr${pr}.log
+      allow_file_to_age $logfile 600
+      echo "- Starting regression for pr${pr}."
+      echo "  Log: $logfile"
+      $regdir/draco/regression/regression-master.sh -r -b Debug \
+        -p "${projects}" -f "${featurebranches}" \
+        &> $logfile &
       ;;
 
     # Trinitite: Release
     tt-fey*)
       logfile=$regdir/logs/tt-capsaicin-Release-master-pr${pr}.log
+      allow_file_to_age $logfile 600
       echo "- Starting regression (Release) for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Release \
@@ -525,6 +620,20 @@ for prline in $capsaicin_prs; do
       ;;
   esac
 done
+
+# Wait for all subprocesses to finish before exiting this script
+if [[ `jobs -p | wc -l` -gt 0 ]]; then
+  echo " "
+  echo "Jobs still running (if any):"
+  for job in `jobs -p`; do
+    echo "  waiting for job $job to finish..."
+    wait $job
+    echo "  waiting for job $job to finish...done"
+  done
+fi
+
+echo " "
+echo "All done."
 
 #------------------------------------------------------------------------------#
 # End sync_repository.sh

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -23,14 +23,15 @@
 #    the compute node to access the latest git repository. This also copies down
 #    all pull requests.
 
+target="`uname -n | sed -e s/[.].*//`"
+
 # Prevent multiple copies of this script from running at the same time:
-[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -en "$0" "$0" "$@" || :
+[ "${FLOCKER}" != "${0}-$target" ] && exec env FLOCKER="${0}-$target" flock -en "${0}-$target" "${0}" "$@" || :
 
 # Locate the directory that this script is located in:
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Redirect all output to a log file.
-target="`uname -n | sed -e s/[.].*//`"
 logdir="$( cd $scriptdir/../../logs && pwd )"
 logfile=$logdir/sync_repository_$target.log
 exec > $logfile
@@ -312,6 +313,7 @@ esac
 # Draco CI ------------------------------------------------------------
 draco_prs=`grep 'refs/pull/[0-9]*/head$' $TMPFILE_DRACO | awk '{print $NF}'`
 for prline in $draco_prs; do
+  echo " "
   case ${target} in
 
     # CCS-NET: Coverage (Debug) & Valgrind (Debug)
@@ -346,9 +348,9 @@ for prline in $draco_prs; do
     # Snow ----------------------------------------
     sn-fe*)
       pr=`echo $prline |  sed -r 's/^[^0-9]*([0-9]+).*/\1/'`
-      logfile=$regdir/logs/sn-draco-Debug-fulldiagnostics-master-pr${pr}.log
+      logfile=$regdir/logs/sn-draco-Debug-master-pr${pr}.log
       allow_file_to_age $logfile 600
-      echo "- Starting regression (fulldiagnostics) for pr${pr}."
+      echo "- Starting regression for pr${pr}."
       echo "  Log: $logfile"
       $regdir/draco/regression/regression-master.sh -r -b Debug \
         -p draco -f pr${pr} &> $logfile &

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -1,8 +1,7 @@
 # crontab for tt-fey
 
-
 # Create a svn hotcopy of capsaicin at /usr/projects/jayenne/regress/svn
-*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh &> /usr/projects/jayenne/regress/logs/sync_repository.tt.log
+*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
 
 #------------------------------------------------------------------------------#
 # Regression Options:
@@ -23,14 +22,14 @@
 # --------------------
 
 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Debug-master.log
-
 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Release-master.log
 
 # --------------------
 # KNL
 # --------------------
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco" -e knl &> /usr/projects/jayenne/regress/logs/tt-Debug-knl-master.log
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco" -e knl &> /usr/projects/jayenne/regress/logs/tt-Release-knl-master.log
+# 01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e "perfbench knl" -p "jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Release-perfbench-master.log
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command


### PR DESCRIPTION
**Background**

If a PR is submitted and then updated a short time later, the CI system would fall over because it would kick off jobs for the updated PR that would clobber the CI jobs running for the initial PR.

**Resolution**
I have chosen to use the `flock` tool on Linux to prevent the second set of jobs from starting until the first set have finished. There are a few other updates in this PR that provide general cleanup in the CI and regression scripts. The script `sync_repository.sh` was modified by adding file-lock checking and forcing the script to wait until all subprocesses are complete before exiting. Additionally, a second check was put into place (via a new bash function `allow_file_to_age` to ensure that individual builds do not start too soon.

**Other changes in this PR**
+ CI tests will begin running on snow.
+ The `sync_repository.sh` script was updated to correctly load the module environment on snow.
+ I use the _access_ queue to run CI jobs on Toss2 machines. Toss3 machines will use the _dev_ queue (once available). Update script logic to look for and use the _dev_ queue if available for the current user.
+ Updated the `sync_repository.sh` and `update_regression_scripts.sh` scripts to use internal logic to save all output to log files. Crontabs were updated since these scripts no longer need to be started with syntax that captures output.
+ Logic was added to `update_regression_scripts.sh` to identify old log files and old CI build directories. Once I am happy with how this logic works, the script will remove these old files and directories.
+ Modify the bashrc file for the red-fta and redcap machines. If the 'user_contrib' modulefiles are available at $HOME, use those instead of the published files.
+ Alex and I submitted a couple of PRs to try and identify test failures on the KNL nodes of trinitite.  It looks like one of the CFLAGS was changed and never changed back: `-fp-model precise` --> `-fp-model fast`.  The later should be the default except on KNL.
+ refs [#841](https://rtt.lanl.gov/redmine/issues/841)

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
