### PR TITLE
Extend c4::Processor_Group::sum to any random access container.

### DIFF
--- a/src/c4/Processor_Group.hh
+++ b/src/c4/Processor_Group.hh
@@ -57,7 +57,8 @@ public:
 
   //! Sum a set of values over the group, returning the sum to all
   //! processors.
-  template <typename T> void sum(std::vector<T> &values);
+  template <typename RandomAccessContainer>
+  void sum(RandomAccessContainer &values);
 
   //! Assemble a set of local vectors into global vectors.
   template <typename T>

--- a/src/c4/Processor_Group.i.hh
+++ b/src/c4/Processor_Group.i.hh
@@ -14,6 +14,8 @@
 #ifndef c4_Processor_Group_i_hh
 #define c4_Processor_Group_i_hh
 
+#include "Processor_Group.hh"
+
 #include "MPI_Traits.hh"
 #include "c4/config.h"
 #include "ds++/Assert.hh"

--- a/src/c4/Processor_Group.i.hh
+++ b/src/c4/Processor_Group.i.hh
@@ -22,9 +22,12 @@
 
 namespace rtt_c4 {
 //---------------------------------------------------------------------------//
-template <typename T> void Processor_Group::sum(std::vector<T> &x) {
+template <typename RandomAccessContainer>
+void Processor_Group::sum(RandomAccessContainer &x) {
+  typedef typename RandomAccessContainer::value_type T;
+
   // copy data into send buffer
-  std::vector<T> y = x;
+  std::vector<T> y(x.begin(), x.end());
 
   // do global MPI reduction (result is on all processors) into x
   int status =


### PR DESCRIPTION
The random access container must conform to the C++11 conventions for such a container. In particular, the value_type must be defined and &x[0] must return a pointer to T pointing to the beginning of the raw storage underlying the container.

This is needed to support use of Teuchos::ArrayView and Teuchos::ArrayRCP in the Capsaicin project.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
