### PR TITLE
Environment and build system changes to support XCP machine 'toolbox.'

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -86,7 +86,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
     # LTO appears to be broken for gcc/4.8.5 (at least for Jayenne).
     # LTO appears to be broken for gcc/5.3.0 (Draco on Moonlight).
-    #string( APPEND CMAKE_C_FLAGS_RELEASE " -flto" )
+    # string( APPEND CMAKE_C_FLAGS_RELEASE " -flto" )
 
     # See https://gcc.gnu.org/gcc-5/changes.html
     # UndefinedBehaviorSanitizer gained a few new sanitization options:
@@ -112,7 +112,14 @@ if( NOT CXX_FLAGS_INITIALIZED )
     # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
   endif()
 
-  if (NOT APPLE AND HAS_MARCH_NATIVE)
+  # [2017-04-15 KT] -march=native doesn't seem to work correctly on toolbox
+  # Systems running CRAY_PE use commpile wrappers to specify this option.
+  site_name( sitename )
+  string( REGEX REPLACE "([A-z0-9]+).*" "\\1" sitename ${sitename} )
+  if (HAS_MARCH_NATIVE AND
+      NOT APPLE AND
+      NOT CRAY_PE AND
+      NOT "${sitename}" MATCHES "toolbox")
     string( APPEND CMAKE_C_FLAGS " -march=native" )
   endif()
 

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -4,7 +4,7 @@
 ## File  : environment/bashrc/.bashrc
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##
 ##  Bash configuration file upon bash shell startup
@@ -204,7 +204,7 @@ if test ${DRACO_BASHRC_DONE:-no} = no && test ${INTERACTIVE} = true; then
 
     # Assume CCS machine (ccscs[0-9] or personal workstation)
     *)
-      if test -d /ccs/codes/radtran; then
+      if [[ -d /ccs/codes/radtran ]]; then
         # assume this is a CCS LAN machine (64-bit)
         if test `uname -m` = 'x86_64'; then
           # draco environment only supports 64-bit linux...
@@ -214,6 +214,9 @@ if test ${DRACO_BASHRC_DONE:-no} = no && test ${INTERACTIVE} = true; then
           echo "Module support may not be available. Email kgt@lanl.gov for more information."
           source ${DRACO_ENV_DIR}/bashrc/.bashrc_linux32
         fi
+      elif [[ -d /usr/projects/draco ]]; then
+        # XCP machine like 'toolbox'?
+        source ${DRACO_ENV_DIR}/bashrc/.bashrc_linux64
       fi
       export NoModules=1
       ;;

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -1,6 +1,13 @@
-##-*- Mode: sh -*-
+#!/bin/bash
+##-*- Mode: bash -*-
 ##---------------------------------------------------------------------------##
-## .bashrc_ccs4_linux - my bash configuration file upon bash login
+## File  : environment/bashrc/.bashrc_linux64
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+##  Bash configuration file upon bash shell startup
 ##---------------------------------------------------------------------------##
 
 if test -n "$verbose"; then
@@ -12,7 +19,7 @@ fi
 ##---------------------------------------------------------------------------##
 
 # unlimit stack and core dump sizes.
-ulimit -s unlimited
+# ulimit -s unlimited
 
 # Is the module function available?
 found=`declare -f module | wc -l`
@@ -46,6 +53,19 @@ ccsnet3*)
     fi
     module load user_contrib
     export dracomodules="dracoscripts subversion python git"
+    ;;
+toolbox*)
+    # Locate the vendor directory
+    if ! [[ $VENDOR_DIR ]]; then
+      export VENDOR_DIR=/usr/projects/draco/vendors
+    fi
+    module use --append $VENDOR_DIR/spack/share/spack/modules/linux-rhel6-x86_64
+    export IGNOREMODULECONFLICTS=1
+    export dracomodules="python gcc/6.1.0 intel/17.0.1 openmpi/1.10.5 \
+cmake emacs git-2.12.0-gcc-5.3.0 gsl-2.1-intel-17.0.1 \
+numdiff-5.8.1-gcc-5.3.0 random123-1.09-gcc-5.3.0 \
+netlib-lapack-3.5.0-intel-17.0.1 metis-5.1.0-intel-17.0.1 \
+parmetis-4.0.3-intel-17.0.1 superlu-dist-4.3-intel-17.0.1"
     ;;
 *)
     # Locate the vendor directory

--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -18,10 +18,9 @@ project( dsxx CXX )
 # Choose platforms for fpe_trap
 if( ${CMAKE_SYSTEM} MATCHES "OSF" )
    set( FPETRAP_OSF_ALPHA 1 )
-elseif( ${CMAKE_SYSTEM} MATCHES "Linux" OR ${CMAKE_SYSTEM} MATCHES "Catamount" )
-   # If the OS is Linux, fpe_trap should work as long as
-   # feenableexscept is available.  That is, it should work for both
-   # GNU and Intel compiler suites.
+elseif( ${CMAKE_SYSTEM} MATCHES "Linux" )
+   # If the OS is Linux, fpe_trap should work as long as feenableexcept is
+   # available.  That is, it should work for both GNU and Intel compiler suites.
    set( FPETRAP_LINUX_X86 1 )
 
    # Turn fpe_trap off for PGI compilers.

--- a/src/rng/Rnd_Control_Inline.hh
+++ b/src/rng/Rnd_Control_Inline.hh
@@ -4,14 +4,14 @@
  * \author Paul Henning
  * \brief  Rnd_Control header file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_rng_Rnd_Control_Inline_hh
 #define rtt_rng_Rnd_Control_Inline_hh
 
 #include "Counter_RNG.hh"
+#include <limits>
 
 namespace rtt_rng {
 


### PR DESCRIPTION
* Add draco developer environment for toolbox (VENDOR_DIR, modulefiles, etc.)  This commit is specifically for toolbox, but should also work for other Linux machines on the XCP network.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
