### PR TITLE
Add prefix sum function to C4 library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,11 @@ addons:
 
 before_install:
   - mkdir -p ${VENDOR_DIR}/bin & export PATH=${VENDOR_DIR}/bin:$PATH
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
   - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
-  - pip install --upgrade pip
-  - pip install --upgrade setuptools
   - ./.travis-install-dependencies.sh
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ before_install:
   - mkdir -p ${VENDOR_DIR}/bin & export PATH=${VENDOR_DIR}/bin:$PATH
   - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
-install: ./.travis-install-dependencies.sh
+install:
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
+  - ./.travis-install-dependencies.sh
 
 before_script:
   - if [[ ${WERROR} ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} -Werror\"; done; fi

--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -472,8 +472,7 @@ DLL_PUBLIC_c4 std::string get_processor_name();
 /*!
  * \brief Return the value of the prefix sum at this processor.
  *
- * \param node_value
- * Current node's value of variable to be prefix summed
+ * \param node_value Current node's value of variable to be prefix summed
  * \return Sum of value over nodes up to and including this node.
  */
 template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value);

--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -476,7 +476,7 @@ DLL_PUBLIC_c4 std::string get_processor_name();
  * Current node's value of variable to be prefix summed
  * \return Sum of value over nodes up to and including this node.
  */
-template <typename T> DLL_PUBLIC_c4 T prefix_sum(T& node_value);
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value);
 
 } // end namespace rtt_c4
 

--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -466,6 +466,18 @@ DLL_PUBLIC_c4 bool isScalar();
 //! Return the processor name for each rank.
 DLL_PUBLIC_c4 std::string get_processor_name();
 
+//---------------------------------------------------------------------------//
+// prefix_sum
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Return the value of the prefix sum at this processor.
+ *
+ * \param node_value
+ * Current node's value of variable to be prefix summed
+ * \return Sum of value over nodes up to and including this node.
+ */
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(T& node_value);
+
 } // end namespace rtt_c4
 
 //---------------------------------------------------------------------------//

--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -58,7 +58,7 @@ class C4_Req;
  * \brief Initialize a parallel job.
  */
 DLL_PUBLIC_c4 int initialize(int &argc, char **&argv,
-                             int required = MPI_THREAD_SINGLE);
+                             int required = DRACO_MPI_THREAD_SINGLE);
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -358,7 +358,7 @@ template <typename T> DLL_PUBLIC_c4 void global_max(T *x, int n) {
 template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value) {
   T prefix_sum = 0;
   MPI_Scan(&node_value, &prefix_sum, 1, MPI_Traits<T>::element_type(), MPI_SUM,
-    communicator);
+           communicator);
   return prefix_sum;
 }
 

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -353,6 +353,15 @@ template <typename T> DLL_PUBLIC_c4 void global_max(T *x, int n) {
                 communicator);
 }
 
+//---------------------------------------------------------------------------//
+
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value) {
+  T prefix_sum = 0;
+  MPI_Scan(&node_value, &prefix_sum, 1, MPI_Traits<T>::element_type(), MPI_SUM,
+    communicator);
+  return prefix_sum;
+}
+
 } // end namespace rtt_c4
 
 #endif // C4_MPI

--- a/src/c4/C4_MPI_blocking_pt.cc
+++ b/src/c4/C4_MPI_blocking_pt.cc
@@ -104,6 +104,12 @@ template DLL_PUBLIC_c4 int send_receive(double *sendbuf, int sendcount,
                                         int recvcount, int source, int sendtag,
                                         int recvtag);
 
+template DLL_PUBLIC_c4 int prefix_sum(int &node_value);
+template DLL_PUBLIC_c4 uint32_t prefix_sum(uint32_t &node_value);
+template DLL_PUBLIC_c4 long prefix_sum(long &node_value);
+template DLL_PUBLIC_c4 float prefix_sum(float &node_value);
+template DLL_PUBLIC_c4 double prefix_sum(double &node_value);
+
 } // end namespace rtt_c4
 
 #endif // C4_MPI

--- a/src/c4/C4_Serial.hh
+++ b/src/c4/C4_Serial.hh
@@ -79,6 +79,7 @@ DLL_PUBLIC_c4 int send_receive(TS * /*sendbuf*/, int /*sendcount*/,
                                int /*recvcount*/, int /*source*/,
                                int /*sendtag*/, int /*recvtag*/) {
   Insist(false, "send_receive is not support for C4_SCALAR builds.");
+  return 1;
 }
 
 //---------------------------------------------------------------------------//
@@ -98,6 +99,10 @@ template <typename T>
 DLL_PUBLIC_c4 int receive_udt(T * /*buffer*/, int /*size*/, int /*destination*/,
                               C4_Datatype & /*data_type*/, int /*tag*/) {
   return C4_SUCCESS;
+}
+
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value) {
+  return node_value;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/c4/Invert_Comm_Map.cc
+++ b/src/c4/Invert_Comm_Map.cc
@@ -70,11 +70,11 @@ void invert_comm_map(Invert_Comm_Map_t const &to_map,
 #elif defined(C4_SCALAR)
 void invert_comm_map(Invert_Comm_Map_t const &to_map,
                      Invert_Comm_Map_t &from_map) {
-  Require(to_map.size() == 0u || (to_map.size() == 1u && to_map[0] > 0));
+  Require(to_map.size() == 0u || (to_map.size() == 1u && to_map.at(0) > 0));
   from_map.clear();
   auto it = to_map.find(0);
   if (it != to_map.end()) {
-    from_map.push_back(it->second);
+    from_map[0] = it->second;
   }
 }
 #else

--- a/src/c4/c4_mpi.h
+++ b/src/c4/c4_mpi.h
@@ -1,7 +1,7 @@
 /*-----------------------------------*-C-*-----------------------------------*/
 /*!
- * \file   c4_mpi.h 
- * \author Thomas M. Evans 
+ * \file   c4_mpi.h
+ * \author Thomas M. Evans
  * \date   Fri Jan  8 15:06:30 1999
  * \brief  put the right includes for MPI header files
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
@@ -19,10 +19,10 @@
 /* defined in ac_vendors.m4, location of <mpi.h> */
 #include <mpi.h>
 
+#ifndef DRACO_MAX_PROCESSOR_NAME
 #ifdef MPI_MAX_PROCESSOR_NAME
 #define DRACO_MAX_PROCESSOR_NAME MPI_MAX_PROCESSOR_NAME
-#else
-
+#endif
 #endif
 
 #endif /* __c4_c4_mpi_h__ */

--- a/src/c4/config.h.in
+++ b/src/c4/config.h.in
@@ -61,9 +61,11 @@
 #else
 #define DRACO_MAX_PROCESSOR_NAME 64
 #endif
-#ifndef MPI_THREAD_SINGLE
-#define MPI_THREAD_SINGLE 0
+#ifndef DRACO_MPI_THREAD_SINGLE
+  #define DRACO_MPI_THREAD_SINGLE 0
 #endif
+#else
+  #define DRACO_MPI_THREAD_SINGLE MPI_THREAD_SINGLE
 #endif
 
 /* Ensure that Sequoia mpi.h uses 'const' in function signatures. This is

--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -193,7 +193,6 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
 //---------------------------------------------------------------------------//
 void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
 
-
   // Calculate prefix sums on rank ID with MPI call and by hand and compare
   // the output. As a reminder, the prefix sum on a node includes all previos
   // node's value and the value of the current node
@@ -208,8 +207,8 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
       int_answer += i + 1;
   }
 
-  std::cout<<"Prefix sum on this node: "<<xint_prefix_sum;
-  std::cout<<" Answer: "<<int_answer<<std::endl;
+  std::cout << "Prefix sum on this node: " << xint_prefix_sum;
+  std::cout << " Answer: " << int_answer << std::endl;
 
   if (xint_prefix_sum != int_answer)
     ITFAILS;
@@ -220,12 +219,12 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
 
   long long_answer = 0;
   for (int i = 0; i < rtt_c4::nodes(); i++) {
-    if (i <= rtt_c4::node() || i==0)
+    if (i <= rtt_c4::node() || i == 0)
       long_answer += i + 1000;
   }
 
-  std::cout<<"Prefix sum on this node: "<<xlong_prefix_sum;
-  std::cout<<" Answer: "<<long_answer<<std::endl;
+  std::cout << "Prefix sum on this node: " << xlong_prefix_sum;
+  std::cout << " Answer: " << long_answer << std::endl;
 
   if (xlong_prefix_sum != long_answer)
     ITFAILS;
@@ -236,12 +235,12 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
 
   double dbl_answer = 0.0;
   for (int i = 0; i < rtt_c4::nodes(); i++) {
-    if (i <= rtt_c4::node() || i==0)
+    if (i <= rtt_c4::node() || i == 0)
       dbl_answer += static_cast<double>(i) + 0.1;
   }
 
-  std::cout<<"Prefix sum on this node: "<<xdbl_prefix_sum;
-  std::cout<<" Answer: "<<dbl_answer<<std::endl;
+  std::cout << "Prefix sum on this node: " << xdbl_prefix_sum;
+  std::cout << " Answer: " << dbl_answer << std::endl;
 
   if (!soft_equiv(xdbl_prefix_sum, dbl_answer))
     ITFAILS;
@@ -249,7 +248,6 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
   if (ut.numFails == 0)
     PASSMSG("Prefix sum ok.");
   return;
-
 }
 
 //---------------------------------------------------------------------------//

--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -213,6 +213,24 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
   if (xint_prefix_sum != int_answer)
     ITFAILS;
 
+  // test unsigned ints (start at max of signed int)
+  uint32_t xuint = rtt_c4::node();
+  if (rtt_c4::node() == 0)
+    xuint = std::numeric_limits<int>::max();
+  uint32_t xuint_prefix_sum = prefix_sum(xuint);
+
+  uint32_t uint_answer = std::numeric_limits<int>::max();
+  for (int i = 0; i < rtt_c4::nodes(); i++) {
+    if (i < rtt_c4::node())
+      uint_answer += i + 1;
+  }
+
+  std::cout << "Prefix sum on this node: " << xuint_prefix_sum;
+  std::cout << " Answer: " << uint_answer << std::endl;
+
+  if (xuint_prefix_sum != uint_answer)
+    ITFAILS;
+
   // test longs
   long xlong = rtt_c4::node() + 1000;
   long xlong_prefix_sum = prefix_sum(xlong);
@@ -229,16 +247,33 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
   if (xlong_prefix_sum != long_answer)
     ITFAILS;
 
+  // test floats
+  float xfloat = static_cast<float>(rtt_c4::node()) + 0.01;
+  float xfloat_prefix_sum = prefix_sum(xfloat);
+
+  float float_answer = 0.0;
+  for (int i = 0; i < rtt_c4::nodes(); i++) {
+    if (i <= rtt_c4::node() || i == 0)
+      float_answer += static_cast<float>(i) + 0.01;
+  }
+
+  std::cout << "Prefix sum on this node: " << xfloat_prefix_sum;
+  std::cout << " Answer: " << float_answer << std::endl;
+
+  if (!soft_equiv(xfloat_prefix_sum, float_answer))
+    ITFAILS;
+
   // test doubles
-  double xdbl = static_cast<double>(rtt_c4::node()) + 0.1;
+  double xdbl = static_cast<double>(rtt_c4::node()) + 1.0e-9;
   double xdbl_prefix_sum = prefix_sum(xdbl);
 
   double dbl_answer = 0.0;
   for (int i = 0; i < rtt_c4::nodes(); i++) {
     if (i <= rtt_c4::node() || i == 0)
-      dbl_answer += static_cast<double>(i) + 0.1;
+      dbl_answer += static_cast<double>(i) + 1.0e-9;
   }
 
+  std::cout.precision(16);
   std::cout << "Prefix sum on this node: " << xdbl_prefix_sum;
   std::cout << " Answer: " << dbl_answer << std::endl;
 


### PR DESCRIPTION
+ The MPI scan function calculates a prefix sum (often used in determining offsets in parallel problems) without forming a n_proc length array on every node.
+ Templated prefix_sum function was added to the "blocking" section of the C4 library
+ A section for prefix_sum was added to the "tstReduction" test
* Purpose of Pull Request
  * Address Jayenne #892 (https://rtt.lanl.gov/redmine/issues/892)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (regression broken after slurm install).
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
