### PR TITLE
Significant update to regression scripts.

### DIFF
--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -1,16 +1,16 @@
 # crontab for ccscs7
 
 # Keep vendor installations in sync between ccs-net servers.
-45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh &> /scratch/regress/logs/sync_vendors_ccscs7.log
+45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh
 
 # Update the regression scripts.
-01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh &> /scratch/regress/logs/update_regression_scripts.log
+01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh
 
 # Send a copy of our repositories to the Red.
 00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /scratch/regress/logs/push_repositories_xf.log
 
 # Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
-*/15 * * * * /scratch/regress/draco/regression/sync_repository.sh &> /scratch/regress/logs/sync_repository.log
+*/15 * * * * /scratch/regress/draco/regression/sync_repository.sh
 
 #------------------------------------------------------------------------------#
 # Regressions with system default compiler (gcc-4.8.5)

--- a/regression/push_repositories_xf.sh
+++ b/regression/push_repositories_xf.sh
@@ -3,7 +3,7 @@
 ## File  : regression/push_repositories_xf.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -3,7 +3,7 @@
 ## File  : regression/regression-master.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -346,7 +346,7 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
   cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-joblaunch.log"
   echo "${subproj}: $cmd"
   eval "${cmd} &"
-  sleep 1
+  sleep 1s
   draco_jobid=`jobs -p | sort -gr | head -n 1`
   ((ifb++))
 fi
@@ -363,7 +363,7 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
   cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-joblaunch.log"
   echo "${subproj}: $cmd"
   eval "${cmd} &"
-  sleep 1
+  sleep 1s
   jayenne_jobid=`jobs -p | sort -gr | head -n 1`
   ((ifb++))
 fi
@@ -391,13 +391,24 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
   cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-joblaunch.log"
   echo "${subproj}: $cmd"
   eval "${cmd} &"
-  sleep 1
+  sleep 1s
   capsaicin_jobid=`jobs -p | sort -gr | head -n 1`
   ((ifb++))
 fi
 
 # Wait for all parallel jobs to finish
-while [ 1 ]; do fg 2> /dev/null; [ $? == 1 ] && break; done
+#while [ 1 ]; do fg 2> /dev/null; [ $? == 1 ] && break; done
+
+# Wait for all subprocesses to finish before exiting this script
+if [[ `jobs -p | wc -l` -gt 0 ]]; then
+  echo " "
+  echo "Jobs still running (if any):"
+  for job in `jobs -p`; do
+    echo "  waiting for job $job to finish..."
+    wait $job
+    echo "  waiting for job $job to finish...done"
+  done
+fi
 
 # set permissions
 chgrp -R draco ${logdir} &> /dev/null

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -21,20 +21,12 @@
 #------------------------------------------------------------------------------#
 
 #------------------------------------------------------------------------------#
-# Intel/16.0.3 and OpenMPI/1.10.3
+# Intel/17.0.1 and OpenMPI/1.10.5
 #------------------------------------------------------------------------------#
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/sn-Debug-master.log
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/sn-Release-master.log
-
-#------------------------------------------------------------------------------#
-# Periodic usage reports
-#------------------------------------------------------------------------------#
-
-# 01 00 1 * * /usr/projects/packages/user_contrib/usage_logs/bin/user_contrib_monthly_report.sh
-
-# 01 01 * * 4 /users/kellyt/bin/weekly_report.sh
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/sn-job-launch.sh
+++ b/regression/sn-job-launch.sh
@@ -3,7 +3,7 @@
 ## File  : regression/sn-job-launch.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -67,15 +67,12 @@ if test $subproj == draco || test $subproj == jayenne; then
   fi
 fi
 
-# What queue should we use
-#access_queue=""
-#if test -x /opt/MOAB/bin/drmgroups; then
-#   avail_queues=`/opt/MOAB/bin/drmgroups`
+# What queue should we use ('-A access' or '-A dev')?
 avail_queues=`mdiag -u $LOGNAME | grep ALIST | sed -e 's/.*ALIST=//' | sed -e 's/,/ /g'`
 case $avail_queues in
 *access*) access_queue="-A access" ;;
+*dev*) access_queue="-l qos=dev" ;;
 esac
-#fi
 
 # Banner
 echo "==========================================================================="

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -3,12 +3,12 @@
 ## File  : regression/sn-regression.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
 #MSUB -l walltime=08:00:00
-#MSUB -l nodes=1:ppn=16
+#MSUB -l nodes=1:ppn=36
 #MSUB -j oe
 
 #----------------------------------------------------------------------#

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -2,7 +2,7 @@
 
 
 # Create a svn hotcopy of capsaicin at /usr/projects/jayenne/regress/svn
-*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh &> /usr/projects/jayenne/regress/logs/sync_repository.tt.log
+*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
 
 #------------------------------------------------------------------------------#
 # Regression Options:
@@ -30,7 +30,9 @@
 # KNL
 # --------------------
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco" -e knl &> /usr/projects/jayenne/regress/logs/tt-Debug-knl-master.log
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco" -e knl &> /usr/projects/jayenne/regress/logs/tt-Release-knl-master.log
+
+# 01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e "perfbench knl" -p "jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Release-perfbench-master.log
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -3,7 +3,7 @@
 ## File  : regression/tt-job-launch.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -108,7 +108,7 @@ done
 # Select haswell or knl partition
 # option '-e knl' will select KNL, default is haswell.
 case $extra_params in
-knl) partition_options="-lnodes=2:knl:ppn=68,walltime=8:00:00" ;;
+knl) partition_options="-lnodes=4:knl:ppn=68,walltime=8:00:00" ;;
 #knl) partition_options="-lnodes=2:ppn=68:knl,advres=quadflat,walltime=8:00:00" ;;
 *)   partition_options="-lnodes=4:haswell:ppn=32,walltime=8:00:00" ;;
 esac

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -4,7 +4,7 @@
 ## File  : regression/tt-regress.msub
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -160,13 +160,12 @@ fi
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if test "$USER" == "kellyt"; then
   run "module load git"
-  MYHOSTNAME="`uname -n`"
   keychain=keychain-2.7.1
   $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
-  if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
-    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+  if test -f $HOME/.keychain/$HOSTNAME-sh; then
+    run "source $HOME/.keychain/$HOSTNAME-sh"
   else
-    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+    echo "Error: could not find $HOME/.keychain/$HOSTNAME-sh"
   fi
 fi
 


### PR DESCRIPTION
The initial goal of this work was to prevent two simultaneous CI instances of the same PR.  However, after working through several potential solutions it has resulted in a bigger set of changes as detailed below. refs #841
+ Begin running nightly tests and PRs on snow. Also teach the snow regression scripts to use qos=dev and to use all 36 cores on each node.
+ Use `flock` to prevent some scripts from having more than one concurrent instance. Also add some job control cleanup to the end of these scripts. `flock` doesn't seem to work well with if the log file (on a NFS mount) is used as the locking file.  Instead I create an empty file at /var/tmp. This mechanism now is used in these files:
  + regression-master.sh
  + sync_repository.sh
  + sync_vendors.sh
+ Teach some scripts to capture and write all of their output to a log file. This simplifies the crontab commands that previously redirected all output to a file.  This change was made in these files:
  + sync_vendors.sh
  + sync_repository.sh
  + update_regression_scripts.sh
+ Clean up old work directories and log files automatically (delete files or directories that are more than 14 days old).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [ ] Manually test these scripts on Snow, Moonlight, Trinitite and ccscs7.
