### PR TITLE
Add C4 interface for MPI_Sendrecv function.

### DIFF
--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -143,6 +143,14 @@ DLL_PUBLIC_c4 int send_udt(const T *buffer, int size, int destination,
                            C4_Datatype &, int tag = C4_Traits<T *>::tag);
 
 //---------------------------------------------------------------------------//
+//! Do a point-to-point, blocking send-receive.
+template <typename TS, typename TR>
+DLL_PUBLIC_c4 int send_receive(TS *sendbuf, int sendcount, int destination,
+                               TR *recvbuf, int recvcount, int source,
+                               int sendtag = C4_Traits<TS *>::tag,
+                               int recvtag = C4_Traits<TR *>::tag);
+
+//---------------------------------------------------------------------------//
 //! Do a point-to-point, blocking receive of a user-defined type.
 template <typename T>
 DLL_PUBLIC_c4 int receive_udt(T *buffer, int size, int source, C4_Datatype &,

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -53,7 +53,7 @@ DLL_PUBLIC_c4 int receive(T *buffer, int size, int source, int tag) {
   return count;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 template <typename T>
 DLL_PUBLIC_c4 int send_udt(const T *buffer, int size, int destination,
                            C4_Datatype &data_type, int tag) {
@@ -78,6 +78,26 @@ DLL_PUBLIC_c4 int receive_udt(T *buffer, int size, int source,
   // get the count of received data
   MPI_Get_count(&status, data_type, &count);
   return count;
+}
+
+//---------------------------------------------------------------------------//
+template <typename TS, typename TR>
+DLL_PUBLIC_c4 int send_receive(TS *sendbuf, int sendcount, int destination,
+                               TR *recvbuf, int recvcount, int source,
+                               int sendtag, int recvtag) {
+  Require(sendbuf != nullptr);
+  Require(recvbuf != nullptr);
+  Require(recvbuf + recvcount <= sendbuf || recvbuf >= sendbuf + sendcount);
+  // buffers must not overlap
+
+  // get a handle to the MPI_Status
+  MPI_Status status;
+
+  int check = MPI_Sendrecv(sendbuf, sendcount, MPI_Traits<TS>::element_type(),
+                           destination, sendtag, recvbuf, recvcount,
+                           MPI_Traits<TR>::element_type(), source, recvtag,
+                           communicator, &status);
+  return check;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/c4/C4_MPI_blocking_pt.cc
+++ b/src/c4/C4_MPI_blocking_pt.cc
@@ -83,6 +83,27 @@ template DLL_PUBLIC_c4 int broadcast<float>(float *, int, int);
 template DLL_PUBLIC_c4 int broadcast<double>(double *, int, int);
 template DLL_PUBLIC_c4 int broadcast<long double>(long double *, int, int);
 
+template DLL_PUBLIC_c4 int send_receive(char *sendbuf, int sendcount,
+                                        int destination, char *recvbuf,
+                                        int recvcount, int source, int sendtag,
+                                        int recvtag);
+template DLL_PUBLIC_c4 int send_receive(int *sendbuf, int sendcount,
+                                        int destination, int *recvbuf,
+                                        int recvcount, int source, int sendtag,
+                                        int recvtag);
+template DLL_PUBLIC_c4 int send_receive(long *sendbuf, int sendcount,
+                                        int destination, long *recvbuf,
+                                        int recvcount, int source, int sendtag,
+                                        int recvtag);
+template DLL_PUBLIC_c4 int send_receive(float *sendbuf, int sendcount,
+                                        int destination, float *recvbuf,
+                                        int recvcount, int source, int sendtag,
+                                        int recvtag);
+template DLL_PUBLIC_c4 int send_receive(double *sendbuf, int sendcount,
+                                        int destination, double *recvbuf,
+                                        int recvcount, int source, int sendtag,
+                                        int recvtag);
+
 } // end namespace rtt_c4
 
 #endif // C4_MPI

--- a/src/c4/C4_Serial.hh
+++ b/src/c4/C4_Serial.hh
@@ -73,6 +73,14 @@ DLL_PUBLIC_c4 int send_udt(const T * /*buffer*/, int /*size*/,
   return C4_SUCCESS;
 }
 
+template <typename TS, typename TR>
+DLL_PUBLIC_c4 int send_receive(TS * /*sendbuf*/, int /*sendcount*/,
+                               int /*destination*/, TR * /*recvbuf*/,
+                               int /*recvcount*/, int /*source*/,
+                               int /*sendtag*/, int /*recvtag*/) {
+  Insist(false, "send_receive is not support for C4_SCALAR builds.");
+}
+
 //---------------------------------------------------------------------------//
 
 template <class T>


### PR DESCRIPTION
I have run into situations in my code where this seems the best operation for what I want to accomplish.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
