### PR TITLE
Add option to UnitTest to suppress pass messages in UnitTest::check

### DIFF
--- a/src/c4/ParallelUnitTest.cc
+++ b/src/c4/ParallelUnitTest.cc
@@ -23,6 +23,8 @@ namespace rtt_c4 {
  * \arg argv A list of strings containg the command line arguments
  * \arg release_ A function pointer to this package's release function.
  * \arg out_ A user specified iostream that defaults to std::cout.
+ * \arg verbose_ flags whether to print messages for successful tests. Defaults
+ * to true.
  * \exception rtt_dsxx::assertion An exception with the message "Success" will
  * be thrown if \c --version is found in the argument list.
  *
@@ -32,8 +34,9 @@ namespace rtt_c4 {
  * and provides the unit test name.
  */
 ParallelUnitTest::ParallelUnitTest(int &argc, char **&argv,
-                                   string_fp_void release_, std::ostream &out_)
-    : UnitTest(argc, argv, release_, out_) {
+                                   string_fp_void release_, std::ostream &out_,
+                                   bool const verbose_)
+    : UnitTest(argc, argv, release_, out_, verbose_) {
   using std::string;
 
   initialize(argc, argv);

--- a/src/c4/ParallelUnitTest.hh
+++ b/src/c4/ParallelUnitTest.hh
@@ -76,7 +76,8 @@ public:
   //! Default constructor.
   DLL_PUBLIC_c4 ParallelUnitTest(int &argc, char **&argv,
                                  string_fp_void release_,
-                                 std::ostream &out_ = std::cout);
+                                 std::ostream &out_ = std::cout,
+                                 bool verbose_ = true);
 
   //!  The copy constructor is disabled.
   ParallelUnitTest(ParallelUnitTest const &rhs);

--- a/src/ds++/ScalarUnitTest.cc
+++ b/src/ds++/ScalarUnitTest.cc
@@ -25,6 +25,8 @@ namespace rtt_dsxx {
  * \arg argv A list of strings containg the command line arguments
  * \arg release_ A function pointer to this package's release function.
  * \arg out_ A user specified iostream that defaults to std::cout.
+ * \arg verbose_ flags whether to print messages for successful tests. Defaults
+ * to true.
  * \exception rtt_dsxx::assertion An exception with the message "Success" will
  * be thrown if \c --version is found in the argument list.
  *
@@ -33,8 +35,8 @@ namespace rtt_dsxx {
  * scalar unit test and provides the unit test name.
  */
 ScalarUnitTest::ScalarUnitTest(int &argc, char **&argv, string_fp_void release_,
-                               std::ostream &out_)
-    : UnitTest(argc, argv, release_, out_) {
+                               std::ostream &out_, bool const verbose_)
+    : UnitTest(argc, argv, release_, out_, verbose_) {
   using std::endl;
   using std::string;
 

--- a/src/ds++/ScalarUnitTest.hh
+++ b/src/ds++/ScalarUnitTest.hh
@@ -58,7 +58,8 @@ public:
   //! Default constructors.
   DLL_PUBLIC_dsxx ScalarUnitTest(int &argc, char **&argv,
                                  string_fp_void release_,
-                                 std::ostream &out_ = std::cout);
+                                 std::ostream &out_ = std::cout,
+                                 bool verbose_ = true);
 
   //! The copy constructor is disabled.
   ScalarUnitTest(const ScalarUnitTest &rhs);

--- a/src/ds++/UnitTest.cc
+++ b/src/ds++/UnitTest.cc
@@ -28,20 +28,22 @@ namespace rtt_dsxx {
  * \param argv A list of command line arguments.
  * \param release_ A function pointer to the local package's release() function.
  * \param out_ A user selectable output stream.  By default this is std::cout.
+ * \param verbose_ Print the messages for passing tests. By default, this is
+ * set to true.
  *
  * This constructor automatically parses the command line to setup the name of
  * the unit test (used when generating status reports).  The object produced by
  * this constructor will respond to the command line argument "--version."
  */
 UnitTest::UnitTest(int & /* argc */, char **&argv, string_fp_void release_,
-                   std::ostream &out_)
+                   std::ostream &out_, bool const verbose_)
     : numPasses(0), numFails(0), fpe_trap_active(false),
       testName(getFilenameComponent(std::string(argv[0]), rtt_dsxx::FC_NAME)),
       testPath(getFilenameComponent(
           getFilenameComponent(std::string(argv[0]), rtt_dsxx::FC_REALPATH),
           rtt_dsxx::FC_PATH)),
       release(release_), out(out_), m_dbcRequire(false), m_dbcCheck(false),
-      m_dbcEnsure(false), m_dbcNothrow(false) {
+      m_dbcEnsure(false), m_dbcNothrow(false), verbose(verbose_) {
   Require(release != NULL);
   Ensure(numPasses == 0);
   Ensure(numFails == 0);
@@ -116,8 +118,10 @@ bool UnitTest::failure(int line, char const *file) {
  * \param passmsg The message to be printed to the iostream \c UnitTest::out.
  */
 bool UnitTest::passes(const std::string &passmsg) {
-  out << "Test: passed" << std::endl;
-  out << "     " << passmsg << std::endl;
+  if (verbose) {
+    out << "Test: passed" << std::endl;
+    out << "     " << passmsg << std::endl;
+  }
   UnitTest::numPasses++;
   return true;
 }

--- a/src/ds++/UnitTest.hh
+++ b/src/ds++/UnitTest.hh
@@ -71,7 +71,7 @@ public:
 
   //! Default constructors.
   DLL_PUBLIC_dsxx UnitTest(int &argc, char **&argv, string_fp_void release_,
-                           std::ostream &out_ = std::cout);
+                           std::ostream &out_ = std::cout, bool verbose = true);
 
   //! The copy constructor is disabled.
   UnitTest(UnitTest const &rhs);
@@ -227,6 +227,9 @@ protected:
   bool m_dbcCheck;
   bool m_dbcEnsure;
   bool m_dbcNothrow;
+
+  /* Report successful tests? */
+  bool verbose;
 };
 
 } // end namespace rtt_dsxx

--- a/src/ds++/test/tstScalarUnitTest.cc
+++ b/src/ds++/test/tstScalarUnitTest.cc
@@ -351,6 +351,12 @@ int main(int argc, char *argv[]) {
     tstVersion(ut, argv[0]);
 
     tstPaths(ut, argv[0]);
+
+    // Silenced version
+    ScalarUnitTest ssut(argc, argv, release, messages, false);
+    messages.str("");
+    ssut.check(true, "this test must pass");
+    ut.check(messages.str().size() == 0, "verbose==false is silent");
   }
 
   catch (rtt_dsxx::assertion &err) {


### PR DESCRIPTION
This new feature addresses the problem of finding the one failing test among a slew of pass messsages for a test code that does many checks. 

By default this option is off, so existing behavior is unchanged. When this option is turned on, messages are generated by UnitTest::check only if the bool argument is false (meaning the test failed.) This can be extremely useful for debugging a test executable that has many check calls in it.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
