### PR TITLE
For now, disable AVX2 instructions for Win32 builds.

### DIFF
--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -12,7 +12,9 @@
 #
 if( NOT ${CMAKE_GENERATOR} MATCHES "Visual Studio" AND
     NOT ${CMAKE_GENERATOR} MATCHES  "NMake Makefiles" )
-  message( FATAL_ERROR "config/windows-cl.cmake must be taught to build for this compiler (CMAKE_GENERATOR = ${CMAKE_GENERATOR}).  Yell atkt for help on this error." )
+  message( FATAL_ERROR
+  "config/windows-cl.cmake must be taught to build for this compiler "
+  "(CMAKE_GENERATOR = ${CMAKE_GENERATOR}). Yell at kt for help on this error." )
 endif()
 
 #
@@ -38,7 +40,7 @@ set( _USE_MATH_DEFINES 1 )
 
 set( MD_or_MT_debug "${MD_or_MT}d" )
 if( "${DEBUG_RUNTIME_EXT}" STREQUAL "d" )
-  set( MD_or_MT_debug "${MD_or_MT}${DEBUG_RUNTIME_EXT} /RTC1" ) # RTC requires /MDd
+  set( MD_or_MT_debug "${MD_or_MT}${DEBUG_RUNTIME_EXT} /RTC1" )
 endif()
 
 set( numproc $ENV{NUMBER_OF_PROCESSORS} )
@@ -49,13 +51,17 @@ endif()
 if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
-  # /wd 4251 disable warning #4251: 'identifier' : class 'type' needs to have
-  # dll-interface to be used by clients of class 'type2'
-  set( CMAKE_C_FLAGS "/W2 /Gy /Gm /fp:precise /arch:AVX2 /DWIN32 /D_WINDOWS /MP${numproc} /wd4251" )
-  set( CMAKE_C_FLAGS_DEBUG "/${MD_or_MT_debug} /Od /Zi /DDEBUG /D_DEBUG" ) # /Ob0
+  # Notes on options:
+  # - /wd 4251 disable warning #4251: 'identifier' : class 'type' needs to have
+  #   dll-interface to be used by clients of class 'type2'
+  # - /arch:AVX2 At least for VS2013 with NMake Makefiles, CMake doesn't
+  #   populate the correct project property. Also, this option causes 'illegal
+  #   instruction' for rng on KT's desktop (2017-02-14).
+  set( CMAKE_C_FLAGS "/W2 /Gy /fp:precise /DWIN32 /D_WINDOWS /MP${numproc} /wd4251" )
+  set( CMAKE_C_FLAGS_DEBUG "/${MD_or_MT_debug} /Od /Gm /Zi /DDEBUG /D_DEBUG" )
   set( CMAKE_C_FLAGS_RELEASE "/${MD_or_MT} /O2 /DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL "/${MD_or_MT} /O1 /DNDEBUG" )
-  set( CMAKE_C_FLAGS_RELWITHDEBINFO "/${MD_or_MT} /O2 /Zi /DDEBUG" )
+  set( CMAKE_C_FLAGS_RELWITHDEBINFO "/${MD_or_MT} /O2 /Gm /Zi /DDEBUG" )
 
   # Suppress some MSVC warnings about "unsafe" pointer use.
   if(MSVC_VERSION GREATER 1399)
@@ -74,7 +80,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}" )
   set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_CXX_FLAGS_MINSIZEREL "/${MD_or_MT} /O1 /DNDEBUG" )
-  set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "/${MD_or_MT} /O2 /Zi /DDEBUG" )
+  set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "/${MD_or_MT} /O2 /Gm /Zi /DDEBUG" )
 
 endif()
 


### PR DESCRIPTION
+ The `/arch:AVX2` compile option was generating 'invalid instructions' from within RNG.
+ Move option `/Gm` from the general flags to Debug builds. It is typically used alongside `/Zi`.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
