### PR TITLE
Provide FMA macro to simulate more accurate math on older machines.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ query_have_gethostname()
 query_have_maxpathlen()
 query_have_sys_headers() # sets HAVE_UNISTD_H, etc.
 query_have_restrict_keyword()
-query_cxx11_features()
+query_fma_on_hardware()
 
 # Set compiler options
 include( compilerEnv )

--- a/config/query_fma.cc
+++ b/config/query_fma.cc
@@ -1,0 +1,107 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   config/query_fma.cc
+ * \author Kelly Thompson <kgt@lanl.gov>
+ * \date   Thursday, Feb 09, 2017, 08:11 am
+ * \brief  FMA features test.
+ * \note   Copyright (C) 2017 Los Alamos National Security, LLC.
+ *         All rights reserved.
+ *
+ * Supporting functions:
+ *
+ * This code is adopted from
+ * https://software.intel.com/en-us/node/405250?language=es&wapkw=avx2+cpuid
+ */
+//---------------------------------------------------------------------------//
+
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1300)
+
+#include <immintrin.h>
+
+int check_4th_gen_intel_core_features() {
+  const int the_4th_gen_features =
+      (_FEATURE_AVX2 | _FEATURE_FMA | _FEATURE_BMI | _FEATURE_LZCNT |
+       _FEATURE_MOVBE);
+  return _may_i_use_cpu_feature(the_4th_gen_features);
+}
+
+#else /* non-Intel compiler */
+
+#include <stdint.h>
+#if defined(_MSC_VER)
+#define MYINT int
+#include <intrin.h>
+#else
+#define MYINT uint32_t
+#endif
+
+void run_cpuid(MYINT eax, MYINT ecx, MYINT *abcd) {
+#if defined(_MSC_VER)
+  __cpuidex(abcd, eax, ecx);
+#else
+  MYINT ebx(42), edx(42);
+#if defined(__i386__) && defined(__PIC__)
+  /* in case of PIC under 32-bit EBX cannot be clobbered */
+  __asm__("movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi"
+          : "=D"(ebx),
+#else
+  __asm__("cpuid"
+          : "+b"(ebx),
+#endif
+            "+a"(eax), "+c"(ecx), "=d"(edx));
+  abcd[0] = eax;
+  abcd[1] = ebx;
+  abcd[2] = ecx;
+  abcd[3] = edx;
+#endif
+}
+
+int check_xcr0_ymm() {
+  MYINT xcr0;
+#if defined(_MSC_VER)
+  xcr0 = (MYINT)_xgetbv(0); /* min VS2010 SP1 compiler is required */
+#else
+  __asm__("xgetbv" : "=a"(xcr0) : "c"(0) : "%edx");
+#endif
+  return ((xcr0 & 6) ==
+          6); /* checking if xmm and ymm state are enabled in XCR0 */
+}
+
+int check_4th_gen_intel_core_features() {
+  MYINT abcd[4];
+  MYINT fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
+  MYINT avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
+
+  /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1   &&
+       CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
+       CPUID.(EAX=01H, ECX=0H):ECX.OSXSAVE[bit 27]==1 */
+  run_cpuid(1, 0, abcd);
+  if ((abcd[2] & fma_movbe_osxsave_mask) != fma_movbe_osxsave_mask)
+    return 0;
+
+  if (!check_xcr0_ymm())
+    return 0;
+
+  /*  CPUID.(EAX=07H, ECX=0H):EBX.AVX2[bit 5]==1  &&
+        CPUID.(EAX=07H, ECX=0H):EBX.BMI1[bit 3]==1  &&
+        CPUID.(EAX=07H, ECX=0H):EBX.BMI2[bit 8]==1  */
+  run_cpuid(7, 0, abcd);
+  if ((abcd[1] & avx2_bmi12_mask) != avx2_bmi12_mask)
+    return 0;
+
+  /* CPUID.(EAX=80000001H):ECX.LZCNT[bit 5]==1 */
+  run_cpuid(0x80000001, 0, abcd);
+  if ((abcd[2] & (1 << 5)) == 0)
+    return 0;
+
+  return 1;
+}
+
+#endif /* non-Intel compiler */
+
+//---------------------------------------------------------------------------//
+int main(int argc, char *argv[]) { return check_4th_gen_intel_core_features(); }
+
+//---------------------------------------------------------------------------//
+// end of query_fma.cc
+//---------------------------------------------------------------------------//

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -79,7 +79,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
      # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
    #endif()
    set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -DDEBUG")
-   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
+   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -flto -DNDEBUG" )
 # -ffast-math -mtune=native -ftree-vectorize
 # -fno-finite-math-only -fno-associative-math -fsignaling-nans
    set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -49,8 +49,9 @@ endif()
 if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
-  # /wd 4251 disable warning #4251: 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
-  set( CMAKE_C_FLAGS "/W2 /Gy /DWIN32 /D_WINDOWS /MP${numproc} /wd4251" )
+  # /wd 4251 disable warning #4251: 'identifier' : class 'type' needs to have
+  # dll-interface to be used by clients of class 'type2'
+  set( CMAKE_C_FLAGS "/W2 /Gy /Gm /fp:precise /arch:AVX2 /DWIN32 /D_WINDOWS /MP${numproc} /wd4251" )
   set( CMAKE_C_FLAGS_DEBUG "/${MD_or_MT_debug} /Od /Zi /DDEBUG /D_DEBUG" ) # /Ob0
   set( CMAKE_C_FLAGS_RELEASE "/${MD_or_MT} /O2 /DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL "/${MD_or_MT} /O1 /DNDEBUG" )
@@ -71,10 +72,10 @@ if( NOT CXX_FLAGS_INITIALIZED )
 
   # Suppress some MSVC warnings about "unsafe" pointer use.
   if(MSVC_VERSION GREATER 1399)
-    set( CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} /D_CRT_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE /D_SECURE_SCL=0" )
-    set( CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE /D_SECURE_SCL=0" )
+    string( APPEND CMAKE_C_FLAGS
+      " /D_CRT_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE /D_SECURE_SCL=0" )
+    string( APPEND CMAKE_CXX_FLAGS
+      "$ /D_CRT_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE /D_SECURE_SCL=0" )
     #set( CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} /D_HAS_ITERATOR_DEBUGGING=0" )
     #set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_HAS_ITERATOR_DEBUGGING=0" )
   endif()

--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -5,10 +5,7 @@
  * \date   Wednesday, Nov 07, 2012, 18:49 pm
  * \brief  Small executable that prints the version and copyright strings.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: tstScalarUnitTest.cc 6864 2012-11-08 01:34:45Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "draco_info.hh"
@@ -30,10 +27,9 @@ DracoInfo::DracoInfo(void)
       build_type(normalizeCapitalization(CMAKE_BUILD_TYPE)),
       library_type("static"), system_type("Unknown"), site_name("Unknown"),
       cuda(false), mpi(false), mpirun_cmd(""), openmp(false),
-      diagnostics_level("disabled"), diagnostics_timing(false), cxx11(false),
-      cxx11_features(), cxx(CMAKE_CXX_COMPILER), cxx_flags(CMAKE_CXX_FLAGS),
-      cc(CMAKE_C_COMPILER), cc_flags(CMAKE_C_FLAGS), fc("none"),
-      fc_flags("none") {
+      diagnostics_level("disabled"), diagnostics_timing(false),
+      cxx(CMAKE_CXX_COMPILER), cxx_flags(CMAKE_CXX_FLAGS), cc(CMAKE_C_COMPILER),
+      cc_flags(CMAKE_C_FLAGS), fc("none"), fc_flags("none") {
 #ifdef DRACO_SHARED_LIBS
   library_type = "Shared";
 #endif
@@ -65,8 +61,6 @@ DracoInfo::DracoInfo(void)
 #ifdef DRACO_TIMING
   diagnostics_timing = true;
 #endif
-  cxx11 = true;
-  cxx11_features = rtt_dsxx::UnitTest::tokenize(CXX11_FEATURE_LIST, ";", false);
   if (build_type == std::string("Release")) {
     cxx_flags += CMAKE_CXX_FLAGS_RELEASE;
     cc_flags += CMAKE_C_FLAGS_RELEASE;
@@ -113,19 +107,6 @@ std::string DracoInfo::fullReport(void) {
               << "\n    Diagnostics    : " << diagnostics_level
               << "\n    Diagnostics Timing: "
               << (diagnostics_timing ? "enabled" : "disabled");
-
-  // C++11
-
-  infoMessage << "\n    C++11 Support  : " << (cxx11 ? "enabled" : "disabled");
-
-  if (cxx11) {
-    infoMessage << "\n      Feature list : ";
-    for (size_t i = 0; i < cxx11_features.size(); ++i)
-      if (i == 0)
-        infoMessage << cxx11_features[i];
-      else
-        infoMessage << "\n                     " << cxx11_features[i];
-  }
 
   // Compilers and Flags
 

--- a/src/diagnostics/draco_info.hh
+++ b/src/diagnostics/draco_info.hh
@@ -5,10 +5,7 @@
  * \date   Wednesday, Nov 07, 2012, 18:49 pm
  * \brief  Small executable that prints the version and copyright strings.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: tstScalarUnitTest.cc 6864 2012-11-08 01:34:45Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_diagnostics_draco_info_hh
@@ -47,12 +44,6 @@ namespace rtt_diagnostics {
  *     OpenMPI support: enabled
  *     Diagnostics    : disabled
  *     Diagnostics Timing: disabled
- *     C++11 Support  : enabled
- *       Feature list : HAS_CXX11_AUTO_TYPE
- *                      HAS_CXX11_NULLPTR
- *                      HAS_CXX11_LAMBDA
- *                      HAS_CXX11_STATIC_ASSERT
- *                      HAS_CXX11_SHARED_PTR
  * \endverbatim
  */
 //===========================================================================//
@@ -69,7 +60,7 @@ public:
   // -------
 
   /*! \brief Construct an information message that includes Draco's version,
-     * copyright and basic build parameters. */
+   * copyright and basic build parameters. */
   std::string fullReport(void);
 
   //! Version and Copyright only
@@ -98,8 +89,6 @@ private:
   bool openmp;
   std::string diagnostics_level;
   bool diagnostics_timing;
-  bool cxx11;
-  std::vector<std::string> cxx11_features;
   std::string cxx;
   std::string cxx_flags;
   std::string cc;

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -1,0 +1,67 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file    ds++/FMA.hh
+ * \author  Kelly Thompson
+ * \date    Thursday, Feb 09, 2017, 11:22 am
+ * \brief   Provide extra control for FMA operations.
+ * \note    Copyright (C) 2017 Los Alamos National Security, LLC.
+ *          All rights reserved.
+ *
+ * Intel Haswell and later (and also modern AMD cpus), have hardware FMA
+ * features. Using \c fma(c,b,a) is more accurate than \c a*b+c because there is
+ * less roundoff error. This difference in accuracy causes issues for IMC
+ * because solutions are not consistent between older and newer hardware.
+ *
+ * To improve solution consistency across platforms, we can choose to use a
+ * software-based infinite precision fma call.
+ *
+ * \note Intel's code for detecting FMA availability on hardware.
+ * https://software.intel.com/en-us/node/405250?language=es&wapkw=avx2+cpuid
+ */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_dsxx_FMA_hh
+#define rtt_dsxx_FMA_hh
+
+#include "ds++/config.h"
+
+//---------------------------------------------------------------------------//
+// HAVE_HARDWARE_FMA is set by config/platform_checks.cmake.
+
+#ifdef HAVE_HARDWARE_FMA
+
+/* This will be the default for new machines. Both versions should be equally
+ * accurate, choose whatever is faster. FP_FAST_FMA is set by the compiler
+ *
+ * \ref http://en.cppreference.com/w/c/numeric/math/fma
+ */
+#ifdef FP_FAST_FMA
+#define FMA(a, b, c) fma(a, b, c)
+#else
+#define FMA(a, b, c) ((a) * (b) + c)
+#endif
+
+#else /* HAVE_HARDWARE_FMA is false */
+
+/*! For older hardware that does not support FMA natively, provide a macro that
+ *  will call an infinite precision fma function so that numerical
+ *  reproducibility is enhanced (if FP_ACCURATE_FMA is defined). This allows
+ *  solutions generated on older machines to match solutions generated on newer
+ *  machines. */
+#ifndef FP_ACCURATE_FMA
+#error "Must set FP_ACCURATE_FMA to 0 or 1."
+#endif
+
+#if FP_ACCURATE_FMA > 0
+#define FMA(a, b, c) fma(a, b, c)
+#else
+#define FMA(a, b, c) ((a) * (b) + c)
+#endif
+
+#endif /* HAVE_HARDWARE_FMA */
+
+#endif // rtt_dsxx_FMA_hh
+
+//---------------------------------------------------------------------------//
+// end of ds++/FMA.hh
+//---------------------------------------------------------------------------//

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -24,6 +24,7 @@
 #define rtt_dsxx_FMA_hh
 
 #include "ds++/config.h"
+#include <cmath>
 
 //---------------------------------------------------------------------------//
 // HAVE_HARDWARE_FMA is set by config/platform_checks.cmake.

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -3,8 +3,7 @@
  * \file   config.h
  * \brief  CPP defines necessary for the ds++ package.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
 #ifndef __dsxx_config_h__
@@ -52,6 +51,9 @@
 /*---------------------------------------------------------------------------*/
 /* Platform checks */
 /*---------------------------------------------------------------------------*/
+
+/* Does this machine support hardware FMA? */
+#cmakedefine HAVE_HARDWARE_FMA @HAVE_HARDWARE_FMA@
 
 /* Support for C99's restrict keyword */
 #cmakedefine HAVE_RESTRICT
@@ -171,27 +173,6 @@
 #if DRACO_DIAGNOSTICS & 4
 #define DRACO_DIAGNOSTICS_LEVEL_3
 #endif
-
-/* ---------------------------------------- */
-/* C++ 11 support */
-/* ---------------------------------------- */
-
-/* These values are set in
- * config/platform_checks.cmake::query_cxx11_features. */
-
-#cmakedefine CXX11_FEATURE_LIST "@CXX11_FEATURE_LIST@"
-#cmakedefine HAS_CXX11_ARRAY
-#cmakedefine HAS_CXX11_AUTO_TYPE
-#cmakedefine HAS_CXX11_DECLTYPE_AUTO
-#cmakedefine HAS_CXX11_NULLPTR
-#cmakedefine HAS_CXX11_LAMBDAS
-#cmakedefine HAS_CXX11_RVALUE_REFERENCES
-#cmakedefine HAS_CXX11_LONG_LONG
-#cmakedefine HAS_CXX11_STATIC_ASSERT
-#cmakedefine HAS_CXX11_DECLTYPE
-#cmakedefine HAS_CXX11_VARIADIC_TEMPLATES
-#cmakedefine HAS_CXX11_SIZEOF_MEMBER
-#cmakedefine HAS_CXX11_GENERALIZED_INITIALIZERS
 
 /* ---------------------------------------- */
 /* Configuration Options used by CMake      */

--- a/src/ds++/test/tstFMA.cc
+++ b/src/ds++/test/tstFMA.cc
@@ -25,19 +25,50 @@ void test_fma1(rtt_dsxx::UnitTest &ut) {
 
   double const a(1.0e-16), b(1.0e16), c(-1.0);
 
+  double const result = a * b + c;
   double const fma_result = fma(a, b, c);
   double const macro_fma_result = FMA(a, b, c);
 
   std::cout.precision(17);
-  std::cout << "\nresult a*b+c      = " << fma_result << "\n"
-            << "result fma(a,b,c) = " << fma(a, b, c) << "\n"
+  std::cout << "\nresult a*b+c      = " << result << "\n"
+            << "result fma(a,b,c) = " << fma_result << "\n"
             << "result FMA(a,b,c) = " << macro_fma_result << "\n"
             << std::endl;
+
+#ifdef HAVE_HARDWARE_FMA
+
+  std::cout << "Hardware FMA is available.\n";
+
+#ifdef FP_FAST_FMA
+  std::cout << "\t#define FMA(a,b,c) fma(a,b,c)\n" << std::endl;
 
   if (fma_result == macro_fma_result)
     PASSMSG("With FP_ACCURATE_FMA=1, fma(a,b,c) == FMA(a,b,c).");
   else
     FAILMSG("With FP_ACCURATE_FMA=1, fma(a,b,c) != FMA(a,b,c).");
+
+#else
+  std::cout << "\t#define FMA(a,b,c) ((a)*(b)+(c))\n" << std::endl;
+
+  if (result == macro_fma_result)
+    PASSMSG("With FP_ACCURATE_FMA=1, a*b+c == FMA(a,b,c).");
+  else
+    FAILMSG("With FP_ACCURATE_FMA=1, a*b+c != FMA(a,b,c).");
+
+#endif
+
+#else
+
+  std::cout << "Hardware FMA is not available.\n"
+            << "\t#define FMA(a,b,c) fma(a,b,c)\n"
+            << std::endl;
+
+  if (fma_result == macro_fma_result)
+    PASSMSG("With FP_ACCURATE_FMA=1, a*b+c == FMA(a,b,c).");
+  else
+    FAILMSG("With FP_ACCURATE_FMA=1, a*b+c != FMA(a,b,c).");
+
+#endif
 
   return;
 }

--- a/src/ds++/test/tstFMA.cc
+++ b/src/ds++/test/tstFMA.cc
@@ -1,0 +1,56 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   ds++/test/tstFMA.cc
+ * \author Kelly Thompson <kgt@lanl.gov>
+ * \date   Wed Nov 10 09:35:09 2010
+ * \brief  Test functions defined in ds++/FMA.cc
+ * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include <sstream>
+
+#define FP_ACCURATE_FMA 1
+#include "ds++/FMA.hh"
+
+//---------------------------------------------------------------------------//
+// Test 1: Accurate FMA
+void test_fma1(rtt_dsxx::UnitTest &ut) {
+  std::cout << "\n>>> Begin test 1..." << std::endl;
+
+#define FP_ACCURATE_FMA 1
+#include "ds++/FMA.hh"
+
+  double const a(1.0e-16), b(1.0e16), c(-1.0);
+
+  double const fma_result = fma(a, b, c);
+  double const macro_fma_result = FMA(a, b, c);
+
+  std::cout.precision(17);
+  std::cout << "\nresult a*b+c      = " << fma_result << "\n"
+            << "result fma(a,b,c) = " << fma(a, b, c) << "\n"
+            << "result FMA(a,b,c) = " << macro_fma_result << "\n"
+            << std::endl;
+
+  if (fma_result == macro_fma_result)
+    PASSMSG("With FP_ACCURATE_FMA=1, fma(a,b,c) == FMA(a,b,c).");
+  else
+    FAILMSG("With FP_ACCURATE_FMA=1, fma(a,b,c) != FMA(a,b,c).");
+
+  return;
+}
+
+//---------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
+  try {
+    test_fma1(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of tstFMA.cc
+//---------------------------------------------------------------------------//

--- a/src/ds++/test/tstFMA2.cc
+++ b/src/ds++/test/tstFMA2.cc
@@ -1,0 +1,87 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   ds++/test/tstFMA.cc
+ * \author Kelly Thompson <kgt@lanl.gov>
+ * \date   Wed Nov 10 09:35:09 2010
+ * \brief  Test functions defined in ds++/FMA.cc
+ * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include <sstream>
+
+#define FP_ACCURATE_FMA 0
+#include "ds++/FMA.hh"
+
+//---------------------------------------------------------------------------//
+// Test 2: Don't use FMA because it is too slow.
+void test_fma2(rtt_dsxx::UnitTest &ut) {
+  std::cout << "\n>>> Begin test 2..." << std::endl;
+
+  double const a(1.0e-16), b(1.0e16), c(-1.0);
+
+  double const result = a * b + c;
+  double const macro_fma_result = FMA(a, b, c);
+
+  std::cout.precision(17);
+  std::cout << "\nresult a*b+c      = " << result << "\n"
+            << "result fma(a,b,c) = " << fma(a, b, c) << "\n"
+            << "result FMA(a,b,c) = " << macro_fma_result << "\n"
+            << std::endl;
+
+#ifdef HAVE_HARDWARE_FMA
+
+  std::cout << "Hardware FMA is available.\n";
+
+#ifdef FP_FAST_FMA
+  std::cout << "\t#define FMA(a,b,c) fma(a,b,c)\n" << std::endl;
+
+  if (fma(a, b, c) == macro_fma_result)
+    PASSMSG("With FP_ACCURATE_FMA=0, fma(a,b,c) == FMA(a,b,c).");
+  else
+    FAILMSG("With FP_ACCURATE_FMA=0, fma(a,b,c) != FMA(a,b,c).");
+
+#else
+  std::cout << "\t#define FMA(a,b,c) ((a)*(b)+(c))\n" << std::endl;
+
+  if (result == macro_fma_result)
+    PASSMSG("With FP_ACCURATE_FMA=0, a*b+c == FMA(a,b,c).");
+  else
+    FAILMSG("With FP_ACCURATE_FMA=0, a*b+c != FMA(a,b,c).");
+
+#endif
+
+#else
+  std::cout << "Hardware FMA is not available.\n"
+
+#if FP_ACCURATE_FMA > 0
+            << "\t#define FMA(a,b,c) fma(a,b,c)\n"
+#else
+            << "\t#define FMA(a,b,c) ((a)*(b)+(c))\n"
+#endif
+            << std::endl;
+
+  if (result == macro_fma_result)
+    PASSMSG("With FP_ACCURATE_FMA=0, a*b+c == FMA(a,b,c).");
+  else
+    FAILMSG("With FP_ACCURATE_FMA=0, a*b+c != FMA(a,b,c).");
+
+#endif
+
+  return;
+}
+
+//---------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
+  try {
+    test_fma2(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of tstFMA.cc
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
+ Add a cmake function, query_fma_on_hardware (called by `CMakeLists.txt`) that will determine if the local hardware supports fused multiply-add.  This function uses CMake's try_run commands to compile and run a program that derives from an example provided by Intel (`config/query_fma.cc`). The program returns 1 if FMA is supported on the hardware. 
+ Add an FMA macro that controls fma behavior. This is used in Jayenne to improve numerical reproducibility between machines. In general, new machines use hardware provided FMA that is more accurate than math performed on older hardware. To improve numerical reproducibility, this macro can be used to call a high precision multiply+add operation.  The downside, is that this higher precision call can be very expensive.
+ The behavior of the new FMA macro can be tuned by using the `FP_ACCURATE_FMA` macro.  If this macro is defined to be 1, the more accurate and more expensive  fma call will be used on older hardware.  Otherwise, the FMA macro will simply evaluate `a*b+c`. Jayenne will set `FP_ACCURATE_FMA=0` for non-reproducible build modes.
+ Add two new unit tests for FMA.
+ On Visual Studio, turn on AVX2 features by default (needed for fma).
+ Also retire some build system stuff that tried to detect C++11 features. We now assume that all C++11 features are always available.  I pruned the reporting of available C++11 features from draco_info.
+ refs #872 (redmine)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
