### PR TITLE
Fix a bug that caused python to use wrong line-endings on Windows.

### DIFF
--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -342,10 +342,10 @@ class UnitTest:
       if (stdin_file):
         print("About to run \'{0}\'".format(' '.join(clean_run_args)))
         test_process = subprocess.Popen(clean_run_args, stdout=subprocess.PIPE, \
-          stderr=subprocess.PIPE, stdin=f_in)
+          stderr=subprocess.PIPE, stdin=f_in, universal_newlines=True)
       else:
         test_process = subprocess.Popen(clean_run_args, stdout=subprocess.PIPE, \
-          stderr=subprocess.PIPE)
+          stderr=subprocess.PIPE, universal_newlines=True)
 
       test_out, test_err = test_process.communicate()
       if (stdin_file): f_in.close();


### PR DESCRIPTION
+ PR #193 changed the way Application Unit Test parsed line-endings.
+ This change didn't account for the different formats used for Linux, '\n' and Windows, '\r\n'.
+ Add an optional parameter for subprocess.Popen to tell Python to do the right thing.
+ Ref: https://docs.python.org/2/library/subprocess.html
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
