### PR TITLE
For Draco's Emacs mode, make divider lines one char longer.

### DIFF
--- a/environment/elisp/draco-mode.el
+++ b/environment/elisp/draco-mode.el
@@ -3,15 +3,9 @@
 ;; file   : draco-mode.el
 ;; Author : Kelly Thompson
 ;; Created: 30 Nov 2004
-;;
 ;; Brief  : ELisp package for making Draco related stuff easier.
-;;
-;; Copyright (C) 2016-2017 Los Alamos National Security, LLC
-;;
-;; Version: 0.0.1
-;;
-;; $Id$
-;;============================================================
+;; Note   : Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+;;======================================================================
 ;; Commentary:
 ;;
 ;; - Customize the variable ccs4-env-dirs
@@ -34,8 +28,6 @@
 ;;   (add-hook 'font-lock-mode-hook 'my-draco-font-lock-hook)
 ;;
 ;;   This will add the Draco keywords to c-mode and c++-mode only.
-;;
-
 ;;============================================================
 ;; Front matter and variables
 
@@ -456,7 +448,7 @@ function or method. Width is set by draco-code-comment-width.
   (interactive)
   (beginning-of-line)
   (insert "//")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "//\n")
   (insert "/*! \n")
   (insert " * \\brief \n")
@@ -481,13 +473,13 @@ by draco-code-comment-width.
 "
   (interactive)
   (insert "//")
-  (insert (make-string (- draco-code-comment-width 5) ?=))
+  (insert (make-string (- draco-code-comment-width 4) ?=))
   (insert "//\n")
   (insert "/*!\n")
   (insert " * \\class \n")
   (insert " * \\brief \n")
   (insert "//")
-  (insert (make-string (- draco-code-comment-width 5) ?=))
+  (insert (make-string (- draco-code-comment-width 4) ?=))
   (insert "//\n")
   (previous-line 2)
   (end-of-line)
@@ -498,7 +490,7 @@ by draco-code-comment-width.
   (interactive)
   (beginning-of-line)
   (insert "//")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "//\n")
 )
 
@@ -689,7 +681,7 @@ c-----------------------------------------------------------------------------c
   (interactive)
   (beginning-of-line)
   (insert "/*")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "*/\n")
   (end-of-line)
 )
@@ -704,21 +696,13 @@ c-----------------------------------------------------------------------------c
   (interactive)
   (beginning-of-line)
   (insert "/*")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "*/\n/* \n/*")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "*/\n\n")
   (previous-line 3)
   (end-of-line)
 )
-
-;(defun draco-cc-comment-divider ()
-;"Insert a C++ style divider."
-;  (interactive)
-;  (beginning-of-line)
-;  (insert "//---------------------------------------------------------------------------//\n")
-;  (end-of-line)
-;)
 
 (defun draco-html-comment-divider ()
 "Insert a HTML style divider."
@@ -736,9 +720,9 @@ c-----------------------------------------------------------------------------c
   (interactive)
   (beginning-of-line)
   (insert "//")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "//\n// \n//")
-  (insert (make-string (- draco-code-comment-width 5) ?-))
+  (insert (make-string (- draco-code-comment-width 4) ?-))
   (insert "//\n\n")
   (previous-line 3)
   (end-of-line)


### PR DESCRIPTION
+ For some reason the divider lines were one character shorter than the
  clang-format line length (80 chars). Fix it.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
