### PR TITLE
Convert xgetbv to equivalent machine code in query_fma.

### DIFF
--- a/config/query_fma.cc
+++ b/config/query_fma.cc
@@ -61,7 +61,10 @@ int check_xcr0_ymm() {
 #if defined(_MSC_VER)
   xcr0 = (MYINT)_xgetbv(0); /* min VS2010 SP1 compiler is required */
 #else
-  __asm__("xgetbv" : "=a"(xcr0) : "c"(0) : "%edx");
+  /* named form of xgetbv not supported on OSX, so must use byte form, see:
+     https://github.com/asmjit/asmjit/issues/78
+   */
+  __asm__(".byte 0x0F, 0x01, 0xd0" : "=a"(xcr0) : "c"(0) : "%edx");
 #endif
   return ((xcr0 & 6) ==
           6); /* checking if xmm and ymm state are enabled in XCR0 */


### PR DESCRIPTION
GCC on Mac does not recognize xgetbv.
Executable with updated query_fma (compiled with clang) produced no difference with original.
The patch was found here: https://github.com/asmjit/asmjit/issues/78

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
