### PR TITLE
Update bashrc and regression launch scripts for ccscs machines 

### DIFF
--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -37,7 +37,7 @@ ccscs[1-9]*)
     module load user_contrib
     export dracomodules="gcc/4.8.5 openmpi cmake \
 lapack random123 eospac gsl dracoscripts subversion ndi python
-metis parmetis superlu-dist trilinos git"
+metis parmetis superlu-dist trilinos git csk"
     ;;
 ccsnet3*)
     # Locate the vendor directory
@@ -58,7 +58,7 @@ ccsnet3*)
     module use /ccs/codes/radtran/vendors/Modules
   export dracomodules="gcc openmpi emacs/24.4 totalview cmake grace \
 lapack random123 eospac dracoscripts git svn dia graphviz doxygen \
-metis parmetis superlu-dist trilinos ndi"
+metis parmetis superlu-dist trilinos ndi csk"
     ;;
 esac
 

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -97,7 +97,7 @@ run "module load dracoscripts subversion random123 valgrind"
 run "module load eospac lapack gsl" # grace
 run "module load superlu-dist/4.3"
 run "module load ndi metis parmetis trilinos"
-run "module load doxygen graphviz" # qt
+run "module load doxygen graphviz csk" # qt
 comp=gcc
 
 case $extra_params in
@@ -142,7 +142,7 @@ case $extra_params in
     run "module load lapack gsl" # eospac
     run "module load superlu-dist/4.3"
     run "module load ndi metis parmetis trilinos"
-    run "module load graphviz"
+    run "module load graphviz csk"
     comp=clang
     ;;
   fulldiagnostics)
@@ -155,7 +155,7 @@ case $extra_params in
     run "module load dracoscripts subversion random123"
     run "module load lapack gsl eospac"
     run "module load superlu-dist"
-    run "module load ndi metis parmetis trilinos"
+    run "module load ndi metis parmetis trilinos csk"
     comp=gcc-5.3.0
     ;;
   gcc610)
@@ -165,7 +165,7 @@ case $extra_params in
     run "module load dracoscripts subversion random123"
     run "module load lapack gsl eospac"
     run "module load superlu-dist"
-    run "module load ndi metis parmetis trilinos"
+    run "module load ndi metis parmetis trilinos csk"
     comp=gcc-6.1.0
     ;;
   valgrind)


### PR DESCRIPTION
This pull request adds "module load csk" to the ccscs[1-9] bashrc file (.bashrc_linux64) and the regression launch script (ccscs-regress.msub).

Right now, csk is built for four compiler versions: gcc-4.8.5, -5.3.0, -6.1.0, and clang-3.9.0.

* Purpose of Pull Request
  * Add automatic loading of csk module on ccscs machines
  * If all goes well, this should close Jayenne redmine task #869 

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation