### PR TITLE
Adding parser check to ensure even azimuthal order

### DIFF
--- a/src/quadrature/Product_Chebyshev_Legendre__Parser.cc
+++ b/src/quadrature/Product_Chebyshev_Legendre__Parser.cc
@@ -32,6 +32,7 @@ Product_Chebyshev_Legendre::parse(Token_Stream &tokens) {
   unsigned azimuthal_order = parse_positive_integer(tokens);
   tokens.check_semantics(azimuthal_order > 0,
                          "order must be greater than zero");
+  tokens.check_semantics(azimuthal_order % 2 == 0, "order must be even");
 
   bool has_axis_assignments;
   unsigned mu_axis, eta_axis;


### PR DESCRIPTION
Quadratures with an odd number of azimuthal angles should cause a parser error.
Previously, error only occurred in DBC check, which is often turned off in
release.

* Purpose of Pull Request
  * Increase robustness when no DBC checks are used by adding parser check

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
