### PR TITLE
Make it easier to set compile and link flags.

### DIFF
--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -37,8 +37,8 @@ macro( dbsSetDefaults )
   mark_as_advanced( LIBRARY_OUTPUT_PATH )
   mark_as_advanced( DART_TESTING_TIMEOUT )
 
-  # For win32 platforms avoid copying all dependent dll libraries into the test directories
-  # by using a common runtime directory.
+  # For win32 platforms avoid copying all dependent dll libraries into the test
+  # directories by using a common runtime directory.
   if( WIN32 )
      if( CMAKE_CONFIGURATION_TYPES )
         set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR} )
@@ -58,6 +58,13 @@ macro( dbsSetDefaults )
      set( CMAKE_SUPPRESS_REGENERATION ON )
   endif()
 
+  if( CMAKE_CONFIGURATION_TYPES )
+    set( Draco_BUILD_TYPE "Multi-config")
+  else()
+    set( Draco_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+    string( TOUPPER ${CMAKE_BUILD_TYPE} Draco_BUILD_TYPE )
+  endif()
+
   # Design-by-Contract
   if( NOT DEFINED DRACO_DBC_LEVEL )
 
@@ -68,8 +75,12 @@ macro( dbsSetDefaults )
     #   Ensure() postconditions: add +4 to DBC_LEVEL
     #   Do not throw on error  : add +8 to DBC_LEVEL
     set( DRACO_DBC_LEVEL "7" )
-    if( NOT CMAKE_CONFIGURATION_TYPES AND "${CMAKE_BUILD_TYPE}" MATCHES "[Rr][Ee][Ll][Ee][Aa][Ss][Ee]" )
-      set( DRACO_DBC_LEVEL "0" )
+    if( NOT CMAKE_CONFIGURATION_TYPES )
+      if( "${Draco_BUILD_TYPE}" MATCHES "RELEASE" )
+        set( DRACO_DBC_LEVEL "0" )
+      elseif( "${CMAKE_BUILD_TYPE}" MATCHES "RELWITHDEBINFO" )
+        set( DRACO_DBC_LEVEL "15" )
+      endif()
     endif()
     set( DRACO_DBC_LEVEL "${DRACO_DBC_LEVEL}" CACHE STRING "Design-by-Contract (0-31)?" )
     # provide a constrained drop down menu in cmake-gui
@@ -79,12 +90,12 @@ macro( dbsSetDefaults )
   endif()
 
   if( CMAKE_CONFIGURATION_TYPES )
-    # This generator expression will be expanded when the project is
-    # installed (CMake-3.4.0+)
+    # This generator expression will be expanded when the project is installed
+    # (CMake-3.4.0+)
     set(DBSCFGDIR "\$<CONFIG>/" CACHE STRING "Install subdirectory for multiconfig build tools.")
-    # Generate a complete installation directory structure to avoid
-    # errors of the form "imported target includes non-existent path"
-    # when configuring Jayenne.
+    # Generate a complete installation directory structure to avoid errors of
+    # the form "imported target includes non-existent path" when configuring
+    # Jayenne.
     foreach( config ${CMAKE_CONFIGURATION_TYPES} )
       file( MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${config}/include )
     endforeach()

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -243,6 +243,25 @@ macro(dbsSetupCxx)
     set( CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_DARWIN_C_SOURCE ")
   endif()
 
+  #----------------------------------------------------------------------------#
+  # Add user provided options:
+  #
+  # 1. Users may set environment variables
+  #    - C_FLAGS
+  #    - CXX_FLAGS
+  #    - Fortran_FLAGS
+  #    - EXE_LINKER_FLAGS
+  # 2. Provide these as arguments to cmake as -DC_FLAGS="whatever".
+  #----------------------------------------------------------------------------#
+  foreach( lang C CXX Fortran EXE_LINKER )
+    if( DEFINED ENV{${lang}_FLAGS} )
+      string( APPEND ${lang}_FLAGS " $ENV{${lang}_FLAGS}")
+    endif()
+    if( ${lang}_FLAGS )
+      toggle_compiler_flag( TRUE "${${lang}_FLAGS}" ${lang} "" )
+    endif()
+  endforeach()
+
   # From https://crascit.com/2016/04/09/using-ccache-with-cmake/
   message( STATUS "Looking for ccache...")
   find_program(CCACHE_PROGRAM ccache)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,13 +107,6 @@ feature_summary(
   INCLUDE_QUIET_PACKAGES
   DESCRIPTION "Disabled features:")
 
-if( CMAKE_CONFIGURATION_TYPES )
-  set( Draco_BUILD_TYPE "Multi-config")
-else()
-  set( Draco_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
-  string( TOUPPER ${CMAKE_BUILD_TYPE} Draco_BUILD_TYPE )
-endif()
-
 message("
 Draco build summary:
 
@@ -139,11 +132,11 @@ if( CMAKE_CONFIGURATION_TYPES )
     message("FC Release F: ${CMAKE_Fortran_FLAGS_RELEASE}")
   endif()
 else()
-  message("C FLAGS     : ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE}}")
-  message("CXX FLAGS   : ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
+  message("C FLAGS     : ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${Draco_BUILD_TYPE}}")
+  message("CXX FLAGS   : ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${Draco_BUILD_TYPE}}")
   if( _LANGUAGES_ MATCHES Fortran)
     message("Fortran     : ${CMAKE_Fortran_COMPILER}")
-    message("FC FLAGS    : ${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE}}")
+    message("FC FLAGS    : ${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${Draco_BUILD_TYPE}}")
   endif()
 endif()
 if( CAFS_Fortran_COMPILER )


### PR DESCRIPTION
+ When running cmake, developers can now specify:
```
  -D C_FLAGS="whatever"
  -D CXX_FLAGS="whatever"
  -D Fortran_FLAGS="whatever"
  -D EXE_LINKER_FLAGS="whatever"
```
+ Or, before running cmake, developers can set these variables in the local environment:
```
  export C_FLAGS="whatever"
  export CXX_FLAGS="whatever"
  export Fortran_FLAGS="whatever"
  export EXE_LINKER_FLAGS="whatever"
```
+ With this PR, the Draco build system will look for both of the above add these flags to the default set.
+ Default to `DRACO_DBC_LEVEL=15` for `RelWithDebInfo` builds.
+ [Refs #896](https://rtt.lanl.gov/redmine/issues/896)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
