### PR TITLE
Eliminate all uses of rtt_dsxx::SP in Draco.

### DIFF
--- a/src/RTT_Format_Reader/CellDefs.hh
+++ b/src/RTT_Format_Reader/CellDefs.hh
@@ -5,19 +5,16 @@
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for CellDefs library.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __RTT_Format_Reader_CellDefs_hh__
 #define __RTT_Format_Reader_CellDefs_hh__
 
 #include "Dims.hh"
-#include "ds++/SP.hh"
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -149,7 +146,7 @@ class CellDefs {
   typedef std::vector<std::vector<std::vector<int>>> vector_vector_vector_int;
 
   const Dims &dims;
-  std::vector<rtt_dsxx::SP<CellDef>> defs;
+  std::vector<std::shared_ptr<CellDef>> defs;
   bool redefined;
 
 public:
@@ -186,7 +183,7 @@ public:
  * \return The cell definition.
  */
   const CellDef &get_cell_def(size_t i) const { return *(defs[i]); }
-  rtt_dsxx::SP<CellDef> get_def(size_t i) const { return defs[i]; }
+  std::shared_ptr<CellDef> get_def(size_t i) const { return defs[i]; }
   /*!
  * \brief Returns the number of nodes associated with the specified cell
  *        definition.

--- a/src/RTT_Format_Reader/CellFlags.hh
+++ b/src/RTT_Format_Reader/CellFlags.hh
@@ -1,14 +1,11 @@
 //----------------------------------*-C++-*----------------------------------//
-/*! 
+/*!
  * \file   RTT_Format_Reader/CellFlags.hh
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for RTT_Format_Reader/CellFlags class.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __RTT_Format_Reader_CellFlags_hh__
@@ -16,15 +13,15 @@
 
 #include "Dims.hh"
 #include "Flags.hh"
-#include "ds++/SP.hh"
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace rtt_RTT_Format_Reader {
 /*!
- * \brief Controls parsing, storing, and accessing the data specific to the 
+ * \brief Controls parsing, storing, and accessing the data specific to the
  *        cell flags block of the mesh file.
  */
 class CellFlags {
@@ -33,7 +30,7 @@ class CellFlags {
   typedef std::string string;
 
   const Dims &dims;
-  std::vector<rtt_dsxx::SP<Flags>> flagTypes;
+  std::vector<std::shared_ptr<Flags>> flagTypes;
 
 public:
   CellFlags(const Dims &dims_)

--- a/src/RTT_Format_Reader/NodeFlags.hh
+++ b/src/RTT_Format_Reader/NodeFlags.hh
@@ -1,14 +1,11 @@
 //----------------------------------*-C++-*----------------------------------//
-/*! 
+/*!
  * \file   RTT_Format_Reader/NodeFlags.hh
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for RTT_Format_Reader/NodeFlags class.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __RTT_Format_Reader_NodeFlags_hh__
@@ -16,15 +13,15 @@
 
 #include "Dims.hh"
 #include "Flags.hh"
-#include "ds++/SP.hh"
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace rtt_RTT_Format_Reader {
 /*!
- * \brief Controls parsing, storing, and accessing the data specific to the 
+ * \brief Controls parsing, storing, and accessing the data specific to the
  *        node flags block of the mesh file.
  */
 class NodeFlags {
@@ -33,7 +30,7 @@ class NodeFlags {
   typedef std::string string;
 
   const Dims &dims;
-  std::vector<rtt_dsxx::SP<Flags>> flagTypes;
+  std::vector<std::shared_ptr<Flags>> flagTypes;
 
 public:
   NodeFlags(const Dims &dims_)

--- a/src/RTT_Format_Reader/RTT_Format_Reader.hh
+++ b/src/RTT_Format_Reader/RTT_Format_Reader.hh
@@ -5,10 +5,7 @@
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for RTT_Format_Reader library.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __RTT_Format_Reader_RTT_Format_Reader_hh__
@@ -62,19 +59,19 @@ class DLL_PUBLIC_RTT_Format_Reader RTT_Format_Reader {
 private:
   Header header;
   Dims dims;
-  rtt_dsxx::SP<NodeFlags> spNodeFlags;
-  rtt_dsxx::SP<SideFlags> spSideFlags;
-  rtt_dsxx::SP<CellFlags> spCellFlags;
-  rtt_dsxx::SP<NodeDataIDs> spNodeDataIds;
-  rtt_dsxx::SP<SideDataIDs> spSideDataIds;
-  rtt_dsxx::SP<CellDataIDs> spCellDataIds;
-  rtt_dsxx::SP<CellDefs> spCellDefs;
-  rtt_dsxx::SP<Nodes> spNodes;
-  rtt_dsxx::SP<Sides> spSides;
-  rtt_dsxx::SP<Cells> spCells;
-  rtt_dsxx::SP<NodeData> spNodeData;
-  rtt_dsxx::SP<SideData> spSideData;
-  rtt_dsxx::SP<CellData> spCellData;
+  std::shared_ptr<NodeFlags> spNodeFlags;
+  std::shared_ptr<SideFlags> spSideFlags;
+  std::shared_ptr<CellFlags> spCellFlags;
+  std::shared_ptr<NodeDataIDs> spNodeDataIds;
+  std::shared_ptr<SideDataIDs> spSideDataIds;
+  std::shared_ptr<CellDataIDs> spCellDataIds;
+  std::shared_ptr<CellDefs> spCellDefs;
+  std::shared_ptr<Nodes> spNodes;
+  std::shared_ptr<Sides> spSides;
+  std::shared_ptr<Cells> spCells;
+  std::shared_ptr<NodeData> spNodeData;
+  std::shared_ptr<SideData> spSideData;
+  std::shared_ptr<CellData> spCellData;
 
 public:
   //! Constructor
@@ -485,7 +482,7 @@ public:
     return spCellDefs->get_cell_def(i);
   }
 
-  rtt_dsxx::SP<CellDef> get_cell_defs_def(int i) const {
+  std::shared_ptr<CellDef> get_cell_defs_def(int i) const {
     return spCellDefs->get_def(i);
   }
   /*!

--- a/src/RTT_Format_Reader/RTT_Mesh_Reader.cc
+++ b/src/RTT_Format_Reader/RTT_Mesh_Reader.cc
@@ -1,17 +1,15 @@
 //----------------------------------*-C++-*--------------------------------//
-/*! 
+/*!
  * \file   RTT_Format_Reader/RTT_Mesh_Reader.cc
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Implementation file for RTT_Mesh_Reader library.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <algorithm>
-
 #include "RTT_Mesh_Reader.hh"
+#include <algorithm>
 
 namespace rtt_RTT_Format_Reader {
 
@@ -22,8 +20,8 @@ using rtt_mesh_element::Element_Definition;
  */
 void RTT_Mesh_Reader::transform2CGNS(void) {
   Element_Definition::Element_Type cell_def;
-  rtt_dsxx::SP<rtt_mesh_element::Element_Definition> cell;
-  std::vector<rtt_dsxx::SP<rtt_mesh_element::Element_Definition>>
+  std::shared_ptr<rtt_mesh_element::Element_Definition> cell;
+  std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>
       cell_definitions;
   vector_int new_side_types;
   std::vector<std::vector<size_t>> new_ordered_sides;
@@ -78,7 +76,7 @@ void RTT_Mesh_Reader::transform2CGNS(void) {
     if (cell_def == Element_Definition::POLYGON) {
       Insist(rttMesh->get_dims_ndim() == 2,
              "Polygon cell definition only supported in 2D");
-      rtt_dsxx::SP<CellDef> cell_definition(rttMesh->get_cell_defs_def(cd));
+      std::shared_ptr<CellDef> cell_definition(rttMesh->get_cell_defs_def(cd));
 
       std::vector<Element_Definition> elem_defs;
       elem_defs.push_back(Element_Definition(Element_Definition::BAR_2));
@@ -92,7 +90,7 @@ void RTT_Mesh_Reader::transform2CGNS(void) {
     } else if (cell_def == Element_Definition::POLYHEDRON) {
       Insist(rttMesh->get_dims_ndim() == 3,
              "Polyhedron cell definition only supported in 3D");
-      rtt_dsxx::SP<CellDef> cell_definition(rttMesh->get_cell_defs_def(cd));
+      std::shared_ptr<CellDef> cell_definition(rttMesh->get_cell_defs_def(cd));
 
       // check to see if the QUAD_9 element is present in the cell_definitions
       // and check for QUAD_4 in the event that a QUAD_9 is in fact present
@@ -201,7 +199,7 @@ std::vector<std::vector<int>> RTT_Mesh_Reader::get_element_nodes() const {
 /*!
  * \brief Returns the nodes associated with each node_flag_type_name and
  *        node_flag_name combination.
- * \return The nodes associated with each node_flag_type_name/node_flag_name 
+ * \return The nodes associated with each node_flag_type_name/node_flag_name
  *         combination.
  */
 std::map<std::string, std::set<int>> RTT_Mesh_Reader::get_node_sets() const {
@@ -228,10 +226,10 @@ std::map<std::string, std::set<int>> RTT_Mesh_Reader::get_node_sets() const {
   return node_sets;
 }
 /*!
- * \brief Returns the elements (i.e., sides and cells) associated with each 
+ * \brief Returns the elements (i.e., sides and cells) associated with each
  *        flag_type_name and flag_name combination for the sides and cells
  *        read from the mesh file data.
- * \return The elements associated with each flag_type_name/flag_name 
+ * \return The elements associated with each flag_type_name/flag_name
  *         combination.
  */
 std::map<std::string, std::set<int>> RTT_Mesh_Reader::get_element_sets() const {

--- a/src/RTT_Format_Reader/RTT_Mesh_Reader.hh
+++ b/src/RTT_Format_Reader/RTT_Mesh_Reader.hh
@@ -52,7 +52,8 @@ class DLL_PUBLIC_RTT_Format_Reader RTT_Mesh_Reader
 
 private:
   std::shared_ptr<RTT_Format_Reader> rttMesh;
-  std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>> element_defs;
+  std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>
+      element_defs;
   std::vector<rtt_mesh_element::Element_Definition::Element_Type> element_types;
   std::vector<rtt_mesh_element::Element_Definition::Element_Type>
       unique_element_types;

--- a/src/RTT_Format_Reader/RTT_Mesh_Reader.hh
+++ b/src/RTT_Format_Reader/RTT_Mesh_Reader.hh
@@ -1,14 +1,11 @@
 //----------------------------------*-C++-*----------------------------------//
-/*! 
+/*!
  * \file   RTT_Format_Reader/RTT_Mesh_Reader.hh
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for RTT_Mesh_Reader library.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __RTT_Format_Reader_RTT_Mesh_Reader_hh__
@@ -26,12 +23,12 @@ namespace rtt_RTT_Format_Reader {
  * \brief An input routine to parse an RTT Format mesh file using the DRACO
  *        meshReaders standard interface.
  *
- *\sa The RTT_Mesh_Reader class is a derived-type of the Mesh_Reader abstract 
- *    base class specified in the meshReaders package. Packages using the 
+ *\sa The RTT_Mesh_Reader class is a derived-type of the Mesh_Reader abstract
+ *    base class specified in the meshReaders package. Packages using the
  *    RTT_Mesh_Reader should thus include the RTT_Mesh_Reader.hh decorator
- *    file located in the meshReaders directory to resolve the namespace. 
- *    RTT_Mesh_Reader contains a RTT_Format_Reader as a private data member, 
- *    so none of the RTT_Format_Reader class public accessor functions are 
+ *    file located in the meshReaders directory to resolve the namespace.
+ *    RTT_Mesh_Reader contains a RTT_Format_Reader as a private data member,
+ *    so none of the RTT_Format_Reader class public accessor functions are
  *    accessible.
  */
 //
@@ -54,8 +51,8 @@ class DLL_PUBLIC_RTT_Format_Reader RTT_Mesh_Reader
   // DATA
 
 private:
-  rtt_dsxx::SP<RTT_Format_Reader> rttMesh;
-  std::vector<rtt_dsxx::SP<rtt_mesh_element::Element_Definition>> element_defs;
+  std::shared_ptr<RTT_Format_Reader> rttMesh;
+  std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>> element_defs;
   std::vector<rtt_mesh_element::Element_Definition::Element_Type> element_types;
   std::vector<rtt_mesh_element::Element_Definition::Element_Type>
       unique_element_types;
@@ -115,13 +112,13 @@ public:
     return element_types;
   }
 
-  virtual std::vector<rtt_dsxx::SP<rtt_mesh_element::Element_Definition>>
+  virtual std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>
   get_element_defs() const {
     return element_defs;
   }
 
   /*!
- * \brief Returns the unique element types (e.g., TRI_3 and TETRA_4) that 
+ * \brief Returns the unique element types (e.g., TRI_3 and TETRA_4) that
  *        are defined in the mesh file.
  * \return Element definitions.
  */

--- a/src/RTT_Format_Reader/SideFlags.cc
+++ b/src/RTT_Format_Reader/SideFlags.cc
@@ -1,21 +1,18 @@
 //----------------------------------*-C++-*--------------------------------//
-/*! 
+/*!
  * \file   RTT_Format_Reader/SideFlags.cc
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Implementation file for RTT_Format_Reader/SideFlags class.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "SideFlags.hh"
 
 namespace rtt_RTT_Format_Reader {
 /*!
- * \brief Parses the side_flags data block of the mesh file via calls to 
+ * \brief Parses the side_flags data block of the mesh file via calls to
  *        private member functions.
  * \param meshfile Mesh file name.
  */

--- a/src/RTT_Format_Reader/SideFlags.hh
+++ b/src/RTT_Format_Reader/SideFlags.hh
@@ -5,10 +5,7 @@
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for RTT_Format_Reader/SideFlags class.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __RTT_Format_Reader_SideFlags_hh__
@@ -16,7 +13,7 @@
 
 #include "Dims.hh"
 #include "Flags.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_RTT_Format_Reader {
 /*!
@@ -29,7 +26,7 @@ class SideFlags {
   typedef std::string string;
 
   const Dims &dims;
-  std::vector<rtt_dsxx::SP<Flags>> flagTypes;
+  std::vector<std::shared_ptr<Flags>> flagTypes;
 
 public:
   SideFlags(const Dims &dims_)

--- a/src/RTT_Format_Reader/test/TestRTTPolyhedron.cc
+++ b/src/RTT_Format_Reader/test/TestRTTPolyhedron.cc
@@ -5,17 +5,13 @@
  * \date   Fri Aug 19 12:31:47 2016
  * \brief  Testing the POLYHEDRON Element_Definition
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <sstream>
-
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/ScalarUnitTest.hh"
-
 #include "RTT_Format_Reader/RTT_Mesh_Reader.hh"
+#include <sstream>
 
 using rtt_RTT_Format_Reader::RTT_Mesh_Reader;
 using rtt_mesh_element::Element_Definition;
@@ -50,7 +46,7 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
 
   for (unsigned i = 0; i < filenames.size(); ++i) {
     string filename(filenames[i]);
-    SP<RTT_Mesh_Reader> mesh(new RTT_Mesh_Reader(filename));
+    shared_ptr<RTT_Mesh_Reader> mesh(new RTT_Mesh_Reader(filename));
 
     ostringstream m;
     m << "Read mesh file " << filename << std::endl;
@@ -61,7 +57,7 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
       FAILMSG("Unexpected dimension.");
     }
 
-    vector<SP<Element_Definition>> const element_defs(mesh->get_element_defs());
+    vector<shared_ptr<Element_Definition>> const element_defs(mesh->get_element_defs());
     for (size_t j = 0; j < element_defs.size(); ++j) {
       cout << "Element definition for element " << j << endl;
       element_defs[j]->print(cout);
@@ -79,7 +75,7 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
 
     for (unsigned i = 0; i < filenames.size(); ++i) {
       string filename(filenames[i]);
-      SP<RTT_Mesh_Reader> mesh(new RTT_Mesh_Reader(filename));
+      shared_ptr<RTT_Mesh_Reader> mesh(new RTT_Mesh_Reader(filename));
 
       ostringstream m;
       m << "Read mesh file " << filename << std::endl;
@@ -97,7 +93,7 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
           mesh->get_element_types());
       vector<vector<int>> const element_nodes(mesh->get_element_nodes());
       map<string, set<int>> element_sets(mesh->get_element_sets());
-      vector<SP<Element_Definition>> const element_defs(
+      vector<shared_ptr<Element_Definition>> const element_defs(
           mesh->get_element_defs());
 
       if (ndim != 3) {
@@ -143,7 +139,7 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
             static_cast<Element_Definition::Element_Type>(
                 element_types[representative_element]);
 
-        SP<Element_Definition const> type(new Element_Definition(type_index));
+        shared_ptr<Element_Definition const> type(new Element_Definition(type_index));
 
         if (type->get_dimension() == ndim) {
           std::cout << " Elements with flags " + it->first
@@ -164,7 +160,7 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
       unsigned ncorner = 0;
       for (unsigned et = nsides; et < element_types.size(); et++) {
         unsigned const c = et - nsides;
-        SP<Element_Definition> cell_def = element_defs[c];
+        shared_ptr<Element_Definition> cell_def = element_defs[c];
         unsigned const number_of_nodes = cell_def->get_number_of_nodes();
         ncorner += number_of_nodes;
       }

--- a/src/RTT_Format_Reader/test/TestRTTPolyhedron.cc
+++ b/src/RTT_Format_Reader/test/TestRTTPolyhedron.cc
@@ -8,9 +8,9 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
+#include "RTT_Format_Reader/RTT_Mesh_Reader.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
-#include "RTT_Format_Reader/RTT_Mesh_Reader.hh"
 #include <sstream>
 
 using rtt_RTT_Format_Reader::RTT_Mesh_Reader;
@@ -57,7 +57,8 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
       FAILMSG("Unexpected dimension.");
     }
 
-    vector<shared_ptr<Element_Definition>> const element_defs(mesh->get_element_defs());
+    vector<shared_ptr<Element_Definition>> const element_defs(
+        mesh->get_element_defs());
     for (size_t j = 0; j < element_defs.size(); ++j) {
       cout << "Element definition for element " << j << endl;
       element_defs[j]->print(cout);
@@ -139,7 +140,8 @@ void test_polyhedron(rtt_dsxx::UnitTest &ut) {
             static_cast<Element_Definition::Element_Type>(
                 element_types[representative_element]);
 
-        shared_ptr<Element_Definition const> type(new Element_Definition(type_index));
+        shared_ptr<Element_Definition const> type(
+            new Element_Definition(type_index));
 
         if (type->get_dimension() == ndim) {
           std::cout << " Elements with flags " + it->first

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -5,10 +5,7 @@
  * \date   Thu Jun 22 16:22:07 2000
  * \brief  CDI class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "CDI.hh"
@@ -31,7 +28,7 @@ namespace rtt_cdi {
  * that all of the set objects point to the same material.  CDI does do
  * checking that only one of each Model:Reaction pair of opacity objects
  * are assigned; however, the user can "fake" CDI with different
- * materials if he/she is malicious enough.  
+ * materials if he/she is malicious enough.
  *
  * CDI does allow a string material ID indicator.  It is up to the client
  * to ascribe meaning to the indicator.
@@ -73,7 +70,7 @@ std::vector<double> CDI::opacityCdfBandBoundaries = std::vector<double>();
  * Every multigroup opacity object held by any CDI object contains the
  * same frequency group boundaries.  This static function allows CDI
  * users to access the group boundaries without referencing a particular
- * material. 
+ * material.
  *
  * Note, the group boundaries are not set until a multigroup opacity
  * object is set for the first time (in any CDI object) with the
@@ -88,7 +85,7 @@ std::vector<double> CDI::getFrequencyGroupBoundaries() {
  * Every multiband opacity object held by any CDI object contains the
  * same band boundaries, and also inside each group.  This static function
  * allows CDI users to access the band boundaries without referencing a
- * particular material. 
+ * particular material.
  *
  * Note, the band boundaries are not set until a multigroup opacity
  * object is set for the first time (in any CDI object) with the
@@ -109,7 +106,7 @@ size_t CDI::getNumberFrequencyGroups() {
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Return the number of opacity bands. 
+ * \brief Return the number of opacity bands.
  */
 size_t CDI::getNumberOpacityBands() {
   return opacityCdfBandBoundaries.empty() ? 0
@@ -440,7 +437,7 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
  * \return A single interval Planckian weighted opacity value.
  *
  * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum. 
+ * this function to obtain planckSpectrum.
  */
 double CDI::collapseMultigroupOpacitiesPlanck(
     std::vector<double> const &groupBounds,
@@ -508,7 +505,7 @@ double CDI::collapseMultigroupOpacitiesPlanck(
  * \return A single interval Planckian weighted reciprocal opacity value.
  *
  * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum. 
+ * this function to obtain planckSpectrum.
  */
 double CDI::collapseMultigroupReciprocalOpacitiesPlanck(
     std::vector<double> const &groupBounds, std::vector<double> const &opacity,
@@ -574,7 +571,7 @@ double CDI::collapseMultigroupReciprocalOpacitiesPlanck(
  *    modified calculation that does not depend on the Rosseland integral.
  *
  * If neither of the special cases are in effect, then do the normal
- * evaluation. 
+ * evaluation.
  */
 double CDI::collapseMultigroupOpacitiesRosseland(
     std::vector<double> const &groupBounds, std::vector<double> const &opacity,
@@ -651,7 +648,7 @@ double CDI::collapseMultigroupOpacitiesRosseland(
  * \return A single interval Planckian weighted opacity value.
  *
  * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum. 
+ * this function to obtain planckSpectrum.
  */
 double CDI::collapseOdfmgOpacitiesPlanck(
     std::vector<double> const &groupBounds,
@@ -729,7 +726,7 @@ double CDI::collapseOdfmgOpacitiesPlanck(
  *                  CDI::integrate_Rosseland_Planckian_Sectrum(...).
  *
  * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum. 
+ * this function to obtain planckSpectrum.
  */
 double CDI::collapseOdfmgReciprocalOpacitiesPlanck(
     std::vector<double> const &groupBounds,
@@ -794,19 +791,18 @@ double CDI::collapseOdfmgReciprocalOpacitiesPlanck(
  * This function sets a gray opacity object of type rtt_cdi::GrayOpacity with
  * the CDI object.  It stores the gray opacity object based upon its
  * rtt_cdi::Model and rtt_cdi::Reaction types.  If a GrayOpacity with these
- * types has already been registered an exception is thrown.  To register a
- * new set of GrayOpacity objects call CDI::reset() first.  You cannot
- * overwrite registered objects with the setGrayOpacity() function!
+ * types has already been registered an exception is thrown.  To register a new
+ * set of GrayOpacity objects call CDI::reset() first.  You cannot overwrite
+ * registered objects with the setGrayOpacity() function!
  *
- * \param spGOp smart pointer (rtt_dsxx::SP) to a GrayOpacity object
+ * \param spGOp smart pointer to a GrayOpacity object
  */
 void CDI::setGrayOpacity(const SP_GrayOpacity &spGOp) {
   Require(spGOp);
 
-  // determine the model and reaction type (these MUST be in the correct
-  // range because the Model and Reaction are constrained by the
-  // rtt_cdi::Model and rtt_cdi::Reaction enumerations, assuming nobody
-  // hosed these)
+  // determine the model and reaction type (these MUST be in the correct range
+  // because the Model and Reaction are constrained by the rtt_cdi::Model and
+  // rtt_cdi::Reaction enumerations, assuming nobody hosed these)
   rtt_cdi::Model model = spGOp->getModelType();
   rtt_cdi::Reaction reaction = spGOp->getReactionType();
 
@@ -832,7 +828,7 @@ void CDI::setGrayOpacity(const SP_GrayOpacity &spGOp) {
  * call CDI::reset() first.  You cannot overwrite registered objects with the
  * setMultigroupOpacity() function!
  *
- * \param spGOp smart pointer (rtt_dsxx::SP) to a MultigroupOpacity object
+ * \param spGOp smart pointer to a MultigroupOpacity object
  */
 void CDI::setMultigroupOpacity(const SP_MultigroupOpacity &spMGOp) {
   using rtt_dsxx::soft_equiv;
@@ -885,7 +881,7 @@ void CDI::setMultigroupOpacity(const SP_MultigroupOpacity &spMGOp) {
  * call CDI::reset() first.  You cannot overwrite registered objects with the
  * setOdfmgOpacity() function!
  *
- * \param spGOp smart pointer (rtt_dsxx::SP) to a OdfmgOpacity object
+ * \param spGOp smart pointer to a OdfmgOpacity object
  */
 void CDI::setOdfmgOpacity(const SP_OdfmgOpacity &spODFOp) {
   using rtt_dsxx::soft_equiv;
@@ -964,13 +960,14 @@ void CDI::setEoS(const SP_EoS &in_spEoS) {
 /*!
  * \brief This fuction returns a GrayOpacity object.
  *
- * This provides the CDI with the full functionality of the interface
- * defined in GrayOpacity.hh.  For example, the host code could make the
- * following call: <tt> double newOp = spCDI1->gray()->getOpacity(
- * 55.3, 27.4 ); </tt>
+ * This provides the CDI with the full functionality of the interface defined in
+ * GrayOpacity.hh.  For example, the host code could make the following call:
+ * \code
+ * double newOp = spCDI1->gray()->getOpacity( 55.3, 27.4 );
+ * \endcode
  *
- * The appropriate gray opacity is returned for the given model and
- * reaction type.
+ * The appropriate gray opacity is returned for the given model and reaction
+ * type.
  *
  * \param m rtt_cdi::Model specifying the desired physics model
  * \param r rtt_cdi::Reaction specifying the desired reaction type
@@ -985,15 +982,15 @@ CDI::SP_GrayOpacity CDI::gray(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
  *
  * This provides the CDI with the full functionality of the interface
  * defined in MultigroupOpacity.hh.  For example, the host code could
- * make the following call:<br> <tt> size_t numGroups =
- * spCDI1->mg()->getNumGroupBoundaries(); </tt>
+ * make the following call:
+ * \code
+ * size_t numGroups = spCDI1->mg()->getNumGroupBoundaries();
+ * \endcode
  *
- * The appropriate multigroup opacity is returned for the given reaction
- * type.
+ * The appropriate multigroup opacity is returned for the given reaction type.
  *
  * \param m rtt_cdi::Model specifying the desired physics model
  * \param r rtt_cdi::Reaction specifying the desired reaction type.
- *
  */
 CDI::SP_MultigroupOpacity CDI::mg(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
   Insist(multigroupOpacities[m][r], "Undefined MultigroupOpacity!");
@@ -1003,17 +1000,16 @@ CDI::SP_MultigroupOpacity CDI::mg(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
 /*!
  * \brief This fuction returns the OdfmgOpacity object.
  *
- * This provides the CDI with the full functionality of the interface
- * defined in OdfmgOpacity.hh.  For example, the host code could
- * make the following call:<br> <tt> size_t numGroups =
- * spCDI1->mg()->getNumGroupBoundaries(); </tt>
+ * This provides the CDI with the full functionality of the interface defined in
+ * OdfmgOpacity.hh.  For example, the host code could make the following call:
+ * \code
+ * size_t numGroups = spCDI1->mg()->getNumGroupBoundaries();
+ * \endcode
  *
- * The appropriate multigroup opacity is returned for the given reaction
- * type.
+ * The appropriate multigroup opacity is returned for the given reaction type.
  *
  * \param m rtt_cdi::Model specifying the desired physics model
  * \param r rtt_cdi::Reaction specifying the desired reaction type.
- *
  */
 CDI::SP_OdfmgOpacity CDI::odfmg(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
   Insist(odfmgOpacities[m][r], "Undefined OdfmgOpacity!");
@@ -1027,9 +1023,10 @@ CDI::SP_OdfmgOpacity CDI::odfmg(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
  *
  * This provides the CDI with the full functionality of the interface
  * defined in EoS.hh.  For example, the host code could make the
- * following call:<br> <tt> double Cve =
- * spCDI1->eos()->getElectronHeatCapacity( * density, temperature );
- * </tt>
+ * following call:
+ * \code
+ * double Cve = spCDI1->eos()->getElectronHeatCapacity( * density, temperature );
+ * \endcode
  */
 CDI::SP_EoS CDI::eos() const {
   Insist(spEoS, "Undefined EoS!");
@@ -1043,15 +1040,14 @@ CDI::SP_EoS CDI::eos() const {
 /*!
  * \brief Reset the CDI object.
  *
- * This function "clears" all data objects (GrayOpacity,
- * MultigroupOpacity, EoS) held by CDI.  After clearing, new objects can
- * be set using the set functions.  
+ * This function "clears" all data objects (GrayOpacity, MultigroupOpacity, EoS)
+ * held by CDI.  After clearing, new objects can be set using the set functions.
  *
  * As stated in the set functions documentation, you are not allowed to
- * overwrite a data object with the same attributes as one that already
- * has been set.  The only way to "reset" these objects is to call
- * CDI::reset().  Note that CDI::reset() resets \b ALL of the objects
- * stored by CDI (including group boundaries).
+ * overwrite a data object with the same attributes as one that already has been
+ * set.  The only way to "reset" these objects is to call CDI::reset().  Note
+ * that CDI::reset() resets \b ALL of the objects stored by CDI (including group
+ * boundaries).
  */
 void CDI::reset() {
   Check(grayOpacities.size() == constants::num_Models);

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -1061,13 +1061,13 @@ void CDI::reset() {
     Check(odfmgOpacities[i].size() == constants::num_Reactions);
 
     for (size_t j = 0; j < constants::num_Reactions; j++) {
-      // reassign the GrayOpacity SP to a null SP
+      // reassign the GrayOpacity shared_ptr to a null shared_ptr
       grayOpacities[i][j] = SP_GrayOpacity();
 
-      // reassign the MultigroupOpacity SP to a null SP
+      // reassign the MultigroupOpacity shared_ptr to a null shared_ptr
       multigroupOpacities[i][j] = SP_MultigroupOpacity();
 
-      // reassign the OdfmgOpacity SP to a null SP
+      // reassign the OdfmgOpacity shared_ptr to a null shared_ptr
       odfmgOpacities[i][j] = SP_OdfmgOpacity();
 
       // check it
@@ -1084,7 +1084,7 @@ void CDI::reset() {
   opacityCdfBandBoundaries.clear();
   Check(opacityCdfBandBoundaries.empty());
 
-  // reset the EoS SP
+  // reset the EoS shared_ptr
   spEoS = SP_EoS();
   Check(!spEoS);
 }

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -5,10 +5,7 @@
  * \date   Thu Jun 22 16:22:06 2000
  * \brief  CDI class header file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_cdi_CDI_hh
@@ -18,16 +15,16 @@
 #include "GrayOpacity.hh"
 #include "MultigroupOpacity.hh"
 #include "OdfmgOpacity.hh"
-#include "ds++/SP.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <algorithm>
+#include <memory>
 
 //---------------------------------------------------------------------------//
 // UNNAMED NAMESPACE
 //---------------------------------------------------------------------------//
-// Nested unnamed namespace that holds data and services used by the
-// Planckian integration routines.  The data in this namespace is accessible
-// by the methods in this file only (internal linkage).
+// Nested unnamed namespace that holds data and services used by the Planckian
+// integration routines.  The data in this namespace is accessible by the
+// methods in this file only (internal linkage).
 
 namespace {
 
@@ -73,7 +70,6 @@ static double const NORM_FACTOR = 0.25 * coeff; // 15/(4*pi^4);
  * \param  The point at which the Planck integral is evaluated.
  * \return The integral value.
  */
-
 static inline double taylor_series_planck(double x) {
   Require(x >= 0.0);
 
@@ -421,9 +417,9 @@ namespace rtt_cdi {
  * \example cdi/test/tCDI.cc
  *
  * This test code provides an example of how to use CDI to access an user
- * defined opacity class.  We have created an opacity class called
- * dummyOpacity that is used in the creation of a CDI object.  The CDI object
- * is then used to obtain obacity data (via dummyOpacity).
+ * defined opacity class.  We have created an opacity class called dummyOpacity
+ * that is used in the creation of a CDI object.  The CDI object is then used to
+ * obtain obacity data (via dummyOpacity).
  *
  * The test code also provides a mechanism to test the CDI independent of any
  * "real" data objects.
@@ -432,10 +428,10 @@ namespace rtt_cdi {
 
 class DLL_PUBLIC_cdi CDI {
   // NESTED CLASSES AND TYPEDEFS
-  typedef rtt_dsxx::SP<const GrayOpacity> SP_GrayOpacity;
-  typedef rtt_dsxx::SP<const MultigroupOpacity> SP_MultigroupOpacity;
-  typedef rtt_dsxx::SP<const OdfmgOpacity> SP_OdfmgOpacity;
-  typedef rtt_dsxx::SP<const EoS> SP_EoS;
+  typedef std::shared_ptr<const GrayOpacity> SP_GrayOpacity;
+  typedef std::shared_ptr<const MultigroupOpacity> SP_MultigroupOpacity;
+  typedef std::shared_ptr<const OdfmgOpacity> SP_OdfmgOpacity;
+  typedef std::shared_ptr<const EoS> SP_EoS;
   typedef std::vector<SP_GrayOpacity> SF_GrayOpacity;
   typedef std::vector<SF_GrayOpacity> VF_GrayOpacity;
   typedef std::vector<SP_MultigroupOpacity> SF_MultigroupOpacity;
@@ -447,65 +443,59 @@ class DLL_PUBLIC_cdi CDI {
   // DATA
 
   /*!
-     * \brief Array that stores the matrix of possible GrayOpacity types.
-     *
-     * gray_opacities contains smart pointers that links a CDI object to a
-     * GrayOpacity object (any type of gray opacity - Gandolf, EOSPAC,
-     * Analytic, etc.).  The smart pointers is entered in the set functions.
-     *
-     * grayOpacities is indexed [0,num_Models-1][0,num_Reactions-1].  It is
-     * accessed by [rtt_cdi::Model][rtt_cdi::Reaction]
-     *
-     */
+   * \brief Array that stores the matrix of possible GrayOpacity types.
+   *
+   * gray_opacities contains smart pointers that links a CDI object to a
+   * GrayOpacity object (any type of gray opacity - Gandolf, EOSPAC, Analytic,
+   * etc.).  The smart pointers is entered in the set functions.
+   *
+   * grayOpacities is indexed [0,num_Models-1][0,num_Reactions-1].  It is
+   * accessed by [rtt_cdi::Model][rtt_cdi::Reaction]
+   */
   VF_GrayOpacity grayOpacities;
 
   /*!
-     * \brief Array that stores the list of possible MultigroupOpacity types.
-     *
-     * multigroupOpacities contains a list of smart pointers to
-     * MultigroupOpacity objects for different rtt_cdi::Reaction types.  It
-     * is indexed [0,num_Models-1][0,num_Reactions-1].  It is accessed by
-     * [rtt_cdi::Model][rtt_cdi::Reaction].
-     */
+   * \brief Array that stores the list of possible MultigroupOpacity types.
+   *
+   * multigroupOpacities contains a list of smart pointers to MultigroupOpacity
+   * objects for different rtt_cdi::Reaction types.  It is indexed
+   * [0,num_Models-1][0,num_Reactions-1].  It is accessed by
+   * [rtt_cdi::Model][rtt_cdi::Reaction].
+   */
   VF_MultigroupOpacity multigroupOpacities;
 
-  /*!
-     * \brief Array that stores the list of possible OdfmgOpacity types.
-     *
-     */
+  //! Array that stores the list of possible OdfmgOpacity types.
   VF_OdfmgOpacity odfmgOpacities;
 
   /*!
-     * \brief Frequency group boundaries for multigroup data.
-     *
-     * This is a static vector that contains the frequency boundaries for
-     * multigroup data sets.  The number of frequency (energy) groups is the
-     * size of the vector minus one.
-     *
-     * This data is stored as static so that the same structure is guaranteed
-     * for all multigroup data sets.  Thus, each CDI object will have access
-     * to the same energy group structure.
-     *
-     */
+   * \brief Frequency group boundaries for multigroup data.
+   *
+   * This is a static vector that contains the frequency boundaries for
+   * multigroup data sets.  The number of frequency (energy) groups is the size
+   * of the vector minus one.
+   *
+   * This data is stored as static so that the same structure is guaranteed for
+   * all multigroup data sets.  Thus, each CDI object will have access to the
+   * same energy group structure.
+   */
   static std::vector<double> frequencyGroupBoundaries;
 
   /*!
-     * \brief Band boundaries for odf multigroup data.
-     *
-     * This data is stored as static so that the same structure is guaranteed
-     * for all multigroup odf data sets.  Thus, each CDI object will have access
-     * to the same opacity band structure.
-     *
-     */
+   * \brief Band boundaries for odf multigroup data.
+   *
+   * This data is stored as static so that the same structure is guaranteed
+   * for all multigroup odf data sets.  Thus, each CDI object will have access
+   * to the same opacity band structure.
+   */
   static std::vector<double> opacityCdfBandBoundaries;
 
   /*!
-     * \brief Smart pointer to the equation of state object.
-     *
-     * spEoS is a smart pointer that links a CDI object to an equation of
-     * state object (any type of EoS - EOSPAC, Analytic, etc.).  The pointer
-     * is established in the CDI constructor.
-     */
+   * \brief Smart pointer to the equation of state object.
+   *
+   * spEoS is a smart pointer that links a CDI object to an equation of state
+   * object (any type of EoS - EOSPAC, Analytic, etc.).  The pointer is
+   * established in the CDI constructor.
+   */
   SP_EoS spEoS;
 
   //! Material ID.
@@ -567,7 +557,10 @@ public:
                                     std::vector<double> const &planckSpectrum,
                                     std::vector<double> &emission_group_cdf);
 
-  //! Collapse Multigroup data to single-interval reciprocal data with Planck weighting.
+  /*!
+   * \brief Collapse Multigroup data to single-interval reciprocal data with
+   *        Planck weighting.
+   */
   static double collapseMultigroupReciprocalOpacitiesPlanck(
       std::vector<double> const &groupBounds,
       std::vector<double> const &opacity,
@@ -707,16 +700,14 @@ double CDI::integrate_planck(double const scaled_freq) {
  * \param scaled_freq upper integration limit, scaled by the temperature.
  *
  * \return integrated normalized Plankian from 0 to x \f$(\frac{h\nu}{kT})\f$
- *
  */
 double CDI::integrate_planck(double const scaled_freq,
                              double const exp_scaled_freq) {
   double const poly =
       polylog_series_minus_one_planck(scaled_freq, exp_scaled_freq) + 1.0;
   double const taylor = taylor_series_planck(std::min(scaled_freq, 1.0e15));
-  // Truncated argument to avoid overlow with IEEE standard double
-  // precision. At values this large, the next line will always select the
-  // polylog value.
+  // Truncated argument to avoid overlow with IEEE standard double precision. At
+  // values this large, the next line will always select the polylog value.
   double integral = std::min(taylor, poly);
   // FWIW the break is at about scaled_freq == 2.06192398071289
 

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -1258,7 +1258,7 @@ void test_odfmgopacity_collapse(rtt_dsxx::UnitTest &ut) {
   // either Planckian or Rosseland weight functions:
 
   std::shared_ptr<const OdfmgOpacity> op(
-    new DummyOdfmgOpacity(rtt_cdi::ABSORPTION, rtt_cdi::PLANCK));
+      new DummyOdfmgOpacity(rtt_cdi::ABSORPTION, rtt_cdi::PLANCK));
 
   // bounds = { 0.05, 0.5, 5, 50 }
   std::vector<double> const bounds(op->getGroupBoundaries());

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -265,7 +265,7 @@ void check_CDI(rtt_dsxx::UnitTest &ut, CDI const &cdi) {
 //---------------------------------------------------------------------------//
 
 void test_CDI(rtt_dsxx::UnitTest &ut) {
-  // make SPs to opacity and EoS objects
+  // make shared_ptrs to opacity and EoS objects
   std::shared_ptr<const GrayOpacity> gray_planck_abs;
   std::shared_ptr<const GrayOpacity> gray_iso_scatter;
   std::shared_ptr<const MultigroupOpacity> mg_planck_abs;

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -5,10 +5,7 @@
  * \date   Tue Oct  9 15:52:01 2001
  * \brief  CDI test executable.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "DummyEoS.hh"
@@ -19,7 +16,6 @@
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
-
 #include <iomanip>
 #include <limits>
 #include <sstream>
@@ -35,7 +31,6 @@ using rtt_cdi::GrayOpacity;
 using rtt_cdi::MultigroupOpacity;
 using rtt_cdi::OdfmgOpacity;
 using rtt_cdi::EoS;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -271,16 +266,16 @@ void check_CDI(rtt_dsxx::UnitTest &ut, CDI const &cdi) {
 
 void test_CDI(rtt_dsxx::UnitTest &ut) {
   // make SPs to opacity and EoS objects
-  SP<const GrayOpacity> gray_planck_abs;
-  SP<const GrayOpacity> gray_iso_scatter;
-  SP<const MultigroupOpacity> mg_planck_abs;
-  SP<const MultigroupOpacity> mg_iso_scatter;
-  SP<const MultigroupOpacity> mg_diff_bound;
-  SP<const OdfmgOpacity> odfmg_planck_abs;
-  SP<const OdfmgOpacity> odfmg_iso_scatter;
-  SP<const OdfmgOpacity> odfmg_diff_bound;
-  SP<const OdfmgOpacity> odfmg_diff_bound2;
-  SP<const EoS> eos;
+  std::shared_ptr<const GrayOpacity> gray_planck_abs;
+  std::shared_ptr<const GrayOpacity> gray_iso_scatter;
+  std::shared_ptr<const MultigroupOpacity> mg_planck_abs;
+  std::shared_ptr<const MultigroupOpacity> mg_iso_scatter;
+  std::shared_ptr<const MultigroupOpacity> mg_diff_bound;
+  std::shared_ptr<const OdfmgOpacity> odfmg_planck_abs;
+  std::shared_ptr<const OdfmgOpacity> odfmg_iso_scatter;
+  std::shared_ptr<const OdfmgOpacity> odfmg_diff_bound;
+  std::shared_ptr<const OdfmgOpacity> odfmg_diff_bound2;
+  std::shared_ptr<const EoS> eos;
 
   // assign to dummy state objects
   gray_planck_abs.reset(
@@ -685,7 +680,7 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
 
   // Catch an illegal group assertion.
   CDI cdi;
-  SP<const MultigroupOpacity> mg(
+  std::shared_ptr<const MultigroupOpacity> mg(
       new DummyMultigroupOpacity(rtt_cdi::SCATTERING, rtt_cdi::THOMSON));
   cdi.setMultigroupOpacity(mg);
 
@@ -1054,7 +1049,7 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
   // Test functions that collapse MG opacity data into one-group data using
   // either Planckian or Rosseland weight functions:
 
-  SP<const MultigroupOpacity> mg_planck_abs(
+  std::shared_ptr<const MultigroupOpacity> mg_planck_abs(
       new DummyMultigroupOpacity(rtt_cdi::ABSORPTION, rtt_cdi::PLANCK));
 
   // bounds = { 0.05, 0.5, 5, 50 }
@@ -1262,8 +1257,8 @@ void test_odfmgopacity_collapse(rtt_dsxx::UnitTest &ut) {
   // Test functions that collapse MG opacity data into one-group data using
   // either Planckian or Rosseland weight functions:
 
-  SP<const OdfmgOpacity> op(
-      new DummyOdfmgOpacity(rtt_cdi::ABSORPTION, rtt_cdi::PLANCK));
+  std::shared_ptr<const OdfmgOpacity> op(
+    new DummyOdfmgOpacity(rtt_cdi::ABSORPTION, rtt_cdi::PLANCK));
 
   // bounds = { 0.05, 0.5, 5, 50 }
   std::vector<double> const bounds(op->getGroupBoundaries());

--- a/src/cdi/test/tDummyEoS.cc
+++ b/src/cdi/test/tDummyEoS.cc
@@ -5,24 +5,20 @@
  * \date   Tue Oct  9 10:52:50 2001
  * \brief  EoS class test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "DummyEoS.hh"
 #include "cdi/EoS.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <sstream>
+#include <memory>
 
 using namespace std;
 
 using rtt_cdi::EoS;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -35,7 +31,7 @@ void test_EoS(rtt_dsxx::UnitTest &ut) {
   // --------------------- //
 
   // The smart pointer points to a generic EoS object.
-  SP<EoS> spEoS;
+  std::shared_ptr<EoS> spEoS;
 
   // The actual instatniate is specific (dummyEoS).
   if ((spEoS.reset(new rtt_cdi_test::DummyEoS())), spEoS) {

--- a/src/cdi/test/tDummyEoS.cc
+++ b/src/cdi/test/tDummyEoS.cc
@@ -13,8 +13,8 @@
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
-#include <sstream>
 #include <memory>
+#include <sstream>
 
 using namespace std;
 

--- a/src/cdi/test/tDummyOpacity.cc
+++ b/src/cdi/test/tDummyOpacity.cc
@@ -28,7 +28,7 @@ using rtt_dsxx::soft_equiv;
 //---------------------------------------------------------------------------//
 
 void simple_tests(rtt_dsxx::UnitTest &ut) {
-  // make SPs to gray and multigroup opacities
+  // make shared_ptrs to gray and multigroup opacities
   std::shared_ptr<GrayOpacity> gray;
   std::shared_ptr<MultigroupOpacity> mg;
   std::shared_ptr<OdfmgOpacity> odfmg;
@@ -226,9 +226,9 @@ void gray_opacity_test(rtt_dsxx::UnitTest &ut) {
   std::shared_ptr<GrayOpacity> spDGO;
 
   if ((spDGO.reset(new rtt_cdi_test::DummyGrayOpacity())), spDGO)
-    PASSMSG("SP to new GrayOpacity object created.");
+    PASSMSG("shared_ptr to new GrayOpacity object created.");
   else
-    FAILMSG("Unable to create a SP to new GrayOpacity object.");
+    FAILMSG("Unable to create a shared_ptr to new GrayOpacity object.");
 
   // ------------------------ //
   // Dummy Gray Opacity Tests //
@@ -317,7 +317,7 @@ void multigroup_opacity_test(rtt_dsxx::UnitTest &ut) {
 
   if ((spDmgO.reset(new rtt_cdi_test::DummyMultigroupOpacity())), spDmgO) {
     ostringstream message;
-    message << "SP to new MultigroupOpacity object created.";
+    message << "shared_ptr to new MultigroupOpacity object created.";
     PASSMSG(message.str());
   }
 
@@ -434,11 +434,11 @@ void multigroup_opacity_test(rtt_dsxx::UnitTest &ut) {
   if ((spDumMgOp.reset(new rtt_cdi_test::DummyMultigroupOpacity())),
       spDumMgOp) {
     ostringstream message;
-    message << "SP to new DummyMultigroupOpacity object created.";
+    message << "shared_ptr to new DummyMultigroupOpacity object created.";
     PASSMSG(message.str());
   } else {
     ostringstream message;
-    message << "Unable to create a SP "
+    message << "Unable to create a shared_ptr "
             << "to a new DummyMultigroupOpacity object.";
     FAILMSG(message.str());
   }
@@ -490,7 +490,7 @@ void odfmg_opacity_test(rtt_dsxx::UnitTest &ut) {
   if ((spDumOdfmgOpacity.reset(new rtt_cdi_test::DummyOdfmgOpacity())),
       spDumOdfmgOpacity) {
     ostringstream message;
-    message << "SP to new OdfmgOpacity object created.";
+    message << "shared_ptr to new OdfmgOpacity object created.";
     PASSMSG(message.str());
   }
 
@@ -626,21 +626,20 @@ void odfmg_opacity_test(rtt_dsxx::UnitTest &ut) {
 
   // STL-like accessor (MG opacities)
 
-  // We have added STL-like getOpacity functions to DummyOdfmgOpacity,
-  // these are not available through the rtt_cdi::OdfmgOpacity base
-  // class so we test them as a DummyOdfmgOpacity.  This demonstrates
-  // that one could make an opacity class that contains extra
-  // functionality. Of course this functionality is not available through
-  // CDI.
+  // We have added STL-like getOpacity functions to DummyOdfmgOpacity, these are
+  // not available through the rtt_cdi::OdfmgOpacity base class so we test them
+  // as a DummyOdfmgOpacity.  This demonstrates that one could make an opacity
+  // class that contains extra functionality. Of course this functionality is
+  // not available through CDI.
 
   std::shared_ptr<rtt_cdi_test::DummyOdfmgOpacity> spDumMgOp;
   if ((spDumMgOp.reset(new rtt_cdi_test::DummyOdfmgOpacity())), spDumMgOp) {
     ostringstream message;
-    message << "SP to new DummyOdfmgOpacity object created.";
+    message << "shared_ptr to new DummyOdfmgOpacity object created.";
     PASSMSG(message.str());
   } else {
     ostringstream message;
-    message << "Unable to create a SP "
+    message << "Unable to create a shared_ptr "
             << "to a new DummyOdfmgOpacity object.";
     FAILMSG(message.str());
   }

--- a/src/cdi/test/tDummyOpacity.cc
+++ b/src/cdi/test/tDummyOpacity.cc
@@ -5,17 +5,13 @@
  * \date   Tue Oct  9 15:50:53 2001
  * \brief  GrayOpacity and Multigroup opacity test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "DummyGrayOpacity.hh"
 #include "DummyMultigroupOpacity.hh"
 #include "DummyOdfmgOpacity.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <sstream>
@@ -25,7 +21,6 @@ using namespace std;
 using rtt_cdi::GrayOpacity;
 using rtt_cdi::MultigroupOpacity;
 using rtt_cdi::OdfmgOpacity;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -34,13 +29,13 @@ using rtt_dsxx::soft_equiv;
 
 void simple_tests(rtt_dsxx::UnitTest &ut) {
   // make SPs to gray and multigroup opacities
-  SP<GrayOpacity> gray;
-  SP<MultigroupOpacity> mg;
-  SP<OdfmgOpacity> odfmg;
+  std::shared_ptr<GrayOpacity> gray;
+  std::shared_ptr<MultigroupOpacity> mg;
+  std::shared_ptr<OdfmgOpacity> odfmg;
 
   // Assign and check gray opacity
-  SP<rtt_cdi_test::DummyGrayOpacity> gray_total;
-  SP<rtt_cdi_test::DummyGrayOpacity> gray_abs;
+  std::shared_ptr<rtt_cdi_test::DummyGrayOpacity> gray_total;
+  std::shared_ptr<rtt_cdi_test::DummyGrayOpacity> gray_abs;
   gray_total.reset(new rtt_cdi_test::DummyGrayOpacity());
   gray_abs.reset(new rtt_cdi_test::DummyGrayOpacity(rtt_cdi::ABSORPTION));
 
@@ -86,8 +81,8 @@ void simple_tests(rtt_dsxx::UnitTest &ut) {
   }
 
   // Assign and check multigroup opacity
-  SP<rtt_cdi_test::DummyMultigroupOpacity> mg_total;
-  SP<rtt_cdi_test::DummyMultigroupOpacity> mg_abs;
+  std::shared_ptr<rtt_cdi_test::DummyMultigroupOpacity> mg_total;
+  std::shared_ptr<rtt_cdi_test::DummyMultigroupOpacity> mg_abs;
   mg_total.reset(new rtt_cdi_test::DummyMultigroupOpacity());
   mg_abs.reset(new rtt_cdi_test::DummyMultigroupOpacity(rtt_cdi::ABSORPTION));
 
@@ -153,8 +148,8 @@ void simple_tests(rtt_dsxx::UnitTest &ut) {
   }
 
   // Assign and check odfmg opacity
-  SP<rtt_cdi_test::DummyOdfmgOpacity> odfmg_total;
-  SP<rtt_cdi_test::DummyOdfmgOpacity> odfmg_abs;
+  std::shared_ptr<rtt_cdi_test::DummyOdfmgOpacity> odfmg_total;
+  std::shared_ptr<rtt_cdi_test::DummyOdfmgOpacity> odfmg_abs;
   odfmg_total.reset(new rtt_cdi_test::DummyOdfmgOpacity());
   odfmg_abs.reset(new rtt_cdi_test::DummyOdfmgOpacity(rtt_cdi::ABSORPTION));
 
@@ -228,7 +223,7 @@ void gray_opacity_test(rtt_dsxx::UnitTest &ut) {
   // Create a GrayOpacity object. //
   // ---------------------------- //
 
-  SP<GrayOpacity> spDGO;
+  std::shared_ptr<GrayOpacity> spDGO;
 
   if ((spDGO.reset(new rtt_cdi_test::DummyGrayOpacity())), spDGO)
     PASSMSG("SP to new GrayOpacity object created.");
@@ -318,7 +313,7 @@ void multigroup_opacity_test(rtt_dsxx::UnitTest &ut) {
   // Create a Dummy Multigroup Opacity object. //
   // ----------------------------------------- //
 
-  SP<MultigroupOpacity> spDmgO;
+  std::shared_ptr<MultigroupOpacity> spDmgO;
 
   if ((spDmgO.reset(new rtt_cdi_test::DummyMultigroupOpacity())), spDmgO) {
     ostringstream message;
@@ -435,7 +430,7 @@ void multigroup_opacity_test(rtt_dsxx::UnitTest &ut) {
   // functionality. Of course this functionality is not available through
   // CDI.
 
-  SP<rtt_cdi_test::DummyMultigroupOpacity> spDumMgOp;
+  std::shared_ptr<rtt_cdi_test::DummyMultigroupOpacity> spDumMgOp;
   if ((spDumMgOp.reset(new rtt_cdi_test::DummyMultigroupOpacity())),
       spDumMgOp) {
     ostringstream message;
@@ -490,7 +485,7 @@ void odfmg_opacity_test(rtt_dsxx::UnitTest &ut) {
   // Create a Dummy Odfmg Opacity object. //
   // ----------------------------------------- //
 
-  SP<OdfmgOpacity> spDumOdfmgOpacity;
+  std::shared_ptr<OdfmgOpacity> spDumOdfmgOpacity;
 
   if ((spDumOdfmgOpacity.reset(new rtt_cdi_test::DummyOdfmgOpacity())),
       spDumOdfmgOpacity) {
@@ -638,7 +633,7 @@ void odfmg_opacity_test(rtt_dsxx::UnitTest &ut) {
   // functionality. Of course this functionality is not available through
   // CDI.
 
-  SP<rtt_cdi_test::DummyOdfmgOpacity> spDumMgOp;
+  std::shared_ptr<rtt_cdi_test::DummyOdfmgOpacity> spDumMgOp;
   if ((spDumMgOp.reset(new rtt_cdi_test::DummyOdfmgOpacity())), spDumMgOp) {
     ostringstream message;
     message << "SP to new DummyOdfmgOpacity object created.";

--- a/src/cdi_analytic/Analytic_EoS.cc
+++ b/src/cdi_analytic/Analytic_EoS.cc
@@ -5,10 +5,7 @@
  * \date   Tue Oct  2 16:22:32 2001
  * \brief  Analytic_EoS member definitions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Analytic_EoS.hh"
@@ -25,9 +22,8 @@ namespace rtt_cdi_analytic {
  * This constructor builds an analytic EoS model defined by the
  * rtt_cdi_analytic::Analytic_EoS_Model derived class argument.
  *
- * \param analytic_model_in rtt_dsxx::SP to a derived
- * rtt_cdi_analytic::Analytic_EoS_Model object
- *
+ * \param analytic_model_in shared_ptr to a derived
+ *        rtt_cdi_analytic::Analytic_EoS_Model object
  */
 Analytic_EoS::Analytic_EoS(SP_Analytic_Model model_in)
     : analytic_model(model_in) {
@@ -37,7 +33,7 @@ Analytic_EoS::Analytic_EoS(SP_Analytic_Model model_in)
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor.
- * 
+ *
  * This constructor rebuilds and Analytic_EoS from a vector<char> that was
  * created by a call to pack().  It can only rebuild Analytic_Model types
  * that have been registered in the rtt_cdi_analytic::EoS_Models enumeration.

--- a/src/cdi_analytic/Analytic_EoS.hh
+++ b/src/cdi_analytic/Analytic_EoS.hh
@@ -5,10 +5,7 @@
  * \date   Tue Oct  2 16:22:32 2001
  * \brief  Analytic_EoS class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Analytic_EoS_hh__
@@ -16,7 +13,7 @@
 
 #include "Analytic_Models.hh"
 #include "cdi/EoS.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_cdi_analytic {
 
@@ -50,8 +47,8 @@ namespace rtt_cdi_analytic {
 class DLL_PUBLIC_cdi_analytic Analytic_EoS : public rtt_cdi::EoS {
 public:
   // Useful typedefs.
-  typedef rtt_dsxx::SP<Analytic_EoS_Model> SP_Analytic_Model;
-  typedef rtt_dsxx::SP<const Analytic_EoS_Model> const_SP_Model;
+  typedef std::shared_ptr<Analytic_EoS_Model> SP_Analytic_Model;
+  typedef std::shared_ptr<const Analytic_EoS_Model> const_SP_Model;
   typedef std::vector<double> sf_double;
   typedef std::vector<char> sf_char;
 

--- a/src/cdi_analytic/Analytic_Gray_Opacity.cc
+++ b/src/cdi_analytic/Analytic_Gray_Opacity.cc
@@ -5,9 +5,8 @@
  * \date   Fri Aug 24 13:13:46 2001
  * \brief  Analytic_Gray_Opacity member definitions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *         All rights reserved.
  */
-//---------------------------------------------------------------------------//
-// $Id$
 //---------------------------------------------------------------------------//
 
 #include "Analytic_Gray_Opacity.hh"
@@ -28,11 +27,10 @@ namespace rtt_cdi_analytic {
  * The reaction type for this instance of the class is determined by the
  * rtt_cdi::Reaction argument.
  *
- * \param analytic_model_in rtt_dsxx::SP to a derived
+ * \param analytic_model_in shared_ptr to a derived
  * rtt_cdi_analytic::Analytic_Opacity_Model object
  *
  * \param reaction_in rtt_cdi::Reaction type (enumeration)
- *
  */
 Analytic_Gray_Opacity::Analytic_Gray_Opacity(SP_Analytic_Model model_in,
                                              rtt_cdi::Reaction reaction_in,
@@ -47,11 +45,11 @@ Analytic_Gray_Opacity::Analytic_Gray_Opacity(SP_Analytic_Model model_in,
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor.
- * 
+ *
  * This constructor rebuilds and Analytic_Gray_Opacity from a vector<char>
  * that was created by a call to pack().  It can only rebuild Analytic_Model
  * types that have been registered in the rtt_cdi_analytic::Opacity_Models
- * enumeration. 
+ * enumeration.
  */
 Analytic_Gray_Opacity::Analytic_Gray_Opacity(const sf_char &packed)
     : analytic_model(), reaction(), model() {
@@ -111,7 +109,7 @@ Analytic_Gray_Opacity::Analytic_Gray_Opacity(const sf_char &packed)
 // OPACITY INTERFACE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * \brief Return a scalar opacity given a scalar temperature and density. 
+ * \brief Return a scalar opacity given a scalar temperature and density.
  *
  * Given a scalar temperature and density, return an opacity for the reaction
  * type specified by the constructor.  The analytic opacity model is
@@ -137,7 +135,7 @@ double Analytic_Gray_Opacity::getOpacity(double temperature,
 //---------------------------------------------------------------------------//
 /*!
  * \brief Return a field of opacities given a field of temperatures and a
- * scalar density. 
+ * scalar density.
  *
  * Given a field of temperatures and a scalar density, return an opacity
  * field for the reaction type specified by the constructor.  The analytic

--- a/src/cdi_analytic/Analytic_Gray_Opacity.hh
+++ b/src/cdi_analytic/Analytic_Gray_Opacity.hh
@@ -5,10 +5,7 @@
  * \date   Fri Aug 24 13:13:46 2001
  * \brief  Analytic_Gray_Opacity class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Analytic_Gray_Opacity_hh__
@@ -16,7 +13,7 @@
 
 #include "Analytic_Models.hh"
 #include "cdi/GrayOpacity.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_cdi_analytic {
 
@@ -66,8 +63,8 @@ class DLL_PUBLIC_cdi_analytic Analytic_Gray_Opacity
     : public rtt_cdi::GrayOpacity {
 public:
   // Useful typedefs.
-  typedef rtt_dsxx::SP<Analytic_Opacity_Model> SP_Analytic_Model;
-  typedef rtt_dsxx::SP<const Analytic_Opacity_Model> const_SP_Model;
+  typedef std::shared_ptr<Analytic_Opacity_Model> SP_Analytic_Model;
+  typedef std::shared_ptr<const Analytic_Opacity_Model> const_SP_Model;
   typedef std::vector<double> sf_double;
   typedef std::string std_string;
   typedef std::vector<char> sf_char;

--- a/src/cdi_analytic/Analytic_Models.cc
+++ b/src/cdi_analytic/Analytic_Models.cc
@@ -5,10 +5,7 @@
  * \date   Wed Nov 21 14:36:15 2001
  * \brief  Analytic_Models implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Analytic_Models.hh"
@@ -22,8 +19,9 @@ namespace rtt_cdi_analytic {
 // EOS_ANALYTIC_MODEL MEMBER DEFINITIONS
 //===========================================================================//
 
-/*! \brief Calculate the electron temperature given density and Electron internal
- *         energy
+/*!
+ * \brief Calculate the electron temperature given density and Electron internal
+ *        energy
  *
  * \f[
  * U_e(T_i) = \int_{T=0}^{T_i}{C_v(\rho,T)dT}
@@ -32,10 +30,10 @@ namespace rtt_cdi_analytic {
  * Where we assume \f$ U_e(0) \equiv 0 \f$.
  *
  * We have chosen to use absolute electron energy instead of dUe to mimik the
- * behavior of EOSPAC. 
+ * behavior of EOSPAC.
  *
  * \todo Consider using GSL root finding with Newton-Raphson for improved
- *       efficiency. 
+ *       efficiency.
  */
 double Polynomial_Specific_Heat_Analytic_EoS_Model::calculate_elec_temperature(
     double const /*rho*/, double const Ue, double const Te0) const {
@@ -75,10 +73,10 @@ double Polynomial_Specific_Heat_Analytic_EoS_Model::calculate_elec_temperature(
  * Where we assume \f$ U_ic(0) \equiv 0 \f$.
  *
  * We have chosen to use absolute electron energy instead of dUe to mimik the
- * behavior of EOSPAC. 
+ * behavior of EOSPAC.
  *
  * \todo Consider using GSL root finding with Newton-Raphson for improved
- *       efficiency. 
+ *       efficiency.
  */
 double Polynomial_Specific_Heat_Analytic_EoS_Model::calculate_ion_temperature(
     double const /*rho*/, double const Uic, double const Ti0) const {

--- a/src/cdi_analytic/Analytic_Models.hh
+++ b/src/cdi_analytic/Analytic_Models.hh
@@ -5,20 +5,16 @@
  * \date   Wed Aug 29 16:46:52 2001
  * \brief  Analytic_Model definitions
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Analytic_Models_hh__
 #define __cdi_analytic_Analytic_Models_hh__
 
-#include <cmath>
-#include <vector>
-
 #include "cdi/OpacityCommon.hh"
 #include "ds++/Assert.hh"
+#include <cmath>
+#include <vector>
 
 namespace rtt_cdi_analytic {
 
@@ -67,7 +63,7 @@ enum EoS_Models { POLYNOMIAL_SPECIFIC_HEAT_ANALYTIC_EOS_MODEL };
  *
  * \arg vector<char> pack() const;
  *
- * This class is a pure virtual base class. 
+ * This class is a pure virtual base class.
  *
  * The returned opacity should have units of cm^2/g.
  *
@@ -194,9 +190,9 @@ public:
      * \param c_ temperature power
      * \param d_ density power
      * \param e_ frequency power
-     * \param f_ reference temperature 
+     * \param f_ reference temperature
      * \param g_ reference density
-     * \param h_ reference frequency 
+     * \param h_ reference frequency
      */
 
   Polynomial_Analytic_Opacity_Model(double a_, double b_, double c_, double d_,
@@ -282,7 +278,7 @@ public:
  *
  * \arg a = [cm^2/g * (cm^3/g)^d]
  * \arg b = [keV^(-c) * cm^2/g * (cm^3/g)^d]
- * 
+ *
  * For a typical bound-free or free-free absorption model, one should set
  * \arg a = 0
  * \arg b = constant > 0
@@ -290,12 +286,12 @@ public:
  * \arg d = constant
  * \arg e = -3
  *
- * This produces a Planck or Rosseland opacity of the form 
+ * This produces a Planck or Rosseland opacity of the form
  *         \f[ \overline{\sigma} \propto T^{-7/2} \f]
  * which is also known as Kramers' Opacity Law.
  * \sa{ http://en.wikipedia.org/wiki/Kramers'_opacity_law }
  *
- * 
+ *
  */
 
 class DLL_PUBLIC_cdi_analytic Stimulated_Emission_Analytic_Opacity_Model
@@ -319,7 +315,7 @@ public:
      * \param c_ temperature power
      * \param d_ density power
      * \param e_ frequency power
-     * \param f_ reference temperature 
+     * \param f_ reference temperature
      * \param g_ reference density
      * \param h_ reference frequency
      */
@@ -406,15 +402,15 @@ public:
  * \arg double calculate_elec_thermal_conductivity(double T, double rho)
  *
  * The units for each output are:
- * 
+ *
  * \arg electron internal energy      = kJ/g
  * \arg electron heat capacity        = kJ/g/keV
  * \arg ion internal energy           = kJ/g
  * \arg ion heat capacity             = kJ/g/keV
  * \arg electron thermal conductivity = /s/cm
- * 
+ *
  * These units correspond to the units defined by the rtt_cdi::EoS base
- * class. 
+ * class.
  *
  * To enable packing functionality, the class must be registered in the
  * EoS_Models enumeration.  Also, it must contain the following pure
@@ -422,7 +418,7 @@ public:
  *
  * \arg vector<char> pack() const;
  *
- * This class is a pure virtual base class. 
+ * This class is a pure virtual base class.
  */
 //===========================================================================//
 
@@ -485,7 +481,7 @@ public:
  * functions for EoS specific heat data.
  *
  * The electron and ion specific heats are defined:
- * 
+ *
  * \arg elec specific heat = a + bT^c
  * \arg ion specific heat  = d + eT^f
  *
@@ -500,7 +496,7 @@ public:
  * verification purposes.  More complex analytic EoS models can be easily
  * defined if they are required; however, radiation-only packages (without
  * Compton scatter) only require specfic heat data.
- * 
+ *
  */
 class DLL_PUBLIC_cdi_analytic Polynomial_Specific_Heat_Analytic_EoS_Model
     : public Analytic_EoS_Model {
@@ -565,9 +561,9 @@ public:
      * This is done by integrating the specific heat capacity at constant
      * density from T=0 to the specified temperature.
      *
-     * \param T 
+     * \param T
      * Temperature (keV) for which the specific internal energy is to be
-     * evaluated. 
+     * evaluated.
      * \param rho
      * Density (g/cm^3) for which the specific internal energy is to be
      * evaluated. This parameter is not actually used.
@@ -597,9 +593,9 @@ public:
      * This is done by integrating the specific heat capacity at constant
      * density from T=0 to the specified temperature.
      *
-     * \param T 
+     * \param T
      * Temperature (keV) for which the specific internal energy is to be
-     * evaluated. 
+     * evaluated.
      * \param rho
      * Density (g/cm^3) for which the specific internal energy is to be
      * evaluated. This parameter is not actually used.
@@ -661,7 +657,7 @@ public:
  * f(T) = U_e(T_i) - \int_0^{T_i}{C_{v_e}(T) dT}
  * \f]
  * \f[
- * f(T) = U_e(T_i) - a T_i - \frac{b}{c+1} T_i^{c+1} 
+ * f(T) = U_e(T_i) - a T_i - \frac{b}{c+1} T_i^{c+1}
  * \f]
  *
  */

--- a/src/cdi_analytic/Analytic_MultigroupOpacity.hh
+++ b/src/cdi_analytic/Analytic_MultigroupOpacity.hh
@@ -5,10 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  Analytic_MultigroupOpacity class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Analytic_MultigroupOpacity_hh__
@@ -16,7 +13,7 @@
 
 #include "Analytic_Models.hh"
 #include "cdi/MultigroupOpacity.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_cdi_analytic {
 

--- a/src/cdi_analytic/Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/Analytic_Odfmg_Opacity.cc
@@ -5,9 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  Analytic_Odfmg_Opacity class member definitions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Analytic_Odfmg_Opacity.hh"
@@ -53,7 +51,7 @@ Analytic_Odfmg_Opacity::Analytic_Odfmg_Opacity(const sf_double &groups,
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor.
- * 
+ *
  * This constructor rebuilds and Analytic_Odfmg_Opacity from a
  * vector<char> that was created by a call to pack().  It can only rebuild
  * Analytic_Model types that have been registered in the

--- a/src/cdi_analytic/Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/Analytic_Odfmg_Opacity.cc
@@ -32,8 +32,8 @@ namespace rtt_cdi_analytic {
  * \param groups vector containing the group boundaries in keV from lowest to
  * highest
  *
- * \param models vector containing SPs to Analytic_Model derived types for
- * each group, the size should be groups.size() - 1
+ * \param models vector containing shared_ptrs to Analytic_Model derived types
+ * for each group, the size should be groups.size() - 1
  *
  * \param reaction_in rtt_cdi::Reaction type (enumeration)
  *

--- a/src/cdi_analytic/Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/Analytic_Odfmg_Opacity.hh
@@ -5,10 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  Analytic_Odfmg_Opacity class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC..
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Analytic_Odfmg_Opacity_hh__
@@ -16,7 +13,7 @@
 
 #include "Analytic_Models.hh"
 #include "cdi/OdfmgOpacity.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_cdi_analytic {
 
@@ -28,15 +25,14 @@ namespace rtt_cdi_analytic {
  *
  * Primarily code from Analytic_Multigroup_Opacity.
  */
-//
 //===========================================================================//
 
 class DLL_PUBLIC_cdi_analytic Analytic_Odfmg_Opacity
     : public rtt_cdi::OdfmgOpacity {
 public:
   // Useful typedefs.
-  typedef rtt_dsxx::SP<Analytic_Opacity_Model> SP_Analytic_Model;
-  typedef rtt_dsxx::SP<const Analytic_Opacity_Model> const_Model;
+  typedef std::shared_ptr<Analytic_Opacity_Model> SP_Analytic_Model;
+  typedef std::shared_ptr<const Analytic_Opacity_Model> const_Model;
   typedef std::vector<SP_Analytic_Model> sf_Analytic_Model;
   typedef std::vector<double> sf_double;
   typedef std::vector<sf_double> vf_double;

--- a/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.cc
@@ -96,10 +96,11 @@ double PLRW_Functor::operator()(double x) {
 //---------------------------------------------------------------------------//
 Pseudo_Line_Analytic_MultigroupOpacity::Pseudo_Line_Analytic_MultigroupOpacity(
     sf_double const &group_bounds, rtt_cdi::Reaction const reaction,
-    std::shared_ptr<Expression const> const &continuum, unsigned number_of_lines,
-    double line_peak, double line_width, unsigned number_of_edges,
-    double edge_ratio, double Tref, double Tpow, double emin, double emax,
-    Averaging const averaging, unsigned const qpoints, unsigned seed)
+    std::shared_ptr<Expression const> const &continuum,
+    unsigned number_of_lines, double line_peak, double line_width,
+    unsigned number_of_edges, double edge_ratio, double Tref, double Tpow,
+    double emin, double emax, Averaging const averaging, unsigned const qpoints,
+    unsigned seed)
     : Analytic_MultigroupOpacity(group_bounds, reaction),
       Pseudo_Line_Base(continuum, number_of_lines, line_peak, line_width,
                        number_of_edges, edge_ratio, Tref, Tpow, emin, emax,

--- a/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.cc
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \date   Tue Apr  5 08:42:25 MDT 2011
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Pseudo_Line_Analytic_MultigroupOpacity.hh"
@@ -99,7 +96,7 @@ double PLRW_Functor::operator()(double x) {
 //---------------------------------------------------------------------------//
 Pseudo_Line_Analytic_MultigroupOpacity::Pseudo_Line_Analytic_MultigroupOpacity(
     sf_double const &group_bounds, rtt_cdi::Reaction const reaction,
-    SP<Expression const> const &continuum, unsigned number_of_lines,
+    std::shared_ptr<Expression const> const &continuum, unsigned number_of_lines,
     double line_peak, double line_width, unsigned number_of_edges,
     double edge_ratio, double Tref, double Tpow, double emin, double emax,
     Averaging const averaging, unsigned const qpoints, unsigned seed)

--- a/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.hh
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.hh
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \date   Tue Apr  5 08:36:13 MDT 2011
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Pseudo_Line_Analytic_MultigroupOpacity_hh__
@@ -17,7 +14,6 @@
 #include "Pseudo_Line_Base.hh"
 
 namespace rtt_cdi_analytic {
-using rtt_dsxx::SP;
 using rtt_parser::Expression;
 
 //---------------------------------------------------------------------------//
@@ -48,7 +44,7 @@ private:
 public:
   Pseudo_Line_Analytic_MultigroupOpacity(
       sf_double const &group_bounds, rtt_cdi::Reaction reaction,
-      SP<Expression const> const &cont, unsigned number_of_lines,
+      std::shared_ptr<Expression const> const &cont, unsigned number_of_lines,
       double line_peak, double line_width, unsigned number_of_edges,
       double edge_ratio, double Tref, double Tpow, double emin, double emax,
       Averaging averaging, unsigned qpoints, unsigned seed);

--- a/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc
@@ -8,7 +8,6 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <fstream>
 #include "Pseudo_Line_Analytic_Odfmg_Opacity.hh"
 #include "Pseudo_Line_Analytic_MultigroupOpacity.hh"
 #include "cdi/CDI.hh"
@@ -17,6 +16,7 @@
 #include "ode/quad.hh"
 #include "ode/rkqs.hh"
 #include "units/PhysicalConstantsSI.hh"
+#include <fstream>
 
 namespace rtt_cdi_analytic {
 using namespace std;
@@ -67,11 +67,10 @@ void Pseudo_Line_Analytic_Odfmg_Opacity::precalculate(
 Pseudo_Line_Analytic_Odfmg_Opacity::Pseudo_Line_Analytic_Odfmg_Opacity(
     const sf_double &groups, const sf_double &bands,
     rtt_cdi::Reaction reaction_in,
-    std::shared_ptr<Expression const> const &continuum,
-    int number_of_lines, double line_peak, double line_width,
-    int number_of_edges, double edge_ratio, double Tref, double Tpow,
-    double emin, double emax, Averaging averaging, unsigned qpoints,
-    unsigned seed)
+    std::shared_ptr<Expression const> const &continuum, int number_of_lines,
+    double line_peak, double line_width, int number_of_edges, double edge_ratio,
+    double Tref, double Tpow, double emin, double emax, Averaging averaging,
+    unsigned qpoints, unsigned seed)
     : Analytic_Odfmg_Opacity(groups, bands, reaction_in),
       Pseudo_Line_Base(continuum, number_of_lines, line_peak, line_width,
                        number_of_edges, edge_ratio, Tref, Tpow, emin, emax,

--- a/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc
@@ -5,16 +5,11 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  Pseudo_Line_Analytic_Odfmg_Opacity class member definitions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <fstream>
-
 #include "Pseudo_Line_Analytic_Odfmg_Opacity.hh"
-
 #include "Pseudo_Line_Analytic_MultigroupOpacity.hh"
 #include "cdi/CDI.hh"
 #include "ds++/DracoMath.hh"
@@ -71,7 +66,8 @@ void Pseudo_Line_Analytic_Odfmg_Opacity::precalculate(
 //---------------------------------------------------------------------------//
 Pseudo_Line_Analytic_Odfmg_Opacity::Pseudo_Line_Analytic_Odfmg_Opacity(
     const sf_double &groups, const sf_double &bands,
-    rtt_cdi::Reaction reaction_in, SP<Expression const> const &continuum,
+    rtt_cdi::Reaction reaction_in,
+    std::shared_ptr<Expression const> const &continuum,
     int number_of_lines, double line_peak, double line_width,
     int number_of_edges, double edge_ratio, double Tref, double Tpow,
     double emin, double emax, Averaging averaging, unsigned qpoints,
@@ -125,7 +121,7 @@ Pseudo_Line_Analytic_Odfmg_Opacity::Pseudo_Line_Analytic_Odfmg_Opacity(
 // OPACITY INTERFACE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * \brief Return the group opacities given a scalar temperature and density. 
+ * \brief Return the group opacities given a scalar temperature and density.
  *
  * Given a scalar temperature and density, return the group opacities
  * (vector<double>) for the reaction type specified by the constructor.  The

--- a/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh
@@ -43,11 +43,10 @@ public:
   Pseudo_Line_Analytic_Odfmg_Opacity(
       const sf_double &groups, const sf_double &bands,
       rtt_cdi::Reaction reaction_in,
-      std::shared_ptr<Expression const> const &cont,
-      int number_of_lines, double line_peak, double line_width,
-      int number_of_edges, double edge_ratio, double Tref, double Tpow,
-      double emin, double emax, Averaging averaging, unsigned qpoints,
-      unsigned seed);
+      std::shared_ptr<Expression const> const &cont, int number_of_lines,
+      double line_peak, double line_width, int number_of_edges,
+      double edge_ratio, double Tref, double Tpow, double emin, double emax,
+      Averaging averaging, unsigned qpoints, unsigned seed);
 
   // Constructor.
   Pseudo_Line_Analytic_Odfmg_Opacity(

--- a/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh
@@ -5,10 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  Pseudo_Line_Analytic_Odfmg_Opacity class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Pseudo_Line_Analytic_Odfmg_Opacity_hh__
@@ -28,7 +25,6 @@ using std::pair;
  *
  * Primarily code from Analytic_Multigroup_Opacity.
  */
-//
 //===========================================================================//
 
 class DLL_PUBLIC_cdi_analytic Pseudo_Line_Analytic_Odfmg_Opacity
@@ -46,7 +42,8 @@ public:
   // Constructor.
   Pseudo_Line_Analytic_Odfmg_Opacity(
       const sf_double &groups, const sf_double &bands,
-      rtt_cdi::Reaction reaction_in, SP<Expression const> const &cont,
+      rtt_cdi::Reaction reaction_in,
+      std::shared_ptr<Expression const> const &cont,
       int number_of_lines, double line_peak, double line_width,
       int number_of_edges, double edge_ratio, double Tref, double Tpow,
       double emin, double emax, Averaging averaging, unsigned qpoints,

--- a/src/cdi_analytic/Pseudo_Line_Base.cc
+++ b/src/cdi_analytic/Pseudo_Line_Base.cc
@@ -4,14 +4,10 @@
  * \author Kent G. Budge
  * \date   Tue Apr  5 08:42:25 MDT 2011
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <fstream>
-
 #include "Pseudo_Line_Base.hh"
 #include "c4/C4_Functions.hh"
 #include "cdi/CDI.hh"
@@ -53,8 +49,8 @@ void Pseudo_Line_Base::setup_(double emin, double emax) {
     // Sort line centers
     sort(center_.begin(), center_.end());
   }
-  // else fuzz model: Instead of lines, we add a random opacity to each
-  // opacity bin to simulate very fine, unresolvable line structure.
+  // else fuzz model: Instead of lines, we add a random opacity to each opacity
+  // bin to simulate very fine, unresolvable line structure.
 
   unsigned ne = abs(number_of_edges);
   for (unsigned i = 0; i < ne; ++i) {
@@ -62,10 +58,9 @@ void Pseudo_Line_Base::setup_(double emin, double emax) {
       // normal behavior is to place edges randomly
       edge_[i] = (emax - emin) * static_cast<double>(rand()) / RAND_MAX + emin;
     } else {
-      // placed edges evenly; this makes it easier to choose a group
-      // structure that aligns with edges (as would likely be done with
-      // a production calculation using a real opacity with strong
-      // bound-free components)
+      // placed edges evenly; this makes it easier to choose a group structure
+      // that aligns with edges (as would likely be done with a production
+      // calculation using a real opacity with strong bound-free components)
       edge_[i] = (emax - emin) * (i + 1) / (ne + 1) + emin;
     }
     double C;
@@ -88,11 +83,12 @@ void Pseudo_Line_Base::setup_(double emin, double emax) {
 }
 
 //---------------------------------------------------------------------------//
-Pseudo_Line_Base::Pseudo_Line_Base(SP<Expression const> const &continuum,
-                                   int number_of_lines, double line_peak,
-                                   double line_width, int number_of_edges,
-                                   double edge_ratio, double Tref, double Tpow,
-                                   double emin, double emax, unsigned seed)
+Pseudo_Line_Base::Pseudo_Line_Base(
+  std::shared_ptr<Expression const> const &continuum,
+  int number_of_lines, double line_peak,
+  double line_width, int number_of_edges,
+  double edge_ratio, double Tref, double Tpow,
+  double emin, double emax, unsigned seed)
     : continuum_(continuum), continuum_table_(std::vector<double>()),
       emax_(-1.0), nu0_(-1), // as fast flag
       C_(-1.0), Bn_(-1.0), Bd_(-1.0), R_(-1.0), seed_(seed),
@@ -101,7 +97,7 @@ Pseudo_Line_Base::Pseudo_Line_Base(SP<Expression const> const &continuum,
       edge_ratio_(edge_ratio), Tref_(Tref), Tpow_(Tpow),
       center_(std::vector<double>()), edge_(abs(number_of_edges)),
       edge_factor_(abs(number_of_edges)) {
-  Require(continuum != SP<Expression>());
+  Require(continuum != std::shared_ptr<Expression>());
   Require(line_peak >= 0.0);
   Require(line_width >= 0.0);
   Require(edge_ratio >= 0.0);
@@ -131,8 +127,7 @@ Pseudo_Line_Base::Pseudo_Line_Base(const string &cont_file, int number_of_lines,
   Require(edge_ratio >= 0.0);
   Require(emin >= 0.0);
   Require(emax > emin);
-  // Require parameter (other than emin and emax) to be same on all
-  // processors
+  // Require parameter (other than emin and emax) to be same on all processors
 
   ifstream in(cont_file.c_str());
   if (!in) {
@@ -183,8 +178,8 @@ Pseudo_Line_Base::Pseudo_Line_Base(double nu0, double C, double Bn, double Bd,
 
 vector<char> Pseudo_Line_Base::pack() const {
   throw std::range_error("sorry, pack not implemented for Pseudo_Line_Base");
-// Because we haven't implemented packing functionality for Expression
-// trees yet.
+// Because we haven't implemented packing functionality for Expression trees
+// yet.
 
 #if 0
 // caculate the size in bytes
@@ -243,8 +238,8 @@ double Pseudo_Line_Base::monoOpacity(double const x, double const T) const {
       Result += peak / (1 + d * d);
     }
   } else {
-    // Fuzz model. We had better be precalculating opacities for
-    // consistent behavior.
+    // Fuzz model. We had better be precalculating opacities for consistent
+    // behavior.
     Result += peak * static_cast<double>(rand()) / RAND_MAX;
   }
 

--- a/src/cdi_analytic/Pseudo_Line_Base.cc
+++ b/src/cdi_analytic/Pseudo_Line_Base.cc
@@ -7,7 +7,6 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <fstream>
 #include "Pseudo_Line_Base.hh"
 #include "c4/C4_Functions.hh"
 #include "cdi/CDI.hh"
@@ -15,6 +14,7 @@
 #include "ds++/Packing_Utils.hh"
 #include "ode/quad.hh"
 #include "ode/rkqs.hh"
+#include <fstream>
 
 namespace rtt_cdi_analytic {
 using namespace std;
@@ -84,11 +84,9 @@ void Pseudo_Line_Base::setup_(double emin, double emax) {
 
 //---------------------------------------------------------------------------//
 Pseudo_Line_Base::Pseudo_Line_Base(
-  std::shared_ptr<Expression const> const &continuum,
-  int number_of_lines, double line_peak,
-  double line_width, int number_of_edges,
-  double edge_ratio, double Tref, double Tpow,
-  double emin, double emax, unsigned seed)
+    std::shared_ptr<Expression const> const &continuum, int number_of_lines,
+    double line_peak, double line_width, int number_of_edges, double edge_ratio,
+    double Tref, double Tpow, double emin, double emax, unsigned seed)
     : continuum_(continuum), continuum_table_(std::vector<double>()),
       emax_(-1.0), nu0_(-1), // as fast flag
       C_(-1.0), Bn_(-1.0), Bd_(-1.0), R_(-1.0), seed_(seed),

--- a/src/cdi_analytic/Pseudo_Line_Base.hh
+++ b/src/cdi_analytic/Pseudo_Line_Base.hh
@@ -75,10 +75,9 @@ private:
 
 public:
   Pseudo_Line_Base(std::shared_ptr<Expression const> const &cont,
-                   int number_of_lines,
-                   double line_peak, double line_width, int number_of_edges,
-                   double edge_ratio, double Tref, double Tpow, double emin,
-                   double emax, unsigned seed);
+                   int number_of_lines, double line_peak, double line_width,
+                   int number_of_edges, double edge_ratio, double Tref,
+                   double Tpow, double emin, double emax, unsigned seed);
 
   Pseudo_Line_Base(string const &cont_file, int number_of_lines,
                    double line_peak, double line_width, int number_of_edges,

--- a/src/cdi_analytic/Pseudo_Line_Base.hh
+++ b/src/cdi_analytic/Pseudo_Line_Base.hh
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \date   Tue Apr  5 08:36:13 MDT 2011
  * \note   Copyright (C) 2016, Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_Pseudo_Line_Base_hh__
@@ -19,7 +16,6 @@
 namespace rtt_cdi_analytic {
 using std::vector;
 using std::string;
-using rtt_dsxx::SP;
 using rtt_parser::Expression;
 
 #ifdef _MSC_VER
@@ -51,7 +47,7 @@ public:
 
 private:
   // Coefficients
-  SP<Expression const> continuum_; // continuum opacity [cm^2/g]
+  std::shared_ptr<Expression const> continuum_; // continuum opacity [cm^2/g]
   vector<double> continuum_table_;
   double emax_;
 
@@ -78,7 +74,8 @@ private:
   void setup_(double emin, double emax);
 
 public:
-  Pseudo_Line_Base(SP<Expression const> const &cont, int number_of_lines,
+  Pseudo_Line_Base(std::shared_ptr<Expression const> const &cont,
+                   int number_of_lines,
                    double line_peak, double line_width, int number_of_edges,
                    double edge_ratio, double Tref, double Tpow, double emin,
                    double emax, unsigned seed);

--- a/src/cdi_analytic/nGray_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/nGray_Analytic_MultigroupOpacity.cc
@@ -30,17 +30,14 @@ namespace rtt_cdi_analytic {
  * rtt_cdi::Reaction argument.
  *
  * The group structure (in keV) must be provided by the groups argument.  The
- * number of Analytic_Opacity_Model objects given in the models argument must
- * be equal to the number of groups.
+ * number of Analytic_Opacity_Model objects given in the models argument must be
+ * equal to the number of groups.
  *
  * \param groups vector containing the group boundaries in keV from lowest to
  * highest
- *
- * \param models vector containing SPs to Analytic_Model derived types for
- * each group, the size should be groups.size() - 1
- *
+ * \param models vector containing shared_ptrs to Analytic_Model derived types
+ * for each group, the size should be groups.size() - 1
  * \param reaction_in rtt_cdi::Reaction type (enumeration)
- *
  */
 nGray_Analytic_MultigroupOpacity::nGray_Analytic_MultigroupOpacity(
     const sf_double &groups, const sf_Analytic_Model &models,
@@ -55,7 +52,7 @@ nGray_Analytic_MultigroupOpacity::nGray_Analytic_MultigroupOpacity(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor.
- * 
+ *
  * This constructor rebuilds and nGray_Analytic_MultigroupOpacity from a
  * vector<char> that was created by a call to pack().  It can only rebuild
  * Analytic_Model types that have been registered in the
@@ -122,7 +119,7 @@ nGray_Analytic_MultigroupOpacity::nGray_Analytic_MultigroupOpacity(
 // OPACITY INTERFACE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * \brief Return the group opacities given a scalar temperature and density. 
+ * \brief Return the group opacities given a scalar temperature and density.
  *
  * Given a scalar temperature and density, return the group opacities
  * (vector<double>) for the reaction type specified by the constructor.  The
@@ -170,7 +167,7 @@ nGray_Analytic_MultigroupOpacity::getOpacity(double temperature,
  *
  * The field type for temperatures is an std::vector.
  *
- * \param temperature std::vector of material temperatures in keV 
+ * \param temperature std::vector of material temperatures in keV
  *
  * \param density material density in g/cm^3
  *
@@ -219,7 +216,7 @@ nGray_Analytic_MultigroupOpacity::getOpacity(const sf_double &temperature,
  *
  * The field type for density is an std::vector.
  *
- * \param temperature in keV 
+ * \param temperature in keV
  *
  * \param density std::vector of material densities in g/cm^3
  *

--- a/src/cdi_analytic/nGray_Analytic_MultigroupOpacity.hh
+++ b/src/cdi_analytic/nGray_Analytic_MultigroupOpacity.hh
@@ -5,10 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  nGray_Analytic_MultigroupOpacity class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_nGray_Analytic_MultigroupOpacity_hh__
@@ -70,8 +67,8 @@ class DLL_PUBLIC_cdi_analytic nGray_Analytic_MultigroupOpacity
     : public Analytic_MultigroupOpacity {
 public:
   // Useful typedefs.
-  typedef rtt_dsxx::SP<Analytic_Opacity_Model> SP_Analytic_Model;
-  typedef rtt_dsxx::SP<const Analytic_Opacity_Model> const_Model;
+  typedef std::shared_ptr<Analytic_Opacity_Model> SP_Analytic_Model;
+  typedef std::shared_ptr<const Analytic_Opacity_Model> const_Model;
   typedef std::vector<SP_Analytic_Model> sf_Analytic_Model;
   typedef std::vector<double> sf_double;
   typedef std::vector<sf_double> vf_double;

--- a/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.cc
@@ -5,10 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  nGray_Analytic_Odfmg_Opacity class member definitions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "nGray_Analytic_Odfmg_Opacity.hh"
@@ -37,8 +34,8 @@ namespace rtt_cdi_analytic {
  * \param groups vector containing the group boundaries in keV from lowest to
  * highest
  *
- * \param models vector containing SPs to Analytic_Model derived types for
- * each group, the size should be groups.size() - 1
+ * \param models vector containing shared_ptrs to Analytic_Model derived types
+ * for each group, the size should be groups.size() - 1
  *
  * \param reaction_in rtt_cdi::Reaction type (enumeration)
  *
@@ -58,7 +55,7 @@ nGray_Analytic_Odfmg_Opacity::nGray_Analytic_Odfmg_Opacity(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor.
- * 
+ *
  * This constructor rebuilds and nGray_Analytic_Odfmg_Opacity from a
  * vector<char> that was created by a call to pack().  It can only rebuild
  * Analytic_Model types that have been registered in the
@@ -133,7 +130,7 @@ nGray_Analytic_Odfmg_Opacity::nGray_Analytic_Odfmg_Opacity(
 // OPACITY INTERFACE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * \brief Return the group opacities given a scalar temperature and density. 
+ * \brief Return the group opacities given a scalar temperature and density.
  *
  * Given a scalar temperature and density, return the group opacities
  * (vector<double>) for the reaction type specified by the constructor.  The

--- a/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
@@ -5,8 +5,7 @@
  * \date   Tue Nov 13 11:19:59 2001
  * \brief  nGray_Analytic_Odfmg_Opacity class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_nGray_Analytic_Odfmg_Opacity_hh__
@@ -30,8 +29,8 @@ class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity
     : public Analytic_Odfmg_Opacity {
 public:
   // Useful typedefs.
-  typedef rtt_dsxx::SP<Analytic_Opacity_Model> SP_Analytic_Model;
-  typedef rtt_dsxx::SP<const Analytic_Opacity_Model> const_Model;
+  typedef std::shared_ptr<Analytic_Opacity_Model> SP_Analytic_Model;
+  typedef std::shared_ptr<const Analytic_Opacity_Model> const_Model;
   typedef std::vector<SP_Analytic_Model> sf_Analytic_Model;
   typedef std::vector<double> sf_double;
   typedef std::vector<sf_double> vf_double;
@@ -63,16 +62,16 @@ public:
   // >>> INTERFACE SPECIFIED BY rtt_cdi::OdfmgOpacity
 
   /*!
-     * \brief Opacity accessor that returns a 2-D vector of opacities (
-     *     groups * bands ) that correspond to the
-     *     provided temperature and density.
-     *
-     * \param targetTemperature The temperature value for which an
-     *     opacity value is being requested.
-     * \param targetDensity The density value for which an opacity
-     *     value is being requested.
-     * \return A vector of opacities.
-     */
+   * \brief Opacity accessor that returns a 2-D vector of opacities
+   *        (groups*bands) that correspond to the provided temperature and
+   *        density.
+   *
+   * \param targetTemperature The temperature value for which an opacity value
+   *     is being requested.
+   * \param targetDensity The density value for which an opacity value is being
+   *     requested.
+   * \return A vector of opacities.
+   */
   std::vector<std::vector<double>> getOpacity(double targetTemperature,
                                               double targetDensity) const;
 

--- a/src/cdi_analytic/test/tstAnalytic_EoS.cc
+++ b/src/cdi_analytic/test/tstAnalytic_EoS.cc
@@ -354,11 +354,11 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
   try {
     eosdata.eos();
   } catch (const rtt_dsxx::assertion &ass) {
-    PASSMSG("Good, caught an unreferenced EoS SP!");
+    PASSMSG("Good, caught an unreferenced EoS shared_ptr!");
     caught = true;
   }
   if (!caught)
-    FAILMSG("Failed to catch an unreferenced SP<EoS>!");
+    FAILMSG("Failed to catch an unreferenced shared_ptr<EoS>!");
 
   // now assign the analytic eos to CDI directly
   eosdata.setEoS(analytic_eos);

--- a/src/cdi_analytic/test/tstAnalytic_EoS.cc
+++ b/src/cdi_analytic/test/tstAnalytic_EoS.cc
@@ -5,10 +5,7 @@
  * \date   Thu Oct  4 11:45:19 2001
  * \brief  Analytic_EoS test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi/CDI.hh"
@@ -23,7 +20,6 @@ using rtt_cdi_analytic::Analytic_EoS_Model;
 using rtt_cdi_analytic::Polynomial_Specific_Heat_Analytic_EoS_Model;
 using rtt_cdi::CDI;
 using rtt_cdi::EoS;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 using std::dynamic_pointer_cast;
 
@@ -37,7 +33,7 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
   // make an analytic model (polynomial specific heats)
   // elec specific heat = a + bT^c
   // ion specific heat  = d + eT^f
-  SP<Polynomial_Model> model(
+  shared_ptr<Polynomial_Model> model(
       new Polynomial_Model(0.0, 1.0, 3.0, 0.2, 0.0, 0.0));
 
   if (!model)
@@ -155,10 +151,10 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
 
   // Test the get_Analytic_Model() member function.
   {
-    SP<Polynomial_Model const> myEoS_model =
+    shared_ptr<Polynomial_Model const> myEoS_model =
         dynamic_pointer_cast<Polynomial_Model const>(
             analytic.get_Analytic_Model());
-    SP<Polynomial_Model const> expected_model(model);
+    shared_ptr<Polynomial_Model const> expected_model(model);
 
     if (expected_model == myEoS_model)
       PASSMSG("get_Analytic_Model() returned the expected EoS model.");
@@ -192,7 +188,7 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
   // make an analytic model like Su-Olson (polynomial specific heats)
   // elec specific heat = a + bT^c
   // ion specific heat  = d + eT^f
-  SP<Polynomial_Model> so_model(
+  shared_ptr<Polynomial_Model> so_model(
       new Polynomial_Model(0.0, 54880.0, 3.0, 0.2, 0.0, 0.0));
   // make an analtyic eos
   Analytic_EoS so_analytic(so_model);
@@ -267,14 +263,14 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
   CDI eosdata;
 
   // analytic model
-  SP<Analytic_EoS_Model> model(
+  shared_ptr<Analytic_EoS_Model> model(
       new Polynomial_Model(0.0, 1.0, 3.0, 0.0, 0.0, 0.0));
 
   // assign the eos object
-  SP<Analytic_EoS> analytic_eos(new Analytic_EoS(model));
+  shared_ptr<Analytic_EoS> analytic_eos(new Analytic_EoS(model));
 
   // EoS object
-  SP<const EoS> eos = analytic_eos;
+  shared_ptr<const EoS> eos = analytic_eos;
   if (typeid(*eos) != typeid(Analytic_EoS))
     ITFAILS;
 
@@ -428,11 +424,11 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
 
   {
     // make an analytic model (polynomial specific heats)
-    SP<Polynomial_Model> model(
+    shared_ptr<Polynomial_Model> model(
         new Polynomial_Model(0.0, 1.0, 3.0, 0.2, 0.0, 0.0));
 
     // make an analtyic eos
-    SP<EoS> eos(new Analytic_EoS(model));
+    shared_ptr<EoS> eos(new Analytic_EoS(model));
 
     packed = eos->pack();
   }

--- a/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
@@ -163,7 +163,8 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
   // lets make two models
   shared_ptr<Analytic_Opacity_Model> amodel(
       new Polynomial_Analytic_Opacity_Model(0.0, 100.0, -3.0, 0.0));
-  shared_ptr<Analytic_Opacity_Model> smodel(new Constant_Analytic_Opacity_Model(1.0));
+  shared_ptr<Analytic_Opacity_Model> smodel(
+      new Constant_Analytic_Opacity_Model(1.0));
 
   if (!soft_equiv(amodel->calculate_opacity(2.0, 3.0, 4.0),
                   100.0 / (2.0 * 2.0 * 2.0)))

--- a/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
@@ -5,10 +5,7 @@
  * \date   Mon Sep 24 12:08:55 2001
  * \brief  Analytic_Gray_Opacity test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_analytic_test.hh"
@@ -28,7 +25,6 @@ using rtt_cdi_analytic::Constant_Analytic_Opacity_Model;
 using rtt_cdi_analytic::Polynomial_Analytic_Opacity_Model;
 using rtt_cdi::CDI;
 using rtt_cdi::GrayOpacity;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 using std::dynamic_pointer_cast;
 
@@ -37,11 +33,11 @@ using std::dynamic_pointer_cast;
 //---------------------------------------------------------------------------//
 
 void constant_test(rtt_dsxx::UnitTest &ut) {
-  // make an analytic gray opacity that returns the total opacity for a
-  // constant model
+  // make an analytic gray opacity that returns the total opacity for a constant
+  // model
   const double constant_opacity = 5.0;
 
-  SP<Analytic_Opacity_Model> model(
+  shared_ptr<Analytic_Opacity_Model> model(
       new Constant_Analytic_Opacity_Model(constant_opacity));
 
   Analytic_Gray_Opacity anal_opacity(model, rtt_cdi::TOTAL);
@@ -106,7 +102,7 @@ void constant_test(rtt_dsxx::UnitTest &ut) {
 
 void user_defined_test(rtt_dsxx::UnitTest &ut) {
   // make the user defined Marshak model
-  SP<Analytic_Opacity_Model> model(
+  shared_ptr<Analytic_Opacity_Model> model(
       new rtt_cdi_analytic_test::Marshak_Model(10.0));
 
   Analytic_Gray_Opacity anal_opacity(model, rtt_cdi::TOTAL);
@@ -161,13 +157,13 @@ void user_defined_test(rtt_dsxx::UnitTest &ut) {
 
 void CDI_test(rtt_dsxx::UnitTest &ut) {
   // lets make a marshak model gray opacity for scattering and absorption
-  SP<const GrayOpacity> absorption;
-  SP<const GrayOpacity> scattering;
+  shared_ptr<const GrayOpacity> absorption;
+  shared_ptr<const GrayOpacity> scattering;
 
   // lets make two models
-  SP<Analytic_Opacity_Model> amodel(
+  shared_ptr<Analytic_Opacity_Model> amodel(
       new Polynomial_Analytic_Opacity_Model(0.0, 100.0, -3.0, 0.0));
-  SP<Analytic_Opacity_Model> smodel(new Constant_Analytic_Opacity_Model(1.0));
+  shared_ptr<Analytic_Opacity_Model> smodel(new Constant_Analytic_Opacity_Model(1.0));
 
   if (!soft_equiv(amodel->calculate_opacity(2.0, 3.0, 4.0),
                   100.0 / (2.0 * 2.0 * 2.0)))
@@ -184,7 +180,7 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
   if (scattering->getDataDescriptor() != "Analytic Gray Scattering")
     ITFAILS;
   {
-    SP<const GrayOpacity> total(
+    shared_ptr<const GrayOpacity> total(
         new const Analytic_Gray_Opacity(smodel, rtt_cdi::TOTAL));
 
     if (total->getDataDescriptor() != "Analytic Gray Total")
@@ -269,7 +265,7 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
   vector<char> packed;
   {
     // lets make two models
-    SP<Analytic_Opacity_Model> amodel(
+    shared_ptr<Analytic_Opacity_Model> amodel(
         new Polynomial_Analytic_Opacity_Model(0.0, 100.0, -3.0, 0.0));
 
     Analytic_Gray_Opacity absorption(amodel, rtt_cdi::ABSORPTION);
@@ -317,18 +313,18 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
 //---------------------------------------------------------------------------//
 
 void type_test(rtt_dsxx::UnitTest &ut) {
-  // make an analytic gray opacity that returns the total opacity for a
-  // constant model
+  // make an analytic gray opacity that returns the total opacity for a constant
+  // model
   const double constant_opacity = 5.0;
 
-  SP<Analytic_Opacity_Model> model(
+  shared_ptr<Analytic_Opacity_Model> model(
       new Constant_Analytic_Opacity_Model(constant_opacity));
 
-  SP<GrayOpacity> op(new Analytic_Gray_Opacity(model, rtt_cdi::TOTAL));
-  SP<Analytic_Gray_Opacity> opac;
+  shared_ptr<GrayOpacity> op(new Analytic_Gray_Opacity(model, rtt_cdi::TOTAL));
+  shared_ptr<Analytic_Gray_Opacity> opac;
 
   if (typeid(*op) == typeid(rtt_cdi_analytic::Analytic_Gray_Opacity)) {
-    PASSMSG("RTTI type info is correct for SP to GrayOpacity.");
+    PASSMSG("RTTI type info is correct for shared_ptr to GrayOpacity.");
     opac = dynamic_pointer_cast<Analytic_Gray_Opacity>(op);
   }
 
@@ -354,11 +350,11 @@ void type_test(rtt_dsxx::UnitTest &ut) {
 
 //---------------------------------------------------------------------------//
 void default_behavior_tests(rtt_dsxx::UnitTest &ut) {
-  // make an analytic gray opacity that returns the total opacity for a
-  // constant model
+  // make an analytic gray opacity that returns the total opacity for a constant
+  // model
   const double constant_opacity = 5.0;
 
-  SP<Analytic_Opacity_Model> model(
+  shared_ptr<Analytic_Opacity_Model> model(
       new Constant_Analytic_Opacity_Model(constant_opacity));
 
   Analytic_Gray_Opacity opac(model, rtt_cdi::TOTAL);

--- a/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
@@ -510,7 +510,7 @@ void pseudo_line_opacity_test(UnitTest &ut) {
 
   // continuum
   std::shared_ptr<Expression const> const continuum(
-    new Constant_Expression(1, 1.0));
+      new Constant_Expression(1, 1.0));
 
   Pseudo_Line_Analytic_Odfmg_Opacity model(groups, bands, rtt_cdi::ABSORPTION,
                                            continuum,

--- a/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
@@ -5,10 +5,7 @@
  * \date   Tue Nov 13 17:24:12 2001
  * \brief  Analytic_Odfmg_Opacity test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_analytic_test.hh"
@@ -19,7 +16,6 @@
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "parser/Constant_Expression.hh"
-
 #include <sstream>
 
 using namespace std;
@@ -73,7 +69,7 @@ void odfmg_test(UnitTest &ut) {
   bands[1] = 0.75;
   bands[2] = 1.0;
 
-  vector<SP<Analytic_Opacity_Model>> models(3);
+  vector<std::shared_ptr<Analytic_Opacity_Model>> models(3);
 
   // make a Marshak (user-defined) model for the first group
   models[0].reset(new rtt_cdi_analytic_test::Marshak_Model(100.0));
@@ -237,9 +233,9 @@ void odfmg_test(UnitTest &ut) {
   }
 
   // Test the get_Analytic_Model() member function.
-  SP<Analytic_Opacity_Model const> my_mg_opacity_model =
+  std::shared_ptr<Analytic_Opacity_Model const> my_mg_opacity_model =
       opacity.get_Analytic_Model(1);
-  SP<Analytic_Opacity_Model const> expected_model(models[0]);
+  std::shared_ptr<Analytic_Opacity_Model const> expected_model(models[0]);
 
   if (expected_model == my_mg_opacity_model)
     ut.passes(std::string("get_Analytic_Model() returned the expected") +
@@ -267,7 +263,7 @@ void test_CDI(UnitTest &ut) {
   bands[1] = 0.75;
   bands[2] = 1.0;
 
-  vector<SP<Analytic_Opacity_Model>> models(3);
+  vector<std::shared_ptr<Analytic_Opacity_Model>> models(3);
 
   // make a Marshak (user-defined) model for the first group
   models[0].reset(new rtt_cdi_analytic_test::Marshak_Model(100.0));
@@ -280,7 +276,7 @@ void test_CDI(UnitTest &ut) {
   models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
   // make an analytic multigroup opacity object for absorption
-  SP<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
+  std::shared_ptr<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
       groups, bands, models, rtt_cdi::ABSORPTION));
 
   // make a CDI object
@@ -352,7 +348,7 @@ void packing_test(UnitTest &ut) {
   bands[2] = 1.0;
 
   {
-    vector<SP<Analytic_Opacity_Model>> models(3);
+    vector<std::shared_ptr<Analytic_Opacity_Model>> models(3);
 
     // make a Polynomial model for the first group
     models[0].reset(new rtt_cdi_analytic::Polynomial_Analytic_Opacity_Model(
@@ -366,7 +362,7 @@ void packing_test(UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    SP<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
+    std::shared_ptr<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
         groups, bands, models, rtt_cdi::ABSORPTION));
 
     // pack it
@@ -458,7 +454,7 @@ void packing_test(UnitTest &ut) {
   // make sure we catch an assertion showing that we cannot unpack an
   // unregistered opacity
   {
-    vector<SP<Analytic_Opacity_Model>> models(3);
+    vector<std::shared_ptr<Analytic_Opacity_Model>> models(3);
 
     // make a Marshak (user-defined) model for the first group
     models[0].reset(new rtt_cdi_analytic_test::Marshak_Model(100.0));
@@ -471,7 +467,7 @@ void packing_test(UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    SP<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
+    std::shared_ptr<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
         groups, bands, models, rtt_cdi::ABSORPTION));
 
     packed = odfmg->pack();
@@ -513,7 +509,8 @@ void pseudo_line_opacity_test(UnitTest &ut) {
   unsigned const bands_per_group = bands.size() - 1;
 
   // continuum
-  SP<Expression const> const continuum(new Constant_Expression(1, 1.0));
+  std::shared_ptr<Expression const> const continuum(
+    new Constant_Expression(1, 1.0));
 
   Pseudo_Line_Analytic_Odfmg_Opacity model(groups, bands, rtt_cdi::ABSORPTION,
                                            continuum,

--- a/src/cdi_analytic/test/tstPseudo_Line_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/test/tstPseudo_Line_Analytic_MultigroupOpacity.cc
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \date   Tue Apr  5 09:01:03 2011
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
@@ -40,9 +37,7 @@ void tstPseudo_Line_Analytic_MultigroupOpacity(UnitTest &ut) {
   int const number_of_edges = 10;
   unsigned seed = 1;
 
-  //    SP<Expression const> const continuum(new Constant_Expression(1,1.0e-2));;
-
-  SP<Expression const> continuum;
+  std::shared_ptr<Expression const> continuum;
   {
     map<string, pair<unsigned, Unit>> variables;
     variables["x"] = pair<unsigned, Unit>(0, raw);

--- a/src/cdi_analytic/test/tstnGray_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/test/tstnGray_Analytic_MultigroupOpacity.cc
@@ -13,8 +13,8 @@
 #include "cdi_analytic/nGray_Analytic_MultigroupOpacity.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
-#include <sstream>
 #include <memory>
+#include <sstream>
 
 using namespace std;
 

--- a/src/cdi_analytic/test/tstnGray_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/test/tstnGray_Analytic_MultigroupOpacity.cc
@@ -5,19 +5,16 @@
  * \date   Tue Nov 13 17:24:12 2001
  * \brief  nGray_Analytic_MultigroupOpacity test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_analytic_test.hh"
 #include "cdi/CDI.hh"
 #include "cdi_analytic/nGray_Analytic_MultigroupOpacity.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include <sstream>
+#include <memory>
 
 using namespace std;
 
@@ -27,7 +24,6 @@ using rtt_cdi_analytic::Constant_Analytic_Opacity_Model;
 using rtt_cdi_analytic::Polynomial_Analytic_Opacity_Model;
 using rtt_cdi::CDI;
 using rtt_cdi::MultigroupOpacity;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -44,7 +40,7 @@ void multigroup_test(rtt_dsxx::UnitTest &ut) {
     groups[3] = 50.0;
   }
 
-  vector<SP<Analytic_Opacity_Model>> models(3);
+  vector<shared_ptr<Analytic_Opacity_Model>> models(3);
 
   // make a Marshak (user-defined) model for the first group
   models[0].reset(new rtt_cdi_analytic_test::Marshak_Model(100.0));
@@ -173,9 +169,9 @@ void multigroup_test(rtt_dsxx::UnitTest &ut) {
 
   // Test the get_Analytic_Model() member function.
   {
-    SP<Analytic_Opacity_Model const> my_mg_opacity_model =
+    shared_ptr<Analytic_Opacity_Model const> my_mg_opacity_model =
         opacity.get_Analytic_Model(1);
-    SP<Analytic_Opacity_Model const> expected_model(models[0]);
+    shared_ptr<Analytic_Opacity_Model const> expected_model(models[0]);
 
     if (expected_model == my_mg_opacity_model)
       PASSMSG("get_Analytic_Model() returned the expected MG Opacity model.");
@@ -199,7 +195,7 @@ void test_CDI(rtt_dsxx::UnitTest &ut) {
     groups[3] = 50.0;
   }
 
-  vector<SP<Analytic_Opacity_Model>> models(3);
+  vector<shared_ptr<Analytic_Opacity_Model>> models(3);
 
   // make a Marshak (user-defined) model for the first group
   models[0].reset(new rtt_cdi_analytic_test::Marshak_Model(100.0));
@@ -212,7 +208,7 @@ void test_CDI(rtt_dsxx::UnitTest &ut) {
   models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
   // make an analytic multigroup opacity object for absorption
-  SP<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
+  shared_ptr<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
       groups, models, rtt_cdi::ABSORPTION));
 
   // make a CDI object
@@ -270,7 +266,7 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
   }
 
   {
-    vector<SP<Analytic_Opacity_Model>> models(3);
+    vector<shared_ptr<Analytic_Opacity_Model>> models(3);
 
     // make a Polynomial model for the first group
     models[0].reset(new rtt_cdi_analytic::Polynomial_Analytic_Opacity_Model(
@@ -284,7 +280,7 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    SP<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
+    shared_ptr<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
         groups, models, rtt_cdi::ABSORPTION));
 
     // pack it
@@ -363,7 +359,7 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
   // make sure we catch an assertion showing that we cannot unpack an
   // unregistered opacity
   {
-    vector<SP<Analytic_Opacity_Model>> models(3);
+    vector<shared_ptr<Analytic_Opacity_Model>> models(3);
 
     // make a Marshak (user-defined) model for the first group
     models[0].reset(new rtt_cdi_analytic_test::Marshak_Model(100.0));
@@ -376,7 +372,7 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    SP<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
+    shared_ptr<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
         groups, models, rtt_cdi::ABSORPTION));
 
     packed = mg->pack();

--- a/src/cdi_eospac/QueryEospac.cc
+++ b/src/cdi_eospac/QueryEospac.cc
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstdlib> // defines atoi
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -73,7 +74,7 @@ void query_eospac() {
     }
 
     // Generate EOS Table
-    rtt_dsxx::SP<rtt_cdi_eospac::Eospac const> spEospac(
+    std::shared_ptr<rtt_cdi_eospac::Eospac const> spEospac(
         new rtt_cdi_eospac::Eospac(SesameTab));
 
     // Parameters

--- a/src/cdi_eospac/QueryEospac.cc
+++ b/src/cdi_eospac/QueryEospac.cc
@@ -5,10 +5,7 @@
  * \date   Friday, Nov 09, 2012, 13:02 pm
  * \brief  An interactive program for querying data from EOSPAC.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: tEospac.cc 6822 2012-10-12 22:56:00Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Eospac.hh"
@@ -16,9 +13,7 @@
 #include "SesameTables.hh"
 #include "ds++/Assert.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/XGetopt.hh"
-
 #include <cmath>
 #include <cstdlib> // defines atoi
 #include <iostream>

--- a/src/cdi_eospac/doc/cdi_eospac.tex
+++ b/src/cdi_eospac/doc/cdi_eospac.tex
@@ -1,5 +1,5 @@
 %%---------------------------------------------------------------------------%%
-%% 
+%%
 %% \file    draco/src/cdi_eospac/doc/cdi_eospac.tex
 %% \author  Kelly Thompson
 %% \date    Thu Apr 26 14:49:28 MST 2001
@@ -54,7 +54,7 @@
     {\end{quote}\end{quote}}
 
 \newenvironment{codeExample}
-{\footnotesize 
+{\footnotesize
   \VerbatimEnvironment
   \begin{SaveVerbatim}{\mycode}}%
   {\end{SaveVerbatim}%
@@ -89,12 +89,12 @@
 %-------OPTIONS
 %\reference{NPB Star Reimbursable Project}
 %\thru{P. D. Soran, XTM, MS B226}
-%\enc{list}      
+%\enc{list}
 %\attachments{list}
 %\cy{list}
 %\encas
 %\attachmentas
-%\attachmentsas 
+%\attachmentsas
 %-------OPTIONS
 
 %%---------------------------------------------------------------------------%%
@@ -103,38 +103,38 @@
 
 \distribution {
   CCS-4 MS D409:\\
-  Group Leader:  J.E. Morel, X-6 MS D409\\ 
+  Group Leader:  J.E. Morel, X-6 MS D409\\
 %  B.T. Adams, X-6 MS D409\\
-%  R.E. Alcouffe, X-6 MS D409\\ 
+%  R.E. Alcouffe, X-6 MS D409\\
 %  M.L. Alme, X-6 MS D409\\
-  D.G. Archuleta, X-6 MS D409\\ 
-%  R.S. Baker, X-6 MS D409\\ 
-%  F.W. Brinkley, Jr., X-6 MS D409\\ 
-%  J.A. Dahl, X-6 MS D409\\ 
-%  F.H. Dang, X-6 MS D409\\ 
-  T.M. Evans, X-6 MS D409\\ 
-%  S.A. Gallegos, X-6 MS D409\\ 
-%  B.D. Ganapol, X-6 MS D409\\ 
-  M.G. Gray, X-6 MS D409\\ 
-%  J.C. Gulick, X-6 MS D409\\ 
-%  M.L. Hall, X-6 MS D409\\ 
+  D.G. Archuleta, X-6 MS D409\\
+%  R.S. Baker, X-6 MS D409\\
+%  F.W. Brinkley, Jr., X-6 MS D409\\
+%  J.A. Dahl, X-6 MS D409\\
+%  F.H. Dang, X-6 MS D409\\
+  T.M. Evans, X-6 MS D409\\
+%  S.A. Gallegos, X-6 MS D409\\
+%  B.D. Ganapol, X-6 MS D409\\
+  M.G. Gray, X-6 MS D409\\
+%  J.C. Gulick, X-6 MS D409\\
+%  M.L. Hall, X-6 MS D409\\
 %  W.D. Hawkins, X-6 MS D409\\
-  H.G. Hughes, X-6 MS D409\\ 
+  H.G. Hughes, X-6 MS D409\\
 % M.A. Hunter, X-6 \\
- H. Lichtenstein, X-6 MS D409\\ 
-% D.R. Marr, X-6 MS D409\\ 
-  J.M. McGhee, X-6 MS D409\\ 
-%  D. Mihalas, X-6 MS D409\\ 
-%  M.L. Murillo, X-6 MS D409\\ 
-  G.L. Olson, X-6 MS D409\\ 
-  S. Pautz, X-6 MS D409\\ 
-%  A.K. Prinja, X-6\\ 
-%  E.W. Qarsen, X-6 MS D409\\ 
-  R.M. Roberts, X-6 MS D409\\ 
+ H. Lichtenstein, X-6 MS D409\\
+% D.R. Marr, X-6 MS D409\\
+  J.M. McGhee, X-6 MS D409\\
+%  D. Mihalas, X-6 MS D409\\
+%  M.L. Murillo, X-6 MS D409\\
+  G.L. Olson, X-6 MS D409\\
+  S. Pautz, X-6 MS D409\\
+%  A.K. Prinja, X-6\\
+%  E.W. Qarsen, X-6 MS D409\\
+  R.M. Roberts, X-6 MS D409\\
   K.G. Thompson, X-6 MS D409\\
-%  S.A. Turner, X-6 MS D409\\ 
-%  W.T. Urban, X-6 MS D409\\ 
-  T.J. Urbatsch, X-6 MS D409\\ 
+%  S.A. Turner, X-6 MS D409\\
+%  W.T. Urban, X-6 MS D409\\
+  T.J. Urbatsch, X-6 MS D409\\
 %  T.A. Wareing, X-6 MS D409\\
   J.S. Warsa, X-6 MS D409\\
 }
@@ -152,7 +152,7 @@
 \section{Introduction}
 \label{intro}
 
-The \texttt{cdi\_eospac} package has been introduced into the \draco\ 
+The \texttt{cdi\_eospac} package has been introduced into the \draco\
 project to provide a solution to two issues.  First, it provides a C++
 object based interface to LANL's Sesame Tables (equation of state)
 data.  These data tables have been produced by Thoeretical Division's
@@ -163,7 +163,7 @@ components that make up the \texttt{cdi\_eospac} package are shown
 below in Table~\ref{tab:components}.
 
 This initial release of the \texttt{cdi\_eospac} package only provides
-access to the following types of EOSPAC data: 
+access to the following types of EOSPAC data:
 
 \begin{itemize}
 \item Temperature-based specific electron internal energy (kJ/g).
@@ -178,7 +178,7 @@ This list of available queries will expand to include more data types.
 Additionally, this package has only been tested for the IRIX64 64-bit
 architecture.  Versions for Linux, SunOS, Tru64 and 32-bit IRIX64 will
 be released shortly.
-      
+
 % h - here, t - top, p - page
 \begin{table}[!ht]
 %  \begin{quote}
@@ -188,31 +188,31 @@ be released shortly.
   \label{tab:components}
 %  \end{quote}
   \footnotesize
-  
+
     \begin{center}
       \newcolumntype{Y}{>{\raggedleft\setlength{\hsize}{0.3\linewidth}\arraybackslash}X}
       \newcolumntype{Z}{>{\raggedright\setlength{\hsize}{0.7\linewidth}\arraybackslash}X}
                                 %    \begin{tabularx}{\linewidth}{YZ}
       \begin{tabularx}{0.8\linewidth}{YZ}
-        \multicolumn{1}{c}{\textbf{Class}} & \multicolumn{1}{c}{\textbf{Role}} \\ 
-        
+        \multicolumn{1}{c}{\textbf{Class}} & \multicolumn{1}{c}{\textbf{Role}} \\
+
         \hline
         \\
-        
+
         \textbf{SesameTables}    & Provides a map between the available
                                    EOSPAC data types that may be
                                    returned by the library and numeric
                                    material identifiers. \\
         \\
-        \textbf{Eospac}          & Provides access to equation of state 
+        \textbf{Eospac}          & Provides access to equation of state
                                    data for a single material whose
                                    properties are defined by
-                                   \bf{SesameTables}.\\ 
+                                   \bf{SesameTables}.\\
         \\
         \textbf{EospacWrapper}   & Provides C++ style access to the
                                    EOSPAC library functions ensuring
-                                   correct data type translation. \\ 
-        \\                                  
+                                   correct data type translation. \\
+        \\
         \textbf{EospacException} & Provides detailed information about
                                    and handle any exception thrown by
                                    the EOSPAC wrapper or library. \\
@@ -225,14 +225,14 @@ The \texttt{cdi\_eospac} package may be used as a stand-alone package;
 however, it has been designed as a plug-in component for CDI.  Because
 of this, its design follows the interface defined by the CDI package.
 In particular, \texttt{cdi\_eospac} offers no mechanism for mixing
-materials.  The only mixtures that it can utilize are those included 
-in the Sesame data tables provided by T-1 (e.g.: water). 
+materials.  The only mixtures that it can utilize are those included
+in the Sesame data tables provided by T-1 (e.g.: water).
 
 This package provides a wrapper to data access libraries written,
 supported and provided by X-division's data team
 (EOSPAC~\cite{eospac-cranfill,eospac-web-site}).  Because this wrapper
 interacts directly with the Sesame libraries it will only function on
-machines that have these libraries available locally. The \draco\ 
+machines that have these libraries available locally. The \draco\
 project keeps a copy of the EOSPAC libraries for revision control
 purposes.  The EOSPAC libraries are located at
 \url{/radtran/vendors/eospac}.  The \draco\ project does not keep a
@@ -287,20 +287,20 @@ main()
 {
   // Create a SesameTables object for Aluminum.
   // Must still assign material identifiers to one or more EOSPAC data types.
-  
+
   rtt_cdi_eospac::SesameTables AlSt;
-  
-  // This matID for Al has lookup tables for enelc. 
+
+  // This matID for Al has lookup tables for enelc.
   // Al has id=371 and this is table=7 for data category=0.
 
   const int Al3717 = 3717;
-  
-  // This matId for Al has has lookup tables for zfree3.  
+
+  // This matId for Al has has lookup tables for zfree3.
   // Al has id=371, this is table=4 for data category=2.
-  
+
   const int Al23714 = 23714;
 
- // Give the requested data types to AlSt and their associated material 
+ // Give the requested data types to AlSt and their associated material
  // identifiers (both for Al).
 
   AlSt.enelc( Al3717 ).zfree3( Al23714 );
@@ -313,11 +313,11 @@ main()
 \begin{table}[!ht]
   \setcaptionwidth{0.9\textwidth}
   \caption{EOSPAC provides access to 36 equation of state lookup
-    tables.  These fall into three table categories.  These tables can 
+    tables.  These fall into three table categories.  These tables can
     also be queried for derivative information.}
   \label{tab:SesameDataTypes}
   \footnotesize
-  
+
     \begin{center}
       \newcolumntype{C}{>{\centering\setlength{\hsize}{0.1\linewidth}\arraybackslash}X}
       \newcolumntype{D}{>{\centering\setlength{\hsize}{0.15\linewidth}\arraybackslash}X}
@@ -328,9 +328,9 @@ main()
 %        \multicolumn{1}{c}{\textbf{Data Type}} &
 %        \multicolumn{1}{c}{\textbf{Sesame Catalog Number}} &
 %        \multicolumn{1}{c}{\textbf{Table Category}} &
-%        \multicolumn{1}{l}{\textbf{Description}} \\ 
-        
-        \textbf{Data Type} & 
+%        \multicolumn{1}{l}{\textbf{Description}} \\
+
+        \textbf{Data Type} &
         \textbf{Sesame Catalog Number} &
         \textbf{Table Category} &
         \multicolumn{1}{c}{\textbf{Description}}
@@ -338,7 +338,7 @@ main()
         \\
         \hline
         \\
-        
+
         \textbf{prtot} & 301 & 0 & Temperature-based total pressure\\
         \textbf{entot} & 301 & 0 & Temperature-based total internal energy/mass\\
         \textbf{tptot} & 301 & 0 & Pressure-based total temperature\\
@@ -346,59 +346,59 @@ main()
 
         \textbf{pntot} & 301 & 0 & Energy-based total pressure\\
         \textbf{eptot} & 301 & 0 & Pressure-based total internal energy/mass\\
-            
+
 %            // Sesame Catalog 303 entries:
-            
+
         \textbf{prion} & 303 & 0 & Temperature-based ion pressure\\
         \textbf{enion} & 303 & 0 & Temperature-based ion internal energy/mass\\
         \textbf{tpion} & 303 & 0 & pressure-based ion temperature\\
         \textbf{tnion} & 303 & 0 & energy-based ion temperature\\
         \textbf{pnion} & 303 & 0 & energy-based ion pressure\\
         \textbf{epion} & 303 & 0 & pressure-based ion internal energy/mass\\
-            
+
 %            // Sesame Catalog 304 entries:
-            
+
         \textbf{prelc} & 304 & 0 & Temperature-based electron pressure\\
         \textbf{enelc} & 304 & 0 & Temperature-based electron internal energy/mass\\
         \textbf{tpelc} & 304 & 0 & Pressure-based electron temperature\\
         \textbf{tnelc} & 304 & 0 & Energy-based electron temperature\\
         \textbf{pnelc} & 304 & 0 & Energy-based electron pressure\\
         \textbf{epelc} & 304 & 0 & Pressure-based electron internal energy/mass\\
-          
+
 %            // Sesame Catalog 306 entries:
-            
+
         \textbf{prcld} & 306 & 0 & Temperature-based cold curve pressure\\
         \textbf{encld} & 306 & 0 & Temperature-based cold curve internal energy/mass\\
-            
+
 %            // Sesame Catalogs 502-505
-            
+
             \textbf{opacr}  & 502 & 1 & Temperature-based Rosseland mean opacity\\
             \textbf{opacc2} & 503 & 1 & Temperature-based electron conductive opacity\\
             \textbf{zfree2} & 504 & 1 & Temperature-based number of free electrons per ion\\
             \textbf{opacp}  & 505 & 1 & Temperature-based Planck mean opacity\\
-            
+
 %            // Sesame Catalogs 601-605
-            
+
             \textbf{zfree3} & 601 & 2 & Temperature-based number of free electrons per ion\\
             \textbf{econde} & 602 & 2 & Temperature-based electron electrical conductivity\\
             \textbf{tconde} & 603 & 2 & Temperature-based electron thermal conductivity\\
             \textbf{therme} & 604 & 2 & Temperature-based electron thermo-electric coef\\
             \textbf{opacc3} & 605 & 2 & Temperature-based electron conductive opacity\\
-            
+
 %            // Sesame Catalog 411
-            
+
             \textbf{tmelt} & 411 & 3 & Temperature-based melting temperature\\
             \textbf{pmelt} & 411 & 3 & Temperature-based melting pressure\\
             \textbf{emelt} & 411 & 3 & Temperature-based melting internal energy/mass\\
-            
+
 %            // Sesame Catalog 412
-            
+
             \textbf{tfreez} & 412 & 3 & Temperature-based freezing temperature\\
             \textbf{pfreez} & 412 & 3 & Temperature-based freezing pressure\\
             \textbf{efreez} & 412 & 3 & Temperature-based freezing internal energy/mass\\
-            
+
 %            // Sesame Catalog 431
-            
+
             \textbf{shearm} & 431 & 3 & Temperature-based shear modulus\\
 
     \end{tabularx}
@@ -449,11 +449,11 @@ data types listed in \S\ref{intro} (\texttt{enelc}, \texttt{enion},
 package will provide access all of the data types that EOSPAC knows
 about.
 
-In some situations a SesameTables object will only be used once and so 
+In some situations a SesameTables object will only be used once and so
 an explicit instantiation may not be required.  The SesameTables
 object can be a temporary that is passed as an argument to the Eospac
 contructor.  An example of this usage is shown below in Code Example
-\ref{codeExample:EospacInstantiation}. 
+\ref{codeExample:EospacInstantiation}.
 
 
 
@@ -467,7 +467,7 @@ The Eospac object provides access to \emph{Equation of State} data
 found in the Sesame Tables (\texttt{sesame}, \texttt{sescu},
 \texttt{sescu1}, \texttt{sescu9} and \texttt{sesou}) that are
 available on the ACL (\url{/usr/projects/data}) and X-Division
-(\url{/usr/local/codes/data}) networks.  
+(\url{/usr/local/codes/data}) networks.
 
 An Eospac object represents a \emph{single} material that is defined
 by a SesameTables object.  Please refer to the previous section
@@ -500,26 +500,25 @@ available in EOSPAC.
 \begin{codeExample}
 #inlcude "cdi_eospac/SesameTables.hh"
 #inlcude "cdi_eospac/Eospac.hh"
-#inlcude "ds++/SP.hh"
 
 main()
 {
-  // An Eospac object allows the user to access EoS information about a material that has been 
-  // constructed in a SesameTable object.  The constructor for Eospac takes one argument: a 
+  // An Eospac object allows the user to access EoS information about a material that has been
+  // constructed in a SesameTable object.  The constructor for Eospac takes one argument: a
   // SesameTables object.
-  
-  rtt_dsxx::SP< rtt_cdi_eospac::Eospac > spAlEospac;
+
+  std::shared_ptr< rtt_cdi_eospac::Eospac > spAlEospac;
 
   // See the previous code example for a description of these two const values.
 
   const int Al3717  = 3717; const int Al23714 = 23714;
 
   // Try to instantiate the new Eospac object.  Simultaneously, we are assigned material IDs to
-  // more SesameTable values.    
-  
-  spAlEospac = new 
+  // more SesameTable values.
+
+  spAlEospac = new
     rtt_cdi_eospac::Eospac( rtt_cdi_eospac::SesameTables().enion( Al3717 ).tconde( Al23714 ) ) );
- } 
+ }
 \end{codeExample}
 \caption{Example of instantiating an Eospac object.}
 \label{codeExample:EospacInstantiation}
@@ -539,7 +538,7 @@ smart pointer to an Eospac object and then intantiate the Eospac
 object.  The single argument provided to the Eospac constructor is a
 SesameTables object generated \emph{on-the-fly}.  The user can also
 choose to create a presistent SesameTables object as demonstrated in
-Code Example~\ref{codeExample:SesameTablesInstantiation}.  This object 
+Code Example~\ref{codeExample:SesameTablesInstantiation}.  This object
 represents the material Al (material 371) and has cached the data
 tables required accessing information about thermal conductivity and
 specific ion internal energy (and specific ion heat capacity, $C_{v_i} =
@@ -582,13 +581,13 @@ type is a \texttt{vector< double >}.
     \caption{Eospac scalar member functions.}
     \label{tab:accessFunctions}
     \footnotesize
-    
+
     \begin{center}
       \newcolumntype{Y}{>{\raggedright\setlength{\hsize}{0.5\linewidth}\arraybackslash}X}
       \newcolumntype{Z}{>{\raggedright\setlength{\hsize}{0.5\linewidth}\arraybackslash}X}
       \begin{tabularx}{0.9\linewidth}{YZ}
-        \multicolumn{1}{c}{\textbf{Eospac Member Functions}} & \multicolumn{1}{c}{\textbf{Role}} \\ 
-        
+        \multicolumn{1}{c}{\textbf{Eospac Member Functions}} & \multicolumn{1}{c}{\textbf{Role}} \\
+
         \hline
         \\
 \texttt{double~getSpecificElectronInternalEnergy(}
@@ -599,7 +598,7 @@ type is a \texttt{vector< double >}.
 &  Requires \texttt{enelc}. \\
 \\
 \texttt{double~getElectronHeatCapacity(}
-\texttt{\mbox{ double~temp,}} 
+\texttt{\mbox{ double~temp,}}
 \texttt{\mbox{ double~density)}}
 & Given the temperature (keV) and density(g/$cm^3$) information, return a bi-linearly
   interpolated specific electron heat capacity value (kJ/g/keV).\\
@@ -613,7 +612,7 @@ type is a \texttt{vector< double >}.
 &  Requires \texttt{enion}. \\
 \\
 \texttt{double~getIonHeatCapacity(}
-\texttt{\mbox{ double~temp,}} 
+\texttt{\mbox{ double~temp,}}
 \texttt{\mbox{ double~density)}}
 & Given the temperature (keV) and density(g/$cm^3$) information, return a bi-linearly
   interpolated specific ion heat capacity value (kJ/g/keV).\\
@@ -627,7 +626,7 @@ type is a \texttt{vector< double >}.
 &  Requires \texttt{zfree3}. \\
 \\
 \texttt{double~getElectronThermalConductivity(}
-\texttt{\mbox{ double~temp,}} 
+\texttt{\mbox{ double~temp,}}
 \texttt{\mbox{ double~density)}}
 & Given the temperature (keV) and density(g/$cm^3$) information, return a bi-linearly
   interpolated electron thermal conductivity ($cm^{-1}s^{-1}$).\\
@@ -637,7 +636,7 @@ type is a \texttt{vector< double >}.
     \end{center}
     \normalsize
 \end{table}
-  
+
 %In Addition to these \emph{standard} access functions, both
 %GandolfOpacity objects have STL-like accessor routines.  These
 %accessors can be used if the desired opacity container is not a
@@ -655,7 +654,6 @@ the \texttt{tEospac.cc} and \texttt{tEospacWithCDI.cc} unit tests.
 #include "cdi_eospac/Eospac.hh"
 #include "cdi_eospac/SesameTables.hh"
 #include "cdi/CDI.hh"
-#include "ds++/SP.hh"
 
 main()
 {
@@ -664,23 +662,23 @@ main()
   const int Al3717 = 3717;
   const int Al23714 = 23714;
 
-  // Declare a smart pointer to Eospac.  Eospac is derived from the interface defined by 
+  // Declare a smart pointer to Eospac.  Eospac is derived from the interface defined by
   // rtt_cdi:EoS.
 
-   rtt_dsxx::SP< rtt_cdi::EoS > spEosAl;
-        
-   // Use a try block when instantiating the Eospac object so that we can catch any thrown 
+   std::shared_ptr< rtt_cdi::EoS > spEosAl;
+
+   // Use a try block when instantiating the Eospac object so that we can catch any thrown
    // exceptions.
 
    try
       {
 
-        // Create the SesameTables object within the instantiation request.  Request enelc 
-        // (electron heat capacity) and tconde (electron thermal conductivity) data for Al 
+        // Create the SesameTables object within the instantiation request.  Request enelc
+        // (electron heat capacity) and tconde (electron thermal conductivity) data for Al
         // to be cached.
 
-         spEosAl = new 
-            rtt_cdi_eospac::Eospac( 
+         spEosAl = new
+            rtt_cdi_eospac::Eospac(
                SesameTables().enelc( Al3717 ).tconde( Al23714 ) );
       }
    catch ( const rtt_cdi_eospac:EospacException& EosError )
@@ -709,7 +707,7 @@ main()
 \begin{codeExample}
    // continued from above ...
 
-   // Interpolate and return a heat capacity value (kJ/g/keV) for Al at (temp, dens).  
+   // Interpolate and return a heat capacity value (kJ/g/keV) for Al at (temp, dens).
 
    double Cve = spEosAl->getElectronHeatCapacity( temp, dens );
 

--- a/src/cdi_eospac/test/tEospac.cc
+++ b/src/cdi_eospac/test/tEospac.cc
@@ -111,9 +111,9 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
       new rtt_cdi_eospac::Eospac(AlSt.Ue_DT(Al3717).Zfc_DT(Al23714)));
 
   if (spEospac) {
-    PASSMSG("SP to new Eospac object created.");
+    PASSMSG("shared_ptr to new Eospac object created.");
   } else {
-    FAILMSG("Unable to create SP to new Eospac object.");
+    FAILMSG("Unable to create shared_ptr to new Eospac object.");
 
     // if construction fails, there is no reason to continue testing...
     return;
@@ -141,9 +141,9 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   //             ).Uic_DT( Al3717 ).Ktc_DT( Al23714 ) );
 
   //     if ( spEospacAlt )
-  //         PASSMSG("SP to new Eospac object created (Alternate ctor).");
+  //         PASSMSG("shared_ptr to new Eospac object created (Alternate ctor).");
   //     else
-  //         FAILMSG("Unable to create SP to new Eospac object (Alternate ctor).");
+  //         FAILMSG("Unable to create shared_ptr to new Eospac object (Alternate ctor).");
   // }
 
   // --------------------------- //

--- a/src/cdi_eospac/test/tEospac.cc
+++ b/src/cdi_eospac/test/tEospac.cc
@@ -5,25 +5,19 @@
  * \date   Mon Apr 2 14:20:14 2001
  * \brief  Implementation file for tEospac
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_eospac/Eospac.hh"
 #include "cdi_eospac/EospacException.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
-
 #include <iomanip>
 #include <sstream>
 
 namespace rtt_cdi_eospac_test {
 
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -108,7 +102,7 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   // material that has been constructed in a SesameTable object.  The
   // constructor for Eospac takes one argument: a SesameTables object.
 
-  rtt_dsxx::SP<rtt_cdi_eospac::Eospac const> spEospac;
+  std::shared_ptr<rtt_cdi_eospac::Eospac const> spEospac;
 
   // Try to instantiate the new Eospac object.  Simultaneously, we are
   // assigned material IDs to more SesameTable values.
@@ -141,7 +135,7 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   //     // can, instead, create a temporary version that is only used here in
   //     // the constructor of Eospac().
 
-  //     rtt_dsxx::SP< rtt_cdi_eospac::Eospac const > spEospacAlt;
+  //     std::shared_ptr< rtt_cdi_eospac::Eospac const > spEospacAlt;
   //     spEospacAlt = new rtt_cdi_eospac::Eospac(
   //         rtt_cdi_eospac::SesameTables().Ue_DT( Al3717 ).Zfc_DT( Al23714
   //             ).Uic_DT( Al3717 ).Ktc_DT( Al23714 ) );
@@ -394,7 +388,7 @@ void cdi_eospac_except_test(rtt_dsxx::UnitTest &ut) {
 
   // Generate an Eospac object
 
-  rtt_dsxx::SP<rtt_cdi_eospac::Eospac const> spEospac(
+  std::shared_ptr<rtt_cdi_eospac::Eospac const> spEospac(
       new rtt_cdi_eospac::Eospac(FeSt));
 
   // Print table information for Pt_DT:
@@ -454,7 +448,7 @@ void cdi_eospac_tpack(rtt_dsxx::UnitTest &ut) {
   int const Al23714 = 23714;
   rtt_cdi_eospac::SesameTables AlSt;
   AlSt.Uic_DT(Al3717).Ktc_DT(Al23714).Ue_DT(Al3717).Zfc_DT(Al23714);
-  rtt_dsxx::SP<rtt_cdi_eospac::Eospac const> spEospac(
+  std::shared_ptr<rtt_cdi_eospac::Eospac const> spEospac(
       new rtt_cdi_eospac::Eospac(AlSt));
 
   {
@@ -479,7 +473,7 @@ void cdi_eospac_tpack(rtt_dsxx::UnitTest &ut) {
 
     // Create a new Eospac by unpacking the packed data.
     std::cout << "Unpacking an Eospac object." << std::endl;
-    rtt_dsxx::SP<rtt_cdi_eospac::Eospac const> spUnpacked_Eospac(
+    std::shared_ptr<rtt_cdi_eospac::Eospac const> spUnpacked_Eospac(
         new rtt_cdi_eospac::Eospac(packed));
 
     // Sanity Check

--- a/src/cdi_eospac/test/tEospacWithCDI.cc
+++ b/src/cdi_eospac/test/tEospacWithCDI.cc
@@ -114,9 +114,9 @@ void eospac_with_cdi_test(rtt_dsxx::UnitTest &ut) {
           new const rtt_cdi_eospac::Eospac(AlSt.Ue_DT(Al3717).Zfc_DT(Al23714))),
       spEospac)
 
-    PASSMSG("SP to new Eospac object created.");
+    PASSMSG("shared_ptr to new Eospac object created.");
   else {
-    FAILMSG("Unable to create SP to new Eospac object.");
+    FAILMSG("Unable to create shared_ptr to new Eospac object.");
 
     // if construction fails, there is no reason to continue testing...
     return;
@@ -144,9 +144,9 @@ void eospac_with_cdi_test(rtt_dsxx::UnitTest &ut) {
   //             ).Uic_DT( Al3717 ).Ktc_DT( Al23714 ) );
 
   //     if ( spEospacAlt )
-  //         PASSMSG("SP to new Eospac object created (Alternate ctor).");
+  //         PASSMSG("shared_ptr to new Eospac object created (Alternate ctor).");
   //     else
-  //         FAILMSG("Unable to create SP to new Eospac object (Alternate ctor).");
+  //         FAILMSG("Unable to create shared_ptr to new Eospac object (Alternate ctor).");
   // }
 
   // ------------------- //
@@ -155,9 +155,9 @@ void eospac_with_cdi_test(rtt_dsxx::UnitTest &ut) {
 
   std::shared_ptr<rtt_cdi::CDI> spCdiEos;
   if (spCdiEos.reset(new rtt_cdi::CDI()), spCdiEos)
-    PASSMSG("SP to CDI object created successfully.");
+    PASSMSG("shared_ptr to CDI object created successfully.");
   else
-    FAILMSG("Failed to create SP to CDI object.");
+    FAILMSG("Failed to create shared_ptr to CDI object.");
 
   // -------------------- //
   // Assign Eos to CDI    //

--- a/src/cdi_eospac/test/tEospacWithCDI.cc
+++ b/src/cdi_eospac/test/tEospacWithCDI.cc
@@ -5,10 +5,7 @@
  * \date   Thu Apr 19 11:00:24 2001
  * \brief  Implementation file for tEospacWithCDI
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi/CDI.hh"
@@ -16,10 +13,8 @@
 #include "cdi_eospac/EospacException.hh"
 #include "cdi_eospac/SesameTables.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
-
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -27,7 +22,6 @@
 using namespace std;
 
 namespace rtt_cdi_eospac_test {
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -111,7 +105,7 @@ void eospac_with_cdi_test(rtt_dsxx::UnitTest &ut) {
   // material that has been constructed in a SesameTable object.  The
   // constructor for Eospac takes one argument: a SesameTables object.
 
-  rtt_dsxx::SP<const rtt_cdi::EoS> spEospac;
+  std::shared_ptr<const rtt_cdi::EoS> spEospac;
 
   // Try to instantiate the new Eospac object.  Simultaneously, we are
   // assigned material IDs to more SesameTable values.
@@ -144,7 +138,7 @@ void eospac_with_cdi_test(rtt_dsxx::UnitTest &ut) {
   //     // can, instead, create a temporary version that is only used here in
   //     // the constructor of Eospac().
 
-  //     rtt_dsxx::SP< rtt_cdi_eospac::Eospac const > spEospacAlt;
+  //     std::shared_ptr< rtt_cdi_eospac::Eospac const > spEospacAlt;
   //     spEospacAlt = new rtt_cdi_eospac::Eospac(
   //         rtt_cdi_eospac::SesameTables().Ue_DT( Al3717 ).Zfc_DT( Al23714
   //             ).Uic_DT( Al3717 ).Ktc_DT( Al23714 ) );
@@ -159,7 +153,7 @@ void eospac_with_cdi_test(rtt_dsxx::UnitTest &ut) {
   // Create a CDI object //
   // ------------------- //
 
-  rtt_dsxx::SP<rtt_cdi::CDI> spCdiEos;
+  std::shared_ptr<rtt_cdi::CDI> spCdiEos;
   if (spCdiEos.reset(new rtt_cdi::CDI()), spCdiEos)
     PASSMSG("SP to CDI object created successfully.");
   else

--- a/src/cdi_ipcress/IpcressDataTable.cc
+++ b/src/cdi_ipcress/IpcressDataTable.cc
@@ -5,16 +5,12 @@
  * \date   Wednesday, Nov 16, 2011, 17:04 pm
  * \brief  Implementation file for IpcressDataTable objects.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include "IpcressDataTable.hh"  // the associated header file.
-#include "IpcressFile.hh"       // we have a SP to a GandofFile object.
-#include "cdi/OpacityCommon.hh" // defines Model and Reaction
-                                // enumerated values.
+#include "IpcressDataTable.hh"
+#include "IpcressFile.hh"
+#include "cdi/OpacityCommon.hh"
 #include "ds++/Assert.hh"
 #include <cmath> // we need to define log(double)
 
@@ -59,7 +55,7 @@ IpcressDataTable::IpcressDataTable(
     std::string const &in_opacityEnergyDescriptor,
     rtt_cdi::Model in_opacityModel, rtt_cdi::Reaction in_opacityReaction,
     std::vector<std::string> const &in_fieldNames, size_t in_matID,
-    rtt_dsxx::SP<const IpcressFile> const &spIpcressFile)
+    std::shared_ptr<const IpcressFile> const &spIpcressFile)
     : ipcressDataTypeKey(""), dataDescriptor(""),
       opacityEnergyDescriptor(in_opacityEnergyDescriptor),
       opacityModel(in_opacityModel), opacityReaction(in_opacityReaction),
@@ -68,10 +64,9 @@ IpcressDataTable::IpcressDataTable(
       logTemperatures(), temperatures(), logDensities(), densities(),
       groupBoundaries(), logOpacities() {
   // Obtain the Ipcress keyword for the opacity data type specified by the
-  // EnergyPolicy, opacityModel and the opacityReaction.  Valid keywords
-  // are: { ramg, rsmg, rtmg, pmg, rgray, ragray, rsgray, pgray } This
-  // function also ensures that the requested data type is available in the
-  // IPCRESS file.
+  // EnergyPolicy, opacityModel and the opacityReaction.  Valid keywords are: {
+  // ramg, rsmg, rtmg, pmg, rgray, ragray, rsgray, pgray } This function also
+  // ensures that the requested data type is available in the IPCRESS file.
   setIpcressDataTypeKey();
 
   // Retrieve the data set and resize the vector containers.
@@ -91,9 +86,9 @@ IpcressDataTable::IpcressDataTable(
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief This function sets both "ipcressDataTypeKey" and
- *     "dataDescriptor" based on the values given for
- *     opacityEnergyDescriptor, opacityModel and opacityReaction.
+ * \brief This function sets both "ipcressDataTypeKey" and "dataDescriptor"
+ *     based on the values given for opacityEnergyDescriptor, opacityModel and
+ *     opacityReaction.
  */
 void IpcressDataTable::setIpcressDataTypeKey() const {
   // Build the Ipcress key for the requested data.  Valid keys are: { ramg,
@@ -216,14 +211,14 @@ void IpcressDataTable::setIpcressDataTypeKey() const {
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Load the temperature, density, energy boundary and
- *     opacity opacity tables from the IPCRESS file.  Convert all
- *     tables (except energy boundaries) to log values.
+ * \brief Load the temperature, density, energy boundary and opacity opacity
+ *     tables from the IPCRESS file.  Convert all tables (except energy
+ *     boundaries) to log values.
  */
 void IpcressDataTable::loadDataTable(
-    rtt_dsxx::SP<const IpcressFile> const &spIpcressFile) {
-  // The interpolation routines expect everything to be in log form so we
-  // only store the logorithmic temperature, density and opacity data.
+    std::shared_ptr<const IpcressFile> const &spIpcressFile) {
+  // The interpolation routines expect everything to be in log form so we only
+  // store the logorithmic temperature, density and opacity data.
   logTemperatures.resize(temperatures.size());
   std::transform(temperatures.begin(), temperatures.end(),
                  logTemperatures.begin(), unary_log);
@@ -239,7 +234,7 @@ void IpcressDataTable::loadDataTable(
 }
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  * \brief This function returns "true" if "key" is found in the list
  *        of "keys".  This is a static member function.
  */
@@ -256,9 +251,9 @@ bool IpcressDataTable::key_available(T const &key,
 } // end of IpcressDataTable::key_available( string, vector<string> )
 
 //---------------------------------------------------------------------------//
-/*! 
- * \brief 
- * 
+/*!
+ * \brief
+ *
  * \param name description
  * \return description
  *

--- a/src/cdi_ipcress/IpcressDataTable.hh
+++ b/src/cdi_ipcress/IpcressDataTable.hh
@@ -103,7 +103,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressDataTable {
   //! The opacity data table.
   std::vector<double> mutable logOpacities;
 
-  public:
+public:
   // CREATORS
 
   /*!
@@ -183,7 +183,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressDataTable {
   double interpOpac(double const T, double const rho,
                     size_t const group = 0) const;
 
-  private:
+private:
   /*!
    * \brief This function sets both "ipcressDataTypeKey" and
    *     "dataDescriptor" based on the values given for
@@ -200,7 +200,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressDataTable {
 
   //! Search "keys" for "key".  If found return true, otherwise return false.
   template <typename T>
-    bool key_available(const T &key, const std::vector<T> &keys) const;
+  bool key_available(const T &key, const std::vector<T> &keys) const;
 };
 
 } // end namespace

--- a/src/cdi_ipcress/IpcressDataTable.hh
+++ b/src/cdi_ipcress/IpcressDataTable.hh
@@ -5,20 +5,15 @@
  * \date   Wednesday, Nov 16, 2011, 17:07 pm
  * \brief  Header file for IpcressDataTable
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_ipcress_IpcressDataTable_hh__
 #define __cdi_ipcress_IpcressDataTable_hh__
 
 #include "IpcressFile.hh"
-// We must include IpcressOpacity.hh so that the following two
-// enumerated items are defined: { Model, Reaction }
 #include "cdi/OpacityCommon.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_cdi_ipcress {
 
@@ -44,52 +39,52 @@ class DLL_PUBLIC_cdi_ipcress IpcressDataTable {
   // Data Descriptors:
 
   /*!
-     * \brief A string that specifies the type of data being stored.  Possible
-     *     values are rgray, ragray, rsgray, etc.  This key is provided to the
-     *     Ipcress libraries as a data specifier.
-     */
+   * \brief A string that specifies the type of data being stored.  Possible
+   *     values are rgray, ragray, rsgray, etc.  This key is provided to the
+   *     Ipcress libraries as a data specifier.
+   */
   std::string mutable ipcressDataTypeKey;
 
   /*!
-     * \brief A string that specifies the type of data being stored.  This
-     *     variables holds an English version of ipcressDataTypeKey.
-     */
+   * \brief A string that specifies the type of data being stored.  This
+   *     variables holds an English version of ipcressDataTypeKey.
+   */
   std::string mutable dataDescriptor;
 
   /*!
-     * \brief A string that specifies the energy model for the data being
-     *     stored.  Possible values are "mg" or "gray".
-     */
+   * \brief A string that specifies the energy model for the data being
+   *     stored.  Possible values are "mg" or "gray".
+   */
   std::string const opacityEnergyDescriptor;
 
   /*!
-     * \brief An enumerated value defined in IpcressOpacity.hh that specifies
-     *     the data model.  Possible values are "Rosseland" or "Plank".
-     */
+   * \brief An enumerated value defined in IpcressOpacity.hh that specifies
+   *     the data model.  Possible values are "Rosseland" or "Plank".
+   */
   rtt_cdi::Model const opacityModel;
 
   /*!
-     * \brief An enumerated valued defined in IpcressOpacity.hh that specifies
-     *     the reaction model.  Possible values are "Total", "Absorption" or
-     *     "Scattering".
-     */
+   * \brief An enumerated valued defined in IpcressOpacity.hh that specifies
+   *     the reaction model.  Possible values are "Total", "Absorption" or
+   *     "Scattering".
+   */
   rtt_cdi::Reaction const opacityReaction;
 
   //! A list of keys that are known by the IPCRESS file.
   std::vector<std::string> const &fieldNames;
 
   /*!
-     * \brief The IPCRESS material number assocated with the data contained in
-     *     this object.
-     */
+   * \brief The IPCRESS material number assocated with the data contained in
+   *     this object.
+   */
   size_t const matID;
 
   // Data Sizes:
 
   /*
-     * \brief The number of entries in the opacity table.  This should be
-     *     equal to numTemperatures * numDensities * (numGroupBoundaries - 1).
-     */
+   * \brief The number of entries in the opacity table.  This should be
+   *     equal to numTemperatures * numDensities * (numGroupBoundaries - 1).
+   */
   //size_t mutable numOpacities;
 
   // Data Tables:
@@ -108,46 +103,41 @@ class DLL_PUBLIC_cdi_ipcress IpcressDataTable {
   //! The opacity data table.
   std::vector<double> mutable logOpacities;
 
-public:
+  public:
   // CREATORS
 
   /*!
-     * \brief Standard IpcressDataTable constructor.
-     *
-     * The constructor requires that the data state to be completely defined.
-     *     With this information the DataTypeKey is set, then the data table
-     *     sizes are loaded and finally the table data is loaded.
-     *
-     * \param opacityEnergyDescriptor This string variable
-     *     specifies the energy model { "gray" or "mg" } for the
-     *     opacity data contained in this IpcressDataTable object.
-     * \param opacityModel This enumerated value specifies the
-     *     physics model { Rosseland or Plank } for the opacity data
-     *     contained in this object.  The enumeration is defined in
-     *     IpcressOpacity.hh
-     * \param opacityReaction This enumerated value specifies the
-     *     interaction model { total, scattering, absorption " for the
-     *     opacity data contained in this object.  The enumeration is
-     *     defined in IpcressOpacity.hh
-     * \param fieldNames This vector of strings is a list of
-     *     data keys that the IPCRESS file knows about.  This list is
-     *     read from the IPCRESS file when a IpcressOpacity object is
-     *     instantiated but before the associated IpcressDataTable
-     *     object is created.
-     * \param matID The material identifier that specifies a
-     *     particular material in the IPCRESS file to associate with
-     *     the IpcressDataTable container.
-     * \param spIpcressFile A DS++ SmartPointer to a IpcressFile
-     *     object.  One GanolfFile object should exist for each
-     *     IPCRESS file.  Many IpcressOpacity (and thus
-     *     IpcressDataTable) objects may point to the same IpcressFile
-     *     object.
-     */
+   * \brief Standard IpcressDataTable constructor.
+   *
+   * The constructor requires that the data state to be completely defined.
+   * With this information the DataTypeKey is set, then the data table sizes are
+   * loaded and finally the table data is loaded.
+   *
+   * \param opacityEnergyDescriptor This string variable specifies the energy
+   *     model { "gray" or "mg" } for the opacity data contained in this
+   *     IpcressDataTable object.
+   * \param opacityModel This enumerated value specifies the physics model {
+   *     Rosseland or Plank } for the opacity data contained in this object.
+   *     The enumeration is defined in IpcressOpacity.hh
+   * \param opacityReaction This enumerated value specifies the interaction
+   *     model { total, scattering, absorption " for the opacity data contained
+   *     in this object.  The enumeration is defined in IpcressOpacity.hh
+   * \param fieldNames This vector of strings is a list of data keys that the
+   *     IPCRESS file knows about.  This list is read from the IPCRESS file when
+   *     a IpcressOpacity object is instantiated but before the associated
+   *     IpcressDataTable object is created.
+   * \param matID The material identifier that specifies a particular material
+   *     in the IPCRESS file to associate with the IpcressDataTable container.
+   * \param spIpcressFile A DS++ SmartPointer to a IpcressFile object.  One
+   *     GanolfFile object should exist for each IPCRESS file.  Many
+   *     IpcressOpacity (and thus IpcressDataTable) objects may point to the
+   *     same IpcressFile object.
+   */
   IpcressDataTable(std::string const &opacityEnergyDescriptor,
                    rtt_cdi::Model opacityModel,
                    rtt_cdi::Reaction opacityReaction,
                    std::vector<std::string> const &fieldNames, size_t matID,
-                   rtt_dsxx::SP<const IpcressFile> const &spIpcressFile);
+                   std::shared_ptr<const IpcressFile> const &spIpcressFile);
 
   // ACCESSORS
 
@@ -193,24 +183,24 @@ public:
   double interpOpac(double const T, double const rho,
                     size_t const group = 0) const;
 
-private:
+  private:
   /*!
-     * \brief This function sets both "ipcressDataTypeKey" and
-     *     "dataDescriptor" based on the values given for
-     *     opacityEnergyDescriptor, opacityModel and opacityReaction.
-     */
+   * \brief This function sets both "ipcressDataTypeKey" and
+   *     "dataDescriptor" based on the values given for
+   *     opacityEnergyDescriptor, opacityModel and opacityReaction.
+   */
   void setIpcressDataTypeKey() const;
 
   /*!
-     * \brief Load the temperature, density, energy boundary and opacity
-     *     opacity tables from the IPCRESS file.  Convert all tables (except
-     *     energy boundaries) to log values.
-     */
-  void loadDataTable(rtt_dsxx::SP<const IpcressFile> const &spIpcressFile);
+   * \brief Load the temperature, density, energy boundary and opacity
+   *     opacity tables from the IPCRESS file.  Convert all tables (except
+   *     energy boundaries) to log values.
+   */
+  void loadDataTable(std::shared_ptr<const IpcressFile> const &spIpcressFile);
 
   //! Search "keys" for "key".  If found return true, otherwise return false.
   template <typename T>
-  bool key_available(const T &key, const std::vector<T> &keys) const;
+    bool key_available(const T &key, const std::vector<T> &keys) const;
 };
 
 } // end namespace

--- a/src/cdi_ipcress/IpcressGrayOpacity.cc
+++ b/src/cdi_ipcress/IpcressGrayOpacity.cc
@@ -5,19 +5,14 @@
  * \date   Mon Jan 22 14:11:10 2001
  * \brief  IpcressGrayOpacity templated class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "IpcressGrayOpacity.hh"
-#include "IpcressFile.hh"      // we have smart pointers to
-                               // IpcressFile objects.
-#include "IpcressDataTable.hh" // we have a smart pointer to a
-                               // IpcressDataTable object.
-#include "ds++/Assert.hh"      // we make use of Require()
+#include "IpcressFile.hh"
+#include "IpcressDataTable.hh"
+#include "ds++/Assert.hh"
 #include "ds++/Packing_Utils.hh"
-#include "ds++/SP.hh"
 
 namespace rtt_cdi_ipcress {
 
@@ -28,11 +23,11 @@ namespace rtt_cdi_ipcress {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Constructor for IpcressGrayOpacity object.
- * 
+ *
  * See IpcressGrayOpacity.hh for details.
  */
 IpcressGrayOpacity::IpcressGrayOpacity(
-    rtt_dsxx::SP<IpcressFile const> const &spIpcressFile, size_t in_materialID,
+    std::shared_ptr<IpcressFile const> const &spIpcressFile, size_t in_materialID,
     rtt_cdi::Model in_opacityModel, rtt_cdi::Reaction in_opacityReaction)
     : ipcressFilename(spIpcressFile->getDataFilename()),
       materialID(in_materialID), fieldNames(), opacityModel(in_opacityModel),
@@ -59,7 +54,7 @@ IpcressGrayOpacity::IpcressGrayOpacity(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor for IpcressGrayOpacity object.
- * 
+ *
  * See IpcressGrayOpacity.hh for details.
  */
 IpcressGrayOpacity::IpcressGrayOpacity(std::vector<char> const &packed)
@@ -117,7 +112,7 @@ IpcressGrayOpacity::IpcressGrayOpacity(std::vector<char> const &packed)
   Ensure(unpacker.get_ptr() == &packed[0] + packed.size());
 
   // build a new IpcressFile
-  rtt_dsxx::SP<IpcressFile> spIpcressFile;
+  std::shared_ptr<IpcressFile> spIpcressFile;
   spIpcressFile.reset(new IpcressFile(ipcressFilename));
   Check(spIpcressFile);
 
@@ -147,7 +142,7 @@ IpcressGrayOpacity::IpcressGrayOpacity(std::vector<char> const &packed)
 //---------------------------------------------------------------------------//
 /*!
  * \brief Opacity accessor that returns a single opacity (or a
- *     vector of opacities for the multigroup EnergyPolicy) that 
+ *     vector of opacities for the multigroup EnergyPolicy) that
  *     corresponds to the provided temperature and density.
  */
 double IpcressGrayOpacity::getOpacity(double targetTemperature,

--- a/src/cdi_ipcress/IpcressGrayOpacity.cc
+++ b/src/cdi_ipcress/IpcressGrayOpacity.cc
@@ -9,8 +9,8 @@
 //---------------------------------------------------------------------------//
 
 #include "IpcressGrayOpacity.hh"
-#include "IpcressFile.hh"
 #include "IpcressDataTable.hh"
+#include "IpcressFile.hh"
 #include "ds++/Assert.hh"
 #include "ds++/Packing_Utils.hh"
 
@@ -27,8 +27,9 @@ namespace rtt_cdi_ipcress {
  * See IpcressGrayOpacity.hh for details.
  */
 IpcressGrayOpacity::IpcressGrayOpacity(
-    std::shared_ptr<IpcressFile const> const &spIpcressFile, size_t in_materialID,
-    rtt_cdi::Model in_opacityModel, rtt_cdi::Reaction in_opacityReaction)
+    std::shared_ptr<IpcressFile const> const &spIpcressFile,
+    size_t in_materialID, rtt_cdi::Model in_opacityModel,
+    rtt_cdi::Reaction in_opacityReaction)
     : ipcressFilename(spIpcressFile->getDataFilename()),
       materialID(in_materialID), fieldNames(), opacityModel(in_opacityModel),
       opacityReaction(in_opacityReaction), energyPolicyDescriptor("gray"),

--- a/src/cdi_ipcress/IpcressGrayOpacity.hh
+++ b/src/cdi_ipcress/IpcressGrayOpacity.hh
@@ -153,7 +153,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
    */
   std::shared_ptr<IpcressDataTable const> spIpcressDataTable;
 
-  public:
+public:
   // ------------ //
   // Constructors //
   // ------------ //
@@ -229,10 +229,10 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
    */
   template <class TemperatureIterator, class DensityIterator,
             class OpacityIterator>
-    OpacityIterator
-    getOpacity(TemperatureIterator temperatureFirst,
-               TemperatureIterator temperatureLast, DensityIterator densityFirst,
-               DensityIterator densityLast, OpacityIterator opacityFirst) const;
+  OpacityIterator
+  getOpacity(TemperatureIterator temperatureFirst,
+             TemperatureIterator temperatureLast, DensityIterator densityFirst,
+             DensityIterator densityLast, OpacityIterator opacityFirst) const;
 
   /*!
    * \brief Opacity accessor that utilizes STL-like iterators.  This
@@ -255,10 +255,10 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
    *     and density values provied.
    */
   template <class TemperatureIterator, class OpacityIterator>
-    OpacityIterator getOpacity(TemperatureIterator temperatureFirst,
-                               TemperatureIterator temperatureLast,
-                               double targetDensity,
-                               OpacityIterator opacityFirst) const;
+  OpacityIterator getOpacity(TemperatureIterator temperatureFirst,
+                             TemperatureIterator temperatureLast,
+                             double targetDensity,
+                             OpacityIterator opacityFirst) const;
 
   /*!
    * \brief Opacity accessor that utilizes STL-like iterators.  This
@@ -281,9 +281,9 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
    *     and density values provied.
    */
   template <class DensityIterator, class OpacityIterator>
-    OpacityIterator
-    getOpacity(double targetTemperature, DensityIterator densityFirst,
-               DensityIterator densityLast, OpacityIterator opacityFirst) const;
+  OpacityIterator
+  getOpacity(double targetTemperature, DensityIterator densityFirst,
+             DensityIterator densityLast, OpacityIterator opacityFirst) const;
 
   /*!
    * \brief Opacity accessor that returns a single opacity that
@@ -322,8 +322,8 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
    * \return A vector of opacities.
    */
   std::vector<double>
-    getOpacity(double targetTemperature,
-               std::vector<double> const &targetDensity) const;
+  getOpacity(double targetTemperature,
+             std::vector<double> const &targetDensity) const;
 
   /*!
    * \brief Query whether the data is in tables or functional form.
@@ -448,9 +448,9 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
 template <class TemperatureIterator, class DensityIterator,
           class OpacityIterator>
 OpacityIterator IpcressGrayOpacity::getOpacity(
-  TemperatureIterator tempIter, TemperatureIterator tempLast,
-  DensityIterator densIter, DensityIterator Remember(densLast),
-  OpacityIterator opIter) const {
+    TemperatureIterator tempIter, TemperatureIterator tempLast,
+    DensityIterator densIter, DensityIterator Remember(densLast),
+    OpacityIterator opIter) const {
   // assert that the two input iterators have compatible sizes.
   Require(std::distance(tempIter, tempLast) ==
           std::distance(densIter, densLast));

--- a/src/cdi_ipcress/IpcressGrayOpacity.hh
+++ b/src/cdi_ipcress/IpcressGrayOpacity.hh
@@ -5,10 +5,7 @@
  * \date   Mon Jan 22 13:23:37 2001
  * \brief  IpcressGrayOpacity class header file (derived from cdi/GrayOpacity)
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_ipcress_IpcressGrayOpacity_hh__
@@ -22,7 +19,6 @@
 
 // Draco dependencies
 #include "ds++/Assert.hh"
-#include "ds++/SP.hh"
 
 // C++ standard library dependencies
 #include <string>
@@ -103,15 +99,15 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
   // ----------------------- //
 
   /*!
-     * \brief The name of the ipcress data file.  This is saved for the packer
-     *         routines
-     */
+   * \brief The name of the ipcress data file.  This is saved for the packer
+   *         routines
+   */
   std::string mutable ipcressFilename;
 
   /*!
-     * \brief Identification number for one of the materials found in the
-     *     IPCRESS file pointed to by spIpcressFile.
-     */
+   * \brief Identification number for one of the materials found in the
+   *     IPCRESS file pointed to by spIpcressFile.
+   */
   size_t materialID;
 
   // -------------------- //
@@ -128,17 +124,17 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
   // --------------- //
 
   /*!
-     * \brief The physics model that the current data set is based on.
-     *     {Rosseland, Plank}.  This enumeration is defined in
-     *     cdi/OpacityCommon.hh.
-     */
+   * \brief The physics model that the current data set is based on.
+   *     {Rosseland, Plank}.  This enumeration is defined in
+   *     cdi/OpacityCommon.hh.
+   */
   rtt_cdi::Model opacityModel;
 
   /*!
-     * \brief The type of reaction rates that the current data set represents
-     *     { Total, Scattering, Absorption }. This enumeration is defined in
-     *     cdi/OpacityCommon.hh.
-     */
+   * \brief The type of reaction rates that the current data set represents
+   *     { Total, Scattering, Absorption }. This enumeration is defined in
+   *     cdi/OpacityCommon.hh.
+   */
   rtt_cdi::Reaction opacityReaction;
 
   //! A string that identifies the energy model for this class.
@@ -149,61 +145,61 @@ class DLL_PUBLIC_cdi_ipcress IpcressGrayOpacity : public rtt_cdi::GrayOpacity {
   // -------------------- //
 
   /*!
-     * \brief spIpcressDataTable contains a cached copy of the requested
-     *     IPCRESS opacity lookup table.
-     *
-     * There is a one-to-one relationship between IpcressGrayOpacity and
-     * IpcressDataTable.
-     */
-  rtt_dsxx::SP<IpcressDataTable const> spIpcressDataTable;
+   * \brief spIpcressDataTable contains a cached copy of the requested
+   *     IPCRESS opacity lookup table.
+   *
+   * There is a one-to-one relationship between IpcressGrayOpacity and
+   * IpcressDataTable.
+   */
+  std::shared_ptr<IpcressDataTable const> spIpcressDataTable;
 
-public:
+  public:
   // ------------ //
   // Constructors //
   // ------------ //
 
   /*!
-     * \brief This is the default IpcressGrayOpacity constructor.  It requires
-     *     four arguments plus the energy policy (this class) to be
-     *     instantiated.
-     *
-     * The combiniation of a data file and a material ID uniquely specifies a
-     * material.  If we add the Model, Reaction and EnergyPolicy the opacity
-     * table is uniquely defined.
-     *
-     * \param spIpcressFile This smart pointer links an IPCRESS file (via the
-     *     IpcressFile object) to a IpcressOpacity object. There may be many
-     *     IpcressOpacity objects per IpcressFile object but only one
-     *     IpcressFile object for each IpcressOpacity object.
-     * \param materialID An identifier that links the IpcressOpacity object to
-     *     a single material found in the specified IPCRESS file.
-     * \param opacityModel The physics model that the current data set is
-     *     based on.
-     * \param opacityReaction The type of reaction rate that the current data
-     *     set represents.
-     */
-  IpcressGrayOpacity(rtt_dsxx::SP<IpcressFile const> const &spIpcressFile,
+   * \brief This is the default IpcressGrayOpacity constructor.  It requires
+   *     four arguments plus the energy policy (this class) to be
+   *     instantiated.
+   *
+   * The combiniation of a data file and a material ID uniquely specifies a
+   * material.  If we add the Model, Reaction and EnergyPolicy the opacity
+   * table is uniquely defined.
+   *
+   * \param spIpcressFile This smart pointer links an IPCRESS file (via the
+   *     IpcressFile object) to a IpcressOpacity object. There may be many
+   *     IpcressOpacity objects per IpcressFile object but only one
+   *     IpcressFile object for each IpcressOpacity object.
+   * \param materialID An identifier that links the IpcressOpacity object to
+   *     a single material found in the specified IPCRESS file.
+   * \param opacityModel The physics model that the current data set is
+   *     based on.
+   * \param opacityReaction The type of reaction rate that the current data
+   *     set represents.
+   */
+  IpcressGrayOpacity(std::shared_ptr<IpcressFile const> const &spIpcressFile,
                      size_t materialID, rtt_cdi::Model opacityModel,
                      rtt_cdi::Reaction opacityReaction);
 
   /*!
-     * \brief Unpacking constructor.
-     *
-     * This constructor unpacks a IpcressGrayOpacity object from a state
-     * attained through the pack function.
-     *
-     * \param packed vector<char> of packed IpcressGrayOpacity state; the
-     *     packed state is attained by calling pack()
-     */
+   * \brief Unpacking constructor.
+   *
+   * This constructor unpacks a IpcressGrayOpacity object from a state
+   * attained through the pack function.
+   *
+   * \param packed vector<char> of packed IpcressGrayOpacity state; the
+   *     packed state is attained by calling pack()
+   */
   explicit IpcressGrayOpacity(std::vector<char> const &packed);
 
   /*!
-     * \brief Default IpcressOpacity() destructor.
-     *
-     * This is required to correctly release memory when a IpcressGrayOpacity
-     * is destroyed.  We define the destructor in the implementation file to
-     * avoid including the unnecessary header files.
-     */
+   * \brief Default IpcressOpacity() destructor.
+   *
+   * This is required to correctly release memory when a IpcressGrayOpacity
+   * is destroyed.  We define the destructor in the implementation file to
+   * avoid including the unnecessary header files.
+   */
   ~IpcressGrayOpacity(void){/* empty */};
 
   // --------- //
@@ -211,137 +207,137 @@ public:
   // --------- //
 
   /*!
-     * \brief Opacity accessor that utilizes STL-like iterators.  This
-     *     accessor expects a list of (temperature,density) tuples.  An
-     *     opacity value will be returned for each tuple.  The temperature and
-     *     density iterators are required to be the same length.  The opacity
-     *     iterator should also have this same length.
-     *
-     * \param temperatureFirst The beginning position of a STL container that
-     *     holds a list of temperatures.
-     * \param temperatureLast The end position of a STL container that holds a
-     *     list of temperatures.
-     * \param densityFirst The beginning position of a STL container that
-     *     holds a list of densities.
-     * \param densityLast container that holds a list of temperatures.
-     * \param opacityFirst The beginning position of a STL container into
-     *     which opacity values corresponding to the given
-     *     (temperature,density) tuple will be stored.
-     * \return A list (of type OpacityIterator) of opacities are returned.
-     *     These opacities correspond to the temperature and density values
-     *     provied in the two InputIterators.
-     */
+   * \brief Opacity accessor that utilizes STL-like iterators.  This
+   *     accessor expects a list of (temperature,density) tuples.  An
+   *     opacity value will be returned for each tuple.  The temperature and
+   *     density iterators are required to be the same length.  The opacity
+   *     iterator should also have this same length.
+   *
+   * \param temperatureFirst The beginning position of a STL container that
+   *     holds a list of temperatures.
+   * \param temperatureLast The end position of a STL container that holds a
+   *     list of temperatures.
+   * \param densityFirst The beginning position of a STL container that
+   *     holds a list of densities.
+   * \param densityLast container that holds a list of temperatures.
+   * \param opacityFirst The beginning position of a STL container into
+   *     which opacity values corresponding to the given
+   *     (temperature,density) tuple will be stored.
+   * \return A list (of type OpacityIterator) of opacities are returned.
+   *     These opacities correspond to the temperature and density values
+   *     provied in the two InputIterators.
+   */
   template <class TemperatureIterator, class DensityIterator,
             class OpacityIterator>
-  OpacityIterator
-  getOpacity(TemperatureIterator temperatureFirst,
-             TemperatureIterator temperatureLast, DensityIterator densityFirst,
-             DensityIterator densityLast, OpacityIterator opacityFirst) const;
+    OpacityIterator
+    getOpacity(TemperatureIterator temperatureFirst,
+               TemperatureIterator temperatureLast, DensityIterator densityFirst,
+               DensityIterator densityLast, OpacityIterator opacityFirst) const;
 
   /*!
-     * \brief Opacity accessor that utilizes STL-like iterators.  This
-     *     accessor expects a list of temperatures in an STL container.
-     *     An opacity value will be returned for each temperature
-     *     provided.  The opacity iterator should be the same length
-     *     as the temperature STL container.
-     *
-     * \param temperatureFirst The beginning position of a STL
-     *     container that holds a list of temperatures.
-     * \param temperatureLast The end position of a STL
-     *     container that holds a list of temperatures.
-     * \param targetDensity The single density value used when
-     *     computing opacities for each given temperature.
-     * \param opacityFirst The beginning position of a STL
-     *     container into which opacity values (corresponding to the
-     *     provided temperature and density values) will be stored.
-     * \return A list (of type OpacityIterator) of opacities are
-     *     returned.  These opacities correspond to the temperature
-     *     and density values provied.
-     */
+   * \brief Opacity accessor that utilizes STL-like iterators.  This
+   *     accessor expects a list of temperatures in an STL container.
+   *     An opacity value will be returned for each temperature
+   *     provided.  The opacity iterator should be the same length
+   *     as the temperature STL container.
+   *
+   * \param temperatureFirst The beginning position of a STL
+   *     container that holds a list of temperatures.
+   * \param temperatureLast The end position of a STL
+   *     container that holds a list of temperatures.
+   * \param targetDensity The single density value used when
+   *     computing opacities for each given temperature.
+   * \param opacityFirst The beginning position of a STL
+   *     container into which opacity values (corresponding to the
+   *     provided temperature and density values) will be stored.
+   * \return A list (of type OpacityIterator) of opacities are
+   *     returned.  These opacities correspond to the temperature
+   *     and density values provied.
+   */
   template <class TemperatureIterator, class OpacityIterator>
-  OpacityIterator getOpacity(TemperatureIterator temperatureFirst,
-                             TemperatureIterator temperatureLast,
-                             double targetDensity,
-                             OpacityIterator opacityFirst) const;
+    OpacityIterator getOpacity(TemperatureIterator temperatureFirst,
+                               TemperatureIterator temperatureLast,
+                               double targetDensity,
+                               OpacityIterator opacityFirst) const;
 
   /*!
-     * \brief Opacity accessor that utilizes STL-like iterators.  This
-     *     accessor expects a list of densities in an STL container.
-     *     An opacity value will be returned for each density
-     *     provided.  The opacity iterator should be the same length
-     *     as the density STL container.
-     *
-     * \param targetTemperature The single temperature value used when
-     *     computing opacities for each given density.
-     * \param densityFirst The beginning position of a STL
-     *     container that holds a list of densities.
-     * \param densityLast The end position of a STL
-     *     container that holds a list of densities.
-     * \param opacityFirst beginning position of a STL
-     *     container into which opacity values (corresponding to the
-     *     provided temperature and density values) will be stored.
-     * \return A list (of type OpacityIterator) of opacities are
-     *     returned.  These opacities correspond to the temperature
-     *     and density values provied.
-     */
+   * \brief Opacity accessor that utilizes STL-like iterators.  This
+   *     accessor expects a list of densities in an STL container.
+   *     An opacity value will be returned for each density
+   *     provided.  The opacity iterator should be the same length
+   *     as the density STL container.
+   *
+   * \param targetTemperature The single temperature value used when
+   *     computing opacities for each given density.
+   * \param densityFirst The beginning position of a STL
+   *     container that holds a list of densities.
+   * \param densityLast The end position of a STL
+   *     container that holds a list of densities.
+   * \param opacityFirst beginning position of a STL
+   *     container into which opacity values (corresponding to the
+   *     provided temperature and density values) will be stored.
+   * \return A list (of type OpacityIterator) of opacities are
+   *     returned.  These opacities correspond to the temperature
+   *     and density values provied.
+   */
   template <class DensityIterator, class OpacityIterator>
-  OpacityIterator
-  getOpacity(double targetTemperature, DensityIterator densityFirst,
-             DensityIterator densityLast, OpacityIterator opacityFirst) const;
+    OpacityIterator
+    getOpacity(double targetTemperature, DensityIterator densityFirst,
+               DensityIterator densityLast, OpacityIterator opacityFirst) const;
 
   /*!
-     * \brief Opacity accessor that returns a single opacity that
-     *     corresponds to the provided temperature and density.
-     *
-     * \param targetTemperature The temperature value for which an
-     *     opacity value is being requested.
-     * \param targetDensity The density value for which an opacity
-     *     value is being requested.
-     * \return A single opacity.
-     */
+   * \brief Opacity accessor that returns a single opacity that
+   *     corresponds to the provided temperature and density.
+   *
+   * \param targetTemperature The temperature value for which an
+   *     opacity value is being requested.
+   * \param targetDensity The density value for which an opacity
+   *     value is being requested.
+   * \return A single opacity.
+   */
   double getOpacity(double targetTemperature, double targetDensity) const;
 
   /*!
-     * \brief Opacity accessor that returns a vector of opacities
-     *     that correspond to the provided vector of
-     *     temperatures and a single density value.
-     *
-     * \param targetTemperature A vector of temperature values for
-     *     which opacity values are being requested.
-     * \param targetDensity The density value for which an opacity
-     *     value is being requested.
-     * \return A vector of opacities.
-     */
+   * \brief Opacity accessor that returns a vector of opacities
+   *     that correspond to the provided vector of
+   *     temperatures and a single density value.
+   *
+   * \param targetTemperature A vector of temperature values for
+   *     which opacity values are being requested.
+   * \param targetDensity The density value for which an opacity
+   *     value is being requested.
+   * \return A vector of opacities.
+   */
   std::vector<double> getOpacity(std::vector<double> const &targetTemperature,
                                  double targetDensity) const;
 
   /*!
-     * \brief Opacity accessor that returns a vector of opacities that
-     *     correspond to the provided vector of
-     *     densities and a single temperature value.
-     * \param targetTemperature The temperature value for which an
-     *     opacity value is being requested.
-     * \param targetDensity A vector of density values for which
-     *     opacity values are being requested.
-     * \return A vector of opacities.
-     */
+   * \brief Opacity accessor that returns a vector of opacities that
+   *     correspond to the provided vector of
+   *     densities and a single temperature value.
+   * \param targetTemperature The temperature value for which an
+   *     opacity value is being requested.
+   * \param targetDensity A vector of density values for which
+   *     opacity values are being requested.
+   * \return A vector of opacities.
+   */
   std::vector<double>
-  getOpacity(double targetTemperature,
-             std::vector<double> const &targetDensity) const;
+    getOpacity(double targetTemperature,
+               std::vector<double> const &targetDensity) const;
 
   /*!
-     * \brief Query whether the data is in tables or functional form.
-     */
+   * \brief Query whether the data is in tables or functional form.
+   */
   bool data_in_tabular_form() const { return true; }
 
   /*!
-     * \brief Query to determine the reaction model.
-     */
+   * \brief Query to determine the reaction model.
+   */
   rtt_cdi::Reaction getReactionType() const { return opacityReaction; }
 
   /*!
-     * \brief Query to determine the physics model.
-     */
+   * \brief Query to determine the physics model.
+   */
   rtt_cdi::Model getModelType() const { return opacityModel; }
 
   // It is not clear how to assume order of opacity(temp,dens) when
@@ -353,84 +349,84 @@ public:
   // 	const std::vector<double>& targetDensity ) const;
 
   /*!
-     * \brief Returns a string that describes the templated
-     *     EnergyPolicy.  Currently this will return either "mg" or
-     *     "gray."
-     */
+   * \brief Returns a string that describes the templated
+   *     EnergyPolicy.  Currently this will return either "mg" or
+   *     "gray."
+   */
   std::string getEnergyPolicyDescriptor() const {
     return energyPolicyDescriptor;
   }
 
   /*!
-     * \brief Returns a "plain English" description of the opacity
-     *     data that this class references. (e.g. "Gray Rosseland
-     *     Scattering".)
-     *
-     * The definition of this function is not included here to prevent
-     *     the inclusion of the IpcressFile.hh definitions within this
-     *     header file.
-     */
+   * \brief Returns a "plain English" description of the opacity
+   *     data that this class references. (e.g. "Gray Rosseland
+   *     Scattering".)
+   *
+   * The definition of this function is not included here to prevent
+   *     the inclusion of the IpcressFile.hh definitions within this
+   *     header file.
+   */
   std::string getDataDescriptor() const {
     return spIpcressDataTable->getDataDescriptor();
   }
 
   /*!
-     * \brief Returns the name of the associated IPCRESS file.
-     *
-     * The definition of this function is not included here to prevent
-     *     the inclusion of the IpcressFile.hh definitions within this
-     *     header file.
-     */
+   * \brief Returns the name of the associated IPCRESS file.
+   *
+   * The definition of this function is not included here to prevent
+   *     the inclusion of the IpcressFile.hh definitions within this
+   *     header file.
+   */
   std::string getDataFilename() const { return ipcressFilename; }
 
   /*!
-     * \brief Returns a vector of temperatures that define the cached
-     *     opacity data table.
-     *
-     * We do not return a const reference because this function
-     * must construct this information from more fundamental tables.
-     */
+   * \brief Returns a vector of temperatures that define the cached
+   *     opacity data table.
+   *
+   * We do not return a const reference because this function
+   * must construct this information from more fundamental tables.
+   */
   std::vector<double> getTemperatureGrid() const {
     return spIpcressDataTable->getTemperatures();
   }
 
   /*!
-     * \brief Returns a vector of densities that define the cached
-     *     opacity data table.
-     *
-     * We do not return a const reference because this function
-     * must construct this information from more fundamental tables.
-     */
+   * \brief Returns a vector of densities that define the cached
+   *     opacity data table.
+   *
+   * We do not return a const reference because this function
+   * must construct this information from more fundamental tables.
+   */
   std::vector<double> getDensityGrid() const {
     return spIpcressDataTable->getDensities();
   }
 
   /*!
-     * \brief Returns the size of the temperature grid.
-     */
+   * \brief Returns the size of the temperature grid.
+   */
   size_t getNumTemperatures() const {
     return spIpcressDataTable->getNumTemperatures();
   }
 
   /*!
-     * \brief Returns the size of the density grid.
-     */
+   * \brief Returns the size of the density grid.
+   */
   size_t getNumDensities() const {
     return spIpcressDataTable->getNumDensities();
   }
 
   /*!
-     * \brief Pack a IpcressGrayOpacity object.
-     *
-     * \return packed state in a vector<char>
-     */
+   * \brief Pack a IpcressGrayOpacity object.
+   *
+   * \return packed state in a vector<char>
+   */
   std::vector<char> pack() const;
 
   /*!
-     * \brief Returns the general opacity model type, defined in
-     *     OpacityCommon.hh.  Since this is a Ipcress model, return 2
-     *     (rtt_cdi::IPCRESS_TYPE)
-     */
+   * \brief Returns the general opacity model type, defined in
+   *     OpacityCommon.hh.  Since this is a Ipcress model, return 2
+   *     (rtt_cdi::IPCRESS_TYPE)
+   */
   rtt_cdi::OpacityModelType getOpacityModelType() const {
     return rtt_cdi::IPCRESS_TYPE;
   }
@@ -452,9 +448,9 @@ public:
 template <class TemperatureIterator, class DensityIterator,
           class OpacityIterator>
 OpacityIterator IpcressGrayOpacity::getOpacity(
-    TemperatureIterator tempIter, TemperatureIterator tempLast,
-    DensityIterator densIter, DensityIterator Remember(densLast),
-    OpacityIterator opIter) const {
+  TemperatureIterator tempIter, TemperatureIterator tempLast,
+  DensityIterator densIter, DensityIterator Remember(densLast),
+  OpacityIterator opIter) const {
   // assert that the two input iterators have compatible sizes.
   Require(std::distance(tempIter, tempLast) ==
           std::distance(densIter, densLast));

--- a/src/cdi_ipcress/IpcressInterpreter.cc
+++ b/src/cdi_ipcress/IpcressInterpreter.cc
@@ -5,10 +5,7 @@
  * \date   Fri Oct 12 15:39:39 2001
  * \brief  Basic reader to print info in IPCRESS files.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "IpcressFile.hh"
@@ -17,16 +14,14 @@
 #include "cdi/OpacityCommon.hh"
 #include "ds++/Assert.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/XGetopt.hh"
-
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <vector>
 
-using rtt_dsxx::SP;
 using rtt_cdi_ipcress::IpcressFile;
 using rtt_cdi_ipcress::IpcressMultigroupOpacity;
 using rtt_cdi_ipcress::IpcressGrayOpacity;
@@ -61,7 +56,7 @@ void ipcress_file_read(std::string const &op_data_file) {
 
   cout << "Creating a Ipcress File object from " << op_data_file << endl;
 
-  SP<IpcressFile> spGF;
+  std::shared_ptr<IpcressFile> spGF;
   try {
     spGF.reset(new rtt_cdi_ipcress::IpcressFile(op_data_file));
   } catch (rtt_dsxx::assertion const &excpt) {
@@ -83,7 +78,7 @@ void ipcress_file_read(std::string const &op_data_file) {
   cout << "=========================================" << endl;
   cout << "For Material " << i + 1 << " with ID number " << matIDs[i] << endl;
   cout << "=========================================" << endl;
-  SP<MultigroupOpacity> spMgOp;
+  std::shared_ptr<MultigroupOpacity> spMgOp;
   try {
     spMgOp.reset(new IpcressMultigroupOpacity(
         spGF, matIDs[i], rtt_cdi::ROSSELAND, rtt_cdi::TOTAL));
@@ -165,7 +160,7 @@ void ipcress_file_read(std::string const &op_data_file) {
     Insist((selID < 6), "Invalid choice.");
 
     if (selID == 1) {
-      SP<GrayOpacity> spGOp;
+      std::shared_ptr<GrayOpacity> spGOp;
       spGOp.reset(new IpcressGrayOpacity(
           spGF, matIDs[matID], rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
       cout << "The Gray Rosseland Absorption Opacity for " << endl;
@@ -173,7 +168,7 @@ void ipcress_file_read(std::string const &op_data_file) {
            << density << ", temperature " << temperature << " is "
            << spGOp->getOpacity(temperature, density) << endl;
     } else if (selID == 2) {
-      SP<GrayOpacity> spGOp;
+      std::shared_ptr<GrayOpacity> spGOp;
       spGOp.reset(new IpcressGrayOpacity(spGF, matIDs[matID], rtt_cdi::PLANCK,
                                          rtt_cdi::ABSORPTION));
       cout << "The Gray Planck Absorption Opacity for " << endl;
@@ -182,7 +177,7 @@ void ipcress_file_read(std::string const &op_data_file) {
            << spGOp->getOpacity(temperature, density) << endl;
 
     } else if (selID == 3) {
-      SP<MultigroupOpacity> spMGOp;
+      std::shared_ptr<MultigroupOpacity> spMGOp;
       spMGOp.reset(new IpcressMultigroupOpacity(
           spGF, matIDs[matID], rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
       cout << "The Multigroup Rosseland Absorption Opacity for " << endl;
@@ -194,7 +189,7 @@ void ipcress_file_read(std::string const &op_data_file) {
         cout << g + 1 << "\t " << 0.5 * (groups[g] + groups[g + 1]) << "   \t "
              << opData[g] << endl;
     } else if (selID == 4) {
-      SP<MultigroupOpacity> spMGOp;
+      std::shared_ptr<MultigroupOpacity> spMGOp;
       spMGOp.reset(new IpcressMultigroupOpacity(
           spGF, matIDs[matID], rtt_cdi::PLANCK, rtt_cdi::ABSORPTION));
       cout << "The Multigroup Planck Absorption Opacity for " << endl;
@@ -207,7 +202,7 @@ void ipcress_file_read(std::string const &op_data_file) {
              << opData[g] << endl;
     }
     if (selID == 5) {
-      SP<GrayOpacity> spGOp;
+      std::shared_ptr<GrayOpacity> spGOp;
       spGOp.reset(new IpcressGrayOpacity(spGF, matIDs[matID],
                                          rtt_cdi::ROSSELAND, rtt_cdi::TOTAL));
       cout << "The Gray Rosseland Total Opacity for " << endl;

--- a/src/cdi_ipcress/IpcressMultigroupOpacity.cc
+++ b/src/cdi_ipcress/IpcressMultigroupOpacity.cc
@@ -5,21 +5,16 @@
  * \date   Tue Nov 15 15:51:27 2011
  * \brief  IpcressMultigroupOpacity templated class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "IpcressMultigroupOpacity.hh"
-#include "IpcressFile.hh"      // we have smart pointers to
-                               // IpcressFile objects.
-#include "IpcressDataTable.hh" // we have a smart pointer to a
-                               // IpcressDataTable object.
-
-#include "ds++/Assert.hh" // we make use of Require()
+#include "IpcressFile.hh"
+#include "IpcressDataTable.hh"
+#include "ds++/Assert.hh"
 #include "ds++/Packing_Utils.hh"
-#include <cmath> // we need to define log(double) and exp(double)
+#include <cmath>
+#include <memory>
 
 namespace rtt_cdi_ipcress {
 
@@ -30,11 +25,11 @@ namespace rtt_cdi_ipcress {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Constructor for IpcressMultigroupOpacity object.
- * 
+ *
  * See IpcressMultigroupOpacity.hh for details.
  */
 IpcressMultigroupOpacity::IpcressMultigroupOpacity(
-    rtt_dsxx::SP<IpcressFile const> const &spIpcressFile, size_t in_materialID,
+    std::shared_ptr<IpcressFile const> const &spIpcressFile, size_t in_materialID,
     rtt_cdi::Model in_opacityModel, rtt_cdi::Reaction in_opacityReaction)
     : ipcressFilename(spIpcressFile->getDataFilename()),
       materialID(in_materialID), fieldNames(), opacityModel(in_opacityModel),
@@ -61,7 +56,7 @@ IpcressMultigroupOpacity::IpcressMultigroupOpacity(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor for IpcressMultigroupOpacity object.
- * 
+ *
  * See IpcressMultigroupOpacity.hh for details.
  */
 IpcressMultigroupOpacity::IpcressMultigroupOpacity(
@@ -120,7 +115,7 @@ IpcressMultigroupOpacity::IpcressMultigroupOpacity(
   Ensure(unpacker.get_ptr() == &packed[0] + packed.size());
 
   // build a new IpcressFile
-  rtt_dsxx::SP<IpcressFile> spIpcressFile;
+  std::shared_ptr<IpcressFile> spIpcressFile;
   spIpcressFile.reset(new IpcressFile(ipcressFilename));
   Check(spIpcressFile);
 

--- a/src/cdi_ipcress/IpcressMultigroupOpacity.cc
+++ b/src/cdi_ipcress/IpcressMultigroupOpacity.cc
@@ -9,8 +9,8 @@
 //---------------------------------------------------------------------------//
 
 #include "IpcressMultigroupOpacity.hh"
-#include "IpcressFile.hh"
 #include "IpcressDataTable.hh"
+#include "IpcressFile.hh"
 #include "ds++/Assert.hh"
 #include "ds++/Packing_Utils.hh"
 #include <cmath>
@@ -29,8 +29,9 @@ namespace rtt_cdi_ipcress {
  * See IpcressMultigroupOpacity.hh for details.
  */
 IpcressMultigroupOpacity::IpcressMultigroupOpacity(
-    std::shared_ptr<IpcressFile const> const &spIpcressFile, size_t in_materialID,
-    rtt_cdi::Model in_opacityModel, rtt_cdi::Reaction in_opacityReaction)
+    std::shared_ptr<IpcressFile const> const &spIpcressFile,
+    size_t in_materialID, rtt_cdi::Model in_opacityModel,
+    rtt_cdi::Reaction in_opacityReaction)
     : ipcressFilename(spIpcressFile->getDataFilename()),
       materialID(in_materialID), fieldNames(), opacityModel(in_opacityModel),
       opacityReaction(in_opacityReaction), energyPolicyDescriptor("mg"),

--- a/src/cdi_ipcress/IpcressMultigroupOpacity.hh
+++ b/src/cdi_ipcress/IpcressMultigroupOpacity.hh
@@ -170,9 +170,10 @@ public:
    * \param opacityReaction The type of reaction rate that the current data set
    *     represents.
    */
-  IpcressMultigroupOpacity(std::shared_ptr<IpcressFile const> const &spIpcressFile,
-                           size_t materialID, rtt_cdi::Model opacityModel,
-                           rtt_cdi::Reaction opacityReaction);
+  IpcressMultigroupOpacity(
+      std::shared_ptr<IpcressFile const> const &spIpcressFile,
+      size_t materialID, rtt_cdi::Model opacityModel,
+      rtt_cdi::Reaction opacityReaction);
 
   /*!
    * \brief Unpacking constructor.

--- a/src/cdi_ipcress/IpcressMultigroupOpacity.hh
+++ b/src/cdi_ipcress/IpcressMultigroupOpacity.hh
@@ -12,9 +12,9 @@
 #ifndef __cdi_ipcress_IpcressMultigroupOpacity_hh__
 #define __cdi_ipcress_IpcressMultigroupOpacity_hh__
 
-#include "IpcressDataTable.hh" // we have a smart pointer to a
-                               // IpcressDataTable object.
+#include "IpcressDataTable.hh"
 #include "cdi/MultigroupOpacity.hh"
+#include <memory>
 
 namespace rtt_cdi_ipcress {
 // -------------------- //
@@ -143,7 +143,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressMultigroupOpacity
    * There is a one-to-one relationship between IpcressOpacity and
    * IpcressDataTable.
    */
-  rtt_dsxx::SP<const IpcressDataTable> spIpcressDataTable;
+  std::shared_ptr<const IpcressDataTable> spIpcressDataTable;
 
 public:
   // ------------ //
@@ -170,7 +170,7 @@ public:
    * \param opacityReaction The type of reaction rate that the current data set
    *     represents.
    */
-  IpcressMultigroupOpacity(rtt_dsxx::SP<IpcressFile const> const &spIpcressFile,
+  IpcressMultigroupOpacity(std::shared_ptr<IpcressFile const> const &spIpcressFile,
                            size_t materialID, rtt_cdi::Model opacityModel,
                            rtt_cdi::Reaction opacityReaction);
 

--- a/src/cdi_ipcress/IpcressOdfmgOpacity.cc
+++ b/src/cdi_ipcress/IpcressOdfmgOpacity.cc
@@ -5,21 +5,17 @@
  * \date   Mon Jan 22 15:24210 2001
  * \brief  IpcressOdfmgOpacity templated class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "IpcressOdfmgOpacity.hh"
-#include "IpcressFile.hh"      // we have smart pointers to
-                               // IpcressFile objects.
-#include "IpcressDataTable.hh" // we have a smart pointer to a
-                               // IpcressDataTable object.
-#include "ds++/Assert.hh"      // we make use of Require()
+#include "IpcressFile.hh"
+#include "IpcressDataTable.hh"
+#include "ds++/Assert.hh"
 #include "ds++/Packing_Utils.hh"
 #include "ds++/Soft_Equivalence.hh"
-#include <algorithm> // for std::reverse
-#include <cmath>     // we need to define log(double) and exp(double)
+#include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 
@@ -31,11 +27,11 @@ namespace rtt_cdi_ipcress {
 
 /*!
  * \brief Constructor for IpcressOdfmgOpacity object.
- * 
+ *
  * See IpcressOdfmgOpacity.hh for details.
  */
 IpcressOdfmgOpacity::IpcressOdfmgOpacity(
-    rtt_dsxx::SP<const IpcressFile> const &in_spIpcressFile,
+    std::shared_ptr<const IpcressFile> const &in_spIpcressFile,
     size_t in_materialID, rtt_cdi::Model in_opacityModel,
     rtt_cdi::Reaction in_opacityReaction, size_t numBands)
     : spIpcressFile(in_spIpcressFile), materialID(in_materialID),
@@ -69,7 +65,7 @@ IpcressOdfmgOpacity::IpcressOdfmgOpacity(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Unpacking constructor for IpcressOdfmgOpacity object.
- * 
+ *
  * See IpcressOdfmgOpacity.hh for details.
  */
 IpcressOdfmgOpacity::IpcressOdfmgOpacity(std::vector<char> const &packed)

--- a/src/cdi_ipcress/IpcressOdfmgOpacity.cc
+++ b/src/cdi_ipcress/IpcressOdfmgOpacity.cc
@@ -9,8 +9,8 @@
 //---------------------------------------------------------------------------//
 
 #include "IpcressOdfmgOpacity.hh"
-#include "IpcressFile.hh"
 #include "IpcressDataTable.hh"
+#include "IpcressFile.hh"
 #include "ds++/Assert.hh"
 #include "ds++/Packing_Utils.hh"
 #include "ds++/Soft_Equivalence.hh"

--- a/src/cdi_ipcress/IpcressOdfmgOpacity.hh
+++ b/src/cdi_ipcress/IpcressOdfmgOpacity.hh
@@ -11,10 +11,10 @@
 #ifndef __cdi_ipcress_IpcressOdfmgOpacity_hh__
 #define __cdi_ipcress_IpcressOdfmgOpacity_hh__
 
-#include "IpcressDataTable.hh" // we have a smart pointer to a IpcressDataTable
-                               // object.
+#include "IpcressDataTable.hh"
 #include "cdi/OdfmgOpacity.hh"
-#include <cmath> // we need to define log(double) and exp(double)
+#include <cmath>
+#include <memory>
 
 namespace rtt_cdi_ipcress {
 // -------------------- //
@@ -92,7 +92,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressOdfmgOpacity
    * \brief DS++ Smart Pointer to a IpcressFile object. spIpcressFile acts as a
    * hook to link this object to an IPCRESS file.
    */
-  rtt_dsxx::SP<const IpcressFile> spIpcressFile;
+  std::shared_ptr<const IpcressFile> spIpcressFile;
 
   /*!
    * \brief Identification number for one of the materials found in the IPCRESS
@@ -143,7 +143,7 @@ class DLL_PUBLIC_cdi_ipcress IpcressOdfmgOpacity
    * There is a one-to-one relationship between IpcressOpacity and
    * IpcressDataTable.
    */
-  rtt_dsxx::SP<const IpcressDataTable> spIpcressDataTable;
+  std::shared_ptr<const IpcressDataTable> spIpcressDataTable;
 
   /*!
    * \brief The group boundaries that we use are not the same as those read in
@@ -199,7 +199,7 @@ public:
    * \param opacityReaction The type of reaction rate that the current data set
    *     represents.
    */
-  IpcressOdfmgOpacity(rtt_dsxx::SP<const IpcressFile> const &spIpcressFile,
+  IpcressOdfmgOpacity(std::shared_ptr<const IpcressFile> const &spIpcressFile,
                       size_t materialID, rtt_cdi::Model opacityModel,
                       rtt_cdi::Reaction opacityReaction, size_t numBands);
 

--- a/src/cdi_ipcress/test/ReadOdfIpcressFile.cc
+++ b/src/cdi_ipcress/test/ReadOdfIpcressFile.cc
@@ -16,7 +16,6 @@
 
 using rtt_cdi_ipcress::IpcressOdfmgOpacity;
 using rtt_cdi_ipcress::IpcressFile;
-using rtt_dsxx::SP;
 
 using std::cerr;
 using std::cout;
@@ -26,7 +25,7 @@ using std::string;
 using std::istringstream;
 using std::ostringstream;
 
-typedef SP<const IpcressOdfmgOpacity> SP_Goo;
+typedef std::shared_ptr<const IpcressOdfmgOpacity> SP_Goo;
 typedef std::vector<double> vec_d;
 typedef std::vector<std::vector<double>> vec2_d;
 
@@ -118,7 +117,7 @@ int main(int argc, char *argv[]) {
     ipcressFileName =
         ut.getTestInputPath() + std::string("odfregression10.ipcress");
 
-  SP<const IpcressFile> file;
+  std::shared_ptr<const IpcressFile> file;
   try {
     file.reset(new IpcressFile(ipcressFileName));
   } catch (rtt_dsxx::assertion const &excpt) {
@@ -251,7 +250,7 @@ int main(int argc, char *argv[]) {
   Insist(numBands > 0, "Must have a positive number of bands.");
 
   //load the Ipcress ODFMG Opacity
-  SP<const IpcressOdfmgOpacity> spGandOpacity;
+  std::shared_ptr<const IpcressOdfmgOpacity> spGandOpacity;
 
   spGandOpacity.reset(
       new IpcressOdfmgOpacity(file, matID, model, reaction, numBands));

--- a/src/cdi_ipcress/test/tIpcressFile.cc
+++ b/src/cdi_ipcress/test/tIpcressFile.cc
@@ -11,13 +11,11 @@
 #include "cdi_ipcress_test.hh"
 #include "cdi_ipcress/IpcressFile.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/Soft_Equivalence.hh"
 
 using namespace std;
 
 using rtt_cdi_ipcress::IpcressFile;
-using rtt_dsxx::SP;
 
 //---------------------------------------------------------------------------//
 // TESTS
@@ -39,7 +37,7 @@ void ipcress_file_test(rtt_dsxx::ScalarUnitTest &ut) {
 
   std::cout << "Creating a Ipcress File object\n" << std::endl;
 
-  SP<IpcressFile> spGF(new rtt_cdi_ipcress::IpcressFile(op_data_file));
+  shared_ptr<IpcressFile> spGF(new rtt_cdi_ipcress::IpcressFile(op_data_file));
 
   // Test the new object to verify the constructor and accessors.
 

--- a/src/cdi_ipcress/test/tIpcressOdfmgOpacity.cc
+++ b/src/cdi_ipcress/test/tIpcressOdfmgOpacity.cc
@@ -6,26 +6,21 @@
  * \brief  Regression test based on odfregression10.ipcress, also checks
  *         packing and unpacking.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: ReadOdfIpcressFile.cc
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include "../IpcressFile.hh"
-#include "../IpcressMultigroupOpacity.hh"
-#include "../IpcressOdfmgOpacity.hh"
+#include "cdi_ipcress/IpcressFile.hh"
+#include "cdi_ipcress/IpcressMultigroupOpacity.hh"
+#include "cdi_ipcress/IpcressOdfmgOpacity.hh"
 #include "cdi_ipcress_test.hh"
 #include "cdi/OpacityCommon.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <cstdio>
 
 using rtt_cdi_ipcress::IpcressOdfmgOpacity;
 using rtt_cdi_ipcress::IpcressMultigroupOpacity;
 using rtt_cdi_ipcress::IpcressFile;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 using std::cerr;
@@ -36,7 +31,7 @@ using std::string;
 using std::istringstream;
 using std::ostringstream;
 
-typedef SP<IpcressOdfmgOpacity const> SP_Goo;
+typedef std::shared_ptr<IpcressOdfmgOpacity const> SP_Goo;
 typedef std::vector<double> vec_d;
 typedef std::vector<std::vector<double>> vec2_d;
 
@@ -177,12 +172,12 @@ int main(int argc, char *argv[]) {
 
   // get the ipcress file name, and create the ipcress file
   string ipcressFileName = "odfregression10.ipcress";
-  SP<IpcressFile const> file;
+  std::shared_ptr<IpcressFile const> file;
   try {
     file.reset(new IpcressFile(ipcressFileName));
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressFile object for "
+    message << "Failed to create shared_ptr to new IpcressFile object for "
             << "file \"" << ipcressFileName << "\":" << excpt.what();
     FAILMSG(message.str());
     cout << "Aborting tests.";
@@ -190,7 +185,7 @@ int main(int argc, char *argv[]) {
   }
 
   //load the Ipcress ODFMG Opacity
-  SP<IpcressOdfmgOpacity const> spGandOpacity;
+  std::shared_ptr<IpcressOdfmgOpacity const> spGandOpacity;
 
   try {
     spGandOpacity.reset(new IpcressOdfmgOpacity(
@@ -203,7 +198,7 @@ int main(int argc, char *argv[]) {
     PASSMSG(message.str());
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object with "
+    message << "Failed to create shared_ptr to new IpcressOpacity object with "
             << "data from \"" << ipcressFileName << "\":" << excpt.what();
     FAILMSG(message.str());
     cout << "Aborting tests.";
@@ -224,7 +219,7 @@ int main(int argc, char *argv[]) {
 
   packed = spGandOpacity->pack();
 
-  SP<IpcressOdfmgOpacity const> spUnpackedGandOpacity;
+  std::shared_ptr<IpcressOdfmgOpacity const> spUnpackedGandOpacity;
 
   try {
     spUnpackedGandOpacity.reset(new IpcressOdfmgOpacity(packed));
@@ -250,7 +245,8 @@ int main(int argc, char *argv[]) {
   //make sure it won't unpack as something else
   itPassed = false;
   try {
-    SP<IpcressMultigroupOpacity> opacity(new IpcressMultigroupOpacity(packed));
+    std::shared_ptr<IpcressMultigroupOpacity> opacity(
+      new IpcressMultigroupOpacity(packed));
   } catch (rtt_dsxx::assertion const &err) {
     itPassed = true;
     ostringstream message;

--- a/src/cdi_ipcress/test/tIpcressOdfmgOpacity.cc
+++ b/src/cdi_ipcress/test/tIpcressOdfmgOpacity.cc
@@ -9,11 +9,11 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
+#include "cdi_ipcress_test.hh"
+#include "cdi/OpacityCommon.hh"
 #include "cdi_ipcress/IpcressFile.hh"
 #include "cdi_ipcress/IpcressMultigroupOpacity.hh"
 #include "cdi_ipcress/IpcressOdfmgOpacity.hh"
-#include "cdi_ipcress_test.hh"
-#include "cdi/OpacityCommon.hh"
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <cstdio>
@@ -246,7 +246,7 @@ int main(int argc, char *argv[]) {
   itPassed = false;
   try {
     std::shared_ptr<IpcressMultigroupOpacity> opacity(
-      new IpcressMultigroupOpacity(packed));
+        new IpcressMultigroupOpacity(packed));
   } catch (rtt_dsxx::assertion const &err) {
     itPassed = true;
     ostringstream message;

--- a/src/cdi_ipcress/test/tIpcressOpacity.cc
+++ b/src/cdi_ipcress/test/tIpcressOpacity.cc
@@ -5,10 +5,7 @@
  * \date   Fri Oct 26 10:50:44 2001
  * \brief
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_ipcress_test.hh"
@@ -17,7 +14,6 @@
 #include "cdi_ipcress/IpcressGrayOpacity.hh"
 #include "cdi_ipcress/IpcressMultigroupOpacity.hh"
 #include "ds++/Release.hh"
-#include "ds++/SP.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <algorithm>
 
@@ -28,7 +24,6 @@ using rtt_cdi_ipcress::IpcressMultigroupOpacity;
 using rtt_cdi_ipcress::IpcressFile;
 using rtt_cdi::GrayOpacity;
 using rtt_cdi::MultigroupOpacity;
-using rtt_dsxx::SP;
 using rtt_dsxx::soft_equiv;
 
 //---------------------------------------------------------------------------//
@@ -44,7 +39,7 @@ void file_check_Al_BeCu(rtt_dsxx::ScalarUnitTest &ut) {
   // ------------------------- //
 
   {
-    SP<IpcressFile> spIF;
+    shared_ptr<IpcressFile> spIF;
 
     // Attempt to instantiate the object.
     try {
@@ -55,7 +50,8 @@ void file_check_Al_BeCu(rtt_dsxx::ScalarUnitTest &ut) {
     }
 
     // If we make it here then spIF was successfully instantiated.
-    PASSMSG("SP to new IpcressFile object created for Al_BeCu.ipcress data.");
+    PASSMSG( string("shared_ptr to new IpcressFile object created for ") +
+             string("Al_BeCu.ipcress data.") );
 
     // Test the IpcressFile object.
     if (spIF->getDataFilename() == op_data_file) {
@@ -93,16 +89,16 @@ void file_check_Al_BeCu(rtt_dsxx::ScalarUnitTest &ut) {
 
   // Try to instantiate the Opacity object. (Rosseland, Gray Total
   // for material 10001 in the IPCRESS file pointed to by spIF).
-  SP<GrayOpacity> spOp_Al_rgt;
+  shared_ptr<GrayOpacity> spOp_Al_rgt;
 
   try {
-    SP<IpcressFile> spIF(new IpcressFile(op_data_file));
+    shared_ptr<IpcressFile> spIF(new IpcressFile(op_data_file));
     spOp_Al_rgt.reset(new IpcressGrayOpacity(spIF, matid, rtt_cdi::ROSSELAND,
                                              rtt_cdi::TOTAL));
     // spIF goes out of scope
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressOpacity object for "
             << "Al_BeCu.ipcress data." << endl
             << "\t" << excpt.what();
     FAILMSG(message.str());
@@ -111,7 +107,7 @@ void file_check_Al_BeCu(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG("SP to new Opacity object created for Al_BeCu.ipcress data.");
+  PASSMSG("shared_ptr to new Opacity object created for Al_BeCu.ipcress data.");
 
   // ----------------- //
   // Gray Opacity Test //
@@ -174,17 +170,17 @@ void file_check_Al_BeCu(rtt_dsxx::ScalarUnitTest &ut) {
   // --------------- //
 
   // Create a Multigroup Rosseland Total Opacity object (again for Al).
-  SP<MultigroupOpacity> spOp_Al_rtmg;
+  shared_ptr<MultigroupOpacity> spOp_Al_rtmg;
 
   // Try to instantiate the Opacity object.
   try {
-    SP<IpcressFile> spIF(new IpcressFile(op_data_file));
+    shared_ptr<IpcressFile> spIF(new IpcressFile(op_data_file));
     spOp_Al_rtmg.reset(new IpcressMultigroupOpacity(
         spIF, matid, rtt_cdi::ROSSELAND, rtt_cdi::TOTAL));
     // spIF goes out of scope
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressOpacity object for "
             << "Al_BeCu.ipcress data." << endl
             << "\t" << excpt.what();
     FAILMSG(message.str());
@@ -272,7 +268,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // ------------------------- //
 
   // Create a smart pointer to a IpcressFile object
-  SP<IpcressFile> spGFAnalytic;
+  shared_ptr<IpcressFile> spGFAnalytic;
 
   // Try to instantiate the object.
   try {
@@ -285,7 +281,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we make it here then spGFAnalytic was successfully instantiated.
-  PASSMSG("SP to new IpcressFile object created (spGFAnalytic).");
+  PASSMSG("shared_ptr to new IpcressFile object created (spGFAnalytic).");
 
   // Test the IpcressFile object.
   if (spGFAnalytic->getDataFilename() == op_data_file) {
@@ -316,7 +312,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // --------------------- //
 
   // Create a smart pointer to an Opacity object.
-  SP<GrayOpacity> spOp_Analytic_ragray;
+  shared_ptr<GrayOpacity> spOp_Analytic_ragray;
 
   // material ID
   const int matid = 10001;
@@ -333,7 +329,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // catch ( rtt_cdi_ipcress::ggetgrayException GandError )
   {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressOpacity object for "
             << "analyticOpacities.ipcress data." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
@@ -342,7 +338,8 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG("SP to new Opacity object created for analyticOpacities.ipcress.");
+  PASSMSG( string("shared_ptr to new Opacity object created for ") +
+           string("analyticOpacities.ipcress."));
 
   // ----------------- //
   // Gray Opacity Test //
@@ -364,7 +361,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   //---------------- //
 
   // Create a smart pointer to an Opacity object.
-  SP<MultigroupOpacity> spOp_Analytic_ramg;
+  shared_ptr<MultigroupOpacity> spOp_Analytic_ramg;
 
   // Try to instantiate the Opacity object.
   try {
@@ -372,7 +369,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &error) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressOpacity object for "
             << "analyticOpacities.ipcress data." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
@@ -381,7 +378,8 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG("SP to new Opacity object created for analyticOpacities.ipcress.");
+  PASSMSG( string("shared_ptr to new Opacity object created for ") +
+           string ("analyticOpacities.ipcress."));
 
   // Set up the new test problem.
 
@@ -419,7 +417,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // ----------------- //
 
   // Create a smart pointer to an Opacity object.
-  SP<GrayOpacity> spOp_Analytic_pgray;
+  shared_ptr<GrayOpacity> spOp_Analytic_pgray;
 
   // Try to instantiate the Opacity object.
   try {
@@ -427,7 +425,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::PLANCK, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &error) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressOpacity object for "
             << "analyticOpacities.ipcress data." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
@@ -438,7 +436,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // If we get here then the object was successfully instantiated.
   {
     ostringstream message;
-    message << "SP to new Gray Plank Total Opacity object "
+    message << "shared_ptr to new Gray Plank Total Opacity object "
             << "created for analyticOpacities.ipcress.";
     PASSMSG(message.str());
   }
@@ -460,7 +458,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // --------------- //
 
   // Create a smart pointer to an Opacity object.
-  SP<MultigroupOpacity> spOp_Analytic_pmg;
+  shared_ptr<MultigroupOpacity> spOp_Analytic_pmg;
 
   // Try to instantiate the Opacity object.
   try {
@@ -468,7 +466,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::PLANCK, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &error) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressOpacity object for "
             << "analyticOpacities.ipcress data." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
@@ -479,7 +477,7 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   // If we get here then the object was successfully instantiated.
   {
     ostringstream message;
-    message << "SP to new Multigroup Plank Total Opacity object "
+    message << "shared_ptr to new Multigroup Plank Total Opacity object "
             << "created \n\t for \"analyticOpacities.ipcress.\"";
     PASSMSG(message.str());
   }
@@ -720,7 +718,7 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
   // ------------------------- //
 
   // Create a smart pointer to a IpcressFile object
-  SP<IpcressFile> spGFAnalytic;
+  shared_ptr<IpcressFile> spGFAnalytic;
 
   // Try to instantiate the object.
   try {
@@ -740,12 +738,12 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
   // Using const iterators for Gray objects //
   // -------------------------------------- //
 
-  // These accessors are only available in IpcressOpacity objects
-  // so the SP must be templated on IpcressGrayOpacity and not on
+  // These accessors are only available in IpcressOpacity objects so the
+  // shared_ptr must be templated on IpcressGrayOpacity and not on
   // cdi/GrayOpacity.
 
   // Create a new smart pointer to a IpcressGrayOpacity object.
-  SP<IpcressGrayOpacity> spGGOp_Analytic_ra;
+  shared_ptr<IpcressGrayOpacity> spGGOp_Analytic_ra;
 
   // try to instantiate the Opacity object.
   try {
@@ -753,10 +751,10 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &error) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressGrayOpacity object for "
-            << "\n\t analyticOpacityies.ipcress data (SP not templated on "
-            << "cdi/GrayOpacity)." << endl
-            << "\t" << error.what();
+    message << "Failed to create shared_ptr to new IpcressGrayOpacity object "
+            << "fpr \n\t analyticOpacityies.ipcress data (shared_ptr not "
+            << "templated on cdi/GrayOpacity).\n\t"
+            << error.what();
     FAILMSG(message.str());
     FAILMSG("Aborting tests.");
     return;
@@ -913,11 +911,11 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
   // -------------------------------------- //
 
   // These accessors are only available in IpcressOpacity objects
-  // so the SP must be templated on IpcressMultigroupOpacity and not on
+  // so the shared_ptr must be templated on IpcressMultigroupOpacity and not on
   // cdi/MultigroupOpacity.
 
   // Create a new smart pointer to a IpcressGrayOpacity object.
-  SP<IpcressMultigroupOpacity> spGMGOp_Analytic_ra;
+  shared_ptr<IpcressMultigroupOpacity> spGMGOp_Analytic_ra;
 
   // try to instantiate the Opacity object.
   try {
@@ -925,9 +923,9 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &error) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressGrayOpacity "
+    message << "Failed to create shared_ptr to new IpcressGrayOpacity "
             << "object for \n\t analyticOpacities.ipcress data "
-            << "(SP not templated on cdi/GrayOpacity)." << endl
+            << "(shared_ptr not templated on cdi/GrayOpacity)." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
     FAILMSG("Aborting tests.");
@@ -935,7 +933,8 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG("SP to new Opacity object created for analyticOpacities.ipcress.");
+  PASSMSG( string("shared_ptr to new Opacity object created for ") +
+           string("analyticOpacities.ipcress."));
 
   // Here is the reference solution
   int ng = spGMGOp_Analytic_ra->getNumGroupBoundaries() - 1;
@@ -1083,7 +1082,7 @@ void gray_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
     // ------------------------- //
 
     // Create a smart pointer to a IpcressFile object
-    SP<IpcressFile> spGFAnalytic;
+    shared_ptr<IpcressFile> spGFAnalytic;
 
     // Try to instantiate the object.
     try {
@@ -1096,7 +1095,7 @@ void gray_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
     }
 
     // Create a smart pointer to an Opacity object.
-    SP<GrayOpacity> spOp_Analytic_ragray;
+    shared_ptr<GrayOpacity> spOp_Analytic_ragray;
 
     // material ID
     int const matid = 10001;
@@ -1109,15 +1108,15 @@ void gray_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // make a new IpcressGrayOpacity from packed data
-  SP<GrayOpacity> unpacked_opacity;
+  shared_ptr<GrayOpacity> unpacked_opacity;
 
   // Try to instantiate the Opacity object.
   try {
     unpacked_opacity.reset(new IpcressGrayOpacity(packed));
   } catch (rtt_dsxx::assertion const &error) {
     ostringstream message;
-    message << "Failed to create SP to unpacked IpcressOpacity object for "
-            << "analyticOpacities.ipcress data." << endl
+    message << "Failed to create shared_ptr to unpacked IpcressOpacity object "
+            << "for analyticOpacities.ipcress data." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
     FAILMSG("Aborting tests.");
@@ -1150,7 +1149,7 @@ void gray_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
   // try to unpack gray opacity as multigroup opacity
   bool caught = false;
   try {
-    SP<MultigroupOpacity> opacity(new IpcressMultigroupOpacity(packed));
+    shared_ptr<MultigroupOpacity> opacity(new IpcressMultigroupOpacity(packed));
   } catch (rtt_dsxx::assertion const &error) {
     caught = true;
     ostringstream message;
@@ -1176,7 +1175,7 @@ void mg_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
     // ------------------------- //
 
     // Create a smart pointer to a IpcressFile object
-    SP<IpcressFile> spGFAnalytic;
+    shared_ptr<IpcressFile> spGFAnalytic;
 
     // Try to instantiate the object.
     try {
@@ -1196,7 +1195,7 @@ void mg_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
     //---------------- //
 
     // Create a smart pointer to an Opacity object.
-    SP<MultigroupOpacity> spOp_Analytic_pmg;
+    shared_ptr<MultigroupOpacity> spOp_Analytic_pmg;
 
     spOp_Analytic_pmg.reset(new IpcressMultigroupOpacity(
         spGFAnalytic, matid, rtt_cdi::PLANCK, rtt_cdi::ABSORPTION));
@@ -1205,7 +1204,7 @@ void mg_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // make a new IpcressGrayOpacity from packed data
-  SP<MultigroupOpacity> unpacked_opacity;
+  shared_ptr<MultigroupOpacity> unpacked_opacity;
 
   // Try to instantiate the Opacity object.
   try {
@@ -1218,8 +1217,8 @@ void mg_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
   // catch ( rtt_cdi_ipcress::ggetgrayException GandError )
   {
     ostringstream message;
-    message << "Failed to create SP to unpacked IpcressOpacity object for "
-            << "analyticOpacities.ipcress data." << endl
+    message << "Failed to create shared_ptr to unpacked IpcressOpacity object "
+            << "for analyticOpacities.ipcress data." << endl
             << "\t" << error.what();
     FAILMSG(message.str());
     FAILMSG("Aborting tests.");
@@ -1272,7 +1271,7 @@ void mg_opacity_packing_test(rtt_dsxx::ScalarUnitTest &ut) {
   // try to unpack multigroup as gray opacity
   bool caught = false;
   try {
-    SP<GrayOpacity> opacity(new IpcressGrayOpacity(packed));
+    shared_ptr<GrayOpacity> opacity(new IpcressGrayOpacity(packed));
   } catch (rtt_dsxx::assertion const &error) {
     caught = true;
     ostringstream message;

--- a/src/cdi_ipcress/test/tIpcressOpacity.cc
+++ b/src/cdi_ipcress/test/tIpcressOpacity.cc
@@ -50,8 +50,8 @@ void file_check_Al_BeCu(rtt_dsxx::ScalarUnitTest &ut) {
     }
 
     // If we make it here then spIF was successfully instantiated.
-    PASSMSG( string("shared_ptr to new IpcressFile object created for ") +
-             string("Al_BeCu.ipcress data.") );
+    PASSMSG(string("shared_ptr to new IpcressFile object created for ") +
+            string("Al_BeCu.ipcress data."));
 
     // Test the IpcressFile object.
     if (spIF->getDataFilename() == op_data_file) {
@@ -338,8 +338,8 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG( string("shared_ptr to new Opacity object created for ") +
-           string("analyticOpacities.ipcress."));
+  PASSMSG(string("shared_ptr to new Opacity object created for ") +
+          string("analyticOpacities.ipcress."));
 
   // ----------------- //
   // Gray Opacity Test //
@@ -378,8 +378,8 @@ void file_check_analytic(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG( string("shared_ptr to new Opacity object created for ") +
-           string ("analyticOpacities.ipcress."));
+  PASSMSG(string("shared_ptr to new Opacity object created for ") +
+          string("analyticOpacities.ipcress."));
 
   // Set up the new test problem.
 
@@ -753,8 +753,7 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
     ostringstream message;
     message << "Failed to create shared_ptr to new IpcressGrayOpacity object "
             << "fpr \n\t analyticOpacityies.ipcress data (shared_ptr not "
-            << "templated on cdi/GrayOpacity).\n\t"
-            << error.what();
+            << "templated on cdi/GrayOpacity).\n\t" << error.what();
     FAILMSG(message.str());
     FAILMSG("Aborting tests.");
     return;
@@ -933,8 +932,8 @@ void check_ipcress_stl_accessors(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we get here then the object was successfully instantiated.
-  PASSMSG( string("shared_ptr to new Opacity object created for ") +
-           string("analyticOpacities.ipcress."));
+  PASSMSG(string("shared_ptr to new Opacity object created for ") +
+          string("analyticOpacities.ipcress."));
 
   // Here is the reference solution
   int ng = spGMGOp_Analytic_ra->getNumGroupBoundaries() - 1;

--- a/src/cdi_ipcress/test/tIpcressWithCDI.cc
+++ b/src/cdi_ipcress/test/tIpcressWithCDI.cc
@@ -89,9 +89,10 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create shared_ptr to new IpcressGrayOpacity object for "
-            << "Al_BeCu.ipcress data." << endl
-            << "\t" << excpt.what();
+    message
+        << "Failed to create shared_ptr to new IpcressGrayOpacity object for "
+        << "Al_BeCu.ipcress data." << endl
+        << "\t" << excpt.what();
     FAILMSG(message.str());
     FAILMSG("Aborting tests.");
     return;

--- a/src/cdi_ipcress/test/tIpcressWithCDI.cc
+++ b/src/cdi_ipcress/test/tIpcressWithCDI.cc
@@ -5,10 +5,7 @@
  * \date   Mon Oct 29 17:16:32 2001
  * \brief  Ipcress + CDI test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_ipcress_test.hh"
@@ -26,7 +23,6 @@ using rtt_cdi_ipcress::IpcressFile;
 using rtt_cdi::GrayOpacity;
 using rtt_cdi::MultigroupOpacity;
 using rtt_cdi::CDI;
-using rtt_dsxx::SP;
 
 //---------------------------------------------------------------------------//
 // TESTS
@@ -59,7 +55,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   // ------------------------- //
 
   // Create a smart pointer to a IpcressFile object
-  SP<const IpcressFile> spGFAnalytic;
+  shared_ptr<const IpcressFile> spGFAnalytic;
 
   // Try to instantiate the object.
   try {
@@ -74,7 +70,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   }
 
   // If we make it here then spGFAnalytic was successfully instantiated.
-  PASSMSG("SP to new IpcressFile object created (spGFAnalytic).");
+  PASSMSG("shared_ptr to new IpcressFile object created (spGFAnalytic).");
 
   // ----------------------------------- //
   // Create a IpcressGrayOpacity object. //
@@ -85,7 +81,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   int const matid = 10001;
 
   // Create a smart pointer to an opacity object.
-  SP<const GrayOpacity> spOp_Analytic_ragray;
+  shared_ptr<const GrayOpacity> spOp_Analytic_ragray;
 
   // Try to instantiate the opacity object.
   try {
@@ -93,7 +89,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressGrayOpacity object for "
+    message << "Failed to create shared_ptr to new IpcressGrayOpacity object for "
             << "Al_BeCu.ipcress data." << endl
             << "\t" << excpt.what();
     FAILMSG(message.str());
@@ -104,7 +100,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   // If we get here then the object was successfully instantiated.
   {
     ostringstream message;
-    message << "SP to new IpcressGrayOpacity object created "
+    message << "shared_ptr to new IpcressGrayOpacity object created "
             << "for analyticOpacities.ipcress.";
     PASSMSG(message.str());
   }
@@ -113,14 +109,14 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   // Create CDI object //
   // ----------------- //
 
-  SP<CDI> spCDI_Analytic;
+  shared_ptr<CDI> spCDI_Analytic;
   if ((spCDI_Analytic.reset(new CDI())), spCDI_Analytic) {
     ostringstream message;
-    message << "SP to CDI object created successfully (GrayOpacity).";
+    message << "shared_ptr to CDI object created successfully (GrayOpacity).";
     PASSMSG(message.str());
   } else {
     ostringstream message;
-    message << "Failed to create SP to CDI object (GrayOpacity).";
+    message << "Failed to create shared_ptr to CDI object (GrayOpacity).";
     FAILMSG(message.str());
   }
 
@@ -189,7 +185,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   // ----------------------------------------- //
 
   // Create a smart pointer to an opacity object.
-  SP<const MultigroupOpacity> spOp_Analytic_ramg;
+  shared_ptr<const MultigroupOpacity> spOp_Analytic_ramg;
 
   // Try to instantiate the opacity object.
   try {
@@ -197,7 +193,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
         spGFAnalytic, matid, rtt_cdi::ROSSELAND, rtt_cdi::ABSORPTION));
   } catch (rtt_dsxx::assertion const &excpt) {
     ostringstream message;
-    message << "Failed to create SP to new IpcressMultigroupOpacity "
+    message << "Failed to create shared_ptr to new IpcressMultigroupOpacity "
             << "object for Al_BeCu.ipcress data." << endl
             << "\t" << excpt.what();
     FAILMSG(message.str());
@@ -208,7 +204,7 @@ void test_ipcress_CDI(rtt_dsxx::ScalarUnitTest &ut) {
   // If we get here then the object was successfully instantiated.
   {
     ostringstream message;
-    message << "SP to new Ipcress multigroup opacity object created"
+    message << "shared_ptr to new Ipcress multigroup opacity object created"
             << "\n\tfor analyticOpacities.ipcress.";
     PASSMSG(message.str());
   }

--- a/src/ds++/Assert.cc
+++ b/src/ds++/Assert.cc
@@ -109,7 +109,7 @@ void insist(std::string const &cond, std::string const &msg,
  *
  * Having a (non-inlined) version that takes pointers prevents the compiler from
  * having to construct std::strings from the pointers each time.  This is
- * particularly important for things like rtt_dsxx::SP::operator->, that (a)
+ * particularly important for things like std::shared_pt::operator->, that (a)
  * have an insist in them, (b) don't need complicated strings and (c) are called
  * frequently.
  */
@@ -142,7 +142,7 @@ void check_insist(bool const cond, char const *const condstr,
  *
  * Having a (non-inlined) version that takes pointers prevents the compiler from
  * having to construct std::strings from the pointers each time.  This is
- * particularly important for things like rtt_dsxx::SP::operator->, that (a)
+ * particularly important for things like std::shared_ptr::operator->, that (a)
  * have an insist in them, (b) don't need complicated strings and (c) are called
  * frequently.
  */

--- a/src/ds++/Assert.cc
+++ b/src/ds++/Assert.cc
@@ -3,9 +3,7 @@
  * \file   ds++/Assert.cc
  * \brief  Helper functions for the Assert facility.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- * \version $Id$
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Assert.hh"
@@ -70,8 +68,9 @@ void toss_cookies_ptr(char const *const cond, char const *const file,
 /*!
  * \brief Throw a rtt_dsxx::assertion for Require, Check, Ensure macros.
  *
- * This version defers the branch, and so is preferred for testing code coverage by the test
- * suite. However, it has the performance penalty of an extra function call.
+ * This version defers the branch, and so is preferred for testing code coverage
+ * by the test suite. However, it has the performance penalty of an extra
+ * function call.
  *
  * \return Throws an assertion.
  */
@@ -108,11 +107,11 @@ void insist(std::string const &cond, std::string const &msg,
 /*!
  * \brief Throw a rtt_dsxx::assertion for Insist_ptr macros.
  *
- * Having a (non-inlined) version that takes pointers prevents the compiler
- * from having to construct std::strings from the pointers each time.  This
- * is particularly important for things like rtt_dsxx::SP::operator->, that
- * (a) have an insist in them, (b) don't need complicated strings and (c) are
- * called frequently.
+ * Having a (non-inlined) version that takes pointers prevents the compiler from
+ * having to construct std::strings from the pointers each time.  This is
+ * particularly important for things like rtt_dsxx::SP::operator->, that (a)
+ * have an insist in them, (b) don't need complicated strings and (c) are called
+ * frequently.
  */
 void insist_ptr(char const *const cond, char const *const msg,
                 char const *const file, int const line) {
@@ -141,11 +140,11 @@ void check_insist(bool const cond, char const *const condstr,
 /*!
  * \brief Conditionally throw a rtt_dsxx::assertion for Insist_ptr macros.
  *
- * Having a (non-inlined) version that takes pointers prevents the compiler
- * from having to construct std::strings from the pointers each time.  This
- * is particularly important for things like rtt_dsxx::SP::operator->, that
- * (a) have an insist in them, (b) don't need complicated strings and (c) are
- * called frequently.
+ * Having a (non-inlined) version that takes pointers prevents the compiler from
+ * having to construct std::strings from the pointers each time.  This is
+ * particularly important for things like rtt_dsxx::SP::operator->, that (a)
+ * have an insist in them, (b) don't need complicated strings and (c) are called
+ * frequently.
  */
 void check_insist_ptr(bool const cond, char const *const condstr,
                       char const *const msg, char const *const file,
@@ -158,9 +157,9 @@ void check_insist_ptr(bool const cond, char const *const condstr,
 //---------------------------------------------------------------------------//
 /*! \brief Add hostname and pid to error messages.
  *
- * Several of the errors that might be reported by DACS_Device could be
- * specific to one or a few nodes (filesystems not mounted, etc.).
- * verbose_error adds the hostname and pid to error messages.
+ * Several of the errors that might be reported by DACS_Device could be specific
+ * to one or a few nodes (filesystems not mounted, etc.).  verbose_error adds
+ * the hostname and pid to error messages.
  */
 std::string verbose_error(std::string const &message) {
   int pid = draco_getpid();

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -4,10 +4,7 @@
  * \brief  Header file for Draco specific exception class definition
  *         (rtt_dsxx::assertion). Also define Design-by-Contract macros.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef RTT_dsxx_Assert_HH
@@ -21,8 +18,8 @@
 // (IS-A) instead of creating a class that 'HAS-A' std::logic_error.object.
 #if defined(MSVC)
 #pragma warning(push)
-// non dll-interface class 'std::logic_error' used as base for
-// dll-interface class 'rtt_dsxx::assertion'
+// non dll-interface class 'std::logic_error' used as base for dll-interface
+// class 'rtt_dsxx::assertion'
 #pragma warning(disable : 4275)
 #endif
 
@@ -84,86 +81,85 @@ namespace rtt_dsxx {
  *
  * Major changes for class rtt_dsxx::assertion:
  *
- * Let rtt_dsxx::assertion derive from std::runtime_error.  G. Furnish
- * intended for the design to follow this model but the C++ compilers at time
- * did not have full support for \c <stdexcept>.  API is unchanged but the
- * guts of the class are significantly different (i.e.: use copy and
- * assignment operators from base class, use string instead of \c const \c
- * char \c *, etc.).
+ * Let rtt_dsxx::assertion derive from std::runtime_error.  G. Furnish intended
+ * for the design to follow this model but the C++ compilers at time did not
+ * have full support for \c <stdexcept>.  API is unchanged but the guts of the
+ * class are significantly different (i.e.: use copy and assignment operators
+ * from base class, use string instead of \c const \c char \c *, etc.).
  *
  * \subsection date28July1997 28 July 1997
  *
- * Total rewrite of the ds++ Assertion facility.  In the old formulation,
- * Assert and Insist expanded into inline if statements, for which the body
- * were blocks which both contained output to cerr, and which threw an
- * exception.  This has proven problematic because it meant that \c Assert.hh
- * included \c iostream.h, and also because throw was inlined (not a problem
- * for Assert per se, since Assert was generally shut off for optimized codes,
- * but still a problem for Insist).  These effects combined to present
- * problems both at compile time and, possibly, at run time.
+ * Total rewrite of the ds++ Assertion facility.  In the old formulation, Assert
+ * and Insist expanded into inline if statements, for which the body were blocks
+ * which both contained output to cerr, and which threw an exception.  This has
+ * proven problematic because it meant that \c Assert.hh included \c iostream.h,
+ * and also because throw was inlined (not a problem for Assert per se, since
+ * Assert was generally shut off for optimized codes, but still a problem for
+ * Insist).  These effects combined to present problems both at compile time
+ * and, possibly, at run time.
  *
  * The new formulation, motivated by suggestions from Arch Robison and Dave
- * Nystrom, uses a call to an out-of-line function to do the actual logging
- * and throwing of exceptions.  This permits removing \c iostream.h from the
+ * Nystrom, uses a call to an out-of-line function to do the actual logging and
+ * throwing of exceptions.  This permits removing \c iostream.h from the
  * inclusion graph for translation units including \c Assert.hh, and avoids
  * inlining of exception throwing code.  Moreover, it also allows us to get \c
  * __FILE__ into play, which we couldn't do before because there was no way to
  * do string concatenation with it, and you couldn't do free store management
- * effectively in an inlined macro.  By going out to a global function, we
- * pick up the ability to formulate a more complete picture of the error, and
- * provide some optimization capability (both compile time and run time).
+ * effectively in an inlined macro.  By going out to a global function, we pick
+ * up the ability to formulate a more complete picture of the error, and provide
+ * some optimization capability (both compile time and run time).
  *
  * Note also that at this juncture, we go ahead and drop all support for
  * compilers which are incapable of compiling exception code.  From here
- * forward, exceptions are assumed to be available.  And thereby we do our
- * part to promote "standard C++".
+ * forward, exceptions are assumed to be available.  And thereby we do our part
+ * to promote "standard C++".
  *
  * \sa http://akrzemi1.wordpress.com/2013/01/04/preconditions-part-i/
  */
 //===========================================================================//
 
 class DLL_PUBLIC_dsxx assertion : public std::logic_error {
-public:
+  public:
   /*!
-     * \brief Default constructor for ds++/assertion class.
-     *
-     * This constructor creates a ds++ exception object.  This object is
-     * derived form std::runtime_error and has identical functionality.  The
-     * principal purpose for this class is to provide an exception class that
-     * is specialized for Draco.  See the notes on the overall class for more
-     * details.
-     *
-     * \param msg The error message saved with the exception.
-     */
+   * \brief Default constructor for ds++/assertion class.
+   *
+   * This constructor creates a ds++ exception object.  This object is
+   * derived form std::runtime_error and has identical functionality.  The
+   * principal purpose for this class is to provide an exception class that
+   * is specialized for Draco.  See the notes on the overall class for more
+   * details.
+   *
+   * \param msg The error message saved with the exception.
+   */
   explicit assertion(std::string const &msg)
-      : std::logic_error(msg) { /* empty */
+    : std::logic_error(msg) { /* empty */
   }
 
   /*!
-     * \brief Specialized constructor for rtt_dsxx::assertion class.
-     *
-     * This constructor creates a ds++ exception object.  This object is
-     * derived form std::runtime_error and has identical functionality.  This
-     * constructor is specialized for use by Draco DbC commands (Require,
-     * Ensure, Check, and Insist).  It forms the error message from the test
-     * condition and the file and line number of the DbC command.
-     *
-     * \param cond The expression that failed a DbC test.
-     * \param file The source code file name that contains the DbC test.
-     * \param line The source code line number that contains the DbC test.
-     *
-     * \sa \ref Draco_DBC, --with-dbc[=level], Require, Ensure, Check, Insist
-     */
+   * \brief Specialized constructor for rtt_dsxx::assertion class.
+   *
+   * This constructor creates a ds++ exception object.  This object is derived
+   * form std::runtime_error and has identical functionality.  This constructor
+   * is specialized for use by Draco DbC commands (Require, Ensure, Check, and
+   * Insist).  It forms the error message from the test condition and the file
+   * and line number of the DbC command.
+   *
+   * \param cond The expression that failed a DbC test.
+   * \param file The source code file name that contains the DbC test.
+   * \param line The source code line number that contains the DbC test.
+   *
+   * \sa \ref Draco_DBC, --with-dbc[=level], Require, Ensure, Check, Insist
+   */
   assertion(std::string const &cond, std::string const &file, int const line)
-      : std::logic_error(build_message(cond, file, line)) { /* empty */
+    : std::logic_error(build_message(cond, file, line)) { /* empty */
   }
 
   /*! \brief Destructor for ds++/assertion class.
-     * We do not allow the destructor to throw! */
+   * We do not allow the destructor to throw! */
   virtual ~assertion() throw();
 
-  /*! Helper function to build error message that includes source file name
-     *  and line number. */
+  /*! Helper function to build error message that includes source file name and
+   *  line number. */
   static std::string build_message(std::string const &cond,
                                    std::string const &file, int const line);
 };
@@ -226,41 +222,42 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
  *
  * If the assertion fails, the code should just bomb.  Philosophically, it
  * should be used to feret out bugs in preceding code, making sure that prior
- * results are within reasonable bounds before proceeding to use those
- * results in further computation, etc.
+ * results are within reasonable bounds before proceeding to use those results
+ * in further computation, etc.
  *
- * These macros are provided to support the Design By Contract formalism.
- * The activation of each macro is keyed off a bit in the DBC macro which can
- * be specified on the command line:
-\verbatim
-     Bit     DBC macro affected
-     ---     ------------------
-      0      Require
-      1      Check
-      2      Ensure, Remember
-      3      (nothrow option)
-\endverbatim
+ * These macros are provided to support the Design By Contract formalism.  The
+ * activation of each macro is keyed off a bit in the DBC macro which can be
+ * specified on the command line:
  *
- * So for instance, \c -DDBC=7 turns them all on, \c -DDBC=0 turns them all
- * off, and \c -DDBC=1 turns on \c Require but turns off \c Check and \c
- * Ensure.  The default is to have them all enabled.  The fourth bit (3) can
- * be toggled on to disable the C++ thrown exception while keeping all of the
- * DBC checks and messages active.
+ \verbatim
+ Bit     DBC macro affected
+ ---     ------------------
+ 0      Require
+ 1      Check
+ 2      Ensure, Remember
+ 3      (nothrow option)
+ \endverbatim
+ *
+ * So for instance, \c -DDBC=7 turns them all on, \c -DDBC=0 turns them all off,
+ * and \c -DDBC=1 turns on \c Require but turns off \c Check and \c Ensure.  The
+ * default is to have them all enabled.  The fourth bit (3) can be toggled on to
+ * disable the C++ thrown exception while keeping all of the DBC checks and
+ * messages active.
  *
  * The \c Insist macro is akin to the \c Assert macro, but it provides the
  * opportunity to specify an instructive message.  The idea here is that you
  * should use Insist for checking things which are more or less under user
- * control.  If the user makes a poor choice, we "insist" that it be
- * corrected, providing a corrective hint.
+ * control.  If the user makes a poor choice, we "insist" that it be corrected,
+ * providing a corrective hint.
  *
- * \note We provide a way to eliminate assertions, but not insistings.  The
- * idea is that \c Assert is used to perform sanity checks during program
+ * \note We provide a way to eliminate assertions, but not insistings.  The idea
+ * is that \c Assert is used to perform sanity checks during program
  * development, which you might want to eliminate during production runs for
  * performance sake.  Insist is used for things which really really must be
  * true, such as "the file must've been opened", etc.  So, use \c Assert for
  * things which you want taken out of production codes (like, the check might
- * inhibit inlining or something like that), but use Insist for those things
- * you want checked even in a production code.
+ * inhibit inlining or something like that), but use Insist for those things you
+ * want checked even in a production code.
  */
 /*!
  * \def Require(condition)
@@ -296,8 +293,8 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
 /*!
  * \def Insist_ptr(condition, message)
  *
- * Same as Insist, except that it uses char pointers, rather than strings.
- * This is more efficient when inlined.
+ * Same as Insist, except that it uses char pointers, rather than strings.  This
+ * is more efficient when inlined.
  */
 //---------------------------------------------------------------------------//
 
@@ -347,11 +344,11 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
 // Regular (exception throwing) versions of DBC, but with the check deferred.
 // This eliminates numerous untestable branches for coverage analysis, but can
 // be costly in run time.
-//---------------------------------------------------------------------------//
+// ---------------------------------------------------------------------------//
 
-// Note that the !!(c) is needed to force the argument to a bool for certain objects,
-// notably instances of the stream classes, which provide an operator! but no direct
-// conversion to bool.
+// Note that the !!(c) is needed to force the argument to a bool for certain
+// objects, notably instances of the stream classes, which provide an operator!
+// but no direct conversion to bool.
 
 // Also note that Bad_Case is always off in this selection.
 

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -119,7 +119,7 @@ namespace rtt_dsxx {
 //===========================================================================//
 
 class DLL_PUBLIC_dsxx assertion : public std::logic_error {
-  public:
+public:
   /*!
    * \brief Default constructor for ds++/assertion class.
    *
@@ -132,7 +132,7 @@ class DLL_PUBLIC_dsxx assertion : public std::logic_error {
    * \param msg The error message saved with the exception.
    */
   explicit assertion(std::string const &msg)
-    : std::logic_error(msg) { /* empty */
+      : std::logic_error(msg) { /* empty */
   }
 
   /*!
@@ -151,7 +151,7 @@ class DLL_PUBLIC_dsxx assertion : public std::logic_error {
    * \sa \ref Draco_DBC, --with-dbc[=level], Require, Ensure, Check, Insist
    */
   assertion(std::string const &cond, std::string const &file, int const line)
-    : std::logic_error(build_message(cond, file, line)) { /* empty */
+      : std::logic_error(build_message(cond, file, line)) { /* empty */
   }
 
   /*! \brief Destructor for ds++/assertion class.

--- a/src/ds++/Check_Strings.hh
+++ b/src/ds++/Check_Strings.hh
@@ -3,22 +3,20 @@
  * \file   ds++/Check_Strings.hh
  * \author John McGhee
  * \date   Sun Jan 30 14:57:09 2000 *
- * \brief  Provides some utilities to check containers of strings. 
+ * \brief  Provides some utilities to check containers of strings.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
  *         All rights reserved.
  *
  * Functions are provided to examine a container of strings: 1) for the
- * occurrence of certain characters, 2) for the length of each string
- * outside of high and low limits, and 3) to determine if there are any 
- * duplicate strings in the container. Return value is a vector of 
- * iterators which point to any strings which are selected.
+ * occurrence of certain characters, 2) for the length of each string outside of
+ * high and low limits, and 3) to determine if there are any duplicate strings
+ * in the container. Return value is a vector of iterators which point to any
+ * strings which are selected.
  *
  * \example ds++/test/tstCheck_Strings.cc
  * The following code provides examples of how to use the Check_Strings
- * utilities. 
+ * utilities.
  */
-//---------------------------------------------------------------------------//
-// $Id$
 //---------------------------------------------------------------------------//
 
 #ifndef __ds_Check_Strings_hh__
@@ -64,27 +62,24 @@ struct strings_equal {
  *        the container use any of the characters specified in the input
  *        parameter "match_chars".
  *
- * For example, if you want to create a set of files or directories from a
- *     list of strings, this function can be used to check for characters
- *     (like "*" for instance) that really shouldn't be used for file or
- *     directory names.
+ * For example, if you want to create a set of files or directories from a list
+ * of strings, this function can be used to check for characters (like "*" for
+ * instance) that really shouldn't be used for file or directory names.
  *
- * \param first iterator for the first string in the container to
- *        be checked.
+ * \param first iterator for the first string in the container to be checked.
  *
- * \param last iterator for the last string in the container to be
- *        to be checked plus one.
+ * \param last iterator for the last string in the container to be to be checked
+ *        plus one.
  *
  * \param match_chars a string containing the characters for which to search.
- *        i.e. - If you want to check for the presence of "*" or "^"
- *        then set std::string match_chars = "*^".
+ *        i.e. - If you want to check for the presence of "*" or "^" then set
+ *        std::string match_chars = "*^".
  *
- * \return a vector of iterators for any strings which contain
- *         one or more of the match characters. If the size of this vector
- *         is 0 no strings that contained any of the matching
- *         characters were found.
+ * \return a vector of iterators for any strings which contain one or more of
+ *         the match characters. If the size of this vector is 0 no strings that
+ *         contained any of the matching characters were found.
  *
- * \sa     Other string checking utilities are available in
+ * \sa Other string checking utilities are available in
  *         rtt_dsxx::check_string_lengths, and rtt_dsxx::check_strings_unique.
  *
  */
@@ -104,34 +99,31 @@ std::vector<IT> check_string_chars(IT const &first, IT const &last,
   return result_vector;
 }
 
+//---------------------------------------------------------------------------//
 /*!
- * \brief Looks through a container of strings to see if the size of any
- *        of the strings in the container is outside the specified
- *        range.
+ * \brief Looks through a container of strings to see if the size of any of the
+ *        strings in the container is outside the specified range.
  *
- * For example, if you want to check a container of strings to make
- *        sure that all lengths are in the range 1:19 inclusive,
- *        set parameter low=1, and parameter high=19.
+ * For example, if you want to check a container of strings to make sure that
+ * all lengths are in the range 1:19 inclusive, set parameter low=1, and
+ * parameter high=19.
  *
- * \param first iterator for the first string in the container to
- *        be checked.
+ * \param first iterator for the first string in the container to be checked.
  *
- * \param last iterator for the last string in the container to be
- *        to be checked plus one.
+ * \param last iterator for the last string in the container to be to be checked
+ *        plus one.
  *
- * \param low lower limit of acceptable string length. If less than
- *        zero, it is assumed to be zero.
+ * \param low lower limit of acceptable string length. If less than zero, it is
+ *        assumed to be zero.
  *
  * \param high upper limit of acceptable string length
  *
- * \return a vector of iterators for any strings which are of 
- *         length less than low or greater than high.
- *         If the size of this vector is 0 no strings with 
- *         out-of-range lengths were found.
+ * \return a vector of iterators for any strings which are of length less than
+ *         low or greater than high.  If the size of this vector is 0 no strings
+ *         with out-of-range lengths were found.
  *
- * \sa     Other string checking utilities are available in
+ * \sa Other string checking utilities are available in
  *         rtt_dsxx::check_string_chars, and rtt_dsxx::check_strings_unique.
- *
  */
 template <class IT>
 std::vector<IT> check_string_lengths(IT const &first, IT const &last,
@@ -151,28 +143,26 @@ std::vector<IT> check_string_lengths(IT const &first, IT const &last,
   return result_vector;
 }
 
+//---------------------------------------------------------------------------//
 /*!
  * \brief Looks through a container of strings to see if there are any
  *        duplicates.
- * 
- * If a string is duplicated more than once, it will appear in the output
- *        vector more than once.
  *
- * \param first iterator for the first string in the container to
- *        be checked. 
+ * If a string is duplicated more than once, it will appear in the output vector
+ * more than once.
  *
- * \param last iterator for the last string in the container to be
- *        to be checked plus one.
+ * \param first iterator for the first string in the container to be checked.
  *
- * \return a vector of iterators for any strings which are found
- *         to be duplicated. 
- *         If the size of this vector is 0 no duplicate strings
- *         were found, that is, all the strings in the container
- *         in the range first:last-1 are unique.
+ * \param last iterator for the last string in the container to be to be checked
+ *        plus one.
  *
- * \sa     Other string checking utilities are available in
+ * \return a vector of iterators for any strings which are found to be
+ *         duplicated.  If the size of this vector is 0 no duplicate strings
+ *         were found, that is, all the strings in the container in the range
+ *         first:last-1 are unique.
+ *
+ * \sa Other string checking utilities are available in
  *         rtt_dsxx::check_string_chars, and rtt_dsxx::check_string_lengths.
- *
  */
 template <class IT>
 std::vector<IT> check_strings_unique(IT first, IT const &last) {

--- a/src/ds++/Data_Table.hh
+++ b/src/ds++/Data_Table.hh
@@ -4,9 +4,7 @@
  * \author  Paul Henning
  * \brief   Declaration of class Data_Table
  * \note    Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- * \version $Id$
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 #ifndef dsxx_Data_Table_hh
 #define dsxx_Data_Table_hh
@@ -16,10 +14,10 @@
 #include <vector>
 
 /*!
-  Data_Table provides read-only, DBC-checked, container-like
-  access to a sequential range of memory locations, or a scalar.  This is
-  useful in situations where the amount of data changes depending on
-  compile-time factors, but you always want to access it as an array.
+  Data_Table provides read-only, DBC-checked, container-like access to a
+  sequential range of memory locations, or a scalar.  This is useful in
+  situations where the amount of data changes depending on compile-time factors,
+  but you always want to access it as an array.
 */
 
 namespace rtt_dsxx {
@@ -48,14 +46,14 @@ private:
   const_iterator const d_begin;
   const_iterator const d_end;
 
-  /*! We hold a copy of the scalar to prevent the problems that would arise
-     *  if you took a pointer to a function-return temporary. */
+  /*! We hold a copy of the scalar to prevent the problems that would arise if
+   *  you took a pointer to a function-return temporary. */
   T const d_value;
 };
 
-/*! 
+/*!
   Copy constructor, but update the pointers to point to the local d_value if
-  they pointed to the d_value in the rhs. 
+  they pointed to the d_value in the rhs.
 */
 template <typename T>
 Data_Table<T>::Data_Table(Data_Table<T> const &rhs)
@@ -82,9 +80,9 @@ Data_Table<T> &Data_Table<T>::operator=(Data_Table<T> const &rhs) {
 }
 
 /*!
-  Bad things will happen if you alter the size of the source vector while
-  this Data_Table is in existence.
-  
+  Bad things will happen if you alter the size of the source vector while this
+  Data_Table is in existence.
+
   \bug Removed ctor because it does not conform to the C++ standard
   (dereferencing of end iterator is not allowed).  This particular ctor causes
   run time failures for STLport and MSVC/Debug.
@@ -105,7 +103,7 @@ inline Data_Table<T>::Data_Table(const_iterator const begin,
   Require(!(begin > end));
 }
 
-/*! 
+/*!
   Copy the scalar into a local variable, and set the pointers to that copy.
 */
 template <typename T>

--- a/src/ds++/DracoMath.hh
+++ b/src/ds++/DracoMath.hh
@@ -5,13 +5,7 @@
  * \date   Wed Jan 22 15:18:23 MST 2003
  * \brief  New or overloaded cmath or cmath-like functions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- *
- * History:
- * 2013-10-17 Many small header files were combined to create DracoMath.hh.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_DracoMath_hh
@@ -32,10 +26,9 @@ namespace rtt_dsxx {
 //
 // Try to use the C++11/C99 functions isinf, isnan and isfinite defined in
 // <cmath> instead of defining our own.  I would like to use C++11
-// implemenations which are true functions in the std:: namespace.  The
-// problem here is that PGI/13.7 does not have these language features.
-// However, PGI does provide the C99 _macros_ of the same name (w/o namespace
-// qualifier).
+// implemenations which are true functions in the std:: namespace.  The problem
+// here is that PGI/13.7 does not have these language features.  However, PGI
+// does provide the C99 _macros_ of the same name (w/o namespace qualifier).
 // ---------------------------------------------------------------------------//
 #if defined _WIN32 || defined __CYGWIN__
 
@@ -61,8 +54,8 @@ template <typename T> bool isFinite(T a) { return std::isfinite(a); }
 /*
  * abs.hh
  *
- * Absolute values are a mess in the STL, in part because they are a mess in
- * the standard C library. We do our best to give a templatized version here.
+ * Absolute values are a mess in the STL, in part because they are a mess in the
+ * standard C library. We do our best to give a templatized version here.
  */
 //---------------------------------------------------------------------------//
 /*!
@@ -92,9 +85,9 @@ template <> inline long abs(long a) { return std::labs(a); }
 /*!
  * \brief Return the conjugate of a quantity.
  *
- * The default implementation assumes a field type that is self-conjugate,
- * such as \c double.  An example of a field type that is \em not
- * self-conjugate is \c complex.
+ * The default implementation assumes a field type that is self-conjugate, such
+ * as \c double.  An example of a field type that is \em not self-conjugate is
+ * \c complex.
  *
  * \arg \a Field type
  */
@@ -129,8 +122,8 @@ template <typename Semigroup> inline Semigroup cube(Semigroup const &x) {
  *
  * This is a replacement for the FORTRAN DIM function.
  *
- * \arg \a Ordered_Group_Element A type for which operator< and unary
- * operator- are defined and which can be constructed from a literal \c 0.
+ * \arg \a Ordered_Group_Element A type for which operator< and unary operator-
+ * are defined and which can be constructed from a literal \c 0.
  *
  * \param a
  * Minuend
@@ -173,15 +166,14 @@ template <typename Semigroup> inline Semigroup square(const Semigroup &x) {
 /*!
  * \brief Compute the hypotenuse of a right triangle.
  *
- * This function evaluates the expression \f$\sqrt{a^2+b^2}\f$ in a way that
- * is insensitive to roundoff and preserves range.
+ * This function evaluates the expression \f$\sqrt{a^2+b^2}\f$ in a way that is
+ * insensitive to roundoff and preserves range.
  *
  * \arg \a Real A real number type
  * \param a First leg of triangle
  * \param b Second leg of triangle
  * \return Hypotenuse, \f$\sqrt{a^2+b^2}\f$
  */
-
 template <typename Real> inline double pythag(Real a, Real b) {
   Real absa = abs(a), absb = abs(b);
   if (absa > absb) {
@@ -201,8 +193,8 @@ template <typename Real> inline double pythag(Real a, Real b) {
  * \brief  Transfer the sign of the second argument to the first argument.
  *
  * This is a replacement for the FORTRAN SIGN function.  It is useful in
- * numerical algorithms that are roundoff or overflow insensitive and should
- * not be deprecated.
+ * numerical algorithms that are roundoff or overflow insensitive and should not
+ * be deprecated.
  *
  * \arg \a Ordered_Group
  * A type for which \c operator< and unary \c operator- are defined and which
@@ -216,7 +208,6 @@ template <typename Real> inline double pythag(Real a, Real b) {
  *
  * \return \f$|a|sgn(b)\f$
  */
-
 template <typename Ordered_Group>
 inline Ordered_Group sign(Ordered_Group a, Ordered_Group b) {
   using rtt_dsxx::abs; // just to be clear
@@ -239,8 +230,8 @@ inline Ordered_Group sign(Ordered_Group a, Ordered_Group b) {
  * \return The y value associated with x based on linear interpolation between
  * (x1,y1) and (x2,y2).
  *
- * Given two points (x1,y1) and (x2,y2), use linaer interpolation to find the
- * y value associated with the provided x value.
+ * Given two points (x1,y1) and (x2,y2), use linaer interpolation to find the y
+ * value associated with the provided x value.
  *
  *          y2-y1
  * y = y1 + ----- * (x-x1)

--- a/src/ds++/Endian.cc
+++ b/src/ds++/Endian.cc
@@ -5,10 +5,7 @@
  * \date   Wed Nov 09 14:15:14 2011
  * \brief  Function declarations for endian conversions
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Endian.hh"
@@ -17,7 +14,6 @@ namespace rtt_dsxx {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Does this platform use big or little endianness
- *
  * \return true if platform uses big endian format
  */
 bool is_big_endian(void) {
@@ -33,9 +29,9 @@ bool is_big_endian(void) {
 /*!
  * \brief Does this platform support IEEE float representation?
  *
- * Some older Cray machines did not support the IEEE float representation.
- * This simple test will identify machines that are IEEE compliant.
- * 
+ * Some older Cray machines did not support the IEEE float representation.  This
+ * simple test will identify machines that are IEEE compliant.
+ *
  * \return true if we support IEEE float representation.
  */
 bool has_ieee_float_representation(void) {

--- a/src/ds++/Endian.hh
+++ b/src/ds++/Endian.hh
@@ -5,10 +5,7 @@
  * \date   Tue Oct 23 14:15:55 2007
  * \brief  Function declarations for endian conversions
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef dsxx_Endian_hh
@@ -35,18 +32,18 @@
  *
  * To convert between big and little endian data we intrepret the data to be
  * converted as a character array by casting a pointer to the data to
- * (char*). We then manipulate the order, but not the contents, of the
- * character data.
+ * (char*). We then manipulate the order, but not the contents, of the character
+ * data.
  *
  * Note that we are implicitly assuming that the size of char on each platform
  * is one byte.
  *
- * In order for these functions to work on floating point data, we are
- * assuming that the floating point representations are identical on the two
+ * In order for these functions to work on floating point data, we are assuming
+ * that the floating point representations are identical on the two
  * architectures _except_ for the difference in endianness. Also, the sign and
  * exponent information of the floating point representation must fit within a
- * single byte of data, so that it does not require extra steps at the
- * bit-level for conversion.
+ * single byte of data, so that it does not require extra steps at the bit-level
+ * for conversion.
  */
 //---------------------------------------------------------------------------//
 
@@ -59,28 +56,28 @@ namespace rtt_dsxx {
  * \arg The data to byte-swap, represented as character data.
  * \arg The size of the data array.
  *
- * This is a core routine used by other functions to convert data between
- * endian representations.
+ * This is a core routine used by other functions to convert data between endian
+ * representations.
  *
- * It swaps the elements of a character array of length n. Element 0 is
- * swapped with element n, 1 with n-1 etc... The contents of the individual
- * elements are not changed, only their order.
+ * It swaps the elements of a character array of length n. Element 0 is swapped
+ * with element n, 1 with n-1 etc... The contents of the individual elements are
+ * not changed, only their order.
  *
  * For example, consider the unsigned integer value: \c 0xDEADBEEF.  (\c 0x
  * means this is a hexidecimal value) Two hexidecimal digits is a single byte
  * (16^2 = 2^8) so the layout of the value in big endian style is:
  * \verbatim
  *       0        1        2        3
- *     D  E     A  D     B  E     E  F 
+ *     D  E     A  D     B  E     E  F
  *  |--------|--------|--------|--------|
  *       ^        ^        ^        ^
  *       |        +--------+        |
  *       +--------------------------+
  *                 swapped
  * \endverbatim
- * The conversion to little endian involves the swap operations pictured in
- * the diagram above. The resulting value (if still interpreted as big-endian)
- * is \c 0xEFBEADDE.
+ * The conversion to little endian involves the swap operations pictured in the
+ * diagram above. The resulting value (if still interpreted as big-endian) is \c
+ * 0xEFBEADDE.
  *
  * We provide two versions for signed and unsigned character data. Internally,
  * we use unsigned. Certain applications use signed char data, and the second
@@ -123,7 +120,6 @@ template <typename T> T byte_swap_copy(T value) {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Does this platform use big or little endianness
- *
  * \return true if platform uses big endian format
  */
 DLL_PUBLIC_dsxx bool is_big_endian(void);
@@ -134,7 +130,7 @@ DLL_PUBLIC_dsxx bool is_big_endian(void);
  *
  * Some older Cray machines did not support the IEEE float representation.
  * This simple test will identify machines that are IEEE compliant.
- * 
+ *
  * \return true if we support IEEE float representation.
  */
 DLL_PUBLIC_dsxx bool has_ieee_float_representation(void);
@@ -146,12 +142,12 @@ DLL_PUBLIC_dsxx bool has_ieee_float_representation(void);
  * \param[in] input
  * \return byte-swapped value.
  *
- * Do byte-swapping one of two ways: either use GNU extended asm for x86
- * (really 486+), or use the "poor people's" method of digging out one byte at
- * a time and moving it to the right place. The poor method is really not that
- * bad: GCC for example seems to optimize it down to about 5 instructions in
- * the 32 bit case, including loads, versus 2 instructions (including load)
- * for the inline asm case.
+ * Do byte-swapping one of two ways: either use GNU extended asm for x86 (really
+ * 486+), or use the "poor people's" method of digging out one byte at a time
+ * and moving it to the right place. The poor method is really not that bad: GCC
+ * for example seems to optimize it down to about 5 instructions in the 32 bit
+ * case, including loads, versus 2 instructions (including load) for the inline
+ * asm case.
  */
 template <> inline uint32_t byte_swap_copy<uint32_t>(uint32_t const input) {
 #ifdef __use_x86_gnu_asm
@@ -182,12 +178,12 @@ template <> inline uint32_t byte_swap_copy<uint32_t>(uint32_t const input) {
  * \param[in] input
  * \return byte-swapped value.
  *
- * Do byte-swapping one of two ways: either use GNU extended asm for x86
- * (really 486+), or use the "poor people's" method of digging out one byte at
- * a time and moving it to the right place. The poor method is really not that
- * bad: GCC for example seems to optimize it down to about 5 instructions in
- * the 32 bit case, including loads, versus 2 instructions (including load)
- * for the inline asm case.
+ * Do byte-swapping one of two ways: either use GNU extended asm for x86 (really
+ * 486+), or use the "poor people's" method of digging out one byte at a time
+ * and moving it to the right place. The poor method is really not that bad: GCC
+ * for example seems to optimize it down to about 5 instructions in the 32 bit
+ * case, including loads, versus 2 instructions (including load) for the inline
+ * asm case.
  */
 template <> inline double byte_swap_copy<double>(double const input) {
 #ifdef __use_x86_gnu_asm

--- a/src/ds++/Field_Traits.hh
+++ b/src/ds++/Field_Traits.hh
@@ -4,10 +4,7 @@
  * \author Kent Budge
  * \brief  Define the Field_Traits class template.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef dsxx_Field_Traits_hh
@@ -31,10 +28,9 @@ namespace rtt_dsxx {
 
 template <typename Field> class Field_Traits {
 public:
-  //! Field types can be "labeled." For example, a value-plus-derivatives
-  //! class has a field value that is labeled with its derivatives. The
-  //! following typedef specifies the unlabeled type, by default the field
-  //! type itself.
+  //! Field types can be "labeled." For example, a value-plus-derivatives class
+  //! has a field value that is labeled with its derivatives. The following
+  //! typedef specifies the unlabeled type, by default the field type itself.
   typedef Field unlabeled_type;
 
   //! Return the unique zero element of the field. By default, this is
@@ -54,10 +50,9 @@ public:
  */
 template <> class Field_Traits<const double> {
 public:
-  //! Field types can be "labeled." For example, a value-plus-derivatives
-  //! class has a field value that is labeled with its derivatives. The
-  //! following typedef specifies the unlabeled type, by default the field
-  //! type itself.
+  //! Field types can be "labeled." For example, a value-plus-derivatives class
+  //! has a field value that is labeled with its derivatives. The following
+  //! typedef specifies the unlabeled type, by default the field type itself.
   typedef double unlabeled_type;
 
   //! Return the unique zero element of the field. By default, this is
@@ -73,11 +68,11 @@ public:
 //---------------------------------------------------------------------------//
 /*! Strip a field type of any labeling.
  *
- * Implicit conversion of a labeled field type (such as a
- * value-plus-derivatives class) to an underlying unlabeled field type can
- * be dangerous. However, unlike conversion constructors, conversion operators
- * cannot be flagged explicit. Our alternative is to templatize a conversion
- * function from labeled field type to unlabeled field type.
+ * Implicit conversion of a labeled field type (such as a value-plus-derivatives
+ * class) to an underlying unlabeled field type can be dangerous. However,
+ * unlike conversion constructors, conversion operators cannot be flagged
+ * explicit. Our alternative is to templatize a conversion function from labeled
+ * field type to unlabeled field type.
  *
  * The default implementation assumes there is no labeling to strip.
  *

--- a/src/ds++/dbc.hh
+++ b/src/ds++/dbc.hh
@@ -7,13 +7,11 @@
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
  *         All rights reserved.
  *
- * This header defines several function templates that perform common
- * numerical operations not standardized in the STL algorithm header. It also
- * defines some useful STL-style predicates. These predicates are
- * particularly useful for writing Design by Contract assertions.
+ * This header defines several function templates that perform common numerical
+ * operations not standardized in the STL algorithm header. It also defines some
+ * useful STL-style predicates. These predicates are particularly useful for
+ * writing Design by Contract assertions.
  */
-//---------------------------------------------------------------------------//
-// $Id$
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_dbc_hh

--- a/src/ds++/dbc.i.hh
+++ b/src/ds++/dbc.i.hh
@@ -7,13 +7,11 @@
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
  *         All rights reserved.
  *
-  * This header defines several function templates that perform common
- * numerical operations not standardized in the STL algorithm header. It also
- * defines some useful STL-style predicates. These predicates are particularly
- * useful for writing Design by Contract assertions.
+ * This header defines several function templates that perform common numerical
+ * operations not standardized in the STL algorithm header. It also defines some
+ * useful STL-style predicates. These predicates are particularly useful for
+ * writing Design by Contract assertions.
  */
-//---------------------------------------------------------------------------//
-// $Id$
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_dbc_i_hh
@@ -21,7 +19,6 @@
 
 #include <algorithm>
 #include <functional>
-//#include <limits>
 #include "Soft_Equivalence.hh"
 
 namespace rtt_dsxx {
@@ -32,9 +29,9 @@ namespace rtt_dsxx {
  * \date Thu Jan 23 08:41:54 MST 2003
  * \brief Check whether a sequence is monotonically increasing.
  *
- * Checks whether every element in a sequence is less than or equal
- * to the next element of the sequence.  This is particularly useful for
- * Design by Contract assertions that check that a sequence is sorted.
+ * Checks whether every element in a sequence is less than or equal to the next
+ * element of the sequence.  This is particularly useful for Design by Contract
+ * assertions that check that a sequence is sorted.
  *
  * \arg \a Forward_Iterator
  * A forward iterator whose value type supports \c operator<.
@@ -66,9 +63,9 @@ bool is_monotonic_increasing(Forward_Iterator first, Forward_Iterator last) {
  * \date Thu Jan 23 08:41:54 MST 2003
  * \brief Check whether a sequence is strictly monotonically increasing.
  *
- * Checks whether every element in a sequence is less than the next element
- * of the sequence.  This is particularly useful for Design by Contract
- * assertions that check the validity of a table of data.
+ * Checks whether every element in a sequence is less than the next element of
+ * the sequence.  This is particularly useful for Design by Contract assertions
+ * that check the validity of a table of data.
  *
  * \arg \a Forward_Iterator
  * A forward iterator whose value type supports \c operator<.
@@ -100,8 +97,8 @@ bool is_strict_monotonic_increasing(Forward_Iterator first,
  * \date Thu Jan 23 08:41:54 MST 2003
  * \brief Check whether a sequence is strictly monotonically decreasing.
  *
- * Checks whether every element in a sequence is greater than
- * the next element of the sequence.
+ * Checks whether every element in a sequence is greater than the next element
+ * of the sequence.
  *
  * \arg \a Forward_Iterator
  * A forward iterator whose value type supports \c operator<.

--- a/src/ds++/dbc_pt.cc
+++ b/src/ds++/dbc_pt.cc
@@ -5,10 +5,7 @@
  * \date   Tue Feb 19 14:28:59 2008
  * \brief  Explicit template instatiations for class dbc.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "dbc.i.hh"

--- a/src/ds++/path.hh
+++ b/src/ds++/path.hh
@@ -4,7 +4,6 @@
  * \brief  Encapsulate path information (path separator, etc.)
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
  *         All rights reserved.
- * \version $Id$
  *
  * \bug Consider replacing path.cc and path.hh with Boost FileSystem.
  */
@@ -65,8 +64,8 @@ public:
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Walk a directory tree structure, perform myOperator() action on
- *        each entry.
+ * \brief Walk a directory tree structure, perform myOperator() action on each
+ *        entry.
  * \arg dirname String representing the top node of the directory to be parsed.
  * \arg myOperator Functor that defines action to be taken on each entry in
  *      the directory. Recommend using wdtOpPrint or wdtOpRemove
@@ -74,8 +73,8 @@ public:
  *
  * \sa draco_remove_dir Helper function to recurively delete a directory and all
  * its contents.
- * \sa draco_dir_print Helper function that will print a directory and all
- * its contents.
+ * \sa draco_dir_print Helper function that will print a directory and all its
+ * contents.
  *
  * Sample implementation for Win32 (uses Win API which I don't want to do)
  * http://forums.codeguru.com/showthread.php?239271-Windows-SDK-File-System-How-to-delete-a-directory-and-subdirectories
@@ -112,9 +111,9 @@ void draco_walk_directory_tree(std::string const &dirname,
   }
 
 #ifdef WIN32
-  /*! \note If path contains the location of a directory, it cannot contain
-     * a trailing backslash. If it does, -1 will be returned and errno will be
-     * set to ENOENT. */
+  /*! \note If path contains the location of a directory, it cannot contain a
+     * trailing backslash. If it does, -1 will be returned and errno will be set
+     * to ENOENT. */
   std::string d_name;
   if (dirname[dirname.size() - 1] == rtt_dsxx::WinDirSep ||
       dirname[dirname.size() - 1] == rtt_dsxx::UnixDirSep)
@@ -156,8 +155,6 @@ void draco_walk_directory_tree(std::string const &dirname,
     // Close handle
     ::FindClose(hFile);
 
-    //DWORD dwError = ::GetLastError();
-    //Insist( dwError != ERROR_NO_MORE_FILES, "ERROR: No more files to delete." );
   }
 
   // Perform action on the top level entry

--- a/src/ds++/path_getFilenameComponent.cc
+++ b/src/ds++/path_getFilenameComponent.cc
@@ -3,9 +3,7 @@
  * \file   ds++/path_getFilenameComponent.cc
  * \brief  Encapsulate path information (path separator, etc.)
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- * \version $Id: path.cc 7388 2015-01-22 16:02:07Z kellyt $
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "path.hh"
@@ -20,8 +18,8 @@ namespace rtt_dsxx {
  * \param fqName A fully qualified filename (/path/to/the/unit/test)
  * \return filename only, or path to file only.
  *
- * This function expects a fully qualfied name of a unit test (e.g.:
- * argv[0]).  It strips off the path and returns the name of the unit test.
+ * This function expects a fully qualfied name of a unit test (e.g.: argv[0]).
+ * It strips off the path and returns the name of the unit test.
  *
  * Options:
  *    FC_PATH        Return path portion only for fqName
@@ -30,7 +28,8 @@ namespace rtt_dsxx {
  *    FC_EXT         not implemented.
  *    FC_NAME_WE     not implemented.
  *    FC_REALPATH    resolve all symlinks
- *    FC_NATIVE      convert path to use native slashes for the current filesystem
+ *    FC_NATIVE      convert path to use native slashes for the current
+ *                   filesystem
  *    FC_LASTVALUE
  */
 std::string getFilenameComponent(std::string const &fqName,
@@ -42,8 +41,7 @@ std::string getFilenameComponent(std::string const &fqName,
 
   switch (fc) {
   case FC_PATH:
-    // if fqName is a directory and ends with "/", trim the trailing
-    // dirSep.
+    // if fqName is a directory and ends with "/", trim the trailing dirSep.
     if (fqName.rfind(rtt_dsxx::UnixDirSep) == fqName.length() - 1)
       fullName = fqName.substr(0, fqName.length() - 1);
     if (fqName.rfind(rtt_dsxx::WinDirSep) == fqName.length() - 1)
@@ -51,8 +49,8 @@ std::string getFilenameComponent(std::string const &fqName,
 
     idx = fullName.rfind(rtt_dsxx::UnixDirSep);
     if (idx == string::npos) {
-      // Didn't find directory separator, as 2nd chance look for
-      // Windows directory separator.
+      // Didn't find directory separator, as 2nd chance look for Windows
+      // directory separator.
       idx = fullName.rfind(rtt_dsxx::WinDirSep);
     }
     // If we still cannot find a path separator, return "./"
@@ -72,12 +70,12 @@ std::string getFilenameComponent(std::string const &fqName,
 
     idx = fullName.rfind(UnixDirSep);
     if (idx == string::npos) {
-      // Didn't find directory separator, as 2nd chance look for
-      // Windows directory separator.
+      // Didn't find directory separator, as 2nd chance look for Windows
+      // directory separator.
       idx = fullName.rfind(WinDirSep);
     }
-    // If we still cannot find a path separator, return the whole
-    // string as the test name.
+    // If we still cannot find a path separator, return the whole string as the
+    // test name.
     if (idx == string::npos)
       retVal = fullName;
     else
@@ -106,7 +104,8 @@ std::string getFilenameComponent(std::string const &fqName,
     Insist(false, "case for FC_NAME_WE not implemented.");
     break;
   case FC_NATIVE:
-    // This is always done before returning (see implementation found after the case statement)
+    // This is always done before returning (see implementation found after the
+    // case statement)
     retVal = fullName;
     break;
 

--- a/src/meshReaders/Hex_Mesh_Reader.hh
+++ b/src/meshReaders/Hex_Mesh_Reader.hh
@@ -5,10 +5,7 @@
  * \date   Tue Mar  7 08:38:04 2000
  * \brief  Header file for CIC-19 Hex format mesh reader.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __meshReaders_Hex_Mesh_Reader_hh__
@@ -27,21 +24,16 @@ namespace rtt_meshReaders {
  *
  * \brief Reads a CIC-19 Hex Mesh format mesh data file.
  *
- * \sa The rtt_mesh_element::Element_Definition class provides
- *     information on the hex, quad, and line elements used in
- *     this class. The \ref rtt_meshreaders_overview page provides
- *     an overview of the other utilities in the rtt_meshReaders
- *     namespace. the \ref rtt_meshreaders_hexformat page provides
- *     a description of the Hex file format.
+ * \sa The rtt_mesh_element::Element_Definition class provides information on
+ *     the hex, quad, and line elements used in this class. The \ref
+ *     rtt_meshreaders_overview page provides an overview of the other utilities
+ *     in the rtt_meshReaders namespace. the \ref rtt_meshreaders_hexformat page
+ *     provides a description of the Hex file format.
  */
-// revision history:
-// -----------------
-// 0) original
-//
 //===========================================================================//
 
 class DLL_PUBLIC_meshReaders Hex_Mesh_Reader
-    : public rtt_meshReaders::Mesh_Reader {
+  : public rtt_meshReaders::Mesh_Reader {
 
   // NESTED CLASSES AND TYPEDEFS
 
@@ -67,7 +59,7 @@ class DLL_PUBLIC_meshReaders Hex_Mesh_Reader
 
   std::map<std::string, std::set<int>> node_sets;
 
-public:
+  public:
   // CREATORS
 
   explicit Hex_Mesh_Reader(std::string filename);
@@ -82,35 +74,30 @@ public:
   // ACCESSORS
 
   /*!
-     *  Returns the point coordinates.
-     */
+   *  Returns the point coordinates.
+   */
   std::vector<std::vector<double>> get_node_coords() const {
     return point_coords;
   }
 
   /*!
-     * The Hex mesh format has no provision for labeling coordinate units
-     * Consequently, this method always returns the default string:
-     * "unknown".
-     *
-     */
+   * The Hex mesh format has no provision for labeling coordinate units
+   * Consequently, this method always returns the default string: "unknown".
+   */
   std::string get_node_coord_units() const { return "unknown"; }
+
   /*!
-     * The Hex mesh format has no provision for flagging nodes.
-     * This method therefore always returns a map with one entry
-     * which contains all the nodes.
-     *
-     */
+   * The Hex mesh format has no provision for flagging nodes.  This method
+   * therefore always returns a map with one entry which contains all the nodes.
+   */
   std::map<std::string, std::set<int>> get_node_sets() const {
     return node_sets;
   }
 
   /*!
-     * There is no provision in the Hex format for naming a mesh.
-     * This function always returns the defualt string:
-     * "Untitled -- CIC-19 Hex Mesh"
-     *
-     */
+   * There is no provision in the Hex format for naming a mesh.  This function
+   * always returns the defualt string: "Untitled -- CIC-19 Hex Mesh"
+   */
   std::string get_title() const { return "Untitled -- CIC-19 Hex Mesh"; }
 
   std::vector<std::vector<int>> get_element_nodes(void) const;
@@ -120,14 +107,14 @@ public:
   std::map<std::string, std::set<int>> get_element_sets() const;
 
   std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-  get_element_types() const;
+    get_element_types() const;
 
   std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-  get_unique_element_types() const;
+    get_unique_element_types() const;
 
   size_t get_dims_ndim() const { return ndim; };
 
-private:
+  private:
   bool check_dims() const;
 
   // IMPLEMENTATION
@@ -141,21 +128,20 @@ private:
  * \page rtt_meshreaders_hexformat The CIC-19 Hex Mesh File Format
  *
  * <h3> Introduction </h3>
- * The CIC-19 Hex Format was developed primarily for small-scale testing
- * and development purposes. It's chief virtue is its simplicity.
- * A Hex mesh format
- * file is usually only a few hundred lines long, and is in ASCII text
- * format that can easily be directly modified by the developer with any
- * text editor. Moreover, the format does not requires a sophisticated
- * mesh generator. These
- * characteristics make the Hex format very useful for the creation and
- * manipulation of small, simple test problems in  support of an initial
- * debugging and development effort.
+
+ * The CIC-19 Hex Format was developed primarily for small-scale testing and
+ * development purposes. It's chief virtue is its simplicity.  A Hex mesh format
+ * file is usually only a few hundred lines long, and is in ASCII text format
+ * that can easily be directly modified by the developer with any text
+ * editor. Moreover, the format does not requires a sophisticated mesh
+ * generator. These characteristics make the Hex format very useful for the
+ * creation and manipulation of small, simple test problems in support of an
+ * initial debugging and development effort.
  *
- * The format is restricted to three element types: Line elements in
- * 1D, quadrilateral elements in 2D, and hexahedra in 3D. One flag
- * field is provided for interior elements, and one for non-reflective
- * boundary elements. Reflective boundary elements are listed separately.
+ * The format is restricted to three element types: Line elements in 1D,
+ * quadrilateral elements in 2D, and hexahedra in 3D. One flag field is provided
+ * for interior elements, and one for non-reflective boundary
+ * elements. Reflective boundary elements are listed separately.
  *
  * Support for reading this file format is provided by the
  * rtt_meshReaders::Hex_Mesh_Reader class.
@@ -195,17 +181,16 @@ private:
  *      nvrpf+1 integers per line.
  *</ul>
  *
- * The  "cube.mesh.in" file found in the Examples section provides
- * an example CIC-19 Hex format mesh file.
- *
+ * The "cube.mesh.in" file found in the Examples section provides an example
+ * CIC-19 Hex format mesh file.
  */
 
 /*!
  * \example meshReaders/test/cube.mesh.in
  *
- *   The following provides an example of a 3D, 5x5x5 hexahedra CIC-19
- *   Hex mesh format file. The mesh has 125 cells, 125 vacuum boundary
- *   faces, 25 reflective boundary faces, and four cell flag values.
+ *   The following provides an example of a 3D, 5x5x5 hexahedra CIC-19 Hex mesh
+ *   format file. The mesh has 125 cells, 125 vacuum boundary faces, 25
+ *   reflective boundary faces, and four cell flag values.
  */
 
 //---------------------------------------------------------------------------//

--- a/src/meshReaders/Hex_Mesh_Reader.hh
+++ b/src/meshReaders/Hex_Mesh_Reader.hh
@@ -33,7 +33,7 @@ namespace rtt_meshReaders {
 //===========================================================================//
 
 class DLL_PUBLIC_meshReaders Hex_Mesh_Reader
-  : public rtt_meshReaders::Mesh_Reader {
+    : public rtt_meshReaders::Mesh_Reader {
 
   // NESTED CLASSES AND TYPEDEFS
 
@@ -59,7 +59,7 @@ class DLL_PUBLIC_meshReaders Hex_Mesh_Reader
 
   std::map<std::string, std::set<int>> node_sets;
 
-  public:
+public:
   // CREATORS
 
   explicit Hex_Mesh_Reader(std::string filename);
@@ -107,14 +107,14 @@ class DLL_PUBLIC_meshReaders Hex_Mesh_Reader
   std::map<std::string, std::set<int>> get_element_sets() const;
 
   std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-    get_element_types() const;
+  get_element_types() const;
 
   std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-    get_unique_element_types() const;
+  get_unique_element_types() const;
 
   size_t get_dims_ndim() const { return ndim; };
 
-  private:
+private:
   bool check_dims() const;
 
   // IMPLEMENTATION

--- a/src/meshReaders/Mesh_Reader.hh
+++ b/src/meshReaders/Mesh_Reader.hh
@@ -5,38 +5,30 @@
  * \date   Fri Feb 25 08:14:54 2000
  * \brief  Header file for the RTT Mesh_Reader base class.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __meshReaders_Mesh_Reader_hh__
 #define __meshReaders_Mesh_Reader_hh__
 
-#include "ds++/SP.hh"
 #include "mesh_element/Element_Definition.hh"
 #include <map>
 #include <set>
+#include <memory>
 
 namespace rtt_meshReaders {
 
 //===========================================================================//
 /*!
  * \class Mesh_Reader
- * \brief Base class for the RTT mesh readers. 
+ * \brief Base class for the RTT mesh readers.
  *
- * This class provides the template from which all other
- * mesh readers inherit. It provides a standard intefrace
- * to mesh information for all clients. The interface
- * supports structured and unstructured meshes. Both
- * so called "AMR" or "hanging-node" meshes and C0 connectivity
- * meshes can be described.
+ * This class provides the template from which all other mesh readers
+ * inherit. It provides a standard intefrace to mesh information for all
+ * clients. The interface supports structured and unstructured meshes. Both so
+ * called "AMR" or "hanging-node" meshes and C0 connectivity meshes can be
+ * described.
  */
-// revision history:
-// -----------------
-// 0) original
-//
 //===========================================================================//
 
 class DLL_PUBLIC_meshReaders Mesh_Reader {
@@ -44,7 +36,7 @@ class DLL_PUBLIC_meshReaders Mesh_Reader {
 
   // DATA
 
-public:
+  public:
   // CREATORS
 
   //Defaulted: Mesh_Reader();
@@ -61,87 +53,77 @@ public:
   // ACCESSORS
 
   /*!
-     * \brief Provides node coordinates for all the nodes in the
-     * mesh.
-     *
-     * Not all the nodes returned herein have to be used to define 
-     * a mesh element. For example some nodes may be children, dudded,
-     * or tracer nodes. The operator [i][j] returns
-     * node i, coordinate j.
-     *
-     */
+   * \brief Provides node coordinates for all the nodes in the mesh.
+   *
+   * Not all the nodes returned herein have to be used to define a mesh
+   * element. For example some nodes may be children, dudded, or tracer
+   * nodes. The operator [i][j] returns node i, coordinate j.
+   */
   virtual std::vector<std::vector<double>> get_node_coords() const = 0;
 
   /*!
-     * \brief Provides the units (inches, feet, cm, meters, etc.) of the
-     *        node coordinates. 
-     */
+   * \brief Provides the units (inches, feet, cm, meters, etc.) of the node
+   *        coordinates.
+   */
   virtual std::string get_node_coord_units() const = 0;
 
   /*!
-     * \brief Returns node numbers of the mesh elements.
-     *
-     * Node numbers are 0 based and refer to the nodes 
-     * returned by the Mesh_Reader.get_node_coords() method. This
-     * information determines the connectivity of the mesh. It
-     * uniquely defines all the elements in the mesh, and their
-     * relationship to each other. Any mix of element types is
-     * allowed including multple dimensions. The elements
-     * may be spatially disjoint. The operator [i][j] returns
-     * cell i, node j.
-     *
-     */
+   * \brief Returns node numbers of the mesh elements.
+   *
+   * Node numbers are 0 based and refer to the nodes returned by the
+   * Mesh_Reader.get_node_coords() method. This information determines the
+   * connectivity of the mesh. It uniquely defines all the elements in the mesh,
+   * and their relationship to each other. Any mix of element types is allowed
+   * including multple dimensions. The elements may be spatially disjoint. The
+   * operator [i][j] returns cell i, node j.
+   */
   virtual std::vector<std::vector<int>> get_element_nodes() const = 0;
 
   /*!
-     * \brief Returns the type of all the elements in the mesh. 
-     *
-     */
+   * \brief Returns the type of all the elements in the mesh.
+   */
   virtual std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-  get_element_types() const = 0;
+    get_element_types() const = 0;
 
   /*!
-     * \brief Returns the unique element types that are defined in the mesh.
-     *
-     */
+   * \brief Returns the unique element types that are defined in the mesh.
+   */
   virtual std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-  get_unique_element_types() const = 0;
+    get_unique_element_types() const = 0;
 
   /*!
-     * \brief Returns node sub-sets.
-     *
-     * Returned node numbers are 0 based and refer to the nodes 
-     * returned by the Mesh_Reader.get_node_coords() method.
-     * This method provides a capability to flag certain sub-sets of the
-     * nodes returned by the Mesh_Reader.get_node_coords() method. This
-     * can be useful for flagging certain nodes or sets of nodes for
-     * some special treatement such as edits or sources. The string
-     * key to the map provides a unique and hopefully descriptive name
-     * for each node sub-set.
-     */
+   * \brief Returns node sub-sets.
+   *
+   * Returned node numbers are 0 based and refer to the nodes returned by the
+   * Mesh_Reader.get_node_coords() method.  This method provides a capability to
+   * flag certain sub-sets of the nodes returned by the
+   * Mesh_Reader.get_node_coords() method. This can be useful for flagging
+   * certain nodes or sets of nodes for some special treatement such as edits or
+   * sources. The string key to the map provides a unique and hopefully
+   * descriptive name for each node sub-set.
+   */
   virtual std::map<std::string, std::set<int>> get_node_sets() const = 0;
 
   /*!
-     * \brief Returns element sub-sets.
-     *
-     * Returned element numbers are 0 based and refer to the elements
-     * returned by the Mesh_Reader.get_element_nodes() method.
-     * This method provides a capability to flag certain sub-sets of the
-     * elements returned by the Mesh_Reader.get_element_nodes() method. This
-     * can be useful for flagging certain elements or sets of elements for
-     * some special treatement such as edits, sources, material assignments,
-     * boudndary conditions, etc. The string
-     * key to the map provides a unique and hopefully descriptive name
-     * for each element sub-set.
-     */
+   * \brief Returns element sub-sets.
+   *
+   * Returned element numbers are 0 based and refer to the elements returned by
+   * the Mesh_Reader.get_element_nodes() method.  This method provides a
+   * capability to flag certain sub-sets of the elements returned by the
+   * Mesh_Reader.get_element_nodes() method. This can be useful for flagging
+   * certain elements or sets of elements for some special treatement such as
+   * edits, sources, material assignments, boudndary conditions, etc. The string
+   * key to the map provides a unique and hopefully descriptive name for each
+   * element sub-set.
+   */
   virtual std::map<std::string, std::set<int>> get_element_sets() const = 0;
 
   //! Returns the title of the mesh.
   virtual std::string get_title() const = 0;
 
-  virtual std::vector<rtt_dsxx::SP<rtt_mesh_element::Element_Definition>>
-  get_element_defs() const {
-    return std::vector<rtt_dsxx::SP<rtt_mesh_element::Element_Definition>>();
+  virtual std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>
+    get_element_defs() const {
+    return std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>();
   };
 
   //! Provides a check on the integrity of the mesh data.
@@ -149,7 +131,7 @@ public:
 
   virtual size_t get_dims_ndim() const = 0;
 
-private:
+  private:
   // IMPLEMENTATION
 };
 

--- a/src/meshReaders/Mesh_Reader.hh
+++ b/src/meshReaders/Mesh_Reader.hh
@@ -13,8 +13,8 @@
 
 #include "mesh_element/Element_Definition.hh"
 #include <map>
-#include <set>
 #include <memory>
+#include <set>
 
 namespace rtt_meshReaders {
 
@@ -36,7 +36,7 @@ class DLL_PUBLIC_meshReaders Mesh_Reader {
 
   // DATA
 
-  public:
+public:
   // CREATORS
 
   //Defaulted: Mesh_Reader();
@@ -83,13 +83,13 @@ class DLL_PUBLIC_meshReaders Mesh_Reader {
    * \brief Returns the type of all the elements in the mesh.
    */
   virtual std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-    get_element_types() const = 0;
+  get_element_types() const = 0;
 
   /*!
    * \brief Returns the unique element types that are defined in the mesh.
    */
   virtual std::vector<rtt_mesh_element::Element_Definition::Element_Type>
-    get_unique_element_types() const = 0;
+  get_unique_element_types() const = 0;
 
   /*!
    * \brief Returns node sub-sets.
@@ -122,7 +122,7 @@ class DLL_PUBLIC_meshReaders Mesh_Reader {
   virtual std::string get_title() const = 0;
 
   virtual std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>
-    get_element_defs() const {
+  get_element_defs() const {
     return std::vector<std::shared_ptr<rtt_mesh_element::Element_Definition>>();
   };
 
@@ -131,7 +131,7 @@ class DLL_PUBLIC_meshReaders Mesh_Reader {
 
   virtual size_t get_dims_ndim() const = 0;
 
-  private:
+private:
   // IMPLEMENTATION
 };
 

--- a/src/meshReaders/test/TestHexMeshReader.cc
+++ b/src/meshReaders/test/TestHexMeshReader.cc
@@ -46,8 +46,8 @@ void runTest(UnitTest &ut) {
   }
 
   rtt_meshReaders_test::check_mesh(ut, mesh_1D, "slab");
-  vector<std::shared_ptr<Element_Definition>> element_defs
-    = mesh_1D.get_element_defs();
+  vector<std::shared_ptr<Element_Definition>> element_defs =
+      mesh_1D.get_element_defs();
   if (element_defs.size() > 0)
     FAILMSG("element defs is NOT empty for slab");
 

--- a/src/meshReaders/test/TestHexMeshReader.cc
+++ b/src/meshReaders/test/TestHexMeshReader.cc
@@ -5,10 +5,7 @@
  * \date   Tue Mar 26 16:37:01 2002
  * \brief  Hex Mesh Reader test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "TestHexMeshReader.hh"
@@ -32,7 +29,6 @@ using namespace rtt_dsxx;
 
 void runTest(UnitTest &ut) {
   using rtt_meshReaders::Hex_Mesh_Reader;
-  using rtt_dsxx::SP;
   using rtt_mesh_element::Element_Definition;
 
   cout << "\n******* CIC-19 Hex Mesh Reader Tests *******" << std::endl;
@@ -50,7 +46,8 @@ void runTest(UnitTest &ut) {
   }
 
   rtt_meshReaders_test::check_mesh(ut, mesh_1D, "slab");
-  vector<SP<Element_Definition>> element_defs = mesh_1D.get_element_defs();
+  vector<std::shared_ptr<Element_Definition>> element_defs
+    = mesh_1D.get_element_defs();
   if (element_defs.size() > 0)
     FAILMSG("element defs is NOT empty for slab");
 

--- a/src/parser/Abstract_Class_Parser.hh
+++ b/src/parser/Abstract_Class_Parser.hh
@@ -4,17 +4,13 @@
  * \author Kent Budge
  * \brief  Define class Abstract_Class_Parser
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef parser_Abstract_Class_Parser_hh
 #define parser_Abstract_Class_Parser_hh
 
 #include "Parse_Table.hh"
-#include "ds++/SP.hh"
 #include <functional>
 #include <iostream>
 
@@ -22,7 +18,6 @@ namespace rtt_parser {
 using std::string;
 using std::vector;
 using std::pointer_to_unary_function;
-using rtt_dsxx::SP;
 
 //===========================================================================//
 /*!
@@ -41,13 +36,13 @@ template <typename Abstract_Class, typename Context,
           Context const &get_context()>
 class Contextual_Parse_Functor {
 public:
-  Contextual_Parse_Functor(SP<Abstract_Class> parse_function(Token_Stream &,
-                                                             Context const &));
+  Contextual_Parse_Functor(std::shared_ptr<Abstract_Class>
+                           parse_function(Token_Stream &, Context const &));
 
-  SP<Abstract_Class> operator()(Token_Stream &) const;
+  std::shared_ptr<Abstract_Class> operator()(Token_Stream &) const;
 
 private:
-  SP<Abstract_Class> (*f_)(Token_Stream &, Context const &);
+  std::shared_ptr<Abstract_Class> (*f_)(Token_Stream &, Context const &);
 };
 
 //===========================================================================//
@@ -82,8 +77,8 @@ private:
  * end
  *
  * Note that Abstract_Class_Parser does not actually do any parsing itself. It
- * is simply a repository for keyword-parser combinations that is typically
- * used by the Class_Parser for the abstract class.
+ * is simply a repository for keyword-parser combinations that is typically used
+ * by the Class_Parser for the abstract class.
  *
  * See test/tstAbstract_Class_Parser.cc for an example of its use.
  *
@@ -93,10 +88,11 @@ private:
  */
 //===========================================================================//
 template <typename Abstract_Class, Parse_Table &get_parse_table(),
-          SP<Abstract_Class> &get_parsed_object(),
-          typename Parse_Function =
-              pointer_to_unary_function<Token_Stream &, SP<Abstract_Class>>>
-class Abstract_Class_Parser {
+  std::shared_ptr<Abstract_Class> &get_parsed_object(),
+  typename Parse_Function =
+  pointer_to_unary_function<Token_Stream &,
+  std::shared_ptr<Abstract_Class>>>
+  class Abstract_Class_Parser {
 public:
   // TYPES
 
@@ -108,7 +104,8 @@ public:
 
   //! Register children of the abstract class
   static void register_child(string const &keyword,
-                             SP<Abstract_Class> parse_function(Token_Stream &));
+                             std::shared_ptr<Abstract_Class>
+                             parse_function(Token_Stream &));
 
   //! Check the class invariants
   static bool check_static_class_invariants();

--- a/src/parser/Abstract_Class_Parser.hh
+++ b/src/parser/Abstract_Class_Parser.hh
@@ -36,8 +36,8 @@ template <typename Abstract_Class, typename Context,
           Context const &get_context()>
 class Contextual_Parse_Functor {
 public:
-  Contextual_Parse_Functor(std::shared_ptr<Abstract_Class>
-                           parse_function(Token_Stream &, Context const &));
+  Contextual_Parse_Functor(std::shared_ptr<Abstract_Class> parse_function(
+      Token_Stream &, Context const &));
 
   std::shared_ptr<Abstract_Class> operator()(Token_Stream &) const;
 
@@ -88,11 +88,10 @@ private:
  */
 //===========================================================================//
 template <typename Abstract_Class, Parse_Table &get_parse_table(),
-  std::shared_ptr<Abstract_Class> &get_parsed_object(),
-  typename Parse_Function =
-  pointer_to_unary_function<Token_Stream &,
-  std::shared_ptr<Abstract_Class>>>
-  class Abstract_Class_Parser {
+          std::shared_ptr<Abstract_Class> &get_parsed_object(),
+          typename Parse_Function = pointer_to_unary_function<
+              Token_Stream &, std::shared_ptr<Abstract_Class>>>
+class Abstract_Class_Parser {
 public:
   // TYPES
 
@@ -103,9 +102,9 @@ public:
                              Parse_Function parse_function);
 
   //! Register children of the abstract class
-  static void register_child(string const &keyword,
-                             std::shared_ptr<Abstract_Class>
-                             parse_function(Token_Stream &));
+  static void register_child(
+      string const &keyword,
+      std::shared_ptr<Abstract_Class> parse_function(Token_Stream &));
 
   //! Check the class invariants
   static bool check_static_class_invariants();

--- a/src/parser/Abstract_Class_Parser.i.hh
+++ b/src/parser/Abstract_Class_Parser.i.hh
@@ -15,10 +15,9 @@
 template <typename Abstract_Class, typename Context,
           Context const &get_context()>
 Contextual_Parse_Functor<Abstract_Class, Context, get_context>::
-Contextual_Parse_Functor(std::shared_ptr<Abstract_Class> parse_function(
-                           Token_Stream &,
-                           Context const &))
-  : f_(parse_function) {}
+    Contextual_Parse_Functor(std::shared_ptr<Abstract_Class> parse_function(
+        Token_Stream &, Context const &))
+    : f_(parse_function) {}
 
 template <typename Abstract_Class, typename Context,
           Context const &get_context()>
@@ -102,11 +101,10 @@ void Abstract_Class_Parser<
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
-void Abstract_Class_Parser<
-    Class, get_parse_table, get_parsed_object,
-    Parse_Function>::register_child(string const &keyword,
-                                    std::shared_ptr<Class> parse_function(
-                                      Token_Stream &)) {
+void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
+                           Parse_Function>::
+    register_child(string const &keyword,
+                   std::shared_ptr<Class> parse_function(Token_Stream &)) {
   using namespace rtt_parser;
 
   char *cptr = new char[keyword.size() + 1];

--- a/src/parser/Abstract_Class_Parser.i.hh
+++ b/src/parser/Abstract_Class_Parser.i.hh
@@ -5,10 +5,7 @@
  * \date   Thu Jul 17 14:08:42 2008
  * \brief  Member definitions of class Abstract_Class_Parser
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved */
 //---------------------------------------------------------------------------//
 
 #ifndef utils_Abstract_Class_Parser_i_hh
@@ -18,13 +15,14 @@
 template <typename Abstract_Class, typename Context,
           Context const &get_context()>
 Contextual_Parse_Functor<Abstract_Class, Context, get_context>::
-    Contextual_Parse_Functor(SP<Abstract_Class> parse_function(Token_Stream &,
-                                                               Context const &))
-    : f_(parse_function) {}
+Contextual_Parse_Functor(std::shared_ptr<Abstract_Class> parse_function(
+                           Token_Stream &,
+                           Context const &))
+  : f_(parse_function) {}
 
 template <typename Abstract_Class, typename Context,
           Context const &get_context()>
-SP<Abstract_Class>
+std::shared_ptr<Abstract_Class>
 Contextual_Parse_Functor<Abstract_Class, Context, get_context>::
 operator()(Token_Stream &tokens) const {
   return f_(tokens, get_context());
@@ -32,8 +30,8 @@ operator()(Token_Stream &tokens) const {
 
 //===========================================================================//
 /*!
- * Helper class defining a table of raw strings created by strdup that will be properly
- * deallocated using free on program termination.
+ * Helper class defining a table of raw strings created by strdup that will be
+ * properly deallocated using free on program termination.
  */
 class c_string_vector {
 public:
@@ -46,13 +44,16 @@ DLL_PUBLIC_parser extern c_string_vector abstract_class_parser_keys;
 
 //===========================================================================//
 /*
- * The following rather lengthy and clumsy declaration declares storage for
- * the parse functions.
+ * The following rather lengthy and clumsy declaration declares storage for the
+ * parse functions.
  *
- * Remember: typedef SP<Abstract_Class> Parse_Function(Token_Stream &);
+ * Remember:
+ * \code
+ * typedef std::shared_ptr<Abstract_Class> Parse_Function(Token_Stream &);
+ * \code
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object(), typename Parse_Function>
+          std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
 vector<Parse_Function> Abstract_Class_Parser<
     Class, get_parse_table, get_parsed_object, Parse_Function>::map_;
 
@@ -67,7 +68,7 @@ vector<Parse_Function> Abstract_Class_Parser<
  * Token_Stream and returns a corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object(), typename Parse_Function>
+          std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
 void Abstract_Class_Parser<
     Class, get_parse_table, get_parsed_object,
     Parse_Function>::register_child(string const &keyword,
@@ -100,11 +101,12 @@ void Abstract_Class_Parser<
  * Token_Stream and returns a corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object(), typename Parse_Function>
+          std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
 void Abstract_Class_Parser<
     Class, get_parse_table, get_parsed_object,
     Parse_Function>::register_child(string const &keyword,
-                                    SP<Class> parse_function(Token_Stream &)) {
+                                    std::shared_ptr<Class> parse_function(
+                                      Token_Stream &)) {
   using namespace rtt_parser;
 
   char *cptr = new char[keyword.size() + 1];
@@ -128,7 +130,7 @@ void Abstract_Class_Parser<
  * makes use of the Parse_Function associated with each child keyword.
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object(), typename Parse_Function>
+          std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
 void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
                            Parse_Function>::parse_child_(Token_Stream &tokens,
                                                          int const child) {
@@ -145,7 +147,7 @@ void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
 
 //---------------------------------------------------------------------------//
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object(), typename Parse_Function>
+          std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
 bool Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
                            Parse_Function>::check_static_class_invariants() {
   return true; // no significant invariant for now

--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   parser/Class_Parse_Table.hh
  * \author Kent Budge
@@ -10,35 +10,30 @@
  * which is consistent in format with the other parse functins in utilities.hh
  * No implementation is provided. However, we recommend using the templates in
  * this header (Class_Parse_Table.hh) to provide an implementation of the form
-
- template<>
- SP<Class> parse_class(Token_Stream &tokens)
- {
-   return parse_class_from_table<Class_Parse_Table<Class> >(tokens);
- }
-
+ * \code
+ * template<>
+ * std::shared_ptr<Class> parse_class(Token_Stream &tokens) {
+ *   return parse_class_from_table<Class_Parse_Table<Class> >(tokens);
+ * }
+ *
  * Why don't we define this as the default implementation? Because then any file
  * that #included Class_Parse_Table.hh would attempt to use the default
  * implementation for every call to parse_class in the file. When you are
  * parsing objects that include class subobjects, this would require including
  * the definition of the parse table class for every such subobject type. This
- * breaks encapsulation, to put it mildly. So we refrain from providing such
- * a default implementation.
+ * breaks encapsulation, to put it mildly. So we refrain from providing such a
+ * default implementation.
  */
-//---------------------------------------------------------------------------------------//
-// $Id: parse_class.hh 7905 2015-02-24 17:58:45Z kellyt $
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 #ifndef parser_Class_Parse_Table_hh
 #define parser_Class_Parse_Table_hh
 
 #include "Parse_Table.hh"
-#include "ds++/SP.hh"
 
 namespace rtt_parser {
-using rtt_dsxx::SP;
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Template for parse table classes
  *
  * No general implementation is provided. The developer wishing to make his
@@ -99,7 +94,7 @@ using rtt_dsxx::SP;
  * If default values are permitted for some parameters (which is not
  * recommended), then they should be applied here.
  *
- *   SP<Return_Class> create_object();
+ *   shared_ptr<Return_Class> create_object();
  *
  * Create the object from the parsed fields.  This function should have no
  * preconditions that are not guaranteed by a preceding successful call to
@@ -115,7 +110,7 @@ using rtt_dsxx::SP;
 
 template <class Class> class Class_Parse_Table;
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Template for helper function that produces a class object.
  *
  * \param tokens Token stream from which to parse the user input.
@@ -125,7 +120,7 @@ template <class Class> class Class_Parse_Table;
  */
 
 template <class Class_Parse_Table>
-SP<typename Class_Parse_Table::Return_Class>
+std::shared_ptr<typename Class_Parse_Table::Return_Class>
 parse_class_from_table(Token_Stream &tokens) {
   using rtt_parser::Token;
   using rtt_parser::END;
@@ -143,7 +138,7 @@ parse_class_from_table(Token_Stream &tokens) {
   // Parse the class keyword block and check for completeness
   Token const terminator = parse_table.parse_table().parse(tokens);
   bool allow_exit = parse_table.allow_exit(); // improve code coverage
-  SP<Return_Class> Result;
+  std::shared_ptr<Return_Class> Result;
   if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
   // A class keyword block is expected to end with an END or (if
   // allow_exit is true) an EXIT.
@@ -162,20 +157,20 @@ parse_class_from_table(Token_Stream &tokens) {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Template for helper function that produces a class object.
  *
  * \param tokens Token stream from which to parse the user input.
  *
- * \param context A context object that controls the behavior of the parser. This is passed
- * to the constructor for the Class_Parse_Table.
+ * \param context A context object that controls the behavior of the
+ * parser. This is passed to the constructor for the Class_Parse_Table.
  *
  * \return A pointer to an object matching the user specification, or NULL if
  * the specification is not valid.
  */
 
 template <typename Class_Parse_Table, typename Context>
-SP<typename Class_Parse_Table::Return_Class>
+std::shared_ptr<typename Class_Parse_Table::Return_Class>
 parse_class_from_table(Token_Stream &tokens, Context const &context) {
   using rtt_parser::Token;
   using rtt_parser::END;
@@ -193,7 +188,7 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
   // Parse the class keyword block and check for completeness
   Token const terminator = parse_table.parse_table().parse(tokens);
   bool allow_exit = parse_table.allow_exit(); // improve code coverage
-  SP<Return_Class> Result;
+  std::shared_ptr<Return_Class> Result;
   if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
   // A class keyword block is expected to end with an END or (if
   // allow_exit is true) an EXIT.
@@ -217,6 +212,6 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
 
 #endif // parser_Class_Parse_Table_hh
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of parser/Class_Parse_Table.hh
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/parser/Expression.cc
+++ b/src/parser/Expression.cc
@@ -24,8 +24,7 @@ typedef map<string, pair<unsigned, Unit>> Variable_Map;
 class And_Expression : public Expression {
 public:
   And_Expression(pE const &e1, pE const &e2)
-      : Expression(e1->number_of_variables(), dimensionless),
-        e1_(e1), e2_(e2) {
+      : Expression(e1->number_of_variables(), dimensionless), e1_(e1), e2_(e2) {
     Require(e1);
     Require(e2);
     Require(e1->number_of_variables() == e2->number_of_variables());
@@ -1178,18 +1177,17 @@ double Expression::operator()(vector<double> const &x) const {
  * grammatically ill-formed.
  */
 
-std::shared_ptr<Expression> Expression::parse(
-  unsigned const number_of_variables,
-  Variable_Map const &variable_map,
-  Token_Stream &tokens) {
+std::shared_ptr<Expression>
+Expression::parse(unsigned const number_of_variables,
+                  Variable_Map const &variable_map, Token_Stream &tokens) {
   // No index in the variable map can be greater than or equal to the number
   // of variables.
 
   // The top expression is the or expression, which we anticipate will be useful
   // for piecewise functions.
 
-  std::shared_ptr<Expression> Result = parse_or(number_of_variables,
-                                                variable_map, tokens);
+  std::shared_ptr<Expression> Result =
+      parse_or(number_of_variables, variable_map, tokens);
   while (tokens.lookahead().text() == "|") {
     tokens.shift();
     Result.reset(new Or_Expression(
@@ -1222,19 +1220,18 @@ std::shared_ptr<Expression> Expression::parse(
  * \return Pointer to the Expression. If null, the expression was empty or
  * grammatically ill-formed.
  */
-std::shared_ptr<Expression> Expression::parse(unsigned const number_of_variables,
-                                 Variable_Map const &variable_map,
-                                 Unit const &expected_units,
-                                 string const &expected_units_text,
-                                 Token_Stream &tokens) {
+std::shared_ptr<Expression>
+Expression::parse(unsigned const number_of_variables,
+                  Variable_Map const &variable_map, Unit const &expected_units,
+                  string const &expected_units_text, Token_Stream &tokens) {
   // No index in the variable map can be greater than or equal to the number of
   // variables.
 
   // The top expression is the or expression, which we anticipate will be useful
   // for piecewise functions.
 
-  std::shared_ptr<Expression> Result = parse_or(number_of_variables,
-                                                variable_map, tokens);
+  std::shared_ptr<Expression> Result =
+      parse_or(number_of_variables, variable_map, tokens);
   while (tokens.lookahead().text() == "|") {
     tokens.shift();
     Result.reset(new Or_Expression(

--- a/src/parser/Expression.cc
+++ b/src/parser/Expression.cc
@@ -5,9 +5,7 @@
  * \date   Wed Jul 26 07:53:32 2006
  * \brief  Implementation of class Expression
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Constant_Expression.hh"
@@ -15,12 +13,11 @@
 namespace rtt_parser {
 using namespace rtt_dsxx;
 
-typedef SP<Expression> pE;
+typedef std::shared_ptr<Expression> pE;
 typedef map<string, pair<unsigned, Unit>> Variable_Map;
 
 //---------------------------------------------------------------------------//
 /*!
- *
  * The and operator implicitly converts its operands to bool. Hence no unit
  * compatibility of the operands is required, and the result is dimensionless.
  */
@@ -28,18 +25,17 @@ class And_Expression : public Expression {
 public:
   And_Expression(pE const &e1, pE const &e2)
       : Expression(e1->number_of_variables(), dimensionless),
-
         e1_(e1), e2_(e2) {
     Require(e1);
     Require(e2);
     Require(e1->number_of_variables() == e2->number_of_variables());
-
     Ensure(check_class_invariant());
   }
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
   }
@@ -84,7 +80,7 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return expression_ != SP<Expression>() &&
+    return expression_ != std::shared_ptr<Expression>() &&
            is_compatible(expression_->units(), dimensionless) &&
            expression_->number_of_variables() == number_of_variables();
   }
@@ -131,7 +127,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            is_compatible(e1_->units(), e2_->units()) &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
@@ -177,7 +174,7 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return expression_ != SP<Expression>() &&
+    return expression_ != std::shared_ptr<Expression>() &&
            is_compatible(expression_->units(), dimensionless) &&
            expression_->number_of_variables() == number_of_variables();
   }
@@ -224,7 +221,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            is_compatible(e1_->units(), e2_->units()) &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
@@ -272,7 +270,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            is_compatible(e1_->units(), e2_->units()) &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
@@ -320,7 +319,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            is_compatible(e1_->units(), e2_->units()) &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
@@ -368,7 +368,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            is_compatible(e1_->units(), e2_->units()) &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
@@ -414,7 +415,7 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return expression_ != SP<Expression>() &&
+    return expression_ != std::shared_ptr<Expression>() &&
            is_compatible(expression_->units(), dimensionless) &&
            expression_->number_of_variables() == number_of_variables();
   }
@@ -458,7 +459,7 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return expression_ != SP<Expression>() &&
+    return expression_ != std::shared_ptr<Expression>() &&
            expression_->number_of_variables() == number_of_variables();
   }
 
@@ -500,7 +501,7 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return expression_ != SP<Expression>() &&
+    return expression_ != std::shared_ptr<Expression>() &&
            expression_->number_of_variables() == number_of_variables();
   }
 
@@ -544,7 +545,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
   }
@@ -594,7 +596,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
   }
@@ -642,7 +645,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
   }
@@ -688,7 +692,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
   }
@@ -733,7 +738,7 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return expression_ != SP<Expression>() &&
+    return expression_ != std::shared_ptr<Expression>() &&
            is_compatible(expression_->units(), dimensionless) &&
            expression_->number_of_variables() == number_of_variables();
   }
@@ -780,7 +785,8 @@ public:
 
   //! Check the class invariant
   bool check_class_invariant() const {
-    return e1_ != SP<Expression>() && e2_ != SP<Expression>() &&
+    return e1_ != std::shared_ptr<Expression>() &&
+           e2_ != std::shared_ptr<Expression>() &&
            e1_->number_of_variables() == number_of_variables() &&
            e2_->number_of_variables() == number_of_variables();
   }
@@ -1164,7 +1170,7 @@ double Expression::operator()(vector<double> const &x) const {
  * \param variable_map Map specifying variable names and the associated index
  * and units. It is acceptable to alias variable names. The unit dimensions
  * must be identical for aliases. The conversion factor is ignored but should
- * be nonzero. 
+ * be nonzero.
  *
  * \param tokens Token stream from which to parse an Expression.
  *
@@ -1172,16 +1178,18 @@ double Expression::operator()(vector<double> const &x) const {
  * grammatically ill-formed.
  */
 
-SP<Expression> Expression::parse(unsigned const number_of_variables,
-                                 Variable_Map const &variable_map,
-                                 Token_Stream &tokens) {
+std::shared_ptr<Expression> Expression::parse(
+  unsigned const number_of_variables,
+  Variable_Map const &variable_map,
+  Token_Stream &tokens) {
   // No index in the variable map can be greater than or equal to the number
   // of variables.
 
-  // The top expression is the or expression, which we anticipate
-  // will be useful for piecewise functions.
+  // The top expression is the or expression, which we anticipate will be useful
+  // for piecewise functions.
 
-  SP<Expression> Result = parse_or(number_of_variables, variable_map, tokens);
+  std::shared_ptr<Expression> Result = parse_or(number_of_variables,
+                                                variable_map, tokens);
   while (tokens.lookahead().text() == "|") {
     tokens.shift();
     Result.reset(new Or_Expression(
@@ -1201,12 +1209,12 @@ SP<Expression> Expression::parse(unsigned const number_of_variables,
  * be nonzero.
  *
  * \param expected_units Unit dimensions the final expression is expected to
- * have. If the final expression does not have these units, and if
- * unit checking is not disabled (as determined by a call to
- * rtt_parser::are_units_disabled()), then a semantic error will be reported
- * to tokens.
+ * have. If the final expression does not have these units, and if unit checking
+ * is not disabled (as determined by a call to
+ * rtt_parser::are_units_disabled()), then a semantic error will be reported to
+ * tokens.
  *
- * \paran expected_units_text Human-friendly description of the units that
+ * \param expected_units_text Human-friendly description of the units that
  * were expected, e.g. "force", "energy density"
  *
  * \param tokens Token stream from which to parse an Expression.
@@ -1214,19 +1222,19 @@ SP<Expression> Expression::parse(unsigned const number_of_variables,
  * \return Pointer to the Expression. If null, the expression was empty or
  * grammatically ill-formed.
  */
-
-SP<Expression> Expression::parse(unsigned const number_of_variables,
+std::shared_ptr<Expression> Expression::parse(unsigned const number_of_variables,
                                  Variable_Map const &variable_map,
                                  Unit const &expected_units,
                                  string const &expected_units_text,
                                  Token_Stream &tokens) {
-  // No index in the variable map can be greater than or equal to the number
-  // of variables.
+  // No index in the variable map can be greater than or equal to the number of
+  // variables.
 
-  // The top expression is the or expression, which we anticipate
-  // will be useful for piecewise functions.
+  // The top expression is the or expression, which we anticipate will be useful
+  // for piecewise functions.
 
-  SP<Expression> Result = parse_or(number_of_variables, variable_map, tokens);
+  std::shared_ptr<Expression> Result = parse_or(number_of_variables,
+                                                variable_map, tokens);
   while (tokens.lookahead().text() == "|") {
     tokens.shift();
     Result.reset(new Or_Expression(
@@ -1252,5 +1260,5 @@ void Expression::write(Precedence const p, vector<string> const &vars,
 } // end namespace rtt_parser
 
 //---------------------------------------------------------------------------//
-//                 end of Expression.cc
+// end of Expression.cc
 //---------------------------------------------------------------------------//

--- a/src/parser/Expression.hh
+++ b/src/parser/Expression.hh
@@ -4,10 +4,7 @@
  * \author Kent Budge
  * \brief  Definition of class Expression
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef parser_Expression_hh
@@ -15,7 +12,6 @@
 
 #include "Token_Stream.hh"
 #include "Unit.hh"
-#include "ds++/SP.hh"
 #include <map>
 #include <ostream>
 #include <utility>
@@ -27,13 +23,12 @@ using std::pair;
 using std::string;
 using std::map;
 using std::ostream;
-using rtt_dsxx::SP;
 
 //===========================================================================//
 /*!
  * \class Expression
  * \brief Represents a mathematical expression, typically parsed from user
- * input. 
+ * input.
  *
  * Test problems and numerical experiments often require that a problem domain
  * be initialized or driven in a way that varies in space and time.  For
@@ -58,7 +53,7 @@ using rtt_dsxx::SP;
  * Expressions are evaluated for an arbitrary set of variables. These are
  * specified when the Expression is parsed using a map from variable name (as
  * a std::string) to variable index and units. The map can specify any number
- * of variables. 
+ * of variables.
  */
 //===========================================================================//
 
@@ -136,12 +131,12 @@ public:
   // STATIC
 
   //! Parse an Expression from a Token_Stream.
-  static SP<Expression>
+  static std::shared_ptr<Expression>
   parse(unsigned number_of_variables,
         map<string, pair<unsigned, Unit>> const &variables, Token_Stream &);
 
   //! Parse an Expression with specified dimensions from a Token_Stream.
-  static SP<Expression>
+  static std::shared_ptr<Expression>
   parse(unsigned number_of_variables,
         map<string, pair<unsigned, Unit>> const &variables,
         Unit const &expected_units, string const &expected_units_text,
@@ -161,9 +156,9 @@ protected:
       : number_of_variables_(number_of_variables), units_(units) {}
 
   //! allow child classes access to Expression::evaluate
-  static double evaluate_def_(SP<Expression const> const &e,
+  static double evaluate_def_(std::shared_ptr<Expression const> const &e,
                               double const *const x) {
-    Require(e != SP<Expression>());
+    Require(e != std::shared_ptr<Expression>());
 
     return e->evaluate_(x);
   }

--- a/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
@@ -5,8 +5,7 @@
  * \date   Tue Nov  9 14:34:11 2010
  * \brief  Test the Abstract_Class_Contextual_Parser template
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -48,9 +47,9 @@ private:
 
 //---------------------------------------------------------------------------//
 /*
- * Declare a parse table for parsing objects derived from Parent. Note that
- * this must be in the rtt_parser namespace regardless of which namespace
- * Parent lives in.
+ * Declare a parse table for parsing objects derived from Parent. Note that this
+ * must be in the rtt_parser namespace regardless of which namespace Parent
+ * lives in.
  */
 namespace rtt_parser {
 
@@ -83,28 +82,29 @@ public:
     }
   }
 
-  SP<Parent> create_object() { return child_; }
+  std::shared_ptr<Parent> create_object() { return child_; }
 
   // STATICS
 
   Parse_Table const &parse_table() const { return parse_table_; }
 
   static void register_model(string const &keyword,
-                             SP<Parent> parse_function(Token_Stream &,
-                                                       int const &)) {
+                             std::shared_ptr<Parent> parse_function(
+                               Token_Stream &, int const &)) {
     Abstract_Class_Parser<Parent, get_parse_table_, get_parsed_object_,
                           Contextual_Parse_Functor<Parent, int, get_context_>>::
         register_child(keyword,
                        Contextual_Parse_Functor<Parent, int, get_context_>(
                            parse_function));
-    // This function allows downstream developers to add new daughter classes
-    // to the parser without having to modify upstream code.
+    // This function allows downstream developers to add new daughter classes to
+    // the parser without having to modify upstream code.
   }
 
 protected:
   // DATA
 
-  // This is where any parameters shared by all children of Parent would be placed.
+  // This is where any parameters shared by all children of Parent would be
+  // placed.
 
   int context;
   // This is the parser context.
@@ -114,18 +114,18 @@ private:
 
   static Parse_Table &get_parse_table_() { return parse_table_; }
 
-  static SP<Parent> &get_parsed_object_() { return child_; }
+  static std::shared_ptr<Parent> &get_parsed_object_() { return child_; }
 
   static int const &get_context_() { return current_->context; }
 
   // DATA
 
-  static SP<Parent> child_;
+  static std::shared_ptr<Parent> child_;
   static Class_Parse_Table *current_;
   static Parse_Table parse_table_;
 };
 
-SP<Parent> Class_Parse_Table<Parent>::child_;
+std::shared_ptr<Parent> Class_Parse_Table<Parent>::child_;
 Class_Parse_Table<Parent> *Class_Parse_Table<Parent>::current_;
 Parse_Table Class_Parse_Table<Parent>::parse_table_;
 
@@ -133,7 +133,8 @@ Parse_Table Class_Parse_Table<Parent>::parse_table_;
 /*
  * Specialization of the parse_class template function for T=Parent
  */
-template <> SP<Parent> parse_class(Token_Stream &tokens, int const &context) {
+template <> std::shared_ptr<Parent> parse_class(Token_Stream &tokens,
+                                                int const &context) {
   return parse_class_from_table<Class_Parse_Table<Parent>>(tokens, context);
 }
 
@@ -150,16 +151,16 @@ public:
 
   Son(double /*snip_and_snails*/, int const context) : Parent(context) {}
   // "snips and snails" is provided by the parser based on the parsed
-  // specification, while context is provided by the parser context provided
-  // by the client. Since this is a toy example, we don't actually use the
+  // specification, while context is provided by the parser context provided by
+  // the client. Since this is a toy example, we don't actually use the
   // parameter, but we do want to check that the context is got right.
 };
 
 //---------------------------------------------------------------------------//
 /*
- * Now declare a parser class for parsing specifications for Son. Typically
- * the child parser class will be derived from the parent parser class so
- * that parse code for common parameters does not have to be duplicated.
+ * Now declare a parser class for parsing specifications for Son. Typically the
+ * child parser class will be derived from the parent parser class so that parse
+ * code for common parameters does not have to be duplicated.
  */
 namespace rtt_parser {
 template <> class Class_Parse_Table<Son> : public Class_Parse_Table<Parent> {
@@ -173,9 +174,9 @@ public:
   explicit Class_Parse_Table(int const context)
       : Class_Parse_Table<Parent>(context) {
     if (!parse_table_is_initialized_) {
-      // The parser class must populate the parse_table_ with the keywords
-      // and parse functions needed to parse a specification. This is done once
-      // the first time any Class_Parse_Table<Son> object is constructed.
+      // The parser class must populate the parse_table_ with the keywords and
+      // parse functions needed to parse a specification. This is done once the
+      // first time any Class_Parse_Table<Son> object is constructed.
 
       const Keyword keywords[] = {
           {"snips and snails", parse_snips_and_snails, 0, ""},
@@ -188,17 +189,17 @@ public:
     }
 
     // Initialize the parameters about to be parsed, typical with sentinel
-    // values that indicate whether the parameter has been found in the
-    // parsed specification.
+    // values that indicate whether the parameter has been found in the parsed
+    // specification.
     snips_and_snails = -1;
 
-    // Set the current_ pointer to this object so that the parse routines,
-    // which must be static, will know where to find the
-    // Class_Parse_Table<Son> object in which to store parsed parameters.
+    // Set the current_ pointer to this object so that the parse routines, which
+    // must be static, will know where to find the Class_Parse_Table<Son> object
+    // in which to store parsed parameters.
     current_ = this;
     // If the parser is meant to support reentrancy, then the old current_
-    // pointer needs to be saved somewhere (such as a stack) so it can
-    // be retrieved later.
+    // pointer needs to be saved somewhere (such as a stack) so it can be
+    // retrieved later.
   }
 
   // SERVICES
@@ -213,8 +214,8 @@ public:
     }
   }
 
-  SP<Son> create_object() {
-    SP<Son> Result(new Son(snips_and_snails, context));
+  std::shared_ptr<Son> create_object() {
+    std::shared_ptr<Son> Result(new Son(snips_and_snails, context));
     return Result;
   }
 
@@ -236,8 +237,8 @@ private:
       tokens.report_semantic_error("snips and snails must not be "
                                    "negative");
       current_->snips_and_snails = 2;
-      // It's customary to set parameters that have an invalid value
-      // specified to some benign valid value.
+      // It's customary to set parameters that have an invalid value specified
+      // to some benign valid value.
     }
   }
 
@@ -252,7 +253,8 @@ Parse_Table Class_Parse_Table<Son>::parse_table_;
 bool Class_Parse_Table<Son>::parse_table_is_initialized_ = false;
 
 //---------------------------------------------------------------------------//
-template <> SP<Son> parse_class<Son>(Token_Stream &tokens, int const &context) {
+template <> std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens,
+                                                  int const &context) {
   return parse_class_from_table<Class_Parse_Table<Son>>(tokens, context);
 }
 
@@ -275,8 +277,8 @@ public:
 
 //---------------------------------------------------------------------------//
 /*
- * Define a parser class now for Daughter. This is similar to what we do for
- * Son so we will go light on comments.
+ * Define a parser class now for Daughter. This is similar to what we do for Son
+ * so we will go light on comments.
  */
 namespace rtt_parser {
 template <> class Class_Parse_Table<Daughter> {
@@ -315,8 +317,8 @@ public:
     }
   }
 
-  SP<Daughter> create_object() {
-    SP<Daughter> Result(new Daughter(sugar_and_spice));
+  std::shared_ptr<Daughter> create_object() {
+    std::shared_ptr<Daughter> Result(new Daughter(sugar_and_spice));
     return Result;
   }
 
@@ -349,7 +351,8 @@ Parse_Table Class_Parse_Table<Daughter>::parse_table_;
 bool Class_Parse_Table<Daughter>::parse_table_is_initialized_;
 
 //---------------------------------------------------------------------------//
-template <> SP<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
+template <> std::shared_ptr<Daughter> parse_class<Daughter>(
+  Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<Daughter>>(tokens);
 }
 
@@ -358,11 +361,11 @@ template <> SP<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
 // The following are the kinds of parse functions that a downwind developer
 // might write for his own children of the Parent class.
 
-SP<Parent> parse_son(Token_Stream &tokens, int const &context) {
+std::shared_ptr<Parent> parse_son(Token_Stream &tokens, int const &context) {
   return parse_class<Son>(tokens, context);
 }
 
-SP<Parent> parse_daughter(Token_Stream &tokens, int const &) {
+std::shared_ptr<Parent> parse_daughter(Token_Stream &tokens, int const &) {
   return parse_class<Daughter>(tokens);
 }
 
@@ -380,7 +383,7 @@ void test(UnitTest &ut) {
 
   File_Token_Stream tokens(sadInputFile);
 
-  SP<Parent> parent = parse_class<Parent>(tokens, 42);
+  std::shared_ptr<Parent> parent = parse_class<Parent>(tokens, 42);
   // We choose 42 as the magic value for our context, in honor of hitchikers
   // across the Galaxy.
 

--- a/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
@@ -88,9 +88,9 @@ public:
 
   Parse_Table const &parse_table() const { return parse_table_; }
 
-  static void register_model(string const &keyword,
-                             std::shared_ptr<Parent> parse_function(
-                               Token_Stream &, int const &)) {
+  static void register_model(
+      string const &keyword,
+      std::shared_ptr<Parent> parse_function(Token_Stream &, int const &)) {
     Abstract_Class_Parser<Parent, get_parse_table_, get_parsed_object_,
                           Contextual_Parse_Functor<Parent, int, get_context_>>::
         register_child(keyword,
@@ -133,8 +133,8 @@ Parse_Table Class_Parse_Table<Parent>::parse_table_;
 /*
  * Specialization of the parse_class template function for T=Parent
  */
-template <> std::shared_ptr<Parent> parse_class(Token_Stream &tokens,
-                                                int const &context) {
+template <>
+std::shared_ptr<Parent> parse_class(Token_Stream &tokens, int const &context) {
   return parse_class_from_table<Class_Parse_Table<Parent>>(tokens, context);
 }
 
@@ -253,8 +253,9 @@ Parse_Table Class_Parse_Table<Son>::parse_table_;
 bool Class_Parse_Table<Son>::parse_table_is_initialized_ = false;
 
 //---------------------------------------------------------------------------//
-template <> std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens,
-                                                  int const &context) {
+template <>
+std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens,
+                                      int const &context) {
   return parse_class_from_table<Class_Parse_Table<Son>>(tokens, context);
 }
 
@@ -351,8 +352,8 @@ Parse_Table Class_Parse_Table<Daughter>::parse_table_;
 bool Class_Parse_Table<Daughter>::parse_table_is_initialized_;
 
 //---------------------------------------------------------------------------//
-template <> std::shared_ptr<Daughter> parse_class<Daughter>(
-  Token_Stream &tokens) {
+template <>
+std::shared_ptr<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<Daughter>>(tokens);
 }
 

--- a/src/parser/test/tstAbstract_Class_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Parser.cc
@@ -65,9 +65,9 @@ public:
 
   // STATICS
 
-  static void register_model(string const &keyword,
-                             std::shared_ptr<Parent> parse_function(
-                               Token_Stream &)) {
+  static void
+  register_model(string const &keyword,
+                 std::shared_ptr<Parent> parse_function(Token_Stream &)) {
     Abstract_Class_Parser<Parent, get_parse_table_,
                           get_parsed_object_>::register_child(keyword,
                                                               parse_function);
@@ -272,8 +272,8 @@ Parse_Table Class_Parse_Table<Daughter>::parse_table_;
 bool Class_Parse_Table<Daughter>::parse_table_is_initialized_;
 
 //---------------------------------------------------------------------------//
-template <> std::shared_ptr<Daughter> parse_class<Daughter>(
-  Token_Stream &tokens) {
+template <>
+std::shared_ptr<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<Daughter>>(tokens);
 }
 
@@ -297,7 +297,8 @@ const unsigned number_of_top_keywords = sizeof(top_keywords) / sizeof(Keyword);
 Parse_Table top_parse_table(top_keywords, number_of_top_keywords);
 
 std::shared_ptr<Parent> parse_son(Token_Stream &tokens) {
-  return parse_class<Son>(tokens); }
+  return parse_class<Son>(tokens);
+}
 
 std::shared_ptr<Parent> parse_daughter(Token_Stream &tokens) {
   return parse_class<Daughter>(tokens);

--- a/src/parser/test/tstAbstract_Class_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Parser.cc
@@ -5,10 +5,7 @@
  * \date   Tue Nov  9 14:34:11 2010
  * \brief  Test the Abstract_Class_Parser template
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -59,17 +56,18 @@ public:
   bool allow_exit() const { return false; }
 
   void check_completeness(Token_Stream &tokens) {
-    if (child_ == SP<Parent>()) {
+    if (child_ == std::shared_ptr<Parent>()) {
       tokens.report_semantic_error("no parent specified");
     }
   }
 
-  SP<Parent> create_object() { return child_; }
+  std::shared_ptr<Parent> create_object() { return child_; }
 
   // STATICS
 
   static void register_model(string const &keyword,
-                             SP<Parent> parse_function(Token_Stream &)) {
+                             std::shared_ptr<Parent> parse_function(
+                               Token_Stream &)) {
     Abstract_Class_Parser<Parent, get_parse_table_,
                           get_parsed_object_>::register_child(keyword,
                                                               parse_function);
@@ -80,16 +78,16 @@ private:
 
   static Parse_Table &get_parse_table_() { return parse_table_; }
 
-  static SP<Parent> &get_parsed_object_() { return child_; }
+  static std::shared_ptr<Parent> &get_parsed_object_() { return child_; }
 
   // DATA
 
-  static SP<Parent> child_;
+  static std::shared_ptr<Parent> child_;
   static Class_Parse_Table *current_;
   static Parse_Table parse_table_;
 };
 
-SP<Parent> Class_Parse_Table<Parent>::child_;
+std::shared_ptr<Parent> Class_Parse_Table<Parent>::child_;
 Class_Parse_Table<Parent> *Class_Parse_Table<Parent>::current_;
 Parse_Table Class_Parse_Table<Parent>::parse_table_;
 
@@ -97,7 +95,7 @@ Parse_Table Class_Parse_Table<Parent>::parse_table_;
 /*
  * Specialization of the parse_class function for T=Parent
  */
-template <> SP<Parent> parse_class<Parent>(Token_Stream &tokens) {
+template <> std::shared_ptr<Parent> parse_class<Parent>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<Parent>>(tokens);
 }
 
@@ -167,8 +165,8 @@ public:
     }
   }
 
-  SP<Son> create_object() {
-    SP<Son> Result(new Son(parsed_snips_and_snails));
+  std::shared_ptr<Son> create_object() {
+    std::shared_ptr<Son> Result(new Son(parsed_snips_and_snails));
     return Result;
   }
 
@@ -186,7 +184,7 @@ Parse_Table Class_Parse_Table<Son>::parse_table_;
 bool Class_Parse_Table<Son>::parse_table_is_initialized_ = false;
 
 //---------------------------------------------------------------------------//
-template <> SP<Son> parse_class<Son>(Token_Stream &tokens) {
+template <> std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<Son>>(tokens);
 }
 
@@ -256,8 +254,8 @@ public:
     }
   }
 
-  SP<Daughter> create_object() {
-    SP<Daughter> Result(new Daughter(parsed_sugar_and_spice));
+  std::shared_ptr<Daughter> create_object() {
+    std::shared_ptr<Daughter> Result(new Daughter(parsed_sugar_and_spice));
     return Result;
   }
 
@@ -274,7 +272,8 @@ Parse_Table Class_Parse_Table<Daughter>::parse_table_;
 bool Class_Parse_Table<Daughter>::parse_table_is_initialized_;
 
 //---------------------------------------------------------------------------//
-template <> SP<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
+template <> std::shared_ptr<Daughter> parse_class<Daughter>(
+  Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<Daughter>>(tokens);
 }
 
@@ -282,7 +281,7 @@ template <> SP<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
 
 /* the followingn would typically live in some client file for Parent. */
 
-SP<Parent> parent;
+std::shared_ptr<Parent> parent;
 
 //static
 void parse_parent(Token_Stream &tokens, int) {
@@ -297,9 +296,10 @@ const unsigned number_of_top_keywords = sizeof(top_keywords) / sizeof(Keyword);
 
 Parse_Table top_parse_table(top_keywords, number_of_top_keywords);
 
-SP<Parent> parse_son(Token_Stream &tokens) { return parse_class<Son>(tokens); }
+std::shared_ptr<Parent> parse_son(Token_Stream &tokens) {
+  return parse_class<Son>(tokens); }
 
-SP<Parent> parse_daughter(Token_Stream &tokens) {
+std::shared_ptr<Parent> parse_daughter(Token_Stream &tokens) {
   return parse_class<Daughter>(tokens);
 }
 
@@ -321,7 +321,7 @@ void test(UnitTest &ut) {
 
   cout << parent->name() << endl;
 
-  if (tokens.error_count() == 0 && parent != SP<Parent>() &&
+  if (tokens.error_count() == 0 && parent != std::shared_ptr<Parent>() &&
       parent->name() == "son") {
     PASSMSG("Parsed son correctly");
   } else {

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -75,15 +75,15 @@ Parse_Table Class_Parse_Table<DummyClass>::parse_table_;
 bool Class_Parse_Table<DummyClass>::parse_table_is_initialized_ = false;
 
 //---------------------------------------------------------------------------//
-template <> std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream
-                                                                &tokens) {
+template <>
+std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens);
 }
 
 //---------------------------------------------------------------------------//
 template <>
 std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
-                                       bool const &is_indolent) {
+                                                    bool const &is_indolent) {
   return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens,
                                                                is_indolent);
 }
@@ -133,8 +133,8 @@ void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
 
 //---------------------------------------------------------------------------//
 std::shared_ptr<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
-  std::shared_ptr<DummyClass> Result = std::shared_ptr<DummyClass>(
-    new DummyClass(parsed_insouciance));
+  std::shared_ptr<DummyClass> Result =
+      std::shared_ptr<DummyClass>(new DummyClass(parsed_insouciance));
   return Result;
 }
 

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -4,10 +4,7 @@
  * \author Kent Budge
  * \date   Mon Aug 28 07:36:50 2006
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -51,7 +48,7 @@ public:
 
   void check_completeness(Token_Stream &tokens);
 
-  SP<DummyClass> create_object();
+  std::shared_ptr<DummyClass> create_object();
 
 protected:
   // DATA
@@ -78,13 +75,14 @@ Parse_Table Class_Parse_Table<DummyClass>::parse_table_;
 bool Class_Parse_Table<DummyClass>::parse_table_is_initialized_ = false;
 
 //---------------------------------------------------------------------------//
-template <> SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
+template <> std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream
+                                                                &tokens) {
   return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens);
 }
 
 //---------------------------------------------------------------------------//
 template <>
-SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
+std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
                                        bool const &is_indolent) {
   return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens,
                                                                is_indolent);
@@ -134,8 +132,9 @@ void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
 }
 
 //---------------------------------------------------------------------------//
-SP<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
-  SP<DummyClass> Result = SP<DummyClass>(new DummyClass(parsed_insouciance));
+std::shared_ptr<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
+  std::shared_ptr<DummyClass> Result = std::shared_ptr<DummyClass>(
+    new DummyClass(parsed_insouciance));
   return Result;
 }
 
@@ -149,7 +148,7 @@ void tstClass_Parser(UnitTest &ut) {
   string text = "insouciance = 3.3\nend\n";
   String_Token_Stream tokens(text);
 
-  SP<DummyClass> dummy = parse_class<DummyClass>(tokens);
+  std::shared_ptr<DummyClass> dummy = parse_class<DummyClass>(tokens);
 
   ut.check(dummy != nullptr, "parsed the class object", true);
   ut.check(dummy->Get_Insouciance() == 3.3, "parsed the insouciance correctly");
@@ -168,7 +167,7 @@ void tstClass_Parser(UnitTest &ut) {
 
   bool good = false;
   try {
-    SP<DummyClass> dummy = parse_class<DummyClass>(etokens);
+    std::shared_ptr<DummyClass> dummy = parse_class<DummyClass>(etokens);
   } catch (Syntax_Error &) {
     good = true;
   }
@@ -177,7 +176,7 @@ void tstClass_Parser(UnitTest &ut) {
   tokens.rewind();
   good = false;
   try {
-    SP<DummyClass> dummy = parse_class<DummyClass>(etokens, true);
+    std::shared_ptr<DummyClass> dummy = parse_class<DummyClass>(etokens, true);
   } catch (Syntax_Error &) {
     good = true;
   }

--- a/src/parser/test/tstExpression.cc
+++ b/src/parser/test/tstExpression.cc
@@ -8,9 +8,9 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include "ds++/ScalarUnitTest.hh"
 #include "ds++/DracoMath.hh"
 #include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
 #include "parser/Expression.hh"
 #include "parser/String_Token_Stream.hh"
 
@@ -44,8 +44,8 @@ void tstExpression(UnitTest &ut) {
   vars[2] = "z";
   vars[3] = "t";
 
-  std::shared_ptr<Expression const> expression = Expression::parse(
-    4, variable_map, tokens);
+  std::shared_ptr<Expression const> expression =
+      Expression::parse(4, variable_map, tokens);
 
   if (tokens.error_count() == 0 && tokens.lookahead().type() == EXIT) {
     PASSMSG("expression successfully parsed");
@@ -252,8 +252,8 @@ void tstExpression(UnitTest &ut) {
   {
     tokens = String_Token_Stream("log(1.0) + cos(2.0) + exp(3.0) + sin(4.0)");
 
-    std::shared_ptr<Expression> expression = Expression::parse(4, variable_map,
-                                                               tokens);
+    std::shared_ptr<Expression> expression =
+        Expression::parse(4, variable_map, tokens);
 
     if (expression->is_constant(0))
       PASSMSG("expression successfully const tested");
@@ -271,8 +271,8 @@ void tstExpression(UnitTest &ut) {
     tokens = String_Token_Stream(
         "(log(1.0) + cos(2.0) + exp(3.0) + sin(4.0))/(m*s)");
 
-    std::shared_ptr<Expression> expression = Expression::parse(4, variable_map,
-                                                               tokens);
+    std::shared_ptr<Expression> expression =
+        Expression::parse(4, variable_map, tokens);
 
     if (expression->is_constant(0))
       PASSMSG("expression successfully const tested");

--- a/src/parser/test/tstExpression.cc
+++ b/src/parser/test/tstExpression.cc
@@ -5,20 +5,10 @@
  * \date   Wed Jul 26 08:15:18 2006
  * \brief  Test the Expression class and expression parsing.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
-// $Id$
-//---------------------------------------------------------------------------//
-
-// #include <iostream>
-// #include <sstream>
-// #include <vector>
-// #include <stdlib.h>
-// #include <cmath>
 
 #include "ds++/ScalarUnitTest.hh"
-// #include "ds++/Soft_Equivalence.hh"
 #include "ds++/DracoMath.hh"
 #include "ds++/Release.hh"
 #include "parser/Expression.hh"
@@ -54,7 +44,8 @@ void tstExpression(UnitTest &ut) {
   vars[2] = "z";
   vars[3] = "t";
 
-  SP<Expression const> expression = Expression::parse(4, variable_map, tokens);
+  std::shared_ptr<Expression const> expression = Expression::parse(
+    4, variable_map, tokens);
 
   if (tokens.error_count() == 0 && tokens.lookahead().type() == EXIT) {
     PASSMSG("expression successfully parsed");
@@ -68,8 +59,8 @@ void tstExpression(UnitTest &ut) {
 
   char const *expression_text_raw =
       "((1&&1.3||!(y<-m))/5+(2>1)*r/m*pow(2.7-1.1*z/m,2))*t/s";
-  // changes slightly due to stripping of extraneous whitespace,
-  // parentheses, and positive prefix
+  // changes slightly due to stripping of extraneous whitespace, parentheses,
+  // and positive prefix
   if (expression_text_copy.str() == expression_text_raw) {
     PASSMSG("expression successfully rendered as text");
   } else {
@@ -81,7 +72,7 @@ void tstExpression(UnitTest &ut) {
 #if 0
     // Test calculus
 
-    SP<Expression const> deriv = expression->pd(3);
+    std::shared_ptr<Expression const> deriv = expression->pd(3);
 
     ostringstream deriv_text;
     deriv->write(vars, deriv_text);
@@ -144,7 +135,7 @@ void tstExpression(UnitTest &ut) {
 
   expression = Expression::parse(4, variable_map, tokens);
 
-  if (expression != SP<Expression>())
+  if (expression != std::shared_ptr<Expression>())
     PASSMSG("expression successfully parsed");
   else
     FAILMSG("expression NOT successfully parsed");
@@ -161,8 +152,8 @@ void tstExpression(UnitTest &ut) {
     expression->write(vars, expression_text_copy);
 
     char const *expression_text_raw = "20*(r>=1.1*m&&z<=1.5*m||r>=2*m)";
-    // changes slightly due to stripping of extraneous whitespace,
-    // parentheses, and positive prefix
+    // changes slightly due to stripping of extraneous whitespace, parentheses,
+    // and positive prefix
     if (expression_text_copy.str() == expression_text_raw) {
       PASSMSG("expression successfully rendered as text");
     } else {
@@ -199,7 +190,7 @@ void tstExpression(UnitTest &ut) {
 
   expression = Expression::parse(4, variable_map, tokens);
 
-  if (expression != SP<Expression>())
+  if (expression != std::shared_ptr<Expression>())
     PASSMSG("expression successfully parsed");
   else
     FAILMSG("expression NOT successfully parsed");
@@ -217,8 +208,8 @@ void tstExpression(UnitTest &ut) {
 
     char const *expression_text_raw =
         "exp(-0.5*r/m)*(3*cos(2*y/m)+5*sin(3*y/m))";
-    // changes slightly due to stripping of extraneous whitespace,
-    // parentheses, and positive prefix
+    // changes slightly due to stripping of extraneous whitespace, parentheses,
+    // and positive prefix
     if (expression_text_copy.str() == expression_text_raw) {
       PASSMSG("expression successfully rendered as text");
     } else {
@@ -232,7 +223,7 @@ void tstExpression(UnitTest &ut) {
 
   expression = Expression::parse(4, variable_map, tokens);
 
-  if (expression != SP<Expression>())
+  if (expression != std::shared_ptr<Expression>())
     PASSMSG("expression successfully parsed");
   else
     FAILMSG("expression NOT successfully parsed");
@@ -247,8 +238,8 @@ void tstExpression(UnitTest &ut) {
     expression->write(vars, expression_text_copy);
 
     char const *expression_text_raw = "log(1)";
-    // changes slightly due to stripping of extraneous whitespace,
-    // parentheses, and positive prefix
+    // changes slightly due to stripping of extraneous whitespace, parentheses,
+    // and positive prefix
     if (expression_text_copy.str() == expression_text_raw) {
       PASSMSG("expression successfully rendered as text");
     } else {
@@ -261,7 +252,8 @@ void tstExpression(UnitTest &ut) {
   {
     tokens = String_Token_Stream("log(1.0) + cos(2.0) + exp(3.0) + sin(4.0)");
 
-    SP<Expression> expression = Expression::parse(4, variable_map, tokens);
+    std::shared_ptr<Expression> expression = Expression::parse(4, variable_map,
+                                                               tokens);
 
     if (expression->is_constant(0))
       PASSMSG("expression successfully const tested");
@@ -279,7 +271,8 @@ void tstExpression(UnitTest &ut) {
     tokens = String_Token_Stream(
         "(log(1.0) + cos(2.0) + exp(3.0) + sin(4.0))/(m*s)");
 
-    SP<Expression> expression = Expression::parse(4, variable_map, tokens);
+    std::shared_ptr<Expression> expression = Expression::parse(4, variable_map,
+                                                               tokens);
 
     if (expression->is_constant(0))
       PASSMSG("expression successfully const tested");

--- a/src/parser/test/tstutilities.cc
+++ b/src/parser/test/tstutilities.cc
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \date   Feb 18 2003
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -547,7 +544,7 @@ void tstutilities(UnitTest &ut) {
     map<std::string, pair<unsigned, Unit>> variable_map;
     Unit one = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
     variable_map[std::string("x")] = std::make_pair(0, one);
-    SP<Expression> T = parse_temperature(string, 1, variable_map);
+    std::shared_ptr<Expression> T = parse_temperature(string, 1, variable_map);
     vector<double> x(1, 0.0);
     if (soft_equiv((*T)(x), 278.))
       PASSMSG("parsed temperature correctly");
@@ -559,7 +556,7 @@ void tstutilities(UnitTest &ut) {
     map<std::string, pair<unsigned, Unit>> variable_map;
     Unit one = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
     variable_map[std::string("x")] = std::make_pair(0, one);
-    SP<Expression> T = parse_temperature(string, 1, variable_map);
+    std::shared_ptr<Expression> T = parse_temperature(string, 1, variable_map);
     vector<double> x(1, 0.0);
     if (soft_equiv((*T)(x), 1.0 / rtt_units::boltzmannSI))
       PASSMSG("parsed temperature correctly");
@@ -571,7 +568,7 @@ void tstutilities(UnitTest &ut) {
     map<std::string, pair<unsigned, Unit>> variable_map;
     Unit one = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
     variable_map[std::string("x")] = std::make_pair(0, one);
-    SP<Expression> T =
+    std::shared_ptr<Expression> T =
         parse_quantity(string, K, "temperature", 1, variable_map);
     vector<double> x(1, 0.0);
     if (soft_equiv((*T)(x), 278.))
@@ -829,7 +826,7 @@ void tstutilities(UnitTest &ut) {
     set_unit_expressions_are_required(true);
     set_internal_unit_system(UnitSystem(UnitSystemType().SI()));
 
-    SP<Expression> c =
+    std::shared_ptr<Expression> c =
         parse_quantity(expression_with_units, erg * s, "action", 2U, vmap);
 
     if (expression_with_units.error_count() == 0 &&

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -5,9 +5,9 @@
  * \date   18 Feb 2003
  * \brief  Definitions of parsing utility functions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
+
 #include "utilities.hh"
 #include "units/PhysicalConstants.hh"
 #include "units/PhysicalConstantsSI.hh"
@@ -141,9 +141,7 @@ unsigned parse_unsigned_integer(Token_Stream &tokens) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- *
+ * \param tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 unsigned parse_positive_integer(Token_Stream &tokens) {
@@ -159,9 +157,7 @@ unsigned parse_positive_integer(Token_Stream &tokens) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- *
+ * \param tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 int parse_integer(Token_Stream &tokens) {
@@ -193,8 +189,7 @@ int parse_integer(Token_Stream &tokens) {
 /*!
  * This function does not move the cursor in the token stream.
  *
- * \param tokens
- * Token stream from which to parse the quantity.
+ * \param tokens Token stream from which to parse the quantity.
  * \return \c true if the next token is REAL or INTEGER; \c false otherwise.
  */
 bool at_real(Token_Stream &tokens) {
@@ -211,8 +206,7 @@ bool at_real(Token_Stream &tokens) {
  * with the integers being a subset of reals, and with about five decades of
  * common practice in the computer language community.
  *
- * \param tokens
- * Token stream from which to parse the quantity.
+ * \param tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 double parse_real(Token_Stream &tokens) {
@@ -246,9 +240,7 @@ double parse_real(Token_Stream &tokens) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- *
+ * \param tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 double parse_positive_real(Token_Stream &tokens) {
@@ -264,9 +256,7 @@ double parse_positive_real(Token_Stream &tokens) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- *
+ * \param tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 double parse_nonnegative_real(Token_Stream &tokens) {
@@ -282,10 +272,8 @@ double parse_nonnegative_real(Token_Stream &tokens) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- * \param x
- * On return, contains the parsed vector components.
+ * \param tokens Token stream from which to parse the quantity.
+ * \param x On return, contains the parsed vector components.
  * \pre \c x!=NULL
  */
 void parse_vector(Token_Stream &tokens, double x[]) {
@@ -306,17 +294,13 @@ void parse_vector(Token_Stream &tokens, double x[]) {
     x[2] = 0.0;
   }
 }
-//---------------------------------------------------------------------------//
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- * \param x
- * On return, contains the parsed vector components.
+ * \param tokens Token stream from which to parse the quantity.
+ * \param x On return, contains the parsed vector components.
  * \pre \c x!=NULL
  */
-
 void parse_unsigned_vector(Token_Stream &tokens, unsigned x[], unsigned size) {
   Require(x != NULL);
 
@@ -338,18 +322,16 @@ void parse_unsigned_vector(Token_Stream &tokens, unsigned x[], unsigned size) {
 /*!
  * \brief Are we at a unit term?
  *
- * We are at a unit term if the next token on the Token_Stream is a valid
- * unit name.
+ * We are at a unit term if the next token on the Token_Stream is a valid unit
+ * name.
  *
- * \param tokens
- * Token_Stream from which to parse.
- * \param pos
- * Position in Token_Stream at which to parse.  This lookahead capability is
- * needed by parse_unit to see if a hyphen '-' is part of a unit expression.
+ * \param tokens Token_Stream from which to parse.
+ * \param pos Position in Token_Stream at which to parse.  This lookahead
+ * capability is needed by parse_unit to see if a hyphen '-' is part of a unit
+ * expression.
  *
  * \return \c true if we are at the start of a unit term; \c false otherwise
  */
-
 bool at_unit_term(Token_Stream &tokens, unsigned position) {
   Token const token = tokens.lookahead(position);
   if (token.type() == KEYWORD) {
@@ -447,14 +429,12 @@ Unit parse_unit(Token_Stream &tokens);
 /*!
  * \brief Parse a unit name.
  *
- * A unit name can either be a literal unit name, like "kg", or a
- * parenthesized unit expression.
+ * A unit name can either be a literal unit name, like "kg", or a parenthesized
+ * unit expression.
  *
- * \param tokens
- * Token_Stream from which to parse.
+ * \param tokens Token_Stream from which to parse.
  * \return The unit.
  */
-
 static Unit parse_unit_name(Token_Stream &tokens) {
   Token token = tokens.shift();
   if (token.type() == KEYWORD) {
@@ -648,11 +628,9 @@ static Unit parse_unit_name(Token_Stream &tokens) {
  *
  * A unit term is a unit name optionally raised to some power.
  *
- * \param tokens
- * Token_Stream from which to parse.
+ * \param tokens Token_Stream from which to parse.
  * \return The unit term.
  */
-
 static Unit parse_unit_term(Token_Stream &tokens) {
   Unit const Result = parse_unit_name(tokens);
   Token const token = tokens.lookahead();
@@ -673,11 +651,9 @@ static Unit parse_unit_term(Token_Stream &tokens) {
  * expression is permitted and returns rtt_parser::dimensionless, the
  * identity Unit representing the pure number 1.
  *
- * \param tokens
- * Token_Stream from which to parse.
+ * \param tokens Token_Stream from which to parse.
  * \return The unit expression.
  */
-
 Unit parse_unit(Token_Stream &tokens) {
   if (!at_unit_term(tokens))
     return dimensionless;
@@ -710,17 +686,14 @@ Unit parse_unit(Token_Stream &tokens) {
  * will be converted to the desired unit system, as indicated by the \c .conv
  * member of the \c target_unit argument.
  *
- * \param tokens
- * Token stream from which to parse the quantity.
- * \param target_unit
- * Expected units for the quantity parsed, including conversion factor.
- * \param name
- * Name of the units expected for the quantity parsed, such as "length" or
- * "ergs/cm/sec/Hz". Used to generate diagnostic messages.
+ * \param tokens Token stream from which to parse the quantity.
+ * \param target_unit Expected units for the quantity parsed, including
+ * conversion factor.
+ * \param name Name of the units expected for the quantity parsed, such as
+ * "length" or "ergs/cm/sec/Hz". Used to generate diagnostic messages.
  *
  * \return The parsed value, converted to the desired unit system.
  */
-
 double parse_quantity(Token_Stream &tokens, Unit const &target_unit,
                       char const *const name) {
   double const value = parse_real(tokens);
@@ -742,18 +715,15 @@ double parse_quantity(Token_Stream &tokens, Unit const &target_unit,
 /*!
  * \brief Parse a temperature specification
  *
- * It is very common for transport researchers to specify a temperature in
- * units of energy, using Boltzmann's constant as the conversion factor.
- * This function is useful for parsers that accomodate this convention.
+ * It is very common for transport researchers to specify a temperature in units
+ * of energy, using Boltzmann's constant as the conversion factor.  This
+ * function is useful for parsers that accomodate this convention.
  *
- * \param tokens
- * Token stream from which to parse the specification.
- *
+ * \param tokens Token stream from which to parse the specification.
  * \return The parsed temperature.
  *
  * \post \c Result>=0.0
  */
-
 double parse_temperature(Token_Stream &tokens) {
   double T = parse_real(tokens);
 
@@ -786,15 +756,14 @@ double parse_temperature(Token_Stream &tokens) {
 /*!
  * \brief Parse a temperature specification
  *
- * It is very common for transport researchers to specify a temperature in
- * units of energy, using Boltzmann's constant as the conversion factor.
- * This function is useful for parsers that accomodate this convention.
+ * It is very common for transport researchers to specify a temperature in units
+ * of energy, using Boltzmann's constant as the conversion factor.  This
+ * function is useful for parsers that accomodate this convention.
  *
  * This version of the function parses a temperature expression containing
  * user-defined variables.
  *
- * \param tokens
- * Token stream from which to parse the specification.
+ * \param tokens Token stream from which to parse the specification.
  *
  * \param number_of_variables Number of user-defined variables potentially
  * present in the parsed expression.
@@ -805,11 +774,10 @@ double parse_temperature(Token_Stream &tokens) {
  *
  * \post \c Result>=0.0
  */
-
-SP<Expression>
+std::shared_ptr<Expression>
 parse_temperature(Token_Stream &tokens, unsigned const number_of_variables,
                   std::map<string, pair<unsigned, Unit>> const &variable_map) {
-  SP<Expression> T =
+  std::shared_ptr<Expression> T =
       Expression::parse(number_of_variables, variable_map, tokens);
 
   if (!unit_expressions_are_required() && !at_unit_term(tokens)) {
@@ -838,11 +806,9 @@ parse_temperature(Token_Stream &tokens, unsigned const number_of_variables,
 /*!
  * Parses a STRING token and strips the delimiting quotation marks.
  *
- * \param tokens
- * Token_Stream from which to parse.
+ * \param tokens Token_Stream from which to parse.
  * \return The stripped string.
  */
-
 std::string parse_manifest_string(Token_Stream &tokens) {
   Token const token = tokens.shift();
   if (token.type() != STRING) {
@@ -859,8 +825,7 @@ std::string parse_manifest_string(Token_Stream &tokens) {
 /*!
  * \brief Parse a geometry specification.
  *
- * \param tokens
- * Token stream from which to parse the geometry.
+ * \param tokens Token stream from which to parse the geometry.
  * \param parsed_geometry On entry, if the value is not \c END_GEOMETRY, a
  * diagnostic is generated to the token stream. On return, contains the
  * geometry that was parsed.
@@ -895,12 +860,9 @@ void parse_geometry(Token_Stream &tokens,
 
 //---------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
- *
+ * \param tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
-
 bool parse_bool(Token_Stream &tokens) {
   Token const token = tokens.shift();
   if (token.text() == "true") {
@@ -919,27 +881,21 @@ bool parse_bool(Token_Stream &tokens) {
  * will be converted to the desired unit system, as indicated by the \c .conv
  * member of the \c target_unit argument.
  *
- * \param tokens
- * Token stream from which to parse the quantity.
- * \param target_unit
- * Expected units for the quantity parsed, including conversion factor.
- * \param name
- * Name of the units expected for the quantity parsed, such as "length" or
- * "ergs/cm/sec/Hz". Used to generate diagnostic messages.
- *
+ * \param tokens Token stream from which to parse the quantity.
+ * \param target_unit Expected units for the quantity parsed, including
+ * conversion factor.
+ * \param name Name of the units expected for the quantity parsed, such as
+ * "length" or "ergs/cm/sec/Hz". Used to generate diagnostic messages.
  * \param number_of_variables Number of user-defined variables potentially
  * present in the parsed expression.
- *
  * \param variable_map Map of variable names to variables indices.
- *
  * \return The parsed value, converted to the desired unit system.
  */
-
-SP<Expression>
+std::shared_ptr<Expression>
 parse_quantity(Token_Stream &tokens, Unit const &target_unit,
                char const *const name, unsigned const number_of_variables,
                std::map<string, pair<unsigned, Unit>> const &variable_map) {
-  SP<Expression> value =
+  std::shared_ptr<Expression> value =
       Expression::parse(number_of_variables, variable_map, tokens);
 
   if (!unit_expressions_are_required() && !at_unit_term(tokens)) {

--- a/src/parser/utilities.hh
+++ b/src/parser/utilities.hh
@@ -16,6 +16,7 @@
 
 #include "Expression.hh"
 #include "mesh_element/Geometry.hh"
+#include <memory>
 
 namespace rtt_parser {
 //! Can the next token in the stream be interpreted as real number?
@@ -63,14 +64,14 @@ DLL_PUBLIC_parser double parse_quantity(Token_Stream &tokens, Unit const &unit,
                                         char const *name);
 
 //! parse an expression followed by a unit expression.
-DLL_PUBLIC_parser SP<Expression>
+DLL_PUBLIC_parser std::shared_ptr<Expression>
 parse_quantity(Token_Stream &tokens, Unit const &unit, char const *name,
                unsigned number_of_variables,
                std::map<string, pair<unsigned, Unit>> const &);
 
 DLL_PUBLIC_parser double parse_temperature(Token_Stream &);
 
-DLL_PUBLIC_parser SP<Expression>
+DLL_PUBLIC_parser std::shared_ptr<Expression>
 parse_temperature(Token_Stream &, unsigned number_of_variables,
                   std::map<string, pair<unsigned, Unit>> const &);
 
@@ -81,9 +82,9 @@ parse_temperature(Token_Stream &, unsigned number_of_variables,
  * signature for all functions that parse an object of a specified class from a
  * Token_Stream, so that the common code idiom for parsing an object of MyClass
  * is:
- *
- *   SP<MyClass> spMyClass = parse_class<MyClass>(tokens);
- *
+ * \code
+ *   std::shared_ptr<MyClass> spMyClass = parse_class<MyClass>(tokens);
+ * \endcode
  * Developers may specialize this function as needed. A particular
  * implementation is suggested in Class_Parse_Table.hh.
  *
@@ -95,24 +96,23 @@ parse_temperature(Token_Stream &, unsigned number_of_variables,
  * \return A pointer to an object matching the user specification, or NULL if
  * the specification is not valid.
  */
-template <typename Class> rtt_dsxx::SP<Class> parse_class(Token_Stream &tokens);
+template <typename Class>
+std::shared_ptr<Class> parse_class(Token_Stream &tokens);
 
 //----------------------------------------------------------------------------//
 /*! Template for parse function that produces a class object.
  *
- * This function resembles the previous one, but takes a second argument supply a context
- * that may alter the parser behavior..
+ * This function resembles the previous one, but takes a second argument supply
+ * a context that may alter the parser behavior..
  *
  * \param tokens Token stream from which to parse the user input.
- *
  * \param context Context for the parse.
- *
  * \return A pointer to an object matching the user specification, or NULL if
  * the specification is not valid.
  */
-
 template <typename Class, typename Context>
-rtt_dsxx::SP<Class> parse_class(Token_Stream &tokens, Context const &context);
+std::shared_ptr<Class> parse_class(Token_Stream &tokens,
+                                   Context const &context);
 
 } // rtt_parser
 

--- a/src/plot2D/Plot2D.hh
+++ b/src/plot2D/Plot2D.hh
@@ -5,17 +5,13 @@
   \date   2002-04-12
   \brief  Header for Plot2D.
   \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
-          All rights reserved.
-*/
-//---------------------------------------------------------------------------//
-// $Id$
+          All rights reserved.*/
 //---------------------------------------------------------------------------//
 
 #ifndef INCLUDED_plot2D_Plot2D_hh
 #define INCLUDED_plot2D_Plot2D_hh
 
 #include "SetProps.hh"
-#include "ds++/SP.hh"
 #include <vector>
 
 namespace rtt_plot2D {

--- a/src/quadrature/Double_Gauss.cc
+++ b/src/quadrature/Double_Gauss.cc
@@ -1,21 +1,17 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Double_Gauss.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
- * \brief  A class representing an interval dobule Gauss-Legendre quadrature set.
+ * \brief  A class representing an interval dobule Gauss-Legendre quadrature
+ *         set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #include <numeric>
-
 #include "Double_Gauss.hh"
 #include "Gauss_Legendre.hh"
-
 #include "ds++/to_string.hh"
 
 namespace rtt_quadrature {
@@ -37,7 +33,7 @@ Double_Gauss::Double_Gauss(unsigned sn_order) : Interval_Quadrature(sn_order) {
   {
     Check(sn_order == 2);
 
-    SP<Gauss_Legendre> GL(new Gauss_Legendre(sn_order));
+    std::shared_ptr<Gauss_Legendre> GL(new Gauss_Legendre(sn_order));
     for (unsigned m = 0; m < sn_order; ++m) {
       mu_[m] = GL->mu(m);
       wt_[m] = GL->wt(m);
@@ -48,13 +44,13 @@ Double_Gauss::Double_Gauss(unsigned sn_order) : Interval_Quadrature(sn_order) {
     Check(n2 % 2 == 0);
     Check(n2 > 2);
 
-    SP<Gauss_Legendre> GL(new Gauss_Legendre(n2));
+    std::shared_ptr<Gauss_Legendre> GL(new Gauss_Legendre(n2));
 
     // map the quadrature onto the two half-ranges
 
     for (unsigned m = 0; m < n2; ++m) {
-      // Map onto [-1,0] then skew-symmetrize
-      // (ensuring ascending order on [-1, 1])
+      // Map onto [-1,0] then skew-symmetrize (ensuring ascending order on [-1,
+      // 1])
 
       mu_[m] = 0.5 * (GL->mu(m) - 1.0);
       wt_[m] = 0.5 * GL->wt(m);
@@ -68,19 +64,19 @@ Double_Gauss::Double_Gauss(unsigned sn_order) : Interval_Quadrature(sn_order) {
   Ensure(this->sn_order() == sn_order);
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /* virtual */
 string Double_Gauss::name() const { return "Double-Gauss"; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /* virtual */
 string Double_Gauss::parse_name() const { return "double gauss"; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /* virtual */
 unsigned Double_Gauss::number_of_levels() const { return sn_order(); }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /* virtual */ string Double_Gauss::as_text(string const &indent) const {
   string Result = indent + "type = double gauss" + indent + "  order = " +
                   to_string(sn_order()) + indent + "end";
@@ -88,12 +84,12 @@ unsigned Double_Gauss::number_of_levels() const { return sn_order(); }
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 bool Double_Gauss::check_class_invariants() const {
   return sn_order() > 0 && sn_order() % 2 == 0;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /* virtual */
 vector<Ordinate>
 Double_Gauss::create_level_ordinates_(double const norm) const {
@@ -119,6 +115,6 @@ Double_Gauss::create_level_ordinates_(double const norm) const {
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Quadrature.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Double_Gauss.cc
+++ b/src/quadrature/Double_Gauss.cc
@@ -9,10 +9,10 @@
  *         reserved. */
 //---------------------------------------------------------------------------//
 
-#include <numeric>
 #include "Double_Gauss.hh"
 #include "Gauss_Legendre.hh"
 #include "ds++/to_string.hh"
+#include <numeric>
 
 namespace rtt_quadrature {
 using namespace std;

--- a/src/quadrature/Double_Gauss.hh
+++ b/src/quadrature/Double_Gauss.hh
@@ -1,15 +1,13 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//-----------------------*-C++-*----------------------------------------------//
 /*!
  * \file   quadrature/Double_Gauss.hh
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
- * \brief  A class representing an interval double Gauss-Legendre quadrature set.
+ * \brief  A class representing an interval double Gauss-Legendre quadrature
+ *         set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #ifndef __quadrature_Double_Gauss_hh__
 #define __quadrature_Double_Gauss_hh__
@@ -18,7 +16,7 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//============================================================================//
 /*!
  * \class Double_Gauss
  *
@@ -26,11 +24,11 @@ namespace rtt_quadrature {
  *
  * This is an interval (e.g. 1D) angle quadrature set in which the
  * Gauss-Legendre quadrature of order n/2 is mapped separately onto the
- * intervals [-1,0] and [0,1] assuming N>2. The case N=2 does not integrate
- * the flux and we substitute ordinary Gauss-Legendre quadrature (N=2) on the
- * full interval [-1,1].
+ * intervals [-1,0] and [0,1] assuming N>2. The case N=2 does not integrate the
+ * flux and we substitute ordinary Gauss-Legendre quadrature (N=2) on the full
+ * interval [-1,1].
  */
-//=======================================================================================//
+//============================================================================//
 
 class Double_Gauss : public Interval_Quadrature {
 public:
@@ -53,7 +51,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 protected:
   virtual vector<Ordinate> create_level_ordinates_(double norm) const;
@@ -65,6 +63,6 @@ protected:
 
 #endif // __quadrature_Quadrature_hh__
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of quadrature/Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/quadrature/Double_Gauss__Parser.cc
+++ b/src/quadrature/Double_Gauss__Parser.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   quadrature/Double_Gauss.cc
+ * \file   quadrature/Double_Gauss__Parser.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved.  */
+//---------------------------------------------------------------------------//
 
 #include "Double_Gauss.hh"
 #include "parser/utilities.hh"
@@ -17,9 +14,8 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Double_Gauss::parse(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Double_Gauss::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -28,11 +24,11 @@ SP<Quadrature> Double_Gauss::parse(Token_Stream &tokens) {
   tokens.check_semantics(sn_order % 2 == 0, "order must be even");
   tokens.check_syntax(tokens.shift().type() == END, "missing end?");
 
-  return SP<Quadrature>(new Double_Gauss(sn_order));
+  return std::shared_ptr<Quadrature>(new Double_Gauss(sn_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Double_Gauss__Parser.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Gauss_Legendre.hh
+++ b/src/quadrature/Gauss_Legendre.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//---------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   quadrature/Gauss_Legendre.hh
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef __quadrature_Gauss_Legendre_hh__
 #define __quadrature_Gauss_Legendre_hh__
@@ -18,16 +15,16 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Gauss_Legendre
  *
  * \brief A class representing an interval Gauss-Legendre quadrature set.
  *
- * This is an interval (e.g. 1D) angle quadrature set that achieves high
- * formal accuracy by using Gaussian integration based on the Legendre polynomials.
+ * This is an interval (e.g. 1D) angle quadrature set that achieves high formal
+ * accuracy by using Gaussian integration based on the Legendre polynomials.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Gauss_Legendre : public Interval_Quadrature {
 public:
@@ -50,7 +47,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 protected:
   virtual vector<Ordinate> create_level_ordinates_(double norm) const;
@@ -60,6 +57,6 @@ protected:
 
 #endif // __quadrature_Quadrature_hh__
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Gauss_Legendre__Parser.cc
+++ b/src/quadrature/Gauss_Legendre__Parser.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Gauss_Legendre.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Gauss_Legendre.hh"
 #include "parser/utilities.hh"
@@ -17,9 +14,8 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Gauss_Legendre::parse(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Gauss_Legendre::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -28,11 +24,11 @@ SP<Quadrature> Gauss_Legendre::parse(Token_Stream &tokens) {
   tokens.check_semantics(sn_order % 2 == 0, "order must be even");
   tokens.check_syntax(tokens.shift().type() == END, "missing end?");
 
-  return SP<Quadrature>(new Gauss_Legendre(sn_order));
+  return std::shared_ptr<Quadrature>(new Gauss_Legendre(sn_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Gauss_Legendre.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/General_Octant_Quadrature.cc
+++ b/src/quadrature/General_Octant_Quadrature.cc
@@ -8,14 +8,14 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <algorithm>
-#include <cmath>
-#include <iomanip>
-#include <iostream>
 #include "General_Octant_Quadrature.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include "ds++/to_string.hh"
 #include "units/PhysicalConstants.hh"
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
 
 namespace rtt_quadrature {
 using namespace rtt_dsxx;

--- a/src/quadrature/General_Octant_Quadrature.cc
+++ b/src/quadrature/General_Octant_Quadrature.cc
@@ -1,23 +1,18 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/General_Octant_Quadrature.cc
  * \author Kelly Thompson
  * \date   Wed Sep  1 10:19:52 2004
- * \brief  
+ * \brief
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: General_Octant_Quadrature.cc 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
-
 #include "General_Octant_Quadrature.hh"
-
 #include "ds++/Soft_Equivalence.hh"
 #include "ds++/to_string.hh"
 #include "units/PhysicalConstants.hh"
@@ -25,7 +20,7 @@
 namespace rtt_quadrature {
 using namespace rtt_dsxx;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 General_Octant_Quadrature::General_Octant_Quadrature(
     unsigned const sn_order, vector<double> const &mu,
     vector<double> const &eta, vector<double> const &xi,
@@ -58,7 +53,7 @@ General_Octant_Quadrature::General_Octant_Quadrature(
   Ensure(this->quadrature_class() == quadrature_class);
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 bool General_Octant_Quadrature::check_class_invariants() const {
   return (mu_.size() > 0 && eta_.size() == mu_.size() &&
           xi_.size() == mu_.size() && wt_.size() == mu_.size()) &&
@@ -72,27 +67,27 @@ bool General_Octant_Quadrature::check_class_invariants() const {
           2 * number_of_levels_ * number_of_levels_ == 8 * mu_.size());
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string General_Octant_Quadrature::name() const {
   return "General Octant Quadrature";
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string General_Octant_Quadrature::parse_name() const {
   return "general octant quadrature";
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Quadrature_Class General_Octant_Quadrature::quadrature_class() const {
   return quadrature_class_;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 unsigned General_Octant_Quadrature::number_of_levels() const {
   return number_of_levels_;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string General_Octant_Quadrature::as_text(string const &indent) const {
   string Result = indent + "  type = general octant quadrature";
   Result += indent + "  sn order = " + to_string(sn_order());
@@ -112,8 +107,7 @@ string General_Octant_Quadrature::as_text(string const &indent) const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
-/*virtual*/
+//---------------------------------------------------------------------------//
 void General_Octant_Quadrature::create_octant_ordinates_(
     vector<double> &mu, vector<double> &eta, vector<double> &wt) const {
   mu = mu_;
@@ -121,13 +115,13 @@ void General_Octant_Quadrature::create_octant_ordinates_(
   wt = wt_;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 bool General_Octant_Quadrature::is_open_interval() const {
   return is_open_interval_;
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of General_Octant_Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/General_Octant_Quadrature.hh
+++ b/src/quadrature/General_Octant_Quadrature.hh
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/General_Octant_Quadrature.hh
  * \author Kelly Thompson
@@ -7,9 +7,7 @@
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
  *         All rights reserved.
  */
-//---------------------------------------------------------------------------------------//
-// $Id: General_Octant_Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 
 #ifndef quadrature_General_Octant_Quadrature_hh
 #define quadrature_General_Octant_Quadrature_hh
@@ -18,12 +16,12 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class General_Octant_Quadrature
  * \brief A class to encapsulate a client-defined ordinate set.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class General_Octant_Quadrature : public Octant_Quadrature {
 public:
@@ -64,7 +62,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 private:
   // IMPLEMENTATION
@@ -84,6 +82,6 @@ private:
 
 #endif // quadrature_General_Octant_Quadrature_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/General_Octant_Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/General_Octant_Quadrature__Parser.cc
+++ b/src/quadrature/General_Octant_Quadrature__Parser.cc
@@ -1,14 +1,11 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/General_Octant_Quadrature.cc
  * \author Kelly Thompson
  * \brief  Parse routines for parsing a General_Octant_Quadrature specification.
- * \note   © Copyright 2016 LANSLLC All rights reserved.
-
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #include "General_Octant_Quadrature.hh"
 #include "parser/utilities.hh"
@@ -16,20 +13,18 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
- * The specification body must specify the number of ordinates and the number
- * of levels.
- * If it's organized in levels, then there is an sn order 
- * with which it can be associated naturally.
- * A quadrature class specification is optional; the default is octant.
- * The mu, eta, xi, and weight of each ordinate is then specified before
- * the terminating "end" statement.
+ * The specification body must specify the number of ordinates and the number of
+ * levels.  If it's organized in levels, then there is an sn order with which it
+ * can be associated naturally.  A quadrature class specification is optional;
+ * the default is octant.  The mu, eta, xi, and weight of each ordinate is then
+ * specified before the terminating "end" statement.
  *
- * /param tokens Token stream from which to parse the specification.
+ * \param tokens Token stream from which to parse the specification.
  */
-/*static*/
-SP<Quadrature> General_Octant_Quadrature::parse(Token_Stream &tokens) {
+std::shared_ptr<Quadrature> General_Octant_Quadrature::parse(
+  Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "sn order", "expected sn order");
 
@@ -74,12 +69,12 @@ SP<Quadrature> General_Octant_Quadrature::parse(Token_Stream &tokens) {
 
   tokens.check_syntax(tokens.shift().type() == END, "missing end?");
 
-  return SP<Quadrature>(new General_Octant_Quadrature(
+  return std::shared_ptr<Quadrature>(new General_Octant_Quadrature(
       sn_order, mu, eta, xi, wt, number_of_levels, quadrature_class));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Quadrature.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/General_Octant_Quadrature__Parser.cc
+++ b/src/quadrature/General_Octant_Quadrature__Parser.cc
@@ -23,8 +23,8 @@ using namespace rtt_parser;
  *
  * \param tokens Token stream from which to parse the specification.
  */
-std::shared_ptr<Quadrature> General_Octant_Quadrature::parse(
-  Token_Stream &tokens) {
+std::shared_ptr<Quadrature>
+General_Octant_Quadrature::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "sn order", "expected sn order");
 

--- a/src/quadrature/Level_Symmetric.hh
+++ b/src/quadrature/Level_Symmetric.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Level_Symmetric.hh
  * \author Kelly Thompson
  * \date   Wed Sep  1 10:19:52 2004
  * \brief  A class to encapsulate a 3D Level Symmetric quadrature set.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Level_Symmetric.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef quadrature_Level_Symmetric_hh
 #define quadrature_Level_Symmetric_hh
@@ -18,12 +15,12 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Level_Symmetric
  * \brief A class to encapsulate a 3D Level Symmetric quadrature set.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Level_Symmetric : public Octant_Quadrature {
 public:
@@ -58,7 +55,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 private:
   // IMPLEMENTATION
@@ -75,6 +72,6 @@ private:
 
 #endif // quadrature_Level_Symmetric_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Level_Symmetric.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Level_Symmetric__Parser.cc
+++ b/src/quadrature/Level_Symmetric__Parser.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Level_Symmetric.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Level_Symmetric.hh"
 #include "parser/utilities.hh"
@@ -17,9 +14,8 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Level_Symmetric::parse(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Level_Symmetric::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -28,11 +24,11 @@ SP<Quadrature> Level_Symmetric::parse(Token_Stream &tokens) {
 
   tokens.check_syntax(tokens.shift().type() == END, "missing end?");
 
-  return SP<Quadrature>(new Level_Symmetric(sn_order));
+  return std::shared_ptr<Quadrature>(new Level_Symmetric(sn_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Quadrature.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Lobatto.hh
+++ b/src/quadrature/Lobatto.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Lobatto.hh
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef __quadrature_Lobatto_hh__
 #define __quadrature_Lobatto_hh__
@@ -18,17 +15,17 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Lobatto
  *
  * \brief A class representing an interval Lobatto quadrature set.
  *
- * This is an interval (e.g. 1D) angle quadrature set whose abscissae at order
- * N are the roots of the derivative of the Laguerre polynomial of order N-1
- * plus the end points of the interval.
+ * This is an interval (e.g. 1D) angle quadrature set whose abscissae at order N
+ * are the roots of the derivative of the Laguerre polynomial of order N-1 plus
+ * the end points of the interval.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Lobatto : public Interval_Quadrature {
 public:
@@ -53,7 +50,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 protected:
   virtual vector<Ordinate> create_level_ordinates_(double norm) const;
@@ -63,6 +60,6 @@ protected:
 
 #endif // __quadrature_Quadrature_hh__
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Lobatto__Parser.cc
+++ b/src/quadrature/Lobatto__Parser.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Lobatto.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Lobatto.hh"
 #include "parser/utilities.hh"
@@ -17,9 +14,8 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Lobatto::parse(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Lobatto::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -28,11 +24,11 @@ SP<Quadrature> Lobatto::parse(Token_Stream &tokens) {
   tokens.check_semantics(sn_order % 2 == 0, "order must be even");
   tokens.check_syntax(tokens.shift().type() == END, "missing end?");
 
-  return SP<Quadrature>(new Lobatto(sn_order));
+  return std::shared_ptr<Quadrature>(new Lobatto(sn_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Quadrature.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Octant_Quadrature.hh
+++ b/src/quadrature/Octant_Quadrature.hh
@@ -1,17 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Octant_Quadrature.hh
  * \author Kent Budge
  * \date   Friday, Nov 30, 2012, 08:28 am
  * \brief  A class to encapsulate a 3D Level Symmetric quadrature set.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- *
- * Long description.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Octant_Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef quadrature_Octant_Quadrature_hh
 #define quadrature_Octant_Quadrature_hh
@@ -20,20 +15,20 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Octant_Quadrature
  * \brief This is an abstract class representing all quadratures over the unit
  * sphere.
  *
- * At present, all our unit sphere quadratures are symmetric in octants,
- * though we will likely relax this restriction in the future.
+ * At present, all our unit sphere quadratures are symmetric in octants, though
+ * we will likely relax this restriction in the future.
  *
  * For level quadratures, the levels must be in the xi direction cosine. The
  * user may override the default axis assignments when he constructs an
  * Ordinate_Set or an Ordinate_Space from the Octant_Quadrature.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Octant_Quadrature : public Quadrature {
 public:
@@ -97,6 +92,6 @@ private:
 
 #endif // quadrature_Octant_Quadrature_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Octant_Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Ordinate_Set_Factory.cc
+++ b/src/quadrature/Ordinate_Set_Factory.cc
@@ -3,19 +3,16 @@
  * \file   quadrature/Ordinate_Set_Factory.cc
  * \author Allan Wollaber
  * \date   Mon Mar  7 10:42:56 EST 2016
- * \brief  Implementation file for the class rtt_quadrature::Ordinate_Set_Factory.
+ * \brief  Implementation file for the class
+ *         rtt_quadrature::Ordinate_Set_Factory.
  * \note   Copyright (C)  2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved. 
- */
-//---------------------------------------------------------------------------//
-// $Id: Ordinate_Set_Factory.cc 6607 2012-06-14 22:31:45Z kellyt $
+ *         All rights reserved.  */
 //---------------------------------------------------------------------------//
 
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
-
 #include "Gauss_Legendre.hh"
 #include "Level_Symmetric.hh"
 #include "Lobatto.hh"
@@ -46,12 +43,10 @@ namespace rtt_quadrature {
  *  in order to call "create_ordinate_set".  This solution avoids both of those
  *  pitfalls, but it is not ideal and could be refactored into one or the other
  *  classes if their design ever changes.
- *
  */
-SP<Ordinate_Set> Ordinate_Set_Factory::get_Ordinate_Set() const {
+std::shared_ptr<Ordinate_Set> Ordinate_Set_Factory::get_Ordinate_Set() const {
 
   using rtt_mesh_element::Geometry;
-  using rtt_dsxx::SP;
   using namespace ::rtt_quadrature;
 
   bool add_starting_directions = false;
@@ -80,7 +75,7 @@ SP<Ordinate_Set> Ordinate_Set_Factory::get_Ordinate_Set() const {
     geometry = rtt_mesh_element::CARTESIAN;
   }
 
-  SP<Ordinate_Set> ordinate_set;
+  std::shared_ptr<Ordinate_Set> ordinate_set;
 
   if (quad_.dimension == 1) { // 1D quadratures
 
@@ -138,5 +133,5 @@ SP<Ordinate_Set> Ordinate_Set_Factory::get_Ordinate_Set() const {
 } // end namespace rtt_quadrature
 
 //---------------------------------------------------------------------------//
-//              end of quadrature/Ordinate_Set_Factory.cc
+// end of quadrature/Ordinate_Set_Factory.cc
 //---------------------------------------------------------------------------//

--- a/src/quadrature/Ordinate_Set_Factory.cc
+++ b/src/quadrature/Ordinate_Set_Factory.cc
@@ -9,19 +9,19 @@
  *         All rights reserved.  */
 //---------------------------------------------------------------------------//
 
-#include <algorithm>
-#include <iomanip>
-#include <iostream>
-#include <numeric>
+#include "Ordinate_Set_Factory.hh"
 #include "Gauss_Legendre.hh"
 #include "Level_Symmetric.hh"
 #include "Lobatto.hh"
-#include "Ordinate_Set_Factory.hh"
 #include "Product_Chebyshev_Legendre.hh"
 #include "Quadrature.hh"
 #include "Quadrature_Interface.hh"
 #include "Square_Chebyshev_Legendre.hh"
 #include "Tri_Chebyshev_Legendre.hh"
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
 
 namespace rtt_quadrature {
 

--- a/src/quadrature/Ordinate_Set_Factory.hh
+++ b/src/quadrature/Ordinate_Set_Factory.hh
@@ -5,10 +5,7 @@
  * \date   Mon Mar  7 10:42:56 EST 2016
  * \brief  Builds an Ordinate_Set using a Quadrature_Interface struct
  * \note   Copyright (C)  2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: Ordinate.hh 6607 2012-06-14 22:31:45Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef quadrature_Ordinate_Set_Factory_hh
@@ -16,11 +13,9 @@
 
 #include "Ordinate_Set.hh"
 #include "Quadrature_Interface.hh"
-#include "ds++/SP.hh"
+#include <memory>
 
 namespace rtt_quadrature {
-
-using rtt_dsxx::SP;
 
 //===========================================================================//
 /*!
@@ -41,7 +36,7 @@ public:
   // SERVICES
 
   //! Returns a smart pointer to the Quadrature object
-  SP<Ordinate_Set> get_Ordinate_Set() const;
+  std::shared_ptr<Ordinate_Set> get_Ordinate_Set() const;
 
 private:
   // DATA

--- a/src/quadrature/Ordinate_Set_Mapper.cc
+++ b/src/quadrature/Ordinate_Set_Mapper.cc
@@ -3,19 +3,16 @@
  * \file   quadrature/Ordinate_Set_Mapper.cc
  * \author Allan Wollaber
  * \date   Mon Mar  7 10:42:56 EST 2016
- * \brief  Implementation file for the class rtt_quadrature::Ordinate_Set_Mapper.
+ * \brief  Implementation file for the class
+ *         rtt_quadrature::Ordinate_Set_Mapper.
  * \note   Copyright (C)  2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved. 
- */
-//---------------------------------------------------------------------------//
-// $Id: Ordinate_Set_Mapper.cc 6607 2012-06-14 22:31:45Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
-
 #include "Ordinate_Set_Mapper.hh"
 
 namespace {
@@ -23,6 +20,8 @@ using namespace std;
 using namespace rtt_quadrature;
 
 // convenience functions to check ordinates
+
+#if DBC & 1
 
 //---------------------------------------------------------------------------//
 bool check_4(Ordinate const &ordinate) {
@@ -41,6 +40,8 @@ bool check_2(Ordinate const &ordinate) {
     return false;
   return true;
 }
+
+#endif
 
 //---------------------------------------------------------------------------//
 typedef std::pair<double, size_t> dsp;
@@ -63,8 +64,8 @@ bool Ordinate_Set_Mapper::check_class_invariants() const {
  * \param[in] interp_in Selected interpolation scheme to use for remapping
  * \param[out] weights vector of output weights produced by remapping
  *
- *  The output weights preserve the incoming weight assuming that the 
- *  incoming ordinate's weight is associated via a delta function in angle.
+ *  The output weights preserve the incoming weight assuming that the incoming
+ *  ordinate's weight is associated via a delta function in angle.
  */
 void Ordinate_Set_Mapper::map_angle_into_ordinates(
     const Ordinate &ord_in, const Interpolation_Type &interp_in,
@@ -220,5 +221,5 @@ double Ordinate_Set_Mapper::zeroth_moment(const vector<double> &weights) const {
 } // end namespace rtt_quadrature
 
 //---------------------------------------------------------------------------//
-//              end of quadrature/Ordinate_Set_Mapper.cc
+// end of quadrature/Ordinate_Set_Mapper.cc
 //---------------------------------------------------------------------------//

--- a/src/quadrature/Ordinate_Set_Mapper.cc
+++ b/src/quadrature/Ordinate_Set_Mapper.cc
@@ -9,11 +9,11 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
+#include "Ordinate_Set_Mapper.hh"
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
-#include "Ordinate_Set_Mapper.hh"
 
 namespace {
 using namespace std;

--- a/src/quadrature/Product_Chebyshev_Legendre.cc
+++ b/src/quadrature/Product_Chebyshev_Legendre.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Product_Chebyshev_Legendre.cc
  * \author James S. Warsa
  * \date   Wed Sep  1 10:19:52 2004
  * \brief  A class for Product Chebyshev-Gauss-Legendre quadrature sets.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Product_Chebyshev_Legendre.cc 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Product_Chebyshev_Legendre.hh"
 #include "Gauss_Legendre.hh"
@@ -20,25 +17,25 @@
 namespace rtt_quadrature {
 using namespace rtt_dsxx;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Product_Chebyshev_Legendre::name() const {
   return "Product Chebyshev Legendre";
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Product_Chebyshev_Legendre::parse_name() const { return "product cl"; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Quadrature_Class Product_Chebyshev_Legendre::quadrature_class() const {
   return OCTANT_QUADRATURE;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 unsigned Product_Chebyshev_Legendre::number_of_levels() const {
   return sn_order_;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Product_Chebyshev_Legendre::as_text(string const &indent) const {
   string Result = indent + "type = " + parse_name() + indent + "  order = " +
                   to_string(sn_order()) + " " + to_string(azimuthal_order_) +
@@ -47,7 +44,7 @@ string Product_Chebyshev_Legendre::as_text(string const &indent) const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Product_Chebyshev_Legendre::create_octant_ordinates_(
     vector<double> &mu, vector<double> &eta, vector<double> &wt) const {
   using std::fabs;
@@ -67,9 +64,10 @@ void Product_Chebyshev_Legendre::create_octant_ordinates_(
   eta.resize(numOrdinates);
   wt.resize(numOrdinates);
 
-  SP<Gauss_Legendre> GL(new Gauss_Legendre(sn_order_));
+  std::shared_ptr<Gauss_Legendre> GL(new Gauss_Legendre(sn_order_));
 
-  // NOTE: this aligns the gauss points with the x-axis (r-axis in cylindrical coords)
+  // NOTE: this aligns the gauss points with the x-axis (r-axis in cylindrical
+  // coords)
 
   unsigned icount = 0;
 
@@ -94,6 +92,6 @@ void Product_Chebyshev_Legendre::create_octant_ordinates_(
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of Product_Chebyshev_Legendre.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Product_Chebyshev_Legendre.hh
+++ b/src/quadrature/Product_Chebyshev_Legendre.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Product_Chebyshev_Legendre.hh
  * \author James S. Warsa
  * \date   Wed Sep  1 10:19:52 2004
  * \brief  A class for Product Chebyshev-Gauss-Legendre quadrature sets.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Product_Chebyshev_Legendre.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef quadrature_Product_Chebyshev_Legendre_hh
 #define quadrature_Product_Chebyshev_Legendre_hh
@@ -18,12 +15,12 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Product_Chebyshev_Legendre
  * \brief A class to encapsulate a triangular Chebyshev-Legendre quadrature set.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Product_Chebyshev_Legendre : public Octant_Quadrature {
 public:
@@ -65,7 +62,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 private:
   // IMPLEMENTATION
@@ -84,6 +81,6 @@ private:
 
 #endif // quadrature_Product_Chebyshev_Legendre_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Product_Chebyshev_Legendre.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Product_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Product_Chebyshev_Legendre__Parser.cc
@@ -8,16 +8,16 @@
  *         reserved.  */
 //---------------------------------------------------------------------------//
 
-#include <iostream>
 #include "Product_Chebyshev_Legendre.hh"
 #include "parser/utilities.hh"
+#include <iostream>
 
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
 //---------------------------------------------------------------------------//
-std::shared_ptr<Quadrature> Product_Chebyshev_Legendre::parse(
-  Token_Stream &tokens) {
+std::shared_ptr<Quadrature>
+Product_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   // Takes two numbers, first the number of Gauss-Legendre points, which is the
   // SN order
   Token token = tokens.shift();

--- a/src/quadrature/Product_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Product_Chebyshev_Legendre__Parser.cc
@@ -1,28 +1,25 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Product_Chebyshev_Legendre.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an product Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved.  */
+//---------------------------------------------------------------------------//
 
 #include <iostream>
-
 #include "Product_Chebyshev_Legendre.hh"
 #include "parser/utilities.hh"
 
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Product_Chebyshev_Legendre::parse(Token_Stream &tokens) {
-  // Takes two numbers, first the number of Gauss-Legendre points, which is the SN order
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Product_Chebyshev_Legendre::parse(
+  Token_Stream &tokens) {
+  // Takes two numbers, first the number of Gauss-Legendre points, which is the
+  // SN order
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -32,28 +29,24 @@ SP<Quadrature> Product_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   // The second number is the number of azimuthal points on each level
   // corresponding to the Gauss-Legendre points
 
-  //std::cout << " found sn order = " << sn_order << std::endl;
-
   unsigned azimuthal_order = parse_positive_integer(tokens);
   tokens.check_semantics(azimuthal_order > 0,
                          "order must be greater than zero");
-
-  //std::cout << " found azimuthal order = " << azimuthal_order << std::endl;
 
   bool has_axis_assignments;
   unsigned mu_axis, eta_axis;
   Octant_Quadrature::parse(tokens, has_axis_assignments, mu_axis, eta_axis);
 
   if (has_axis_assignments)
-    return SP<Quadrature>(new Product_Chebyshev_Legendre(
+    return std::shared_ptr<Quadrature>(new Product_Chebyshev_Legendre(
         sn_order, azimuthal_order, mu_axis, eta_axis));
   else
-    return SP<Quadrature>(
+    return std::shared_ptr<Quadrature>(
         new Product_Chebyshev_Legendre(sn_order, azimuthal_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Product_Chebyshev_Legendre.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Quadrature.cc
+++ b/src/quadrature/Quadrature.cc
@@ -4,39 +4,29 @@
  * \author Kelly Thompson
  * \date   Tue Feb 22 15:38:56 2000
  * \brief  Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Quadrature.hh"
 #include "Galerkin_Ordinate_Space.hh"
 #include "Sn_Ordinate_Space.hh"
-
 #include <algorithm>
 
 namespace rtt_quadrature {
 typedef Ordinate_Set::Ordering Ordering;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
  * Create a set of ordinates from the Quadrature.
  *
  * \param dimension Dimension of the problem.
-
  * \param geometry Geometry of the problem.
- *
  * \param norm Norm for the ordinate weights.
- *
  * \param mu_axis Which spatial axis maps to the mu direction cosine?
- *
  * \param eta_axis Which spatial axis maps to the eta direction cosine?
- *
  * \param include_starting_directions Should starting directions be included
  * in the ordinate set for each level? This argument is ignored for Cartesian
  * geometries.
- *
  * \param include_extra_starting_directions Should extra starting directions
  * be included in the ordinate set for each level?
  */
@@ -60,20 +50,16 @@ Quadrature::create_ordinates(unsigned const dimension, Geometry const geometry,
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
  * Create a set of ordinates from the Quadrature.
  *
  * \param dimension Dimension of the problem.
-
  * \param geometry Geometry of the problem.
- *
  * \param norm Norm for the ordinate weights.
- *
  * \param include_starting_directions Should starting directions be included
  * in the ordinate set for each level? This argument is ignored for Cartesian
  * geometries.
- *
  * \param include_extra_starting_directions Should extra starting directions
  * be included in the ordinate set for each level?
  */
@@ -93,26 +79,21 @@ Quadrature::create_ordinates(unsigned const dimension, Geometry const geometry,
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
  * Create an ordinate set from the Quadrature.
  *
  * \param dimension Dimension of the problem.
-
  * \param geometry Geometry of the problem.
- *
  * \param norm Norm for the ordinate weights.
- *
  * \param include_starting_directions Should starting directions be included
  * in the ordinate set for each level? This argument is ignored for Cartesian
  * geometries.
- *
  * \param include_extra_starting_directions Should extra starting directions
  * be included in the ordinate set for each level?
- *
  * \param ordering What ordering should be imposed on the ordinates?
  */
-SP<Ordinate_Set> Quadrature::create_ordinate_set(
+std::shared_ptr<Ordinate_Set> Quadrature::create_ordinate_set(
     unsigned const dimension, Geometry const geometry, double const norm,
     bool const include_starting_directions, bool const include_extra_directions,
     Ordering const ordering) const {
@@ -124,14 +105,15 @@ SP<Ordinate_Set> Quadrature::create_ordinate_set(
       create_ordinates_(dimension, geometry, norm, include_starting_directions,
                         include_extra_directions);
 
-  SP<Ordinate_Set> Result(new Ordinate_Set(dimension, geometry, ordinates,
-                                           include_starting_directions,
-                                           include_extra_directions, ordering));
+  std::shared_ptr<Ordinate_Set> Result(
+    new Ordinate_Set(dimension, geometry, ordinates,
+                     include_starting_directions,
+                     include_extra_directions, ordering));
 
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /* protected */
 void Quadrature::add_1D_starting_directions_(
     Geometry const geometry, bool const add_starting_directions,
@@ -167,9 +149,9 @@ void Quadrature::add_2D_starting_directions_(
       std::sort(ordinates.begin(), ordinates.end(),
                 Ordinate_Set::level_compare);
 
-      // Define an impossible value for a direction cosine.  We use
-      // this to simplify the logic of determining when we are at
-      // the head of a new level set.
+      // Define an impossible value for a direction cosine.  We use this to
+      // simplify the logic of determining when we are at the head of a new
+      // level set.
 
       double const SENTINEL_COSINE = 2.0;
 
@@ -182,9 +164,8 @@ void Quadrature::add_2D_starting_directions_(
         double const old_eta = eta;
         eta = a->eta();
         if (!soft_equiv(eta, old_eta))
-        // We are at the start of a new level.  Insert the starting
-        // ordinate.  This has xi==0 and mu determined by the
-        // normalization condition.
+        // We are at the start of a new level.  Insert the starting ordinate.
+        // This has xi==0 and mu determined by the normalization condition.
         {
           Check(1.0 - eta * eta >= 0.0);
 
@@ -207,7 +188,7 @@ void Quadrature::add_2D_starting_directions_(
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Quadrature::map_axes_(unsigned const mu_axis, unsigned const eta_axis,
                            vector<double> &mu, vector<double> &eta,
                            vector<double> &xi) const {
@@ -234,28 +215,22 @@ void Quadrature::map_axes_(unsigned const mu_axis, unsigned const eta_axis,
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
  * Create an Ordinate_Space from the Quadrature.
  *
  * \param dimension Dimension of the problem.
-
  * \param geometry Geometry of the problem.
- *
  * \param moment_expansion_order Expansion order in moment space
- *
  * \param mu_axis Which spatial axis maps to the mu direction cosine?
- *
  * \param eta_axis Which spatial axis maps to the eta direction cosine?
- *
  * \param include_extra_starting_directions Should extra starting directions
  * be included in the ordinate set for each level?
- *
  * \param ordering What ordering should be imposed on the ordinates?
- *
- * \param qim What interpolation model should be used to generate the moment space?
+ * \param qim What interpolation model should be used to generate the moment
+ * space?
  */
-SP<Ordinate_Space> Quadrature::create_ordinate_space(
+std::shared_ptr<Ordinate_Space> Quadrature::create_ordinate_space(
     unsigned const dimension, Geometry const geometry,
     unsigned const moment_expansion_order, unsigned const mu_axis,
     unsigned const eta_axis, bool const include_extra_directions,
@@ -273,7 +248,7 @@ SP<Ordinate_Space> Quadrature::create_ordinate_space(
                        true, // include starting directions
                        include_extra_directions);
 
-  SP<Ordinate_Space> Result;
+  std::shared_ptr<Ordinate_Space> Result;
   switch (qim) {
   case SN:
     Result.reset(new Sn_Ordinate_Space(dimension, geometry, ordinates,
@@ -300,25 +275,21 @@ SP<Ordinate_Space> Quadrature::create_ordinate_space(
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
  * Create an angle operator from the Quadrature.
  *
  * \param dimension Dimension of the problem.
-
  * \param geometry Geometry of the problem.
- *
- * \param moment_expansion_order Expansion order in moment space. If negative, the moment
- * space is not needed.
- *
+ * \param moment_expansion_order Expansion order in moment space. If negative,
+ * the moment space is not needed.
  * \param include_extra_starting_directions Should extra starting directions
  * be included in the ordinate set for each level?
- *
  * \param ordering What ordering should be imposed on the ordinates?
- *
- * \param qim What interpolation model should be used to generate the moment space?
+ * \param qim What interpolation model should be used to generate the moment
+ * space?
  */
-SP<Ordinate_Space> Quadrature::create_ordinate_space(
+std::shared_ptr<Ordinate_Space> Quadrature::create_ordinate_space(
     unsigned const dimension, Geometry const geometry,
     int const moment_expansion_order, bool const include_extra_directions,
     Ordering const ordering, QIM const qim) const {
@@ -333,7 +304,7 @@ SP<Ordinate_Space> Quadrature::create_ordinate_space(
                        true, // include starting directions
                        include_extra_directions);
 
-  SP<Ordinate_Space> Result;
+  std::shared_ptr<Ordinate_Space> Result;
   if (qim == SN)
     Result.reset(new Sn_Ordinate_Space(dimension, geometry, ordinates,
                                        moment_expansion_order,
@@ -346,7 +317,7 @@ SP<Ordinate_Space> Quadrature::create_ordinate_space(
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 bool Quadrature::is_open_interval() const {
   // The great majority are. Lobatto and certain cases of General Octant are
   // at present our only exceptions.
@@ -357,5 +328,5 @@ bool Quadrature::is_open_interval() const {
 } // end namespace rtt_quadrature
 
 //---------------------------------------------------------------------------//
-//                         end of Quadrature.cc
+// end of Quadrature.cc
 //---------------------------------------------------------------------------//

--- a/src/quadrature/Quadrature.cc
+++ b/src/quadrature/Quadrature.cc
@@ -105,10 +105,9 @@ std::shared_ptr<Ordinate_Set> Quadrature::create_ordinate_set(
       create_ordinates_(dimension, geometry, norm, include_starting_directions,
                         include_extra_directions);
 
-  std::shared_ptr<Ordinate_Set> Result(
-    new Ordinate_Set(dimension, geometry, ordinates,
-                     include_starting_directions,
-                     include_extra_directions, ordering));
+  std::shared_ptr<Ordinate_Set> Result(new Ordinate_Set(
+      dimension, geometry, ordinates, include_starting_directions,
+      include_extra_directions, ordering));
 
   return Result;
 }

--- a/src/quadrature/Quadrature.hh
+++ b/src/quadrature/Quadrature.hh
@@ -99,34 +99,27 @@ public:
                                     bool include_extra_directions) const;
 
   std::shared_ptr<Ordinate_Set> create_ordinate_set(
-    unsigned dimension, Geometry,
-    double norm, unsigned mu_axis,
-    unsigned eta_axis,
-    bool include_starting_directions,
-    bool include_extra_directions,
-    Ordinate_Set::Ordering ordering) const;
+      unsigned dimension, Geometry, double norm, unsigned mu_axis,
+      unsigned eta_axis, bool include_starting_directions,
+      bool include_extra_directions, Ordinate_Set::Ordering ordering) const;
 
-  std::shared_ptr<Ordinate_Set> create_ordinate_set(
-    unsigned dimension, Geometry,
-    double norm,
-    bool include_starting_directions,
-    bool include_extra_directions,
-    Ordinate_Set::Ordering ordering) const;
+  std::shared_ptr<Ordinate_Set>
+  create_ordinate_set(unsigned dimension, Geometry, double norm,
+                      bool include_starting_directions,
+                      bool include_extra_directions,
+                      Ordinate_Set::Ordering ordering) const;
 
-  std::shared_ptr<Ordinate_Space> create_ordinate_space(
-    unsigned dimension, Geometry,
-    int moment_expansion_order,
-    bool include_extra_directions,
-    Ordinate_Set::Ordering ordering,
-    QIM qim) const;
+  std::shared_ptr<Ordinate_Space>
+  create_ordinate_space(unsigned dimension, Geometry,
+                        int moment_expansion_order,
+                        bool include_extra_directions,
+                        Ordinate_Set::Ordering ordering, QIM qim) const;
 
-  std::shared_ptr<Ordinate_Space> create_ordinate_space(
-    unsigned dimension, Geometry,
-    unsigned moment_expansion_order,
-    unsigned mu_axis, unsigned eta_axis,
-    bool include_extra_directions,
-    Ordinate_Set::Ordering ordering,
-    QIM qim) const;
+  std::shared_ptr<Ordinate_Space>
+  create_ordinate_space(unsigned dimension, Geometry,
+                        unsigned moment_expansion_order, unsigned mu_axis,
+                        unsigned eta_axis, bool include_extra_directions,
+                        Ordinate_Set::Ordering ordering, QIM qim) const;
 
 protected:
   // IMPLEMENTATION

--- a/src/quadrature/Quadrature.hh
+++ b/src/quadrature/Quadrature.hh
@@ -1,55 +1,49 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//-----------------------*-C++-*----------------------------------------------//
 /*!
  * \file   quadrature/Quadrature.hh
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  Quadrature class header file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id$
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//----------------------------------------------------------------------------//
 
 #ifndef __quadrature_Quadrature_hh__
 #define __quadrature_Quadrature_hh__
 
 #include "Ordinate_Space.hh"
-#include "ds++/SP.hh"
 
 namespace rtt_quadrature {
 using std::string;
 using std::vector;
-using rtt_dsxx::SP;
 using rtt_mesh_element::Geometry;
 
-//=======================================================================================//
+//============================================================================//
 /*!
  * \class Quadrature
  *
  * \brief A class to encapsulate the angular discretization.
  *
  * The Quadrature class is an abstraction representation of an angular
- * quadrature scheme. It can be used to generate an Ordinate_Set containing
- * the correct set of ordinate directions for a given geometry. It can also
- * be used to generate an Ordinate_Space describing both a discrete ordinate
- * and a truncated moment representation of ordinate space.
+ * quadrature scheme. It can be used to generate an Ordinate_Set containing the
+ * correct set of ordinate directions for a given geometry. It can also be used
+ * to generate an Ordinate_Space describing both a discrete ordinate and a
+ * truncated moment representation of ordinate space.
  *
- * All multi-dimensional quadratures (not interval quadratures) are expected
- * to align any level structure they may have with the xi direction
- * cosine.
+ * All multi-dimensional quadratures (not interval quadratures) are expected to
+ * align any level structure they may have with the xi direction cosine.
  *
  * When an Ordinate_Set is constructed from the Quadrature, the direction
  * cosines in the Quadrature must be mapped to coordinate axes in the problem
  * geometry. By default, 1-D non-axisymmetric maps xi to the coordinate axis;
  * 1-D axisymmetric maps mu to the coordinate axis ande xi to the
- * (non-represented) symmetry axis; 2-D maps mu to the first coordinate axis
- * and xi to the second coordinate axis; and 3-D maps mu to the first, eta to
- * the second, and xi to the third coordinate axes. This is to ensure that the
+ * (non-represented) symmetry axis; 2-D maps mu to the first coordinate axis and
+ * xi to the second coordinate axis; and 3-D maps mu to the first, eta to the
+ * second, and xi to the third coordinate axes. This is to ensure that the
  * levels are placed on the axis of symmetry in reduced geometries.
  *
- * The client may override these default assignments. However, if he assigns
- * any direction cosine other than xi to the axis of symmetry in axisymmetric
+ * The client may override these default assignments. However, if he assigns any
+ * direction cosine other than xi to the axis of symmetry in axisymmetric
  * geometry, Bad Things Will Happen with any supported quadrature except
  * Level_Symmetric (for which axis assignment is without effect anyway.)
  */
@@ -80,7 +74,10 @@ public:
   //! Is this an interval or octant (1-D or multi-D) quadrature?
   virtual Quadrature_Class quadrature_class() const = 0;
 
-  //! Number of level sets. A value of 0 indicates this is not a level set quadrature.
+  /*!
+   * \brief Number of level sets. A value of 0 indicates this is not a level set
+   *        quadrature.
+   */
   virtual unsigned number_of_levels() const = 0;
 
   //! Produce a text representation of the object
@@ -101,31 +98,35 @@ public:
                                     bool include_starting_directions,
                                     bool include_extra_directions) const;
 
-  SP<Ordinate_Set> create_ordinate_set(unsigned dimension, Geometry,
-                                       double norm, unsigned mu_axis,
-                                       unsigned eta_axis,
-                                       bool include_starting_directions,
-                                       bool include_extra_directions,
-                                       Ordinate_Set::Ordering ordering) const;
+  std::shared_ptr<Ordinate_Set> create_ordinate_set(
+    unsigned dimension, Geometry,
+    double norm, unsigned mu_axis,
+    unsigned eta_axis,
+    bool include_starting_directions,
+    bool include_extra_directions,
+    Ordinate_Set::Ordering ordering) const;
 
-  SP<Ordinate_Set> create_ordinate_set(unsigned dimension, Geometry,
-                                       double norm,
-                                       bool include_starting_directions,
-                                       bool include_extra_directions,
-                                       Ordinate_Set::Ordering ordering) const;
+  std::shared_ptr<Ordinate_Set> create_ordinate_set(
+    unsigned dimension, Geometry,
+    double norm,
+    bool include_starting_directions,
+    bool include_extra_directions,
+    Ordinate_Set::Ordering ordering) const;
 
-  SP<Ordinate_Space> create_ordinate_space(unsigned dimension, Geometry,
-                                           int moment_expansion_order,
-                                           bool include_extra_directions,
-                                           Ordinate_Set::Ordering ordering,
-                                           QIM qim) const;
+  std::shared_ptr<Ordinate_Space> create_ordinate_space(
+    unsigned dimension, Geometry,
+    int moment_expansion_order,
+    bool include_extra_directions,
+    Ordinate_Set::Ordering ordering,
+    QIM qim) const;
 
-  SP<Ordinate_Space> create_ordinate_space(unsigned dimension, Geometry,
-                                           unsigned moment_expansion_order,
-                                           unsigned mu_axis, unsigned eta_axis,
-                                           bool include_extra_directions,
-                                           Ordinate_Set::Ordering ordering,
-                                           QIM qim) const;
+  std::shared_ptr<Ordinate_Space> create_ordinate_space(
+    unsigned dimension, Geometry,
+    unsigned moment_expansion_order,
+    unsigned mu_axis, unsigned eta_axis,
+    bool include_extra_directions,
+    Ordinate_Set::Ordering ordering,
+    QIM qim) const;
 
 protected:
   // IMPLEMENTATION
@@ -164,6 +165,6 @@ protected:
 
 #endif // __quadrature_Quadrature_hh__
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of quadrature/Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/quadrature/Quadrature_Interface.cc
+++ b/src/quadrature/Quadrature_Interface.cc
@@ -5,8 +5,7 @@
  * \date   Tue Jan 27 08:51:19 2004
  * \brief  Quadrature interface definitions
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Quadrature_Interface.hh"
@@ -56,13 +55,12 @@ void check_quadrature_validity(const quadrature_data &quad) {
 
 //---------------------------------------------------------------------------//
 void get_quadrature(quadrature_data &quad) {
-  using rtt_dsxx::SP;
   using namespace ::rtt_quadrature;
 
   check_quadrature_validity(quad);
 
   Ordinate_Set_Factory osf(quad);
-  SP<Ordinate_Set> ordinate_set = osf.get_Ordinate_Set();
+  std::shared_ptr<Ordinate_Set> ordinate_set = osf.get_Ordinate_Set();
 
   vector<Ordinate> const ordinates(ordinate_set->ordinates());
   size_t i(0);

--- a/src/quadrature/Quadrature__parser.cc
+++ b/src/quadrature/Quadrature__parser.cc
@@ -1,18 +1,14 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Quadrature__parser.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  Parsers for various quadrature classes.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Quadrature__parser.hh"
-
 #include "Double_Gauss.hh"
 #include "Gauss_Legendre.hh"
 #include "General_Octant_Quadrature.hh"
@@ -29,56 +25,57 @@ using namespace rtt_quadrature;
 
 namespace // anonymous
 {
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_gauss_legendre(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_gauss_legendre(Token_Stream &tokens) {
   return Gauss_Legendre::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_level_symmetric(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_level_symmetric(Token_Stream &tokens) {
   return Level_Symmetric::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_tri_cl(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_tri_cl(Token_Stream &tokens) {
   return Tri_Chebyshev_Legendre::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_square_cl(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_square_cl(Token_Stream &tokens) {
   return Square_Chebyshev_Legendre::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_product_cl(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_product_cl(Token_Stream &tokens) {
   return Product_Chebyshev_Legendre::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_double_gauss(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_double_gauss(Token_Stream &tokens) {
   return Double_Gauss::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_general_octant_quadrature(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_general_octant_quadrature(
+  Token_Stream &tokens) {
   return General_Octant_Quadrature::parse(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> parse_lobatto(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> parse_lobatto(Token_Stream &tokens) {
   return Lobatto::parse(tokens);
 }
 
 } // end anonymous
 
 namespace rtt_parser {
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Class_Parse_Table<Quadrature> *Class_Parse_Table<Quadrature>::current_;
 Parse_Table Class_Parse_Table<Quadrature>::parse_table_(NULL, 0,
                                                         Parse_Table::ONCE);
-SP<Quadrature> Class_Parse_Table<Quadrature>::parsed_quadrature_;
+std::shared_ptr<Quadrature> Class_Parse_Table<Quadrature>::parsed_quadrature_;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Class_Parse_Table<Quadrature>::Class_Parse_Table() {
   // Be sure parse table has standard models
   static bool first_time = true;
@@ -108,45 +105,45 @@ Class_Parse_Table<Quadrature>::Class_Parse_Table() {
   current_ = this;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Class_Parse_Table<Quadrature>::check_completeness(Token_Stream &tokens) {
   tokens.check_semantics(parsed_quadrature_ != nullptr,
                          "no quadrature specified");
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> Class_Parse_Table<Quadrature>::create_object() {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Class_Parse_Table<Quadrature>::create_object() {
   return parsed_quadrature_;
 }
 
-//---------------------------------------------------------------------------------------//
-SP<Quadrature> &Class_Parse_Table<Quadrature>::get_parsed_object() {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> &
+Class_Parse_Table<Quadrature>::get_parsed_object() {
   return parsed_quadrature_;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 /*!
- *
  * This function allows local developers to add new transport models to
- * Capsaicin, by adding their names to the set of transport models recognized
- * by the \c Transport_Model parser.
+ * Capsaicin, by adding their names to the set of transport models recognized by
+ * the \c Transport_Model parser.
  *
  * \param keyword Name of the new transport model. Must be unique.
- *
- * \param parse_function Function to call to parse a specification for the
- * new transport model. Must return an instance of the transport model class.
+ * \param parse_function Function to call to parse a specification for the new
+ * transport model. Must return an instance of the transport model class.
  */
 /* static */
 void Class_Parse_Table<Quadrature>::register_quadrature(
-    string const &keyword, SP<Quadrature> parse_function(Token_Stream &)) {
+    string const &keyword, std::shared_ptr<Quadrature>
+    parse_function(Token_Stream &)) {
   Abstract_Class_Parser<Quadrature, get_parse_table,
                         get_parsed_object>::register_child(keyword,
                                                            parse_function);
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 template <>
-DLL_PUBLIC_quadrature SP<Quadrature>
+DLL_PUBLIC_quadrature std::shared_ptr<Quadrature>
 parse_class<Quadrature>(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "type", "expected type keyword");
@@ -156,6 +153,6 @@ parse_class<Quadrature>(Token_Stream &tokens) {
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Quadrature.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Quadrature__parser.cc
+++ b/src/quadrature/Quadrature__parser.cc
@@ -56,8 +56,8 @@ std::shared_ptr<Quadrature> parse_double_gauss(Token_Stream &tokens) {
 }
 
 //---------------------------------------------------------------------------//
-std::shared_ptr<Quadrature> parse_general_octant_quadrature(
-  Token_Stream &tokens) {
+std::shared_ptr<Quadrature>
+parse_general_octant_quadrature(Token_Stream &tokens) {
   return General_Octant_Quadrature::parse(tokens);
 }
 
@@ -134,8 +134,8 @@ Class_Parse_Table<Quadrature>::get_parsed_object() {
  */
 /* static */
 void Class_Parse_Table<Quadrature>::register_quadrature(
-    string const &keyword, std::shared_ptr<Quadrature>
-    parse_function(Token_Stream &)) {
+    string const &keyword,
+    std::shared_ptr<Quadrature> parse_function(Token_Stream &)) {
   Abstract_Class_Parser<Quadrature, get_parse_table,
                         get_parsed_object>::register_child(keyword,
                                                            parse_function);

--- a/src/quadrature/Quadrature__parser.hh
+++ b/src/quadrature/Quadrature__parser.hh
@@ -43,10 +43,9 @@ public:
 
   // STATICS
 
-  static void
-  register_quadrature(string const &keyword,
-                      std::shared_ptr<Quadrature>
-                      parse_function(Token_Stream &));
+  static void register_quadrature(
+      string const &keyword,
+      std::shared_ptr<Quadrature> parse_function(Token_Stream &));
 
 private:
   // STATICS

--- a/src/quadrature/Quadrature__parser.hh
+++ b/src/quadrature/Quadrature__parser.hh
@@ -5,15 +5,13 @@
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  Parser for various quadrature classes.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved.
- */
+ *         reserved. */
 //----------------------------------------------------------------------------//
 
 #include "Quadrature.hh"
 #include "parser/Class_Parse_Table.hh"
 
 namespace rtt_parser {
-using rtt_dsxx::SP;
 using rtt_quadrature::Quadrature;
 
 //============================================================================//
@@ -41,24 +39,25 @@ public:
 
   void check_completeness(Token_Stream &tokens);
 
-  SP<Quadrature> create_object();
+  std::shared_ptr<Quadrature> create_object();
 
   // STATICS
 
   static void
   register_quadrature(string const &keyword,
-                      SP<Quadrature> parse_function(Token_Stream &));
+                      std::shared_ptr<Quadrature>
+                      parse_function(Token_Stream &));
 
 private:
   // STATICS
 
   static Parse_Table &get_parse_table() { return parse_table_; }
 
-  static SP<Quadrature> &get_parsed_object();
+  static std::shared_ptr<Quadrature> &get_parsed_object();
 
   static Class_Parse_Table *current_;
   static Parse_Table parse_table_;
-  static SP<Quadrature> parsed_quadrature_;
+  static std::shared_ptr<Quadrature> parsed_quadrature_;
 };
 
 } // end namespace rtt_quadrature

--- a/src/quadrature/Square_Chebyshev_Legendre.cc
+++ b/src/quadrature/Square_Chebyshev_Legendre.cc
@@ -1,43 +1,40 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Square_Chebyshev_Legendre.cc
  * \author Kelly Thompson
  * \date   Wed Sep  1 10:19:52 2004
- * \brief  
+ * \brief
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Square_Chebyshev_Legendre.cc 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Square_Chebyshev_Legendre.hh"
 #include "Gauss_Legendre.hh"
-
 #include "ds++/to_string.hh"
 #include "units/MathConstants.hh"
 
 namespace rtt_quadrature {
 using namespace rtt_dsxx;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Square_Chebyshev_Legendre::name() const {
   return "Square Chebyshev Legendre";
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Square_Chebyshev_Legendre::parse_name() const { return "square cl"; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Quadrature_Class Square_Chebyshev_Legendre::quadrature_class() const {
   return SQUARE_QUADRATURE;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 unsigned Square_Chebyshev_Legendre::number_of_levels() const {
   return sn_order_;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Square_Chebyshev_Legendre::as_text(string const &indent) const {
   string Result = indent + "type = square cl" + indent + "  order = " +
                   to_string(sn_order()) + Octant_Quadrature::as_text(indent);
@@ -45,7 +42,7 @@ string Square_Chebyshev_Legendre::as_text(string const &indent) const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Square_Chebyshev_Legendre::create_octant_ordinates_(
     vector<double> &mu, vector<double> &eta, vector<double> &wt) const {
   using std::fabs;
@@ -65,9 +62,10 @@ void Square_Chebyshev_Legendre::create_octant_ordinates_(
   eta.resize(numOrdinates);
   wt.resize(numOrdinates);
 
-  SP<Gauss_Legendre> GL(new Gauss_Legendre(sn_order_));
+  std::shared_ptr<Gauss_Legendre> GL(new Gauss_Legendre(sn_order_));
 
-  // NOTE: this aligns the gauss points with the x-axis (r-axis in cylindrical coords)
+  // NOTE: this aligns the gauss points with the x-axis (r-axis in cylindrical
+  // coords)
 
   for (unsigned i = 0; i < levels / 2; ++i) {
     double xmu = GL->mu(i);
@@ -86,6 +84,6 @@ void Square_Chebyshev_Legendre::create_octant_ordinates_(
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                 end of Square_Chebyshev_Legendre.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of Square_Chebyshev_Legendre.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Square_Chebyshev_Legendre.hh
+++ b/src/quadrature/Square_Chebyshev_Legendre.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Square_Chebyshev_Legendre.hh
  * \author Kelly Thompson
  * \date   Wed Sep  1 10:19:52 2004
  * \brief  A class to encapsulate a 3D Level Symmetric quadrature set.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Square_Chebyshev_Legendre.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef quadrature_Square_Chebyshev_Legendre_hh
 #define quadrature_Square_Chebyshev_Legendre_hh
@@ -18,12 +15,12 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Square_Chebyshev_Legendre
  * \brief A class to encapsulate a triangular Chebyshev-Legendre quadrature set.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Square_Chebyshev_Legendre : public Octant_Quadrature {
 public:
@@ -66,7 +63,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 private:
   // IMPLEMENTATION
@@ -83,6 +80,6 @@ private:
 
 #endif // quadrature_Square_Chebyshev_Legendre_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Square_Chebyshev_Legendre.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Square_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Square_Chebyshev_Legendre__Parser.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Square_Chebyshev_Legendre.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved.  */
+//---------------------------------------------------------------------------//
 
 #include "Square_Chebyshev_Legendre.hh"
 #include "parser/utilities.hh"
@@ -17,9 +14,9 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Square_Chebyshev_Legendre::parse(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Square_Chebyshev_Legendre::parse(
+  Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -32,14 +29,14 @@ SP<Quadrature> Square_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   Octant_Quadrature::parse(tokens, has_axis_assignments, mu_axis, eta_axis);
 
   if (has_axis_assignments)
-    return SP<Quadrature>(
+    return std::shared_ptr<Quadrature>(
         new Square_Chebyshev_Legendre(sn_order, mu_axis, eta_axis));
   else
-    return SP<Quadrature>(new Square_Chebyshev_Legendre(sn_order));
+    return std::shared_ptr<Quadrature>(new Square_Chebyshev_Legendre(sn_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Square_Chebyshev_Legendre.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Square_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Square_Chebyshev_Legendre__Parser.cc
@@ -15,8 +15,8 @@ namespace rtt_quadrature {
 using namespace rtt_parser;
 
 //---------------------------------------------------------------------------//
-std::shared_ptr<Quadrature> Square_Chebyshev_Legendre::parse(
-  Token_Stream &tokens) {
+std::shared_ptr<Quadrature>
+Square_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 

--- a/src/quadrature/Tri_Chebyshev_Legendre.cc
+++ b/src/quadrature/Tri_Chebyshev_Legendre.cc
@@ -1,40 +1,36 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Tri_Chebyshev_Legendre.cc
  * \author Kelly Thompson
  * \date   Wed Sep  1 10:19:52 2004
- * \brief  
+ * \brief
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Tri_Chebyshev_Legendre.cc 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Tri_Chebyshev_Legendre.hh"
 #include "Gauss_Legendre.hh"
-
 #include "ds++/to_string.hh"
 #include "units/MathConstants.hh"
 
 namespace rtt_quadrature {
 using namespace rtt_dsxx;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Tri_Chebyshev_Legendre::name() const { return "Tri Chebyshev Legendre"; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Tri_Chebyshev_Legendre::parse_name() const { return "tri cl"; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Quadrature_Class Tri_Chebyshev_Legendre::quadrature_class() const {
   return TRIANGLE_QUADRATURE;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 unsigned Tri_Chebyshev_Legendre::number_of_levels() const { return sn_order_; }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 string Tri_Chebyshev_Legendre::as_text(string const &indent) const {
   string Result = indent + "type = tri cl" + indent + "  order = " +
                   to_string(sn_order_) + Octant_Quadrature::as_text(indent);
@@ -42,7 +38,7 @@ string Tri_Chebyshev_Legendre::as_text(string const &indent) const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Tri_Chebyshev_Legendre::create_octant_ordinates_(
     vector<double> &mu, vector<double> &eta, vector<double> &wt) const {
   using rtt_dsxx::soft_equiv;
@@ -59,9 +55,10 @@ void Tri_Chebyshev_Legendre::create_octant_ordinates_(
   eta.resize(numOrdinates);
   wt.resize(numOrdinates);
 
-  SP<Gauss_Legendre> GL(new Gauss_Legendre(sn_order_));
+  std::shared_ptr<Gauss_Legendre> GL(new Gauss_Legendre(sn_order_));
 
-  // NOTE: this aligns the gauss points with the x-axis (r-axis in cylindrical coords)
+  // NOTE: this aligns the gauss points with the x-axis (r-axis in cylindrical
+  // coords)
 
   unsigned icount = 0;
 
@@ -86,6 +83,6 @@ void Tri_Chebyshev_Legendre::create_octant_ordinates_(
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of Tri_Chebyshev_Legendre.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Tri_Chebyshev_Legendre.hh
+++ b/src/quadrature/Tri_Chebyshev_Legendre.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Tri_Chebyshev_Legendre.hh
  * \author Kelly Thompson
  * \date   Wed Sep  1 10:19:52 2004
  * \brief  A class to encapsulate a 3D Level Symmetric quadrature set.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Tri_Chebyshev_Legendre.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
 
 #ifndef quadrature_Tri_Chebyshev_Legendre_hh
 #define quadrature_Tri_Chebyshev_Legendre_hh
@@ -18,12 +15,12 @@
 
 namespace rtt_quadrature {
 
-//=======================================================================================//
+//===========================================================================//
 /*!
  * \class Tri_Chebyshev_Legendre
  * \brief A class to encapsulate a triangular Chebyshev-Legendre quadrature set.
  */
-//=======================================================================================//
+//===========================================================================//
 
 class Tri_Chebyshev_Legendre : public Octant_Quadrature {
 public:
@@ -67,7 +64,7 @@ public:
 
   // STATICS
 
-  static SP<Quadrature> parse(Token_Stream &tokens);
+  static std::shared_ptr<Quadrature> parse(Token_Stream &tokens);
 
 private:
   // IMPLEMENTATION
@@ -84,6 +81,6 @@ private:
 
 #endif // quadrature_Tri_Chebyshev_Legendre_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of quadrature/Tri_Chebyshev_Legendre.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/quadrature/Tri_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Tri_Chebyshev_Legendre__Parser.cc
@@ -15,8 +15,8 @@ namespace rtt_quadrature {
 using namespace rtt_parser;
 
 //---------------------------------------------------------------------------//
-std::shared_ptr<Quadrature> Tri_Chebyshev_Legendre::parse(
-  Token_Stream &tokens) {
+std::shared_ptr<Quadrature>
+Tri_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 

--- a/src/quadrature/Tri_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Tri_Chebyshev_Legendre__Parser.cc
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   quadrature/Tri_Chebyshev_Legendre.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 10:21:50 2000
  * \brief  A class representing an interval Gauss-Legendre quadrature set.
  * \note   Copyright 2016-2017 Los Alamos National Security, LLC. All rights
- *         reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Quadrature.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         reserved. */
+//---------------------------------------------------------------------------//
 
 #include "Tri_Chebyshev_Legendre.hh"
 #include "parser/utilities.hh"
@@ -17,9 +14,9 @@
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
-/*static*/
-SP<Quadrature> Tri_Chebyshev_Legendre::parse(Token_Stream &tokens) {
+//---------------------------------------------------------------------------//
+std::shared_ptr<Quadrature> Tri_Chebyshev_Legendre::parse(
+  Token_Stream &tokens) {
   Token token = tokens.shift();
   tokens.check_syntax(token.text() == "order", "expected an order");
 
@@ -31,14 +28,14 @@ SP<Quadrature> Tri_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   Octant_Quadrature::parse(tokens, has_axis_assignments, mu_axis, eta_axis);
 
   if (has_axis_assignments)
-    return SP<Quadrature>(
+    return std::shared_ptr<Quadrature>(
         new Tri_Chebyshev_Legendre(sn_order, mu_axis, eta_axis));
   else
-    return SP<Quadrature>(new Tri_Chebyshev_Legendre(sn_order));
+    return std::shared_ptr<Quadrature>(new Tri_Chebyshev_Legendre(sn_order));
 }
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                       end of quadrature/Quadrature.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// end of quadrature/Tri_Chebyshev_Legendre.cc
+//---------------------------------------------------------------------------//

--- a/src/quadrature/doc/level-with-deps.dot
+++ b/src/quadrature/doc/level-with-deps.dot
@@ -15,7 +15,6 @@ digraph bubba_package_level {
    level4 -> level3 -> level2 -> level1 -> level0;
 
    /* level 0 */
-   dsxx_SPhh [shape=box, label="ds++/SP.hh" color=red];
    gsl_gsl_sf_gammah [shape=box, label="gsl/gsl_sf_gamma.h" color=red];
    QuadServicesihh [shape=box, label="QuadServices.i.hh"];
    special_functions_Factorialhh [shape=box, label="special_functions/Factorial.hh" color=red];
@@ -65,7 +64,7 @@ digraph bubba_package_level {
    QuadServicescc [shape=box, label="QuadServices.cc"];
 
    /* Dependencies */
-   {rank=same; level0 dsxx_SPhh gsl_gsl_sf_gammah QuadServicesihh special_functions_Factorialhh gsl_gsl_sf_legendreh special_functions_Ylmhh mesh_element_Geometryhh gsl_gsl_blash dsxx_Asserthh gsl_gsl_linalgh dsxx_Soft_Equivalencehh units_PhysicalConstantshh Releasehh};
+   {rank=same; level0 gsl_gsl_sf_gammah QuadServicesihh special_functions_Factorialhh gsl_gsl_sf_legendreh special_functions_Ylmhh mesh_element_Geometryhh gsl_gsl_blash dsxx_Asserthh gsl_gsl_linalgh dsxx_Soft_Equivalencehh units_PhysicalConstantshh Releasehh};
    {rank=same; level1 Releasecc gaulaghh gauleghh Quadraturehh};
    {rank=same; level2 QuadCreatorhh Q2DSquareChebyshevLegendrehh Q1DGaussLeghh Ordinatehh Q1DDoubleGausshh GeneralQuadraturehh Q1Axialhh Q1DLobattohh Q2DLevelSymhh Quadraturecc Q3DLevelSymhh};
    {rank=same; level3 QuadServiceshh Q2DLevelSymcc Q1Axialcc Ordinatecc Q1DGaussLegcc Q2DSquareChebyshevLegendrecc GeneralQuadraturecc QuadCreatorcc Q3DLevelSymcc Q1DLobattocc Q1DDoubleGausscc};
@@ -83,13 +82,12 @@ digraph bubba_package_level {
 
    /* level 2 */
    QuadCreatorhh -> { Quadraturehh};
-   QuadCreatorhh -> { dsxx_SPhh} [color=red, style=solid];
    Q2DSquareChebyshevLegendrehh -> { Quadraturehh};
    Q2DSquareChebyshevLegendrehh -> {} [color=red, style=solid];
    Q1DGaussLeghh -> { Quadraturehh};
    Q1DGaussLeghh -> {} [color=red, style=solid];
    Ordinatehh -> { Quadraturehh};
-   Ordinatehh -> { dsxx_SPhh dsxx_Soft_Equivalencehh mesh_element_Geometryhh} [color=red, style=solid];
+   Ordinatehh -> { dsxx_Soft_Equivalencehh mesh_element_Geometryhh} [color=red, style=solid];
    Q1DDoubleGausshh -> { Quadraturehh};
    Q1DDoubleGausshh -> {} [color=red, style=solid];
    GeneralQuadraturehh -> { Quadraturehh};

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -7,12 +7,12 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <iomanip>
-#include <iostream>
-#include <numeric>
 #include "quadrature_test.hh"
 #include "parser/String_Token_Stream.hh"
 #include "parser/utilities.hh"
+#include <iomanip>
+#include <iostream>
+#include <numeric>
 
 namespace rtt_quadrature {
 using namespace std;
@@ -388,9 +388,9 @@ void test_axis(UnitTest &ut, Quadrature &quadrature, unsigned const dimension,
   // Build an angle operator
 
   std::shared_ptr<Ordinate_Space> ordinate_space =
-    quadrature.create_ordinate_space(
-      dimension, geometry, expansion_order, mu_axis, eta_axis,
-      add_extra_directions, ordering, qim);
+      quadrature.create_ordinate_space(dimension, geometry, expansion_order,
+                                       mu_axis, eta_axis, add_extra_directions,
+                                       ordering, qim);
 
   test_either(ut, ordinate_space, quadrature, expansion_order);
 }
@@ -545,7 +545,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
   string text = quadrature.as_text("\n");
   String_Token_Stream tokens(text);
   std::shared_ptr<Quadrature> parsed_quadrature =
-    parse_class<Quadrature>(tokens);
+      parse_class<Quadrature>(tokens);
 
   if (tokens.error_count()) {
     ut.failure("Textification and parse did NOT succeed");

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -4,16 +4,13 @@
  * \author Kent G. Budge
  * \brief  Define class quadrature_test
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <iomanip>
 #include <iostream>
 #include <numeric>
-
 #include "quadrature_test.hh"
-
 #include "parser/String_Token_Stream.hh"
 #include "parser/utilities.hh"
 
@@ -22,7 +19,8 @@ using namespace std;
 using namespace rtt_parser;
 
 //----------------------------------------------------------------------------//
-void test_either(UnitTest &ut, SP<Ordinate_Space> const &ordinate_space,
+void test_either(UnitTest &ut,
+                 std::shared_ptr<Ordinate_Space> const &ordinate_space,
                  Quadrature &quadrature, unsigned const expansion_order) {
   vector<Ordinate> const &ordinates = ordinate_space->ordinates();
   unsigned const number_of_ordinates = ordinates.size();
@@ -366,7 +364,7 @@ void test_no_axis(UnitTest &ut, Quadrature &quadrature,
 
   // Build an angle operator
 
-  SP<Ordinate_Space> ordinate_space =
+  std::shared_ptr<Ordinate_Space> ordinate_space =
       quadrature.create_ordinate_space(dimension, geometry, expansion_order,
                                        add_extra_directions, ordering, qim);
 
@@ -389,7 +387,8 @@ void test_axis(UnitTest &ut, Quadrature &quadrature, unsigned const dimension,
 
   // Build an angle operator
 
-  SP<Ordinate_Space> ordinate_space = quadrature.create_ordinate_space(
+  std::shared_ptr<Ordinate_Space> ordinate_space =
+    quadrature.create_ordinate_space(
       dimension, geometry, expansion_order, mu_axis, eta_axis,
       add_extra_directions, ordering, qim);
 
@@ -401,7 +400,7 @@ void quadrature_integration_test(UnitTest & /*ut*/, Quadrature &quadrature) {
 
   if (quadrature.quadrature_class() != INTERVAL_QUADRATURE) {
     // Build an ordinate set
-    SP<Ordinate_Set> ordinate_set =
+    std::shared_ptr<Ordinate_Set> ordinate_set =
         quadrature.create_ordinate_set(3U, // dimension
                                        rtt_mesh_element::CARTESIAN,
                                        1.0,   // norm,
@@ -545,7 +544,8 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
 
   string text = quadrature.as_text("\n");
   String_Token_Stream tokens(text);
-  SP<Quadrature> parsed_quadrature = parse_class<Quadrature>(tokens);
+  std::shared_ptr<Quadrature> parsed_quadrature =
+    parse_class<Quadrature>(tokens);
 
   if (tokens.error_count()) {
     ut.failure("Textification and parse did NOT succeed");
@@ -556,8 +556,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
     ut.failure("Textification and parse did NOT give identical results");
   }
 
-  // ***** Test various geometry, dimensionaly, and interpolation model
-  // ***** options.
+  // ***** Test various geometry, dimensionaly, and interpolation model options.
 
   // Test 1-D options. These requre that the axes have not been reassigned.
 
@@ -565,7 +564,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
 
     // Build an ordinate set
 
-    SP<Ordinate_Set> ordinate_set =
+    std::shared_ptr<Ordinate_Set> ordinate_set =
         quadrature.create_ordinate_set(1U, // dimension
                                        rtt_mesh_element::CARTESIAN,
                                        1.0,   // norm,
@@ -604,9 +603,8 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
                  Ordinate_Set::LEVEL_ORDERED);
 
     if (quadrature.is_open_interval()) {
-      // Our curvilinear angular operator algorithm doesn't work with
-      // closed interval quadratures (those for which mu=-1 is part of the
-      // set).
+      // Our curvilinear angular operator algorithm doesn't work with closed
+      // interval quadratures (those for which mu=-1 is part of the set).
       test_no_axis(ut, quadrature,
                    1U, // dimension,
                    rtt_mesh_element::SPHERICAL,
@@ -630,7 +628,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
   {
     // Build an ordinate set
 
-    SP<Ordinate_Set> ordinate_set =
+    std::shared_ptr<Ordinate_Set> ordinate_set =
         quadrature.create_ordinate_set(3U, // dimension
                                        rtt_mesh_element::CARTESIAN,
                                        1.0,   // norm,
@@ -687,8 +685,8 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
     }
 
     if (!quadrature.has_axis_assignments()) {
-      // Axisymmetric is hosed if axes have been reassigned, since the
-      // levels are only guaranteed on the xi axis.
+      // Axisymmetric is hosed if axes have been reassigned, since the levels
+      // are only guaranteed on the xi axis.
       if (false && quadrature.quadrature_class() == TRIANGLE_QUADRATURE) {
         test_no_axis(ut, quadrature,
                      1U, // dimension,
@@ -736,7 +734,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
 // This test gets called FROM Fortran to ensure that we can successfully create
 // and assign data into a "quadrature_data" type.  See
 // ftest/tstquadrature_interfaces.f90
-//----------------------------------------------------------------------------//
+// ----------------------------------------------------------------------------//
 extern "C" DLL_PUBLIC_quadrature_test void
 rtt_test_quadrature_interfaces(const quadrature_data &quad, int &error_code) {
   using std::cout;

--- a/src/quadrature/test/tstOrdinate_Set_Mapper.cc
+++ b/src/quadrature/test/tstOrdinate_Set_Mapper.cc
@@ -8,14 +8,14 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <algorithm>
-#include <numeric>
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
-#include "quadrature/Ordinate_Set_Mapper.hh"
 #include "quadrature/Gauss_Legendre.hh"
 #include "quadrature/Level_Symmetric.hh"
+#include "quadrature/Ordinate_Set_Mapper.hh"
 #include "quadrature/Product_Chebyshev_Legendre.hh"
+#include <algorithm>
+#include <numeric>
 
 using namespace std;
 using namespace rtt_dsxx;

--- a/src/quadrature/test/tstOrdinate_Set_Mapper.cc
+++ b/src/quadrature/test/tstOrdinate_Set_Mapper.cc
@@ -5,19 +5,14 @@
  * \date   Mon Mar  7 16:21:45 EST 2016
  * \brief  Ordinate Set Mapper tests
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: template_test.cc 5830 2011-05-05 19:43:43Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <algorithm>
 #include <numeric>
-
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "quadrature/Ordinate_Set_Mapper.hh"
-
 #include "quadrature/Gauss_Legendre.hh"
 #include "quadrature/Level_Symmetric.hh"
 #include "quadrature/Product_Chebyshev_Legendre.hh"
@@ -42,8 +37,8 @@ bool is_zero(double a) { return soft_equiv(a, 0.0); }
 struct dot_product_functor_3D {
   dot_product_functor_3D(const Ordinate &o_in) : o1(o_in) {}
 
-  // Returns the dot product of the ordinate passed into the functor
-  // with the local ordinate
+  // Returns the dot product of the ordinate passed into the functor with the
+  // local ordinate
   double operator()(const Ordinate &o2) const {
     return o1.mu() * o2.mu() + o1.eta() * o2.eta() + o1.xi() * o2.xi();
   }
@@ -205,7 +200,7 @@ void ordinate_set_2D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
   Level_Symmetric quadrature(N);
 
-  SP<Ordinate_Set> os_LS2 =
+  std::shared_ptr<Ordinate_Set> os_LS2 =
       quadrature.create_ordinate_set(2, geometry,
                                      1.0,   // norm,
                                      false, //starting_directions?
@@ -306,7 +301,7 @@ void ordinate_set_1D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
   Gauss_Legendre quadrature(N);
 
-  SP<Ordinate_Set> os_LS4 =
+  std::shared_ptr<Ordinate_Set> os_LS4 =
       quadrature.create_ordinate_set(1, //1-D
                                      geometry,
                                      1.0,   // norm,
@@ -404,7 +399,7 @@ void ordinate_set_3D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
   Product_Chebyshev_Legendre quadrature(N, N);
 
-  SP<Ordinate_Set> os_LS2 =
+  std::shared_ptr<Ordinate_Set> os_LS2 =
       quadrature.create_ordinate_set(3, geometry,
                                      1.0,   // norm,
                                      false, //starting_directions?
@@ -511,12 +506,12 @@ void ordinate_set_1D_sph_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::SPHERICAL);
   Gauss_Legendre quadrature(N);
 
-  // Note that this test uses "starting directions" in the Ordinate_Set
-  // These are necessary for SN in curvilinear geometries, but these
-  // starting directions have zero weight and do not actually contribute
-  // to the quadrature integration -- they should not be incluced as
-  // valid ordinates during the remapping!
-  SP<Ordinate_Set> os_LS2 =
+  // Note that this test uses "starting directions" in the Ordinate_Set These
+  // are necessary for SN in curvilinear geometries, but these starting
+  // directions have zero weight and do not actually contribute to the
+  // quadrature integration -- they should not be incluced as valid ordinates
+  // during the remapping!
+  std::shared_ptr<Ordinate_Set> os_LS2 =
       quadrature.create_ordinate_set(1, //1-D
                                      geometry,
                                      1.0,  // norm,
@@ -568,7 +563,7 @@ void ordinate_set_1D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
   Gauss_Legendre quadrature(N);
 
-  SP<Ordinate_Set> os_LS4 =
+  std::shared_ptr<Ordinate_Set> os_LS4 =
       quadrature.create_ordinate_set(1, //1-D
                                      geometry,
                                      1.0,   // norm,
@@ -698,7 +693,7 @@ void ordinate_set_2D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
   Level_Symmetric quadrature(N);
 
-  SP<Ordinate_Set> os_LS2 =
+  std::shared_ptr<Ordinate_Set> os_LS2 =
       quadrature.create_ordinate_set(2, geometry,
                                      1.0,   // norm,
                                      false, //starting_directions?
@@ -799,7 +794,7 @@ void ordinate_set_3D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
   Product_Chebyshev_Legendre quadrature(N, N);
 
-  SP<Ordinate_Set> os_LS2 =
+  std::shared_ptr<Ordinate_Set> os_LS2 =
       quadrature.create_ordinate_set(3, geometry,
                                      1.0,   // norm,
                                      false, //starting_directions?
@@ -917,5 +912,5 @@ int main(int argc, char *argv[]) {
 }
 
 //---------------------------------------------------------------------------//
-// end of tstOrdinate_Set_mapper_Test.cc
+// end of tstOrdinate_Set_Mapper.cc
 //---------------------------------------------------------------------------//

--- a/src/timestep/test/dummy_package.hh
+++ b/src/timestep/test/dummy_package.hh
@@ -5,17 +5,14 @@
  * \date   Thu Aug 27 07:48:41 1998
  * \brief  A dummy package to exercize the field time-step advisors.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __timestep_test_dummy_package_hh__
 #define __timestep_test_dummy_package_hh__
 
-#include "ds++/SP.hh"
 #include "ds++/config.h"
+#include <memory>
 #include <vector>
 
 // FORWARD REFERENCES
@@ -64,9 +61,9 @@ private:
   // DATA
 
   rtt_timestep::ts_manager &tsm;
-  rtt_dsxx::SP<rtt_timestep::field_ts_advisor> sp_te;
-  rtt_dsxx::SP<rtt_timestep::field_ts_advisor> sp_ti;
-  rtt_dsxx::SP<rtt_timestep::field_ts_advisor> sp_ri;
+  std::shared_ptr<rtt_timestep::field_ts_advisor> sp_te;
+  std::shared_ptr<rtt_timestep::field_ts_advisor> sp_ti;
+  std::shared_ptr<rtt_timestep::field_ts_advisor> sp_ri;
 };
 
 } // end namespace rtt_timestep_test

--- a/src/timestep/test/tstTimeStep.cc
+++ b/src/timestep/test/tstTimeStep.cc
@@ -6,15 +6,15 @@
 //---------------------------------------------------------------------------//
 
 #include "dummy_package.hh"
+#include "c4/ParallelUnitTest.hh"
+#include "c4/global.hh"
+#include "ds++/Release.hh"
+#include "ds++/Soft_Equivalence.hh"
 #include "timestep/field_ts_advisor.hh"
 #include "timestep/fixed_ts_advisor.hh"
 #include "timestep/ratio_ts_advisor.hh"
 #include "timestep/target_ts_advisor.hh"
 #include "timestep/ts_manager.hh"
-#include "c4/ParallelUnitTest.hh"
-#include "c4/global.hh"
-#include "ds++/Release.hh"
-#include "ds++/Soft_Equivalence.hh"
 #include <sstream>
 
 // forward declaration

--- a/src/timestep/test/tstTimeStep.cc
+++ b/src/timestep/test/tstTimeStep.cc
@@ -4,8 +4,6 @@
  *  \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
  *          All rights reserved.  */
 //---------------------------------------------------------------------------//
-//! \version $Id$
-//---------------------------------------------------------------------------//
 
 #include "dummy_package.hh"
 #include "timestep/field_ts_advisor.hh"
@@ -13,12 +11,10 @@
 #include "timestep/ratio_ts_advisor.hh"
 #include "timestep/target_ts_advisor.hh"
 #include "timestep/ts_manager.hh"
-
 #include "c4/ParallelUnitTest.hh"
 #include "c4/global.hh"
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
-
 #include <sstream>
 
 // forward declaration
@@ -67,26 +63,26 @@ void run_tests(rtt_dsxx::UnitTest &ut) {
   // reference.  Activating this controller can also be used to freeze the
   // time-step at the current value.
 
-  rtt_dsxx::SP<fixed_ts_advisor> sp_dt(
+  std::shared_ptr<fixed_ts_advisor> sp_dt(
       new fixed_ts_advisor("Current Time-Step", ts_advisor::req, dt, false));
   mngr.add_advisor(sp_dt);
 
   // Set up a required time-step to be activated at the user's discretion
 
-  rtt_dsxx::SP<fixed_ts_advisor> sp_ovr(new fixed_ts_advisor(
+  std::shared_ptr<fixed_ts_advisor> sp_ovr(new fixed_ts_advisor(
       "User Override", ts_advisor::req, override_dt, false));
   mngr.add_advisor(sp_ovr);
 
   // Set up a min timestep
 
-  rtt_dsxx::SP<fixed_ts_advisor> sp_min(
+  std::shared_ptr<fixed_ts_advisor> sp_min(
       new fixed_ts_advisor("Minimum", ts_advisor::min, ts_advisor::ts_small()));
   mngr.add_advisor(sp_min);
   sp_min->set_fixed_value(dt_min);
 
   // Set up a lower limit on the timestep rate of change
 
-  rtt_dsxx::SP<ratio_ts_advisor> sp_llr(
+  std::shared_ptr<ratio_ts_advisor> sp_llr(
       new ratio_ts_advisor("Rate of Change Lower Limit", ts_advisor::min, 0.8));
   mngr.add_advisor(sp_llr);
 
@@ -98,19 +94,19 @@ void run_tests(rtt_dsxx::UnitTest &ut) {
 
   // Set up an upper limit on the time-step rate of change
 
-  rtt_dsxx::SP<ratio_ts_advisor> sp_ulr(
+  std::shared_ptr<ratio_ts_advisor> sp_ulr(
       new ratio_ts_advisor("Rate of Change Upper Limit"));
   mngr.add_advisor(sp_ulr);
 
   // Set up an advisor to watch for an upper limit on the time-step.
 
-  rtt_dsxx::SP<fixed_ts_advisor> sp_max(new fixed_ts_advisor("Maximum"));
+  std::shared_ptr<fixed_ts_advisor> sp_max(new fixed_ts_advisor("Maximum"));
   mngr.add_advisor(sp_max);
   sp_max->set_fixed_value(dt_max);
 
   // Set up a target time advisor
 
-  rtt_dsxx::SP<target_ts_advisor> sp_gd(
+  std::shared_ptr<target_ts_advisor> sp_gd(
       new target_ts_advisor("Graphics Dump", ts_advisor::max, graphics_time));
   mngr.add_advisor(sp_gd);
 

--- a/src/timestep/ts_manager.cc
+++ b/src/timestep/ts_manager.cc
@@ -43,8 +43,8 @@ void ts_manager::add_advisor(const std::shared_ptr<ts_advisor> &new_advisor) {
   }
 }
 
-void ts_manager::remove_advisor(const std::shared_ptr<ts_advisor>
-                                &advisor_to_remove) {
+void ts_manager::remove_advisor(
+    const std::shared_ptr<ts_advisor> &advisor_to_remove) {
   for (list<std::shared_ptr<ts_advisor>>::iterator py = advisors.begin();
        py != advisors.end(); py++) {
     if ((**py).get_name() == (*advisor_to_remove).get_name()) {

--- a/src/timestep/ts_manager.cc
+++ b/src/timestep/ts_manager.cc
@@ -5,10 +5,7 @@
  * \date   Mon Apr  6 17:22:53 1998
  * \brief  Defines a manager utility for time-step advisors.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ts_manager.hh"
@@ -19,7 +16,6 @@ using std::endl;
 using std::cerr;
 using std::cout;
 using std::ios;
-using rtt_dsxx::SP;
 
 namespace rtt_timestep {
 
@@ -31,9 +27,9 @@ ts_manager::ts_manager(void)
   Ensure(invariant_satisfied());
 }
 
-void ts_manager::add_advisor(const SP<ts_advisor> &new_advisor) {
+void ts_manager::add_advisor(const std::shared_ptr<ts_advisor> &new_advisor) {
   bool not_in_use = true;
-  for (list<SP<ts_advisor>>::iterator py = advisors.begin();
+  for (list<std::shared_ptr<ts_advisor>>::iterator py = advisors.begin();
        py != advisors.end(); py++) {
     if ((**py).get_name() == (*new_advisor).get_name()) {
       not_in_use = false;
@@ -47,8 +43,9 @@ void ts_manager::add_advisor(const SP<ts_advisor> &new_advisor) {
   }
 }
 
-void ts_manager::remove_advisor(const SP<ts_advisor> &advisor_to_remove) {
-  for (list<SP<ts_advisor>>::iterator py = advisors.begin();
+void ts_manager::remove_advisor(const std::shared_ptr<ts_advisor>
+                                &advisor_to_remove) {
+  for (list<std::shared_ptr<ts_advisor>>::iterator py = advisors.begin();
        py != advisors.end(); py++) {
     if ((**py).get_name() == (*advisor_to_remove).get_name()) {
       advisors.erase(py);
@@ -68,7 +65,7 @@ double ts_manager::compute_new_timestep() {
   // Check to be sure that there is at least one usable advisor
 
   bool found = false;
-  for (list<SP<ts_advisor>>::iterator py = advisors.begin();
+  for (list<std::shared_ptr<ts_advisor>>::iterator py = advisors.begin();
        py != advisors.end(); py++) {
     if ((**py).advisor_usable(*this)) {
       found = true;
@@ -90,7 +87,7 @@ double ts_manager::compute_new_timestep() {
   // Check for one and only one mandatory advisor
 
   int i = 0;
-  for (list<SP<ts_advisor>>::iterator py = advisors.begin();
+  for (list<std::shared_ptr<ts_advisor>>::iterator py = advisors.begin();
        py != advisors.end(); py++) {
     if ((**py).advisor_usable(*this) && (**py).get_usage() == ts_advisor::req) {
       i++;
@@ -109,11 +106,11 @@ double ts_manager::compute_new_timestep() {
 
   // Loop over the advisors finding the one that controls
 
-  list<SP<ts_advisor>>::iterator py1 = advisors.end();
-  list<SP<ts_advisor>>::iterator py2 = advisors.end();
+  list<std::shared_ptr<ts_advisor>>::iterator py1 = advisors.end();
+  list<std::shared_ptr<ts_advisor>>::iterator py2 = advisors.end();
   double x1 = ts_advisor::ts_small();
   double x2 = ts_advisor::large();
-  for (list<SP<ts_advisor>>::iterator py = advisors.begin();
+  for (list<std::shared_ptr<ts_advisor>>::iterator py = advisors.begin();
        py != advisors.end(); py++) {
     if ((**py).advisor_usable(*this)) {
       if ((**py).get_usage() == ts_advisor::min) {
@@ -168,8 +165,7 @@ double ts_manager::compute_new_timestep() {
 //---------------------------------------------------------------------------//
 /*!
  * Defines a functor which determines if one timestep advisor is less than
- * another. This is done by comparing the recommended time step of each
- * advisor.
+ * another. This is done by comparing the recommended time step of each advisor.
  */
 class sptsa_less_than {
 public:
@@ -182,8 +178,8 @@ public:
   }
 
   // Defines the operator () for sptsa_less_than functor
-  bool operator()(const SP<ts_advisor> &sp_lhs,
-                  const SP<ts_advisor> &sp_rhs) const {
+  bool operator()(const std::shared_ptr<ts_advisor> &sp_lhs,
+                  const std::shared_ptr<ts_advisor> &sp_rhs) const {
     return (sp_lhs->get_dt_rec(tsm) < sp_rhs->get_dt_rec(tsm));
   }
 };
@@ -194,7 +190,7 @@ void ts_manager::print_advisors() const {
 
   cout << endl;
   cout << "*** Time-Step Manager: Advisor Listing ***" << endl;
-  for (list<SP<ts_advisor>>::const_iterator py = advisors.begin();
+  for (list<std::shared_ptr<ts_advisor>>::const_iterator py = advisors.begin();
        py != advisors.end(); py++) {
     cout << (**py).get_name() << endl;
   }
@@ -209,7 +205,7 @@ void ts_manager::print_summary() const {
   cout.setf(ios::scientific, ios::floatfield);
   cout.precision(4);
   cout.setf(ios::left, ios::adjustfield);
-  list<SP<ts_advisor>> temp = advisors;
+  list<std::shared_ptr<ts_advisor>> temp = advisors;
   temp.sort(sptsa_less_than(*this));
   cout << endl;
   cout << "  *** Time-Step Manager Summary ***" << endl;
@@ -221,8 +217,7 @@ void ts_manager::print_summary() const {
   cout << endl;
   cout << "  *** Time-Step Advisor Data Table *** " << endl;
   cout << "    Recommendation   In-Use  Name " << endl;
-  for (list<SP<ts_advisor>>::const_iterator py = temp.begin(); py != temp.end();
-       py++) {
+  for (auto py = temp.begin(); py != temp.end(); py++) {
     (**py).print(*this, (**py).get_name() == controlling_advisor);
   }
   cout << endl;
@@ -235,7 +230,7 @@ void ts_manager::print_adv_states() const {
 
   cout << endl;
   cout << "*** Time-Step Manager: Advisor State Listing ***" << endl;
-  for (list<SP<ts_advisor>>::const_iterator py = advisors.begin();
+  for (list<std::shared_ptr<ts_advisor>>::const_iterator py = advisors.begin();
        py != advisors.end(); py++) {
     (**py).print_state();
   }

--- a/src/timestep/ts_manager.hh
+++ b/src/timestep/ts_manager.hh
@@ -36,7 +36,7 @@ class DLL_PUBLIC_timestep ts_manager {
 
   // DATA
 
-  private:
+private:
   //! the recommendation for the next time-step (time)
   double dt_new;
   //! problem time at the end of current cycle  (time)
@@ -52,7 +52,7 @@ class DLL_PUBLIC_timestep ts_manager {
 
   // CREATORS
 
-  public:
+public:
   //! Creates a timestep manager
   ts_manager();
 

--- a/src/timestep/ts_manager.hh
+++ b/src/timestep/ts_manager.hh
@@ -5,19 +5,15 @@
  * \date    Mon Apr  6 17:22:53 1998
  * \brief   Header file for the manager utility for time-step advisors.
  * \note    Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *          All rights reserved.
- * \version $Id$
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __timestep_ts_manager_hh__
 #define __timestep_ts_manager_hh__
 
 #include "ts_advisor.hh"
-#include "ds++/SP.hh"
 #include <list>
+#include <memory>
 
 namespace rtt_timestep {
 
@@ -25,13 +21,13 @@ namespace rtt_timestep {
 /*!
  * \brief Manages a list of time-step advisors.
  *
- * \sa  The ts_advisor class provides the advisors to be registerd
- *      the the ts_manager class. Also, the \ref timestep_overview
- *      page provides useful info.
+ * \sa The ts_advisor class provides the advisors to be registerd the the
+ *      ts_manager class. Also, the \ref timestep_overview page provides useful
+ *      info.
  *
- * Calculates a new timestep based on the
- * recommended time-steps of its component advisors (i.e. electron energy,
- * radiation energy, ion energy, max allowed change, etc...).
+ * Calculates a new timestep based on the recommended time-steps of its
+ * component advisors (i.e. electron energy, radiation energy, ion energy, max
+ * allowed change, etc...).
  */
 //===========================================================================//
 class DLL_PUBLIC_timestep ts_manager {
@@ -40,7 +36,7 @@ class DLL_PUBLIC_timestep ts_manager {
 
   // DATA
 
-private:
+  private:
   //! the recommendation for the next time-step (time)
   double dt_new;
   //! problem time at the end of current cycle  (time)
@@ -52,11 +48,11 @@ private:
   //! name of the advisor in control
   std::string controlling_advisor;
   //! a list of Smart Pointers to time step advisors
-  std::list<rtt_dsxx::SP<ts_advisor>> advisors;
+  std::list<std::shared_ptr<ts_advisor>> advisors;
 
   // CREATORS
 
-public:
+  public:
   //! Creates a timestep manager
   ts_manager();
 
@@ -65,48 +61,56 @@ public:
 
   // MANIPULATORS
 
-  //! Adds a timestep advisor to a RTT timestep manager
-  /*! \param new_advisor the new advisor to be added
-     */
-  void add_advisor(const rtt_dsxx::SP<ts_advisor> &new_advisor);
+  /*!
+   * \brief Adds a timestep advisor to a RTT timestep manager
+   * \param new_advisor the new advisor to be added
+   */
+  void add_advisor(const std::shared_ptr<ts_advisor> &new_advisor);
 
-  //! Removes a timestep advisor from a RTT timestep manager
-  /*! \param advisor_to_remove the advisor to be removed
-     */
-  void remove_advisor(const rtt_dsxx::SP<ts_advisor> &advisor_to_remove);
+  /*!
+   * \brief Removes a timestep advisor from a RTT timestep manager
+   * \param advisor_to_remove the advisor to be removed
+   */
+  void remove_advisor(const std::shared_ptr<ts_advisor> &advisor_to_remove);
 
-  //! Sets timestep, cycle number, and problem time
-  /*! \param dt_ the timestep (time)
-        \param cycle_ the time cycle
-        \param time_ the problem time (time)
-    */
+  /*!
+   * \brief Sets timestep, cycle number, and problem time
+   * \param dt_ the timestep (time)
+   * \param cycle_ the time cycle
+   * \param time_ the problem time (time)
+   */
   void set_cycle_data(double dt_, int cycle_, double time_);
 
-  //! Computes a new timestep based on the recommendations of each advisor
-  /*! \return the recommended timestep
-     */
+  /*!
+   * \brief Computes a new timestep based on the recommendations of each advisor
+   * \return the recommended timestep
+   */
   double compute_new_timestep();
 
   // ACCESSORS
 
-  //! Prints advisor names
-  /*! \return prints a list of the advisor names to std out
-     */
+  /*!
+   * \brief Prints advisor names
+   * \return prints a list of the advisor names to std out
+   */
   void print_advisors() const;
 
-  //! Prints a concise summary of the manager status
-  /*! \return prints a summary to std out
-     */
+  /*!
+   * \brief Prints a concise summary of the manager status
+   * \return prints a summary to std out
+   */
   void print_summary() const;
 
-  //! Prints advisor information
-  /*! Prints a detailed listing of each advisors internal state to std out
-     */
+  /*!
+   * \brief Prints advisor information
+   * Prints a detailed listing of each advisors internal state to std out
+   */
   void print_adv_states() const;
 
-  //! Returns the recommendation for the next timestep
-  /*! \return the recommended timestep
-     */
+  /*!
+   * \brief Returns the recommendation for the next timestep
+   * \return the recommended timestep
+   */
   double get_dt_new() const { return dt_new; }
 
   //! Returns the current problem time
@@ -118,14 +122,16 @@ public:
   //! Returns the current time cycle number
   int get_cycle() const { return cycle; }
 
-  //! Returns the controlling advisor
-  /*! \return The name of the controlling advisor
-     */
+  /*!
+   * \brief Returns the controlling advisor
+   * \return The name of the controlling advisor
+   */
   std::string get_controlling_advisor() const { return controlling_advisor; }
 
-  //! Defines the timestep manager invariant function
-  /*! \return True if the invariant is satisfied
-     */
+  /*!
+   * \brief Defines the timestep manager invariant function
+   * \return True if the invariant is satisfied
+   */
   bool invariant_satisfied() const;
 };
 

--- a/src/viz/Ensight_Translator.hh
+++ b/src/viz/Ensight_Translator.hh
@@ -5,10 +5,7 @@
  * \date   Fri Jan 21 16:36:10 2000
  * \brief  Ensight_Translator header file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_viz_Ensight_Translator_hh
@@ -17,7 +14,7 @@
 #include "Ensight_Stream.hh"
 #include "Viz_Traits.hh"
 #include "ds++/Check_Strings.hh"
-#include "ds++/SP.hh"
+#include <memory>
 #include <set>
 
 namespace rtt_viz {
@@ -150,7 +147,7 @@ public:
 
   typedef set_int::const_iterator set_const_iterator;
 
-  typedef std::vector<rtt_dsxx::SP<Ensight_Stream>> vec_stream;
+  typedef std::vector<std::shared_ptr<Ensight_Stream>> vec_stream;
 
 private:
   // >>> DATA


### PR DESCRIPTION
+ Except the wrapper class ds++/SP and its unit test.
+ Replace with std::shared_ptr.
+ Cleanup formatting for all touched files. Especially comment blocks.
+ Still need to run clang-format on these files.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Blocked by https://gitlab.lanl.gov/jayenne/jayenne/merge_requests/61
  * [x] Blocked by https://gitlab.lanl.gov/capsaicin/capsaicin/merge_requests/55
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
