### PR TITLE
Re-enable Intel compiler flag '-xHost'.

### DIFF
--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -101,6 +101,7 @@ set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE
 if( NOT CRAY_PE )
  include(CheckCCompilerFlag)
  check_c_compiler_flag(-xHost HAS_XHOST)
+ toggle_compiler_flag( HAS_XHOST "-xHost" "C;CXX" "")
 #else()
  # -craype-verbose
 endif()


### PR DESCRIPTION
+ The Intel compilers only generate FMA hardware instructions if the compiler is told to generate AVX2 or later features. `-xHost` chooses the correct architecture based on the current machine.
+ This flag will not be enabled on Cray machines. The Cray compile wrappers will set this flag based on the currently loaded modules. Also using `-xHost` breaks cross compiling for KNL.
+ This change addresses the two dozen Jayenne tests that are failing on snow.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
