### PR TITLE
Add support for ccache.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -42,10 +42,16 @@ site_name( SITENAME )
 string( REGEX REPLACE "([A-z0-9]+).*" "\\1" SITENAME ${SITENAME} )
 if( ${SITENAME} MATCHES "ml" OR ${SITENAME} MATCHES "lu" )
   set( SITENAME "Moonlight" )
-elseif( ${SITENAME} MATCHES "tt") #" -login[0-9]+" OR ${SITENAME} MATCHES "tt-fey[0-9]+" )
+elseif( ${SITENAME} MATCHES "tt")
   set( SITENAME "Trinitite" )
-elseif( ${SITENAME} MATCHES "tr") #" -login[0-9]+" OR ${SITENAME} MATCHES "tr-fe[0-9]+" )
+elseif( ${SITENAME} MATCHES "tr")
   set( SITENAME "Trinity" )
+elseif( ${SITENAME} MATCHES "sn")
+  set( SITENAME "Snow" )
+elseif( ${SITENAME} MATCHES "fi")
+  set( SITENAME "Fire" )
+elseif( ${SITENAME} MATCHES "ic")
+  set( SITENAME "Ice" )
 elseif( ${SITENAME} MATCHES "ccscs[0-9]+" )
   # do nothing (keep the fullname)
 endif()
@@ -237,6 +243,33 @@ macro(dbsSetupCxx)
     set( CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_DARWIN_C_SOURCE ")
   endif()
 
+  # From https://crascit.com/2016/04/09/using-ccache-with-cmake/
+  message( STATUS "Looking for ccache...")
+  find_program(CCACHE_PROGRAM ccache)
+  if(CCACHE_PROGRAM)
+    message( STATUS "Looking for ccache... ${CCACHE_PROGRAM}")
+    # Set up wrapper scripts
+    set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    # configure_file(launch-c.in   launch-c)
+    # configure_file(launch-cxx.in launch-cxx)
+    # execute_process(COMMAND chmod a+rx "${CMAKE_BINARY_DIR}/launch-c" "${CMAKE_BINARY_DIR}/launch-cxx")
+    # if(CMAKE_GENERATOR STREQUAL "Xcode")
+    #   # Set Xcode project attributes to route compilation and linking
+    #     # through our scripts
+    #     set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
+    #     set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+    #     set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
+    #     set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+    #   else()
+    #     # Support Unix Makefiles and Ninja
+    #     set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
+    #     set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
+    #   endif()
+  else()
+    message( STATUS "Looking for ccache... not found.")
+  endif()
+
 endmacro()
 
 #------------------------------------------------------------------------------#
@@ -405,7 +438,7 @@ macro( dbsSetupProfilerTools )
         PATHS ${PROJECT_BINARY_DIR}
         NO_DEFAULT_PATH
         )
-      find_library( map-sampler
+      findl_ibrary( map-sampler
         NAMES map-sampler
         PATHS ${PROJECT_BINARY_DIR}
         NO_DEFAULT_PATH
@@ -425,7 +458,7 @@ macro( dbsSetupProfilerTools )
     if( NOT EXISTS $ENV{DDTROOT} )
       message( FATAL_ERROR "You must load the Allinea module first!")
     endif()
-    if( "${SITENAME}" STREQUAL "Trinitite" OR "${SITENAME}" STREQUAL "Cielito" )
+    if( "${SITENAME}" STREQUAL "Trinitite" OR "${SITENAME}" STREQUAL "Trinity" )
       #set( OLD_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
       #set( CMAKE_FIND_LIBRARY_SUFFIXES .a )
       find_library( ddt-dmalloc

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -379,9 +379,9 @@ macro(dbsSetupFortran)
 
 endmacro()
 
-##---------------------------------------------------------------------------------------##
+##---------------------------------------------------------------------------##
 ## Setup profile tools: MAP, PAPI, HPCToolkit, TAU, etc.
-##---------------------------------------------------------------------------------------##
+##---------------------------------------------------------------------------##
 macro( dbsSetupProfilerTools )
 
   # ------------------------------------------------------------
@@ -438,7 +438,7 @@ macro( dbsSetupProfilerTools )
         PATHS ${PROJECT_BINARY_DIR}
         NO_DEFAULT_PATH
         )
-      findl_ibrary( map-sampler
+      find_library( map-sampler
         NAMES map-sampler
         PATHS ${PROJECT_BINARY_DIR}
         NO_DEFAULT_PATH


### PR DESCRIPTION
+ Only tested on ccs-net machines.
+ `ccache` is a compiler cache. It speeds up recompilation by caching previous compilations and detecting when the same compilation is being done again.
+ Currently, we recommend the following content for `~/.ccache/ccache.conf`
```
  max_size = 30.0G
  cache_dir = /scratch/ccache
  umask = 0002
```
+ This PR also adds code to set SITENAME to a pretty string for Snow, Fire and Ice and removes a reference to Cielito.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
