### PR TITLE
Ensure timely deallocation of parser resources.

### DIFF
--- a/src/parser/test/tstutilities.cc
+++ b/src/parser/test/tstutilities.cc
@@ -936,6 +936,7 @@ void tstutilities(UnitTest &ut) {
     else
       FAILMSG("did NOT parse bare expression to SI correctly");
     bare_expression.rewind();
+    free_internal_unit_system();
   }
   return;
 }

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -64,6 +64,15 @@ void set_internal_unit_system(rtt_units::UnitSystem const &units) {
   internal_unit_system = new rtt_units::UnitSystem(units);
 }
 
+//---------------------------------------------------------------------------------------//
+// For tracking down memory leaks, it is useful to be able to free any static data.
+
+void free_internal_unit_system() {
+  if (internal_unit_system != nullptr)
+    delete internal_unit_system;
+  internal_unit_system = nullptr;
+}
+
 //---------------------------------------------------------------------------//
 /*! Set whether unit expressions are mandatory.
  *

--- a/src/parser/utilities.hh
+++ b/src/parser/utilities.hh
@@ -57,6 +57,7 @@ set_internal_unit_system(rtt_units::UnitSystem const &units);
 DLL_PUBLIC_parser void set_unit_expressions_are_required(bool);
 DLL_PUBLIC_parser rtt_units::UnitSystem const &get_internal_unit_system();
 DLL_PUBLIC_parser bool unit_expressions_are_required();
+DLL_PUBLIC_parser void free_internal_unit_system();
 
 //! parser a real number followed by a unit expression.
 DLL_PUBLIC_parser double parse_quantity(Token_Stream &tokens, Unit const &unit,

--- a/src/quadrature/Quadrature__parser.cc
+++ b/src/quadrature/Quadrature__parser.cc
@@ -76,7 +76,7 @@ namespace rtt_parser {
 Class_Parse_Table<Quadrature> *Class_Parse_Table<Quadrature>::current_;
 Parse_Table Class_Parse_Table<Quadrature>::parse_table_(NULL, 0,
                                                         Parse_Table::ONCE);
-SP<Quadrature> Class_Parse_Table<Quadrature>::parsed_quadrature_;
+SP<Quadrature> Class_Parse_Table<Quadrature>::child_;
 
 //---------------------------------------------------------------------------------------//
 Class_Parse_Table<Quadrature>::Class_Parse_Table() {
@@ -103,25 +103,20 @@ Class_Parse_Table<Quadrature>::Class_Parse_Table() {
     first_time = false;
   }
 
-  parsed_quadrature_.reset();
-
   current_ = this;
 }
 
 //---------------------------------------------------------------------------------------//
 void Class_Parse_Table<Quadrature>::check_completeness(Token_Stream &tokens) {
-  tokens.check_semantics(parsed_quadrature_ != nullptr,
-                         "no quadrature specified");
+  tokens.check_semantics(child_ != nullptr, "no quadrature specified");
 }
 
 //---------------------------------------------------------------------------------------//
-SP<Quadrature> Class_Parse_Table<Quadrature>::create_object() {
-  return parsed_quadrature_;
-}
+SP<Quadrature> Class_Parse_Table<Quadrature>::create_object() { return child_; }
 
 //---------------------------------------------------------------------------------------//
 SP<Quadrature> &Class_Parse_Table<Quadrature>::get_parsed_object() {
-  return parsed_quadrature_;
+  return child_;
 }
 
 //---------------------------------------------------------------------------------------//

--- a/src/quadrature/Quadrature__parser.hh
+++ b/src/quadrature/Quadrature__parser.hh
@@ -33,6 +33,8 @@ public:
 
   Class_Parse_Table();
 
+  virtual ~Class_Parse_Table() { child_.reset(); }
+
   // SERVICES
 
   Parse_Table const &parse_table() const { return parse_table_; }
@@ -58,7 +60,7 @@ private:
 
   static Class_Parse_Table *current_;
   static Parse_Table parse_table_;
-  static SP<Quadrature> parsed_quadrature_;
+  static SP<Quadrature> child_;
 };
 
 } // end namespace rtt_quadrature


### PR DESCRIPTION
Ensure that destructor of `Class_Parse_Table<Quadrature>` releases the parsed quadrature in a timely manner. Previously the parsed quadrature would not be released until general end of execution cleanups or until another quadrature was parsed.

Provide a way to free the global pointer to the internal unit system. I'm not sure why this is implemented as a raw pointer rather than a `shared_ptr,` but the ability to free this storage manually would be useful even if it were implemented as a` shared_ptr.`

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
