### PR TITLE
GCC's -flto doesn't work correctly with GNU 4.X compilers.

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -8,7 +8,9 @@
 # History
 # ----------------------------------------
 # 6/13/2016  - IPO settings moved to compilerEnv.cmake
-#              (CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON).
+#              (CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON). As of cmake/3.7, this
+#              only turns on IPO for Intel, so we still add -flto for release
+#              builds.
 
 # Notes:
 # ----------------------------------------
@@ -62,51 +64,54 @@ endif()
 #
 # Compiler Flags
 #
-# Consider using these:
+# Consider using these diagnostic flags for Debug builds:
 # -Wundef     - warn about CPP macros read but not defined.
 # -Wcast-qual - warn about casts that remove qualifiers like const.
 # -Wfloat-equal
 # -Wstrict-overflow=4
 # -Wwrite-strings
 # -Wunreachable-code
+#
+# Consider using these optimization flags:
+# -ffast-math -mtune=native -ftree-vectorize
+# -fno-finite-math-only -fno-associative-math -fsignaling-nans
 
 if( NOT CXX_FLAGS_INITIALIZED )
    set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
    set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
-   #if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
+   #if( CMAKE_C_COMPILER_VERSION VERSION_GREATER 5.0 )
      #set( CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -fdiagnostics-color=always" )
      # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
    #endif()
    set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -DDEBUG")
-   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -flto -DNDEBUG" )
-# -ffast-math -mtune=native -ftree-vectorize
-# -fno-finite-math-only -fno-associative-math -fsignaling-nans
+   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
    set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
    set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -funroll-loops" )
 
-   set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS}" ) #  -std=c++11" )
+   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
+     # LTO appears to be broken for gcc/4.8.5 (at least for Jayenne).
+     string( APPEND CMAKE_C_FLAGS_RELEASE " -flto" )
+   endif()
+   if (NOT APPLE AND HAS_MARCH_NATIVE)
+     string( APPEND CMAKE_C_FLAGS " -march=native" )
+   endif()
+
+   set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS}" )
    set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
    set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
    set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
    set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
 
-   # Use C99 standard.
-   set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-
    # Extra Debug flags that only exist in newer gcc versions.
    if( HAS_WNOEXCEPT )
-      set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wnoexcept" )
+     string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wnoexcept" )
    endif()
    if( HAS_WSUGGEST_ATTRIBUTE )
-      set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wsuggest-attribute=const" )
+     string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wsuggest-attribute=const" )
    endif()
    if( HAS_WUNUSED_LOCAL_TYPEDEFS )
-      set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wunused-local-typedefs" )
-   endif()
-   if (NOT APPLE AND HAS_MARCH_NATIVE)
-      set( CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -march=native" )
-      set( CMAKE_CXX_FLAGS       "${CMAKE_CXX_FLAGS} -march=native" )
+     string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wunused-local-typedefs" )
    endif()
 
    # Features for GCC-5.0 or later
@@ -138,7 +143,8 @@ if( NOT CXX_FLAGS_INITIALIZED )
       # Wiki page for more details
       # (https://gcc.gnu.org/wiki/Intel%20MPX%20support%20in%20the%20GCC%20compiler)
 
-      # set( CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=float-divide-by-zero -fcheck-ponter-bounds")
+      # string( APPEND CMAKE_C_FLAGS_DEBUG
+      #         " -fsanitize=float-divide-by-zero -fcheck-ponter-bounds")
    endif()
 endif()
 
@@ -165,11 +171,10 @@ toggle_compiler_flag( GCC_ENABLE_GLIBCXX_DEBUG
    "-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC" "CXX" "DEBUG" )
 toggle_compiler_flag( OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX;EXE_LINKER" "" )
 
-# On SQ, our Random123/1.08 vendor uses a series of include directives
-# that fail to compile with g++-4.7.2 when the -pedantic option is
-# requested. The core issue is that fabs is defined with two different
-# exception signatures in math.h and in ppu_intrinsics.h.  On this
-# platform, we choose not use -pedantic.
+# On SQ, our Random123/1.08 vendor uses a series of include directives that fail
+# to compile with g++-4.7.2 when the -pedantic option is requested. The core
+# issue is that fabs is defined with two different exception signatures in
+# math.h and in ppu_intrinsics.h. On this platform, we choose not use -pedantic.
 if( ${SITENAME} MATCHES "seq" )
    toggle_compiler_flag( OFF "-pedantic" "CXX" "")
 endif()


### PR DESCRIPTION
+ `CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` only works with Intel, so we still need to manually add the `-lfto` compile flag for GNU-based Release builds.
+ Because this options doesn't work correctly with GNU 4.8.5, restrict its use to GNU 5+.
+ Shuffle some assignment operations around to simplify the code logic.
+ Remove the use of `-std=` compile flags. Use the CMake options `CMAKE_C[XX]_STANDARD` instead.
+ Make use of `string(APPEND ...)` to simplify logic.
+ [Redmine #872](https://rtt.lanl.gov/redmine/issues/872)
+ This change should resolve the 24 failing tests on ccscs2 and ccscs7 (Release builds).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
