### PR TITLE
Compton: Remove an unneeded include and improve test coverage

### DIFF
--- a/src/compton/Compton.cc
+++ b/src/compton/Compton.cc
@@ -13,7 +13,6 @@
 #include "ds++/Assert.hh"
 // headers provided in Compton include directory:
 #include "compton_file.hh"
-#include "multigroup_compton_data.hh"
 #include "multigroup_data_types.hh"
 #include "multigroup_lib_builder.hh"
 

--- a/src/compton/test/tCompton.cc
+++ b/src/compton/test/tCompton.cc
@@ -102,6 +102,9 @@ void compton_file_test(rtt_dsxx::UnitTest &ut) {
   if (compton_test->get_num_xi() != 4)
     ITFAILS;
 
+  if (compton_test->get_num_groups() != 1)
+    ITFAILS;
+
   if (ut.numFails == 0)
     std::cout << "\nCorrectly read multigroup data points!" << std::endl;
 
@@ -187,6 +190,9 @@ void const_compton_file_test(rtt_dsxx::UnitTest &ut) {
 
   // get the number of xi evals in the library (we know it should be 4)
   if (compton_test->get_num_xi() != 4)
+    ITFAILS;
+
+  if (compton_test->get_num_groups() != 1)
     ITFAILS;
 
   if (ut.numFails == 0)

--- a/src/compton/test/tCompton.cc
+++ b/src/compton/test/tCompton.cc
@@ -283,7 +283,11 @@ void compton_fail_test(rtt_dsxx::UnitTest &ut) {
   try {
     compton_test.reset(new rtt_compton::Compton(filename));
   } catch (rtt_dsxx::assertion &asrt) {
-    std::cout << "Exception thrown: " << asrt.what() << std::endl;
+    std::cout << "Draco exception thrown: " << asrt.what() << std::endl;
+    // We successfully caught the bad file!
+    caught = true;
+  } catch (const int &asrt) {
+    std::cout << "CSK exception thrown. " << std::endl;
     // We successfully caught the bad file!
     caught = true;
   }


### PR DESCRIPTION
* This pull request should increase test coverage for Compton.hh to 100%. It also removes an unneeded include from Compton.cc.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation