### PR TITLE
Exclude Fortran header files (ending in  _f.h, _f77.h, _f90.h) from clang formatting.

### DIFF
--- a/environment/git/pre-commit-clang-format
+++ b/environment/git/pre-commit-clang-format
@@ -59,6 +59,9 @@ PARSE_EXTS=true
 # FILE_EXTS=".c .h .cpp .hpp"
 FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx"
 
+# file endings for files to exclude from parsing when PARSE_EXTS is true.
+FILE_ENDINGS="_f.h _f77.h _f90.h"
+
 ##################################################################
 # There should be no need to change anything below this line.
 
@@ -100,7 +103,10 @@ set -e
 matches_extension() {
     local filename=$(basename "$1")
     local extension=".${filename##*.}"
+    local end
     local ext
+
+    for end in $FILE_ENDINGS; do [[ "$filename" == *"$end" ]] && return 1; done
 
     for ext in $FILE_EXTS; do [[ "$ext" == "$extension" ]] && return 0; done
 


### PR DESCRIPTION
Exclude Fortran header files (ending in _f.h, _f77.h, _f90.h) from
pre-commit-clang-format hook's scrutiny.

Fortran header files in dependent projects get bad formatting recommendations from the clang formatting requirements.  According to @jhchang-lanl, these files should be excluded from the list of valid extensions for pre-commit hook parsing. 

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
