### PR TITLE
Use std::expm1() in conversion from Planck to Rosseland.

### DIFF
--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -196,9 +196,14 @@ static double polylog_series_minus_one_planck(double const x,
 static double Planck2Rosseland(double const freq, double const exp_freq) {
   Check(rtt_dsxx::soft_equiv(exp_freq, std::exp(-freq)));
 
-  double const freq_4 = freq * freq * freq * freq;
+  double const freq_3 = freq * freq * freq;
 
-  double const factor = NORM_FACTOR * freq_4 / std::expm1(freq);
+  double factor;
+
+  if (freq > 1.0e-5)
+    factor = NORM_FACTOR * (freq_3 * freq) / std::expm1(freq);
+  else
+    factor = NORM_FACTOR * freq_3 / (1 + 0.5 * freq);
 
   return factor;
 }

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -203,7 +203,7 @@ static double Planck2Rosseland(double const freq, double const exp_freq) {
   if (freq > 1.0e-5)
     factor = NORM_FACTOR * (freq_3 * freq) / std::expm1(freq);
   else
-    factor = NORM_FACTOR * freq_3 / (1 + 0.5 * freq);
+    factor = NORM_FACTOR * freq_3 * (1 - 0.5 * freq);
 
   return factor;
 }

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -196,14 +196,9 @@ static double polylog_series_minus_one_planck(double const x,
 static double Planck2Rosseland(double const freq, double const exp_freq) {
   Check(rtt_dsxx::soft_equiv(exp_freq, std::exp(-freq)));
 
-  double const freq_3 = freq * freq * freq;
+  double const freq_4 = freq * freq * freq * freq;
 
-  double factor;
-
-  if (freq > 1.0e-5)
-    factor = NORM_FACTOR * exp_freq * (freq_3 * freq) / (1 - exp_freq);
-  else
-    factor = NORM_FACTOR * freq_3 / (1 - 0.5 * freq);
+  double const factor = NORM_FACTOR * freq_4 / std::expm1(freq);
 
   return factor;
 }


### PR DESCRIPTION
* Purpose of Pull Request
  * This pull request changes how Planck2Rosseland factor is calculated, using a std::expm1(x) which is accurate even for small (x), refs #2 (882)

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
