### PR TITLE
General clean up in Draco (mostly bash scripts).

### DIFF
--- a/README.draco
+++ b/README.draco
@@ -23,7 +23,34 @@ Export Control Classification Number (ECCN) EAR99.
 Configuring and Building
 =============================
 
-Please review the notes at the top of CMakeLists.txt or the wiki page:
+Access the sources
+
+  git clone git@github.com:lanl/Draco.git draco
+
+Build with Makefiles:
+
+  mkdir build_dir && cd $_
+  [C_FLAGS='-Werror'] cmake $source_location [-DOPTION=value]
+  [ccmake] # check settings
+  make [-j] [install|target]
+  ctest [-j]
+
+Common options:
+
+  -DCMAKE_BUILD_TYPE=Release|Debug|RelWithDebInfo
+  -DBUILD_TESTING=OFF
+
+Common targets:
+
+ - all
+ - install
+ - Lib_quadrature       # build a library (and any needed deps)
+ - Exe_draco_info       # build an executable (and any needed deps)
+ - Ut_dsxx_tstSlice_exe # build one unit test (and any needed deps)
+ - help
+ - clean
+ - rebuild_cache
+ - autodoc
 
 Developer Environment Configuration
 =============================
@@ -46,9 +73,8 @@ Active Draco Component Synopsis
 =============================
 
 RTT_Format_Reader:{mesh container and services}
-no description
 
-c4: {Communications library that wrapps MPI}
+c4: {Communications library that wraps MPI}
 
 cdi: {Get access to material data}
 The Common Data Interface specifies an common abstraction for objects and
@@ -59,27 +85,28 @@ cdi_analytic: {Analytic models for physical data}
 
 cdi_eospac: {Equation-of-State data}
 This class wraps the EOSPAC6 libraries (local copy at
-/ccs/codes/radtran/vendors/eospac).  The interface inherits from CDI/EOS.hh and
-can be used as a stand alone component or as a plug-in to CDI.  To make the
-component available you must set in your environment or in the CMakeCache.txt
-the variable EOSPAC_LIB_DIR to the path to libeospac.a
+    /ccs/codes/radtran/vendors/eospac).  The interface inherits from CDI/EOS.hh
+    and can be used as a stand alone component or as a plug-in to CDI.  To make
+    the component available you must set in your environment or in the
+    CMakeCache.txt the variable EOSPAC_LIB_DIR to the path to libeospac.a
 
 cdi_ipcress: {Gray and multigroup opacities}
-The classes in this component will read and parse opacity values from an IPCRESS
-file produced by TOPS.  The component presents this data through various
-accessors.  The interface inherits from CDI/Opacity.hh and can be used as a
-stand alone component or as a plug-in to CDI.
+    The classes in this component will read and parse opacity values from an
+    IPCRESS file produced by TOPS.  The component presents this data through
+    various accessors.  The interface inherits from CDI/Opacity.hh and can be
+    used as a stand alone component or as a plug-in to CDI.
 
 device: {Wrapper for heterogeneous device communication}
-The classes in this component provide access to DaCS and CUDA calls for use on
-heterogeneous architecture platforms (Roadrunner or GPU machines).
+    The classes in this component provide access to DaCS and CUDA calls for use
+    on heterogeneous architecture platforms (Roadrunner or GPU machines).
 
 diagnostics:
 CPP macros that are activated at compile time that can provide additional
 diagnostic verbosity during calculations.
 
 ds++: {Basic services}
-Smart pointers, Array containers, Assertion and Design-by-Contract, etc.
+    Array containers, assertion and Design-by-Contract, Ffle system information,
+    path manipulation, unit test system, etc.
 
 fit: {Least squares fit}
 
@@ -121,8 +148,7 @@ provide service functions that are commonly used.
 rng: {A random number generator component}
 The primary set of functions provided by this component were derived from
 Random123 (https://www.deshawresearch.com/downloads/download_random123.cgi)
-random number library.  A few additional random number generators are also
-provided.
+    random number library.  A few additional random number generators are also provided.
 
 roots: Root solvers
 
@@ -135,8 +161,8 @@ timestep: An object-oriented class that encapsulates a time step controller.
 traits: A traits class used by viz.
 
 units:
-Provides units standardization for Draco. Contains Units class for representing
-arbitrary systems and converting quantities to SI units.
+    Provides units standardization for Draco. Contains Units class for
+    representing arbitrary systems and converting quantities to SI units.
 
 viz:
 Generates Ensight files for data vizualization.

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -143,8 +143,10 @@ macro(dbsSetupCxx)
 
   # C++11 support:
   set( CMAKE_CXX_STANDARD 11 )
+  set( CXX_STANDARD_REQUIRED ON )
 
   # Do not enable extensions (e.g.: --std=gnu++11)
+  # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
   set( CMAKE_CXX_EXTENSIONS OFF )
   set( CMAKE_C_EXTENSIONS   OFF )
 
@@ -201,44 +203,39 @@ macro(dbsSetupCxx)
     message( FATAL_ERROR "Build system does not support CXX=${my_cxx_compiler}" )
   endif()
 
-  # To the greatest extent possible, installed versions of packages
-  # should record the configuration options that were used when they
-  # were built.  For preprocessor macros, this is usually
-  # accomplished via #define directives in config.h files.  A
-  # package's installed config.h file serves as both a record of
-  # configuration options and a central location for macro
-  # definitions that control features in the package.  Defining
-  # macros via the -D command-line option to the preprocessor leaves
-  # no record of configuration choices (except in a build log, which
-  # may not be preserved with the installation).
+  # To the greatest extent possible, installed versions of packages should
+  # record the configuration options that were used when they were built.  For
+  # preprocessor macros, this is usually accomplished via #define directives in
+  # config.h files.  A package's installed config.h file serves as both a record
+  # of configuration options and a central location for macro definitions that
+  # control features in the package.  Defining macros via the -D command-line
+  # option to the preprocessor leaves no record of configuration choices (except
+  # in a build log, which may not be preserved with the installation).
   #
-  # Unfortunately, there are cases where a particular macro must be
-  # defined before some particular system header file is included, or
-  # before any system header files are included.  In these
-  # situations, using the config.h mechanism introduces sensitivity
-  # to the order of header files, which can lead to brittleness;
-  # defining project-wide language- or system-feature macros via -D,
-  # using CMake's add_definitions command, is an acceptable
+  # Unfortunately, there are cases where a particular macro must be defined
+  # before some particular system header file is included, or before any system
+  # header files are included.  In these situations, using the config.h
+  # mechanism introduces sensitivity to the order of header files, which can
+  # lead to brittleness; defining project-wide language- or system-feature
+  # macros via -D, using CMake's add_definitions command, is an acceptable
   # alternative.  Such definitions appear below.
 
-  # Enable the definition of UINT64_C in stdint.h (required by
-  # Random123).
+  # Enable the definition of UINT64_C in stdint.h (required by Random123).
   add_definitions(-D__STDC_CONSTANT_MACROS)
   set( CMAKE_REQUIRED_DEFINITIONS
     "${CMAKE_REQUIRED_DEFINITIONS} -D__STDC_CONSTANT_MACROS" )
 
-  # Define _POSIX_C_SOURCE=200112 and _XOPEN_SOURCE=600, to enable
-  # definitions conforming to POSIX.1-2001, POSIX.2, XPG4, SUSv2,
-  # SUSv3, and C99.  See the feature_test_macros(7) man page for more
-  # information.
+  # Define _POSIX_C_SOURCE=200112 and _XOPEN_SOURCE=600, to enable definitions
+  # conforming to POSIX.1-2001, POSIX.2, XPG4, SUSv2, SUSv3, and C99.  See the
+  # feature_test_macros(7) man page for more information.
   add_definitions(-D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600)
   set( CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_POSIX_C_SOURCE=200112" )
   set( CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_XOPEN_SOURCE=600")
   if ( APPLE )
-    # Defining the above requires adding POSIX extensions,
-    # otherwise, include ordering still goes wrong on Darwin,
-    # (i.e., putting fstream before iostream causes problems)
-    # see https://code.google.com/p/wmii/issues/detail?id=89
+    # Defining the above requires adding POSIX extensions, otherwise, include
+    # ordering still goes wrong on Darwin, (i.e., putting fstream before
+    # iostream causes problems) see
+    # https://code.google.com/p/wmii/issues/detail?id=89
     add_definitions(-D_DARWIN_C_SOURCE)
     set( CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_DARWIN_C_SOURCE ")
   endif()

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -1,4 +1,4 @@
-2#!/bin/bash
+#!/bin/bash
 ##-*- Mode: bash -*-
 ##---------------------------------------------------------------------------##
 ## File  : environment/bashrc/.bashrc
@@ -9,6 +9,9 @@
 ##
 ##  Bash configuration file upon bash shell startup
 ##---------------------------------------------------------------------------##
+
+#uncomment to debug this script.
+#export verbose=true
 
 ## Instructions (customization)
 ##
@@ -99,14 +102,19 @@ case ${-} in
 
 *) # Not an interactive shell (e.g. A PBS shell?)
    export INTERACTIVE=false
-   # return
    ;;
 esac
-#export verbose=true
 
 ##---------------------------------------------------------------------------##
 ## ENVIRONMENTS - once per login
 ##---------------------------------------------------------------------------##
+
+# Bash functions are not inherited by subshells.
+if [[ ${INTERACTIVE} ]]; then
+  # Common bash functions and alias definitions
+  source ${DRACO_ENV_DIR}/bin/bash_functions.sh
+  source ${DRACO_ENV_DIR}/../regression/scripts/common.sh
+fi
 
 if test ${DRACO_BASHRC_DONE:-no} = no && test ${INTERACTIVE} = true; then
 
@@ -118,10 +126,6 @@ if test ${DRACO_BASHRC_DONE:-no} = no && test ${INTERACTIVE} = true; then
   if test -z "$DRACO_ENV_DIR"; then
     export DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment
   fi
-
-  # Common bash functions and alias definitions
-  source ${DRACO_ENV_DIR}/bin/bash_functions.sh
-  source ${DRACO_SRC_DIR}/regression/scripts/common.sh
 
   # Clean up the default path to remove duplicates
   tmpifs=$IFS

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -73,7 +73,7 @@ parmetis-4.0.3-intel-17.0.1 superlu-dist-4.3-intel-17.0.1"
       fi
     fi
     module use /ccs/codes/radtran/vendors/Modules
-  export dracomodules="gcc openmpi emacs/24.4 totalview cmake grace \
+  export dracomodules="gcc openmpi emacs/24.4 totalview cmake \
 lapack random123 eospac dracoscripts git svn dia graphviz doxygen \
 metis parmetis superlu-dist trilinos ndi csk"
     ;;
@@ -83,26 +83,6 @@ esac
 add_to_path ${DRACO_SRC_DIR}/environment/latex TEXINPUTS
 add_to_path ${DRACO_SRC_DIR}/environment/bibtex BSTINPUTS
 add_to_path ${DRACO_SRC_DIR}/environment/bibfiles BIBINPUTS
-# extradirs=". ${DRACO_SRC_DIR}/environment/latex"
-# for mydir in ${extradirs}; do
-#   if test -z "`echo $TEXINPUTS | grep $mydir`" && test -d $mydir; then
-#     export TEXINPUTS=$mydir:$TEXINPUTS
-#   fi
-# done
-# extradirs=". ${DRACO_SRC_DIR}/environment/bibtex"
-# for mydir in ${extradirs}; do
-#   if test -z "`echo $BSTINPUTS | grep $mydir`" && test -d $mydir; then
-#     export BSTINPUTS=$mydir:$BSTINPUTS
-#   fi
-# done
-# extradirs=". ${DRACO_SRC_DIR}/environment/bibfiles"
-# for mydir in ${extradirs}; do
-#   if test -z "`echo $BIBINPUTS | grep $mydir`" && test -d $mydir; then
-#     export BIBINPUTS=$mydir:$BIBINPUTS
-#   fi
-# done
-# unset extradirs
-
 
 ##---------------------------------------------------------------------------##
 ## end of .bashrc_linux64

--- a/regression/alist.sh
+++ b/regression/alist.sh
@@ -28,61 +28,80 @@ function math ()
     bc -l <<< "scale=10;$calc"
 }
 
-#------------------------------------------------------------------------------#
-# List of contributors
-author_list_file=`mktemp`
-git shortlog -s | cut -c8- &> $author_list_file
+#--------------------------------------------------------------------------------
+# Generate basic statistics
+# Exclude some files (especially binary and gold files).
+
+# Generate a temporary file
+author_loc=`mktemp`
+
+# all files
+tmp=`git ls-files`
+
+# exclude data files
+unset projectfiles
+for file in $tmp; do
+  case $file in
+    *bench | *css | *dia | *eps | *fig | *ipcress | *jpg | *logfile )
+      # drop these files from the count.
+      ;;
+    *mesh | *output.in | *png | *ps | *xs4 )
+      # drop these files from the count.
+      ;;
+    *) projectfiles="$projectfiles $file" ;;
+  esac
+done
+
+echo " "
+echo "Collecting data.  This may take a few minutes..."
+echo " "
+echo $projectfiles | xargs -n1 git blame -w | perl -n -e '/^.*?\((.*?)\s+[\d]{4}/; print $1,"\n"' | sort -f | uniq -c | sort -rn > $author_loc
+
+#--------------------------------------------------------------------------------
+# Use pretty names and then de-duplicate.
 
 # Put the user list into an array (some entries may have spaces).
-IFS=$'\r\n' GLOBIGNORE='*' command eval 'user_list=($(cat $author_list_file))'
+IFS=$'\r\n' GLOBIGNORE='*' command eval 'entries=($(cat $author_loc))'
 
-#------------------------------------------------------------------------------#
-# http://stackoverflow.com/questions/1265040/how-to-count-total-lines-changed-by-a-specific-author-in-a-git-repository
+if [[ -f $author_loc ]]; then rm $author_loc; fi
 
-# Ingore some files used in Jayenne:
-# ignorespec=":(exclude)*/output.in" ":(exclude)*/*.bench"
+for entry in "${entries[@]}"; do
 
-# count loc for each author and report.
-author_loc=`mktemp`
-for name in "${user_list[@]}"; do
+  current_loc=`echo $entry | sed -e 's/[ ].*//'`
+  current_author=`echo $entry | sed -e 's/[^ ]* //'`
 
-  if [[ $name == "regress" ]]; then
-    continue
-  fi
+  if [[ $current_loc == "" ]]; then current_loc=0; fi
 
-  # sort by net lines added (lines added - lines removed)
-  numlines=`git log --author="$name" --pretty=tformat: --numstat -- . ":(exclude)clubimc" ":(exclude)wedgehog" ":(exclude)milagro" ":(exclude)*/output.in" ":(exclude)*/*.bench" | awk '{ add += $1; subs += $2; loc += $1 - $2; sum += $1 + $2 } END { printf "%s:\n", loc}'`
-
-  merge_name=$name
-  case $name in
-    along | Alex*  ) merge_name="Alex Long" ;;
-    clevelam) merge_name="Matt Cleveland" ;;
-    gaber) merge_name="Gabe Rockefeller" ;;
-    jdd) merge_name="Jeff Densmore" ;;
-    jhchang | Jae* ) merge_name="Jae Chang" ;;
-    keadyk | Kendra* ) merge_name="Kendra P. Keady" ;;
-    kellyt | kgt | 107638 | Kelly*) merge_name="Kelly Thompson" ;;
-    kgbudge) merge_name="Kent G. Budge" ;;
-    kwang) merge_name="Katherine Wang" ;;
-    lowrie) merge_name="Rob Lowrie" ;;
-    lpritch) merge_name="Lori Pritchett-Sheats" ;;
-    maxrosa) merge_name="Massimiliano Rosa" ;;
-    ntmyers) merge_name="Nick Meyers" ;;
-    pahrens) merge_name="Peter Ahrens" ;;
-    talbotp) merge_name="Paul Talbot" ;;
-    tmonster) merge_name="Todd Urbatsch" ;;
-    warsa) merge_name="James Warsa" ;;
-    wollaber) merge_name="Allan Wollaber" ;;
-    wollaege) merge_name="Ryan Thomas Wollaeger" ;;
+  case $current_author in
+    along | Alex*  ) current_author="Alex Long" ;;
+    clevelam | *Cleveland) current_author="Matt Cleveland" ;;
+    gaber) current_author="Gabe Rockefeller" ;;
+    hkpark) current_author="HyeongKae Park" ;;
+    jdd) current_author="Jeff Densmore" ;;
+    jhchang | Jae* ) current_author="Jae Chang" ;;
+    keadyk | Kendra* ) current_author="Kendra P. Keady" ;;
+    kellyt | kgt | 107638 | Kelly*) current_author="Kelly Thompson" ;;
+    kgbudge) current_author="Kent G. Budge" ;;
+    kwang) current_author="Katherine Wang" ;;
+    lowrie | *Lowrie) current_author="Rob Lowrie" ;;
+    lpritch) current_author="Lori Pritchett-Sheats" ;;
+    maxrosa) current_author="Massimiliano Rosa" ;;
+    ntmyers) current_author="Nick Meyers" ;;
+    pahrens) current_author="Peter Ahrens" ;;
+    talbotp) current_author="Paul Talbot" ;;
+    tmonster) current_author="Todd Urbatsch" ;;
+    warsa) current_author="James Warsa" ;;
+    wollaber) current_author="Allan Wollaber" ;;
+    wollaege) current_author="Ryan Thomas Wollaeger" ;;
   esac
 
-  #echo "$numlines$merge_name"
-  echo "$merge_name:$numlines" | sed -e 's/:$//'
+  echo "$current_author:$current_loc"
 
 done | sort -rn > $author_loc
 
 # cat $author_loc
 
+#--------------------------------------------------------------------------------
 # Merge data
 
 prev_author="none"
@@ -95,7 +114,7 @@ for entry in "${entries[@]}"; do
 
   current_author=`echo $entry | sed -e 's/:.*//'`
   current_loc=`echo $entry | sed -e 's/.*://'`
-  if [[ $current_loc == "" ]]; then current_loc=0; fi
+
   if [[ $current_author == $prev_author ]]; then
     prev_loc=`math "$prev_loc + $current_loc"`
   else
@@ -120,43 +139,6 @@ rm $author_loc $author_list_file
 # while read line; do
 #   echo $line | sed -e 's/\([0-9]*\):/current_developers[\1]=/'
 # done < $author_loc
-
-#------------------------------------------------------------------------------#
-# Old svn based script modified for git
-# # Build a list of files to inspect.
-# files=`find . -name '*.hh' -o -name '*.cc' -o -name '*.txt' \
-#          -o -name '*.cmake' -o -name '*.in' -o -name '*.h'`
-
-# # generate full annotations for these files.
-# author_per_loc=`mktemp`
-# for file in $files; do
-#   echo "annotate $file"
-#   git annotate --line-porcelain $file |  grep '^author ' | sed -e 's/author //' >> $author_per_loc
-# done
-
-# # generate a list of users identified by 'git annotate'
-# #user_list=`cat $author_per_loc | awk '{print $3}' | sort -u`
-# author_list=`mktemp`
-# cat $author_per_loc | sort -u | grep -v Not > $author_list
-
-# # Put the user list into an array (some entries may have spaces).
-# IFS=$'\r\n' GLOBIGNORE='*' command eval 'user_list=($(cat $author_list))'
-
-# # count loc for each author and report.
-# author_loc=`mktemp`
-# for name in "${user_list[@]}"; do
-#   if ! test "$name" == "kgt" && ! test "$name" == "Kelly (KT) Thompson" && \
-#      ! test "$name" == 107638; then
-#     numlines=`grep -c "$name" $author_per_loc`
-#     echo "$numlines:$name"
-#   fi
-# done | sort -rn > $author_loc
-
-# while read line; do
-#   echo $line | sed -e 's/\([0-9]*\):/current_developers[\1]=/'
-# done < $author_loc
-
-
 
 #------------------------------------------------------------------------------#
 # end alist.sh

--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -10,7 +10,12 @@
 00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /scratch/regress/logs/push_repositories_xf.log
 
 # Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
-*/15 * * * * /scratch/regress/draco/regression/sync_repository.sh
+*/20 * * * * /scratch/regress/draco/regression/sync_repository.sh
+
+# Run the metrics report on the first monday of each month.
+00 08 1-7 * * [ "$(date '+%a')" == "Mon" ] && /scratch/regress/draco/regression/metric_report.sh -e kgt@lanl.gov -p draco
+01 08 1-7 * * [ "$(date '+%a')" == "Mon" ] && /scratch/regress/draco/regression/metric_report.sh -e kgt@lanl.gov -p jayenne
+03 08 1-7 * * [ "$(date '+%a')" == "Mon" ] && /scratch/regress/draco/regression/metric_report.sh -e kgt@lanl.gov -p capsaicin
 
 #------------------------------------------------------------------------------#
 # Regressions with system default compiler (gcc-4.8.5)
@@ -21,34 +26,23 @@
 # -p projects:
 # -e extra args:
 #    coverage        - build bullseyecoverage data and send it to cdash
-#    bounds-checking - turn on bounds checking in the STL
 #    clang
-#    gcc530
 #    gcc610
 #------------------------------------------------------------------------------#
-05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p "draco jayenne capsaicin" &> /scratch/regress/logs/ccscs-Release-master.log
 
-00 01 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e coverage &> /scratch/regress/logs/ccscs-Debug-coverage-master.log
+05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p "draco jayenne capsaicin"
 
-00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e bounds_checking &> /scratch/regress/logs/ccscs-Debug-master-bounds_checking.log
+00 01 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e coverage
 
-30 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind &> /scratch/regress/logs/ccscs-Debug-master-valgrind.log
-
-#------------------------------------------------------------------------------#
-# Clang-3.8.0, gcc-5.3.0, gcc-6.1.0
-#------------------------------------------------------------------------------#
-
-00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang &> /scratch/regress/logs/ccscs-Debug-clang-master.log
-
-00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc530 &> /scratch/regress/logs/ccscs-Debug-gcc530-master.log
-
-00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610 &> /scratch/regress/logs/ccscs-Debug-gcc610-master.log
+30 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind
 
 #------------------------------------------------------------------------------#
-# Additional special regressions
+# Clang-3.8.0, gcc-6.1.0
 #------------------------------------------------------------------------------#
 
-00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco capsaicin" -e belosmods &> /scratch/regress/logs/ccscs-Debug-belosmods.log
+00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang
+
+00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs-job-launch.sh
+++ b/regression/ccscs-job-launch.sh
@@ -3,7 +3,7 @@
 ## File  : regression/ccscs-job-launch.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -74,8 +74,13 @@ echo "CCSCS Regression job launcher for ${subproj} - ${build_type} flavor."
 echo "==========================================================================="
 echo " "
 echo "Environment:"
-echo "   subproj        = ${subproj}"
+if [[ ${featurebranch} ]]; then
+  echo "   featurebranch  = ${featurebranch}"
+fi
+echo "   build_autodoc  = ${build_autodoc}"
 echo "   build_type     = ${build_type}"
+echo "   dashboard_type = ${dashboard_type}"
+echo "   epdash         = $epdash"
 if [[ ! ${extra_params} ]]; then
   echo "   extra_params   = none"
 else
@@ -84,11 +89,16 @@ fi
 if [[ ${featurebranch} ]]; then
   echo "   featurebranch  = ${featurebranch}"
 fi
-echo "   regdir         = ${regdir}"
-echo "   rscriptdir     = ${rscriptdir}"
 echo "   logdir         = ${logdir}"
-echo "   dashboard_type = ${dashboard_type}"
-echo "   build_autodoc  = ${build_autodoc}"
+echo "   logfile        = ${logfile}"
+echo "   machine_name_long = $machine_name_long"
+echo "   prdash         = $prdash"
+echo "   projects       = \"${projects}\""
+echo "   regdir         = ${regdir}"
+echo "   regress_mode   = ${regress_mode}"
+echo "   rscriptdir     = ${rscriptdir}"
+echo "   scratchdir     = ${scratchdir}"
+echo "   subproj        = ${subproj}"
 echo " "
 echo "   ${subproj}: dep_jobids = ${dep_jobids}"
 echo " "

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -3,7 +3,7 @@
 ## File  : regression/ccscs-regression.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
@@ -36,8 +36,6 @@ fi
 
 # Environment setup
 # ----------------------------------------
-umask 0002
-ulimit -a
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -79,6 +77,9 @@ echo "CCSCS Regression: ${ctestparts} from ${machine}."
 echo "                  ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
 echo "==========================================================================="
 
+umask 0002
+ulimit -a
+
 # Modules
 # ----------------------------------------
 result=`fn_exists module`
@@ -92,7 +93,7 @@ fi
 source /usr/share/Modules/init/bash
 run "module purge"
 run "module load user_contrib"
-run "module load gcc openmpi cmake git"
+run "module load gcc openmpi cmake git ccache"
 run "module load dracoscripts subversion random123 valgrind"
 run "module load eospac lapack gsl" # grace
 run "module load superlu-dist/4.3"
@@ -112,6 +113,8 @@ case $extra_params in
       exit 1
     fi
     build_type=Coverage
+    # Ccache breaks bullseye coverage!!!
+    run "module unload ccache"
     run "module load bullseyecoverage"
     CXX=`which g++`
     CC=`which gcc`
@@ -137,7 +140,7 @@ case $extra_params in
   clang)
     run "module purge"
     run "module load user_contrib"
-    run "module load llvm openmpi cmake"
+    run "module load llvm openmpi cmake git"
     run "module load dracoscripts subversion random123"
     run "module load lapack gsl" # eospac
     run "module load superlu-dist/4.3"
@@ -151,7 +154,7 @@ case $extra_params in
   gcc530)
     run "module purge"
     run "module load user_contrib"
-    run "module load gcc/5.3.0 openmpi cmake"
+    run "module load gcc/5.3.0 openmpi cmake git"
     run "module load dracoscripts subversion random123"
     run "module load lapack gsl eospac"
     run "module load superlu-dist"
@@ -160,7 +163,7 @@ case $extra_params in
     ;;
   gcc610)
     run "module purge"
-    run "module load user_contrib"
+    run "module load user_contrib git"
     run "module load gcc/6.1.0 openmpi cmake"
     run "module load dracoscripts subversion random123"
     run "module load lapack gsl eospac"
@@ -185,14 +188,8 @@ case $extra_params in
 esac
 run "module list"
 
-# Use a unique regression folder for each github branch
-if test ${USE_GITHUB:-0} == 1; then
-  comp=$comp-$featurebranch
-fi
-
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if test "$USER" == "kellyt"; then
-  run "module load git"
   MYHOSTNAME="`uname -n`"
   keychain=keychain-2.8.2
   $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
@@ -299,10 +296,10 @@ if test "${build_type}" = "Coverage"; then
   # Coverage build imply Debug builds.
   build_type="Debug,${build_type}"
   run "export COVFILE=${work_dir}/build/CMake.cov"
-  if test -f ${COVFILE}; then
+  if [[ -f ${COVFILE} ]]; then
     run "rm -f ${COVFILE}"
-    cov01 --on
   fi
+  run "cov01 --on"
 fi
 if test "${build_type}" = "DynamicAnalysis"; then
   # DynamicAnalysis builds imply Debug builds.

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -82,10 +82,7 @@ ulimit -a
 
 # Modules
 # ----------------------------------------
-result=`fn_exists module`
-if test $result -eq 0; then
-  echo 'module function is defined'
-else
+if [[ `fn_exists module` == 0 ]]; then
   echo 'module function does not exist. defining a local function ...'
   source /usr/share/Modules/init/bash
 fi

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -201,6 +201,7 @@ case $project in
         rflag="-r"
       fi
       run "$rscriptdir/checkpr.sh ${rflag} -p draco"
+      echo " "
 
       # Reset the modified date on the file used to determine when draco was
       # last built.

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -108,7 +108,7 @@ if [[ $regress_mode == "on" ]]; then
   elif [[ -d /usr/projects/jayenne/regress/logs ]]; then
     # HPC machines, Darwin
     logdir=/usr/projects/jayenne/regress/logs
-fi
+  fi
 fi
 export regress_mode logdir
 
@@ -187,7 +187,7 @@ case $project in
     midnight=$(date -d "$today 0" +%s)
     draco_tag_file=$logdir/last-draco-develop-${machine_name_short}.log
     if [[ -f $draco_tag_file ]]; then
-    draco_last_built=$(date +%s -r $draco_tag_file)
+      draco_last_built=$(date +%s -r $draco_tag_file)
     else
       draco_last_built=0
     fi

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -41,15 +41,10 @@ fi
 # defaults
 export target=`uname -n | sed -e 's/[.].*//g'`
 scratchdir=`selectscratchdir`
-export regdir="$scratchdir/$USER"
-export logdir="$regdir/logs"
+export logdir="$scratchdir/$USER/logs"
 pr=develop
 project=draco
 regress_mode="off"
-
-if ! [[ -d $logdir ]]; then
-  run "mkdir -p $logdir"
-fi
 
 ##---------------------------------------------------------------------------##
 ## Support functions
@@ -79,7 +74,7 @@ print_use()
 ## Command options
 ##---------------------------------------------------------------------------##
 
-while getopts ":f:hp:" opt; do
+while getopts ":f:hp:r" opt; do
 case $opt in
 f)  pr=$OPTARG ;;
 h)  print_use; exit 0 ;;
@@ -106,8 +101,20 @@ if [[ $regress_mode == "on" ]]; then
     echo ""; echo "FATAL ERROR: invalid use of -r"
     print_use; exit 1
   fi
+  # special defaults for regress_mode
+  if [[ -d /scratch/regress/logs ]]; then
+    # ccs-net machines
+    logdir=/scratch/regress/logs
+  elif [[ -d /usr/projects/jayenne/regress/logs ]]; then
+    # HPC machines, Darwin
+    logdir=/usr/projects/jayenne/regress/logs
 fi
-export regress_mode
+fi
+export regress_mode logdir
+
+if ! [[ -d $logdir ]]; then
+  run "mkdir -p $logdir" || die "Cannot create logdir = $logdir"
+fi
 
 #------------------------------------------------------------------------------#
 # Banner
@@ -118,7 +125,6 @@ echo "   project      = $project"
 echo "   pr           = $pr"
 echo "   target       = $target"
 echo "   scratchdir   = $scratchdir"
-echo "   regdir       = $regdir"
 echo "   logdir       = $logdir"
 echo "   rscriptdir   = $rscriptdir"
 echo "   regress_mode = $regress_mode"
@@ -185,14 +191,16 @@ case $project in
     else
       draco_last_built=0
     fi
-    # build_draco=0
     if [[ $midnight -gt $draco_last_built ]]; then
       echo " "
       echo "Found a Jayenne or Capsaicin PR, but we need to build draco-develop first..."
       echo " "
 
       # Call this script recursively to build the draco 'develop' branch.
-      $rscriptdir/checkpr.sh draco
+      if [[ ${regress_mode} == "on" ]]; then
+        rflag="-r"
+      fi
+      run "$rscriptdir/checkpr.sh ${rflag} -p draco"
 
       # Reset the modified date on the file used to determine when draco was
       # last built.

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -366,7 +366,7 @@ macro( parse_args )
 
   # Bounds Checking
   if( ${CTEST_SCRIPT_ARG} MATCHES bounds_checking )
-    if( "${compiler_short_name}" STREQUAL "gcc-4.8.5" )
+    if( "${compiler_short_name}" MATCHES "gcc-4.8.5" )
       set( BOUNDS_CHECKING "GCC_ENABLE_GLIBCXX_DEBUG:BOOL=ON" )
     else()
       message(FATAL_ERROR "I don't know how to turn on bounds checking for compiler = ${compiler_short_name}" )

--- a/regression/ml-job-launch.sh
+++ b/regression/ml-job-launch.sh
@@ -64,7 +64,7 @@ fi
 available_queues=`sacctmgr -np list assoc user=$LOGNAME | grep access | sed -e 's/.*|\(.*access.*\)|.*/\1/'  | sed -e 's/|.*//'`
 # snow: available_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\)|.*/\1/' | sed -e 's/|.*//'`
 case $available_queues in
-*access*) access_queue="-A access" ;;
+  *access*) access_queue="-A access --qos=access" ;;
   *dev*) access_queue="--qos=dev" ;;
 esac
 

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -78,10 +78,7 @@ run "ulimit -a"
 
 # Modules
 # ----------------------------------------
-result=`fn_exists module`
-if test $result -eq 0; then
-    echo 'module function is defined'
-else
+if [[ `fn_exists module` == 0 ]]; then
     echo 'module function does not exist. defining a local function ...'
     run "source /usr/share/Modules/init/bash"
 fi
@@ -262,7 +259,7 @@ if [[ ${setup_dirs} ]]; then
 
    # See notes above where scratch_dir is set concerning why these are soft
    # links.
-   if test "${regress_mode}" = "on"; then
+   if [[ "${regress_mode}" == "on" ]]; then
      if ! [[ -d ${scratch_dir}/build ]]; then
        run "mkdir -p ${scratch_dir}/build"
      fi

--- a/regression/pull_repositories_xf.sh
+++ b/regression/pull_repositories_xf.sh
@@ -3,18 +3,19 @@
 ## File  : regression/pull_repositories_xf.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
-# Pull SVN repositories from Yellow
+# Pull Git repositories from Yellow
 #
 # Assumptions:
-# 1. Mercury requests must have the id tag set
-#    tag             tar file              directory name
-#    ---             ---------             ---------------
-#    jayenne.repo    jayenne.hotcopy.tar   jayenne.hotcopy
-#    capsaicin.repo  capsaicin.hotcopy.tar capsaicin.hotcopy
-# 2. SVN repositories live at /usr/projects/draco/svn
+# 1. Tar'ed repository names
+#    repo             tar file
+#    ---             ---------
+#    draco           draco.git.tar
+#    jayenne         jayenne.git.tar
+#    capsaicin       capsaicin.git.tar
+# 2. Git repositories live at /usr/projects/draco/git
 # 3. Kerberos keytab files is at $HOME/.ssh/xfkeytab and is signed
 #    with principal transfer/${USER}push@lanl.gov
 #------------------------------------------------------------------------------#
@@ -26,23 +27,17 @@
 
 # dry_run=1
 
-# Helpful functions:
-die () { echo "FATAL ERROR: $1"; exit 1;}
-
-run () {
-   echo $1
-   if ! test $dry_run; then
-      eval $1
+# load some common bash functions
+export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ -f $rscriptdir/scripts/common.sh ]]; then
+  source $rscriptdir/scripts/common.sh
+else
+  echo " "
+  echo "FATAL ERROR: Unable to locate Draco's bash functions: "
+  echo "   looking for .../regression/scripts/common.sh"
+  echo "   searched rscriptdir = $rscriptdir"
+  exit 1
    fi
-}
-
-fn_exists()
-{
-    type $1 2>/dev/null | grep -q 'is a function'
-    res=$?
-    echo $res
-    return $res
-}
 
 #------------------------------------------------------------------------------#
 function xfpull()
@@ -169,10 +164,7 @@ run "chmod -R g+rwX,o-rwX git"
 
 # Modules
 # ----------------------------------------
-result=`fn_exists module`
-if test $result -eq 0; then
-    echo 'module function is defined'
-else
-    echo 'module function does not exist. defining a local function ...'
-    run "source /usr/share/Modules/init/bash"
-fi
+#if [[ `fn_exists module` == 0 ]]; then
+#    echo 'module function does not exist. defining a local function ...'
+#    run "source /usr/share/Modules/init/bash"
+#fi

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -39,7 +39,7 @@ export host=`uname -n | sed -e 's/[.].*//g'`
 ccs_extra_params="belosmods bounds_checking clang coverage fulldiagnostics gcc530 gcc610 nr perfbench valgrind "
 darwin_extra_params="cuda fulldiagnostics nr perfbench valgrind"
 ml_extra_params="fulldiagnostics nr perfbench pgi valgrind"
-sn_extra_params="fulldiagnostics gcc newtools nr perfbench"
+sn_extra_params="fulldiagnostics gcc610 newtools nr perfbench"
 tt_extra_params="fulldiagnostics knl nr perfbench"
 all_extra_params=`echo $ml_extra_params $tt_extra_params $sn_extra_params $ccs_extra_params $darwin_extra_params | xargs -n1 | sort -u | xargs`
 
@@ -191,7 +191,7 @@ case ${host} in
 ml-*)
     export machine_name_long=Moonlight
     export machine_name_short=ml
-    if [[ `fn_exists module` ]]; then
+    if [[ `fn_exists module` == 0 ]]; then
       source /usr/share/Modules/init/bash
     fi
     module purge
@@ -209,7 +209,7 @@ ml-*)
 sn-*)
     export machine_name_long=Snow
     export machine_name_short=sn
-    if [[ `fn_exists module` ]]; then
+    if [[ `fn_exists module` == 0 ]]; then
       source /usr/share/lmod/lmod/init/bash
     fi
     module purge
@@ -217,7 +217,7 @@ sn-*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        fulldiagnostics | gcc | newtools | nr | perfbench ) # known, continue
+        fulldiagnostics | gcc610 | newtools | nr | perfbench ) # known, continue
         ;;
         *) echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
            print_use; exit 1 ;;

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -39,7 +39,7 @@ export host=`uname -n | sed -e 's/[.].*//g'`
 ccs_extra_params="belosmods bounds_checking clang coverage fulldiagnostics gcc530 gcc610 nr perfbench valgrind "
 darwin_extra_params="cuda fulldiagnostics nr perfbench valgrind"
 ml_extra_params="fulldiagnostics nr perfbench pgi valgrind"
-sn_extra_params="fulldiagnostics gcc610 newtools nr perfbench"
+sn_extra_params="fulldiagnostics gcc newtools nr perfbench"
 tt_extra_params="fulldiagnostics knl nr perfbench"
 all_extra_params=`echo $ml_extra_params $tt_extra_params $sn_extra_params $ccs_extra_params $darwin_extra_params | xargs -n1 | sort -u | xargs`
 
@@ -131,11 +131,7 @@ else
   # default: use 'develop' for all git branches.
   featurebranches=''
   for p in $projects; do
-#    if [[ ${featurebranches} ]]; then
-#      featurebranches+="-develop "
-#    else
-      featurebranches+="develop "
-#    fi
+    featurebranches+="develop "
   done
 fi
 
@@ -195,8 +191,7 @@ case ${host} in
 ml-*)
     export machine_name_long=Moonlight
     export machine_name_short=ml
-    result=`fn_exists module`
-    if ! test $result -eq 0; then
+    if [[ `fn_exists module` ]]; then
       source /usr/share/Modules/init/bash
     fi
     module purge
@@ -214,8 +209,7 @@ ml-*)
 sn-*)
     export machine_name_long=Snow
     export machine_name_short=sn
-    result=`fn_exists module`
-    if ! test $result -eq 0; then
+    if [[ `fn_exists module` ]]; then
       source /usr/share/lmod/lmod/init/bash
     fi
     module purge
@@ -223,7 +217,7 @@ sn-*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        fulldiagnostics | gcc610 | newtools | nr | perfbench ) # known, continue
+        fulldiagnostics | gcc | newtools | nr | perfbench ) # known, continue
         ;;
         *) echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
            print_use; exit 1 ;;
@@ -312,16 +306,21 @@ echo " "
 echo "Host: $host"
 echo " "
 echo "Environment:"
+echo "   build_autodoc  = $build_autodoc"
 echo "   build_type     = ${build_type}"
-echo "   extra_params   = ${extra_params}"
-echo "   regdir         = ${regdir}"
 echo "   dashboard_type = ${dashboard_type}"
-echo "   rscriptdir     = ${rscriptdir}"
+echo "   epdash         = $epdash"
+echo "   extra_params   = ${extra_params}"
+echo "   featurebranches= \"${featurebranches}\""
 echo "   logdir         = ${logdir}"
-echo "   scratchdir     = ${scratchdir}"
+echo "   logfile        = ${logfile}"
+echo "   machine_name_long = $machine_name_long"
+echo "   prdash         = $prdash"
 echo "   projects       = \"${projects}\""
+echo "   regdir         = ${regdir}"
 echo "   regress_mode   = ${regress_mode}"
-echo "   featurebranches  = ${featurebranches}"
+echo "   rscriptdir     = ${rscriptdir}"
+echo "   scratchdir     = ${scratchdir}"
 echo " "
 echo "Descriptions:"
 echo "   rscriptdir -  the location of the draco regression scripts."
@@ -349,13 +348,13 @@ ifb=0
 # do any real work until both draco and clubimc have completed.
 
 # More sanity checks
-if ! test -x ${rscriptdir}/${machine_name_short}-job-launch.sh; then
+if ! [[ -x ${rscriptdir}/${machine_name_short}-job-launch.sh ]]; then
    echo "FATAL ERROR: I cannot find ${rscriptdir}/${machine_name_short}-job-launch.sh."
    exit 1
 fi
 
 export subproj=draco
-if test `echo $projects | grep -c $subproj` -gt 0; then
+if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
   cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
   cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-joblaunch.log"
@@ -367,7 +366,7 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
 fi
 
 export subproj=jayenne
-if test `echo $projects | grep -c $subproj` -gt 0; then
+if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
   # Run the *-job-launch.sh script (special for each platform).
   cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
@@ -384,7 +383,7 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
 fi
 
 export subproj=capsaicin
-if test `echo $projects | grep -c $subproj` -gt 0; then
+if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
   cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
   # Wait for draco regressions to finish

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -38,7 +38,10 @@ function die () { echo " "; echo "FATAL ERROR: $1"; exit 1;}
 function run () { echo "==> $1"; if test ${dry_run:-no} = "no"; then eval $1; fi }
 
 # Return 0 if provided name is a bash function.
-fn_exists() { type $1 2>/dev/null | grep -c 'is a function' }
+function fn_exists ()
+{
+  type $1 2>/dev/null | grep -c 'is a function'
+}
 
 #----------------------------------------------------------------------#
 # The script starts here
@@ -398,7 +401,6 @@ function install_versions
   fi
   # source_dir="$source_prefix/source/$package"
   build_dir="$build_prefix/$version/${package:0:1}"
-
 
   # Purge any existing files before running cmake to configure the build directory.
   if test $config_step == 1; then

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -4,7 +4,7 @@
 ## File  : environment/bin/bash_functions.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 ##
@@ -30,13 +30,14 @@
 
 ##---------------------------------------------------------------------------##
 
+# Print an error message and exit.
+# e.g.: cd $dir || die "can't change dir to $dir".
 function die () { echo " "; echo "FATAL ERROR: $1"; exit 1;}
 
-function run () {
-  echo "==> $1"
-  if test ${dry_run:-no} = "no"; then eval $1; fi
-}
+# Echo a command and then run it.
+function run () { echo "==> $1"; if test ${dry_run:-no} = "no"; then eval $1; fi }
 
+# Return 0 if provided name is a bash function.
 fn_exists()
 {
     type $1 2>/dev/null | grep -q 'is a function'
@@ -44,6 +45,7 @@ fn_exists()
     echo $res
     return $res
 }
+
 #----------------------------------------------------------------------#
 # The script starts here
 #----------------------------------------------------------------------#
@@ -53,10 +55,10 @@ function establish_permissions
   # Permissions - new files should be marked u+rwx,g+rwx,o+rx
   # Group is set to $1 or draco
   umask 0002
-  if test `groups | grep -c othello` = 1; then
+  if [[ `groups | grep -c othello` = 1 ]]; then
     install_group="othello"
     install_permissions="g+rwX,o-rwX"
-  elif test `groups | grep -c dacodes` = 1; then
+  elif [[ `groups | grep -c dacodes` = 1 ]]; then
     install_group="dacodes"
     install_permissions="g+rwX,o-rwX"
   else
@@ -71,16 +73,15 @@ function establish_permissions
 function machineName
 {
   sysName=${sysName="unknown"}
-  if test -f /usr/projects/hpcsoft/utilities/bin/sys_name; then
+  if [[ -f /usr/projects/hpcsoft/utilities/bin/sys_name ]]; then
     sysName=`/usr/projects/hpcsoft/utilities/bin/sys_name`
-  elif test -d /projects/darwin; then
+  elif [[ -d /projects/darwin ]]; then
     sysName=darwin
   elif test -d /usr/gapps/jayenne; then
     sysName=sq
   fi
-  if test "$sysName" = "unknown"; then
-    echo "Unable to determine machine name, please edit scripts/common.sh."
-    exit 1
+  if [[ "$sysName" == "unknown" ]]; then
+    die "Unable to determine machine name, please edit scripts/common.sh."
   fi
   echo $sysName
 }
@@ -89,42 +90,43 @@ function machineName
 function osName
 {
   osName=${osName="unknown"}
-  if test -f /usr/projects/hpcsoft/utilities/bin/sys_os; then
+  if [[ -f /usr/projects/hpcsoft/utilities/bin/sys_os ]]; then
     osName=`/usr/projects/hpcsoft/utilities/bin/sys_os`
-  elif test -d /projects/darwin; then
+  elif [[ -d /projects/darwin ]]; then
     osName=darwin
   elif test -d /usr/gapps/jayenne; then
     osName=`uname -p`
   fi
-  if test "$osName" = "unknown"; then
-    echo "Unable to determine system OS, please edit scripts/common.sh."
-    exit 1
+  if [[ "$osName" == "unknown" ]]; then
+    die "Unable to determine system OS, please edit scripts/common.sh."
   fi
   echo $osName
 }
 
+#------------------------------------------------------------------------------#
+# Generates a string of the form <platform>-<mpi+ver>-<compiler+ver>
 function flavor
 {
   platform=`machineName`
   os=`osName`
   case $os in
     toss*)
-      if test -z $LMPI; then
-        mpiflavor="unknown"
-      else
+      if [[ $LMPI ]]; then
         mpiflavor=$LMPI-$LMPIVER
-      fi
-      if test -z $LCOMPILER; then
-        compilerflavor="unknown"
       else
+        mpiflavor="unknown"
+      fi
+      if [[ $LCOMPILER ]]; then
         compilerflavor=$LCOMPILER-$LCOMPILERVER
+      else
+        compilerflavor="unknown"
       fi
       ;;
     cle*)
-      if test -z $CRAY_MPICH2_VER; then
-        mpiflavor="unknown"
-      else
+      if [[ $CRAY_MPICH2_VER ]]; then
         mpiflavor=mpt-$CRAY_MPICH2_VER
+      else
+        mpiflavor="unknown"
       fi
       # Try to determine the loaded compiler
       loadedmodules=`echo $LOADEDMODULES`
@@ -147,25 +149,25 @@ function flavor
       # pick the first compiler in the list
       compilerflavor=`echo $compilermodules | sed -e 's/ *//'`
       # append target if KNL
-      if test `echo $CRAY_CPU_TARGET | grep -c knl` == 1; then
+      if [[ `echo $CRAY_CPU_TARGET | grep -c knl` == 1 ]]; then
         compilerflavor+='-knl'
       fi
       ;;
     darwin*)
-      if test -z $MPIARCH; then
-        mpiflavor="unknown"
-      else
-        if test -z $MPI_ROOT; then
-          LMPIVER=''
-        else
+      if [[ $MPIARCH ]]; then
+        if [[ $MPI_ROOT ]]; then
           LMPIVER=`echo $MPI_ROOT | sed -r 's%.*/([0-9]+)[.]([0-9]+)[.]([0-9]+).*%\1.\2.\3%'`
+        else
+          LMPIVER=''
         fi
         mpiflavor=$MPIARCH-$LMPIVER
-      fi
-      if test -z $LCOMPILER; then
-        compilerflavor="unknown"
       else
+        mpiflavor="unknown"
+      fi
+      if [[ $LCOMPILER ]]; then
         compilerflavor=$LCOMPILER-$LCOMPILERVER
+      else
+        compilerflavor="unknown"
       fi
       ;;
     ppc64)
@@ -189,11 +191,25 @@ function flavor
           compiler_flavor=unknown-unknown ;;
       esac
       ;;
+    *)
+      # CCS-NET machines or generic Linux?
+      if [[ $MPI_NAME ]]; then
+        mpiflavor=$MPI_NAME-$MPI_VERSION
+      else
+        mpiflavor="unknown"
+      fi
+      if [[ $LCOMPILER ]]; then
+        compilerflavor=$LCOMPILER-$LCOMPILERVER
+      else
+        compilerflavor="unknown"
+      fi
+      ;;
   esac
   echo $platform-$mpiflavor-$compilerflavor
 }
 
 #------------------------------------------------------------------------------#
+# returns a path to a directory
 function selectscratchdir
 {
   # if df is too old this command won't work correctly, use an alternate form.
@@ -215,13 +231,13 @@ function selectscratchdir
     fi
     # if this location is good, return the path.
     mkdir -p $item/$USER &> /dev/null
-    if test -x $item/$USER; then
+    if [[ -x $item/$USER ]]; then
       echo "$item"
       return
     fi
     # might need another directory level 'yellow'
     mkdir -p $item/yellow/$USER &> /dev/null
-    if test -x $item/yellow/$USER; then
+    if [[ -x $item/yellow/$USER ]]; then
       echo "$item/yellow"
       return
     fi
@@ -247,6 +263,7 @@ function lookupppn()
       fi
       ;;
     fi* | ic* | sn* ) ppn=36 ;;
+    *) ppn=`cat /proc/cpuinfo | grep -c processor` ;;
   esac
   echo $ppn
 }
@@ -254,15 +271,16 @@ function lookupppn()
 function npes_build
 {
   local np=1
-  if ! test "${PBS_NP:-notset}" = "notset"; then
+  if [[ ${PBS_NP} ]]; then
     np=${PBS_NP}
-  elif ! test "${SLURM_NPROCS:-notset}" = "notset"; then
+  elif [[ ${SLURM_NPROCS} ]]; then
     np=${SLURM_NPROCS}
-  elif ! test "${SLURM_CPUS_ON_NODE:-notset}" = "notset"; then
+  elif [[  ${SLURM_CPUS_ON_NODE} ]]; then
     np=${SLURM_CPUS_ON_NODE}
-  elif ! test "${SLURM_TASKS_PER_NODE:-notset}" = "notset"; then
-    np=${SLURM_CPUS_ON_NODE}
-  elif test -f /proc/cpuinfo; then
+  elif [[ ${SLURM_TASKS_PER_NODE} ]]; then
+    np=${SLURM_TSKS_PER_NODE}
+  elif [[ -f /proc/cpuinfo ]]; then
+    # lscpu=`lscpu | grep "CPU(s):" | head -n 1 | awk '{ print $2 }'`
     np=`cat /proc/cpuinfo | grep -c processor`
   fi
   echo $np
@@ -271,18 +289,19 @@ function npes_build
 function npes_test
 {
   local np=1
-  if ! test "${PBS_NP:-notset}" = "notset"; then
+  if [[ ${PBS_NP} ]]; then
     np=${PBS_NP}
-  elif ! test "${SLURM_NPROCS:-notset}" = "notset"; then
+  elif [[ ${SLURM_NPROCS} ]]; then
     np=${SLURM_NPROCS}
-  elif ! test "${SLURM_CPUS_ON_NODE:-notset}" = "notset"; then
+  elif [[  ${SLURM_CPUS_ON_NODE} ]]; then
     np=${SLURM_CPUS_ON_NODE}
-  elif ! test "${SLURM_TASKS_PER_NODE:-notset}" = "notset"; then
-    np=${SLURM_CPUS_ON_NODE}
-  elif test `uname -p` = "ppc"; then
+  elif [[ ${SLURM_TASKS_PER_NODE} ]]; then
+    np=${SLURM_TSKS_PER_NODE}
+  elif [[ `uname -p` == "ppc" ]]; then
     # sinfo --long --partition=pdebug (show limits)
     np=64
-  elif test -f /proc/cpuinfo; then
+  elif [[ -f /proc/cpuinfo ]]; then
+    # lscpu=`lscpu | grep "CPU(s):" | head -n 1 | awk '{ print $2 }'`
     np=`cat /proc/cpuinfo | grep -c processor`
   fi
   echo $np
@@ -418,7 +437,6 @@ function install_versions
   if ! test ${build_permissions:-notset} = "notset"; then
     run "chmod -R $build_permissions $build_dir"
   fi
-
 }
 
 ##----------------------------------------------------------------------------##
@@ -456,15 +474,6 @@ function publish_release()
       run "chgrp -R ${install_group} $source_prefix"
       run "chmod -R $install_permissions $source_prefix"
     fi
-
-    # dirs="$script_dir $source_prefix/source $source_prefix/logs"
-    # for dir in $dirs; do
-    #   if test -d $dir; then
-    #     run "chgrp -R draco $dir"
-    #     run "chmod $build_permissions $dir"
-    #   fi
-    # done
-
   fi
 }
 
@@ -504,7 +513,6 @@ function allow_file_to_age
     sleep 30s
   done
 }
-
 
 ##----------------------------------------------------------------------------##
 export die

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -38,13 +38,7 @@ function die () { echo " "; echo "FATAL ERROR: $1"; exit 1;}
 function run () { echo "==> $1"; if test ${dry_run:-no} = "no"; then eval $1; fi }
 
 # Return 0 if provided name is a bash function.
-fn_exists()
-{
-    type $1 2>/dev/null | grep -q 'is a function'
-    res=$?
-    echo $res
-    return $res
-}
+fn_exists() { type $1 2>/dev/null | grep -c 'is a function' }
 
 #----------------------------------------------------------------------#
 # The script starts here

--- a/regression/scripts/common_slurm.sh
+++ b/regression/scripts/common_slurm.sh
@@ -13,10 +13,7 @@ function run () {
 
 fn_exists()
 {
-    type $1 2>/dev/null | grep -q 'is a function'
-    res=$?
-    echo $res
-    return $res
+  type $1 2>/dev/null | grep -c 'is a function'
 }
 
 #----------------------------------------------------------------------#

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -99,6 +99,7 @@ if [[ "${comp}" == "icpc" ]]; then
   comp="intel"
 fi
 
+# Extra parameters
 case $extra_params in
 "")
     # no-op
@@ -277,7 +278,7 @@ ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctes
 if [[ ${regress_mode} == "on" ]]; then
   echo " "
   run "chgrp -R draco ${work_dir}"
-  run "chmod -R g+rwX,o-rwX ${work_dir}"
+  run "chmod -R g+rX,o-rwX ${work_dir}"
 fi
 
 echo "All done."

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -78,10 +78,7 @@ run "ulimit -a"
 
 # Modules
 # ----------------------------------------
-result=`fn_exists module`
-if test $result -eq 0; then
-    echo 'module function is defined'
-else
+if [[ `fn_exists module` == 0 ]]; then
     echo 'module function does not exist. defining a local function ...'
     run "source /usr/share/Modules/init/bash"
 fi

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -64,7 +64,7 @@ source $scriptdir/scripts/common.sh
 #
 
 # If not found, look for it in /usr/share/Modules (ML)
-if [[ `fn_exists module` ]]; then
+if [[ `fn_exists module` == 0 ]]; then
   case ${target} in
     tt-fey*) module_init_dir=/opt/cray/pe/modules/3.2.10.4/init/bash ;;
     # snow (Toss3)
@@ -77,7 +77,7 @@ if [[ `fn_exists module` ]]; then
   else
     echo "ERROR: The module command was not found. No modules will be loaded."
   fi
-  if [[ `fn_exists module` ]]; then
+  if [[ `fn_exists module` == 0 ]]; then
     echo "ERROR: the module command was not found (even after sourcing $module_init_dir"
     exit 1
   fi

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -56,13 +56,15 @@ fi
 exec > $logfile
 exec 2>&1
 
+# import some bash functions
+source $scriptdir/scripts/common.sh
+
 #
 # MODULES
 #
-# Determine if the module command is available
-modcmd=`declare -f module`
+
 # If not found, look for it in /usr/share/Modules (ML)
-if [[ ! ${modcmd} ]]; then
+if [[ `fn_exists module` ]]; then
   case ${target} in
     tt-fey*) module_init_dir=/opt/cray/pe/modules/3.2.10.4/init/bash ;;
     # snow (Toss3)
@@ -70,13 +72,12 @@ if [[ ! ${modcmd} ]]; then
     # ccs-net, darwin, ml
     *)       module_init_dir=/usr/share/Modules/init/bash ;;
   esac
-  if test -f ${module_init_dir}; then
+  if [[ -f ${module_init_dir} ]]; then
     source ${module_init_dir}
   else
     echo "ERROR: The module command was not found. No modules will be loaded."
   fi
-  modcmd=`declare -f module`
-  if [[ ! ${modcmd} ]]; then
+  if [[ `fn_exists module` ]]; then
     echo "ERROR: the module command was not found (even after sourcing $module_init_dir"
     exit 1
   fi
@@ -85,9 +86,6 @@ fi
 #
 # Environment
 #
-
-# import some bash functions
-source $scriptdir/scripts/common.sh
 
 # Ensure that the permissions are correct
 run "umask 0002"
@@ -136,18 +134,20 @@ case ${target} in
     ;;
 esac
 
-if ! test -d $regdir; then
+if ! [[ -d $regdir ]]; then
   mkdir -p $regdir
 fi
 
 # Credentials via Keychain (SSH)
 # http://www.cyberciti.biz/faq/ssh-passwordless-login-with-keychain-for-scripts
-MYHOSTNAME="`uname -n`"
-$VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
-if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
-  run "source $HOME/.keychain/$MYHOSTNAME-sh"
-else
-  echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+if [[ -f $HOME/.ssh/cmake_rsa ]]; then
+  MYHOSTNAME="`uname -n`"
+  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+  if [[ -f $HOME/.keychain/$MYHOSTNAME-sh ]]; then
+    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+  else
+    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+  fi
 fi
 
 # ---------------------------------------------------------------------------- #
@@ -168,15 +168,15 @@ fi
 # datase (GUI repository, wiki/ticket references to commits).
 # ---------------------------------------------------------------------------- #
 
-# DRACO: For all machines running this scirpt, copy all of the git repositories
+# DRACO: For all machines running this script, copy all of the git repositories
 # to the local file system.
 
 # Store some output into a local file to simplify parsing.
-TMPFILE_DRACO=$(mktemp /var/tmp/draco_repo_sync.XXXXXXXXXX) || { echo "Failed to create temporary file"; exit 1; }
+TMPFILE_DRACO=$(mktemp /var/tmp/draco_repo_sync.XXXXXXXXXX) || die "Failed to create temporary file"
 
 echo " "
 echo "Copy Draco git repository to the local file system..."
-if test -d $gitroot/Draco.git; then
+if [[ -d $gitroot/Draco.git ]]; then
   run "cd $gitroot/Draco.git"
   run "git fetch origin +refs/heads/*:refs/heads/*"
   run "git fetch origin +refs/pull/*:refs/pull/*" &> $TMPFILE_DRACO
@@ -192,33 +192,15 @@ else
   run "git fetch origin +refs/heads/*:refs/heads/*"
   run "git fetch origin +refs/pull/*:refs/pull/*"
 fi
-case ${target} in
-  ccscs7*)
-    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-    # PRs since this seems to confuse Redmine.
-    echo " "
-    echo "(Redmine) Copy Draco git repository to the local file system..."
-    if test -d $gitroot/Draco-redmine.git; then
-      run "cd $gitroot/Draco-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-    else
-      run "mkdir -p $gitroot"
-      run "cd $gitroot"
-      run "git clone --mirror git@github.com:lanl/Draco.git Draco-redmine.git"
-      run "chmod -R g+rwX Draco-redmine.git"
-    fi
-    ;;
-esac
 
 # JAYENNE: For all machines running this scirpt, copy all of the git repositories
 # to the local file system.
 
 # Store some output into a local file to simplify parsing.
-TMPFILE_JAYENNE=$(mktemp /var/tmp/jayenne_repo_sync.XXXXXXXXXX) || { echo "Failed to create temporary file"; exit 1; }
+TMPFILE_JAYENNE=$(mktemp /var/tmp/jayenne_repo_sync.XXXXXXXXXX) || die "Failed to create temporary file"
 echo " "
 echo "Copy Jayenne git repository to the local file system..."
-if test -d $gitroot/jayenne.git; then
+if [[ -d $gitroot/jayenne.git ]]; then
   run "cd $gitroot/jayenne.git"
   run "git fetch origin +refs/heads/*:refs/heads/*"
   run "git fetch origin +refs/merge-requests/*:refs/merge-requests/*" &> $TMPFILE_JAYENNE
@@ -233,35 +215,15 @@ else
   run "git fetch origin +refs/heads/*:refs/heads/*"
   run "git fetch origin +refs/merge-requests/*:refs/merge-requests/*"
 fi
-case ${target} in
-  ccscs7*)
-    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-    # PRs since this seems to confuse Redmine.
-    echo " "
-    echo "(Redmine) Copy Jayenne git repository to the local file system..."
-    if test -d $gitroot/jayenne-redmine.git; then
-      run "cd $gitroot/jayenne-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-      run "chgrp -R draco $gitroot/capsaicin.git"
-      run "chmod -R g+rwX $gitroot/capsaicin.git"
-    else
-      run "mkdir -p $gitroot"
-      run "cd $gitroot"
-      run "git clone --mirror git@gitlab.lanl.gov:jayenne/jayenne.git jayenne-redmine.git"
-      run "chmod -R g+rwX jayenne-redmine.git"
-    fi
-    ;;
-esac
 
 # CAPSAICIN: For all machines running this scirpt, copy all of the git repositories
 # to the local file system.
 
 # Store some output into a local file to simplify parsing.
-TMPFILE_CAPSAICIN=$(mktemp /var/tmp/capsaicin_repo_sync.XXXXXXXXXX) || { echo "Failed to create temporary file"; exit 1; }
+TMPFILE_CAPSAICIN=$(mktemp /var/tmp/capsaicin_repo_sync.XXXXXXXXXX) || die "Failed to create temporary file"
 echo " "
 echo "Copy Capsaicin git repository to the local file system..."
-if test -d $gitroot/capsaicin.git; then
+if [[ -d $gitroot/capsaicin.git ]]; then
   run "cd $gitroot/capsaicin.git"
   run "git fetch origin +refs/heads/*:refs/heads/*"
   run "git fetch origin +refs/merge-requests/*:refs/merge-requests/*" &> $TMPFILE_CAPSAICIN
@@ -274,24 +236,71 @@ else
   run "git fetch origin +refs/heads/*:refs/heads/*"
   run "git fetch origin +refs/merge-requests/*:refs/merge-requests/*"
 fi
-case ${target} in
-  ccscs7*)
-    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-    # PRs since this seems to confuse Redmine.
-    echo " "
-    echo "(Redmine) Copy Capsaicin git repository to the local file system..."
-    if test -d $gitroot/capsaicin-redmine.git; then
-      run "cd $gitroot/capsaicin-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-    else
-      run "mkdir -p $gitroot"
-      run "cd $gitroot"
-      run "git clone --mirror git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin-redmine.git"
-      run "chmod -R g+rwX capsaicin-redmine.git"
-    fi
-    ;;
-esac
+
+#------------------------------------------------------------------------------#
+# Mirror git repository for redmine integration
+#------------------------------------------------------------------------------#
+
+# Broken? - KT needs to research this.
+
+# case ${target} in
+#   ccscs7*)
+#     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+#     # PRs since this seems to confuse Redmine.
+#     echo " "
+#     echo "(Redmine) Copy Draco git repository to the local file system..."
+#     if test -d $gitroot/Draco-redmine.git; then
+#       run "cd $gitroot/Draco-redmine.git"
+#       run "git fetch origin +refs/heads/*:refs/heads/*"
+#       run "git reset --soft"
+#     else
+#       run "mkdir -p $gitroot"
+#       run "cd $gitroot"
+#       run "git clone --mirror git@github.com:lanl/Draco.git Draco-redmine.git"
+#       run "chmod -R g+rwX Draco-redmine.git"
+#     fi
+#     ;;
+# esac
+
+# case ${target} in
+#   ccscs7*)
+#     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+#     # PRs since this seems to confuse Redmine.
+#     echo " "
+#     echo "(Redmine) Copy Jayenne git repository to the local file system..."
+#     if test -d $gitroot/jayenne-redmine.git; then
+#       run "cd $gitroot/jayenne-redmine.git"
+#       run "git fetch origin +refs/heads/*:refs/heads/*"
+#       run "git reset --soft"
+#       run "chgrp -R draco $gitroot/capsaicin.git"
+#       run "chmod -R g+rwX $gitroot/capsaicin.git"
+#     else
+#       run "mkdir -p $gitroot"
+#       run "cd $gitroot"
+#       run "git clone --mirror git@gitlab.lanl.gov:jayenne/jayenne.git jayenne-redmine.git"
+#       run "chmod -R g+rwX jayenne-redmine.git"
+#     fi
+#     ;;
+# esac
+
+# case ${target} in
+#   ccscs7*)
+#     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+#     # PRs since this seems to confuse Redmine.
+#     echo " "
+#     echo "(Redmine) Copy Capsaicin git repository to the local file system..."
+#     if test -d $gitroot/capsaicin-redmine.git; then
+#       run "cd $gitroot/capsaicin-redmine.git"
+#       run "git fetch origin +refs/heads/*:refs/heads/*"
+#       run "git reset --soft"
+#     else
+#       run "mkdir -p $gitroot"
+#       run "cd $gitroot"
+#       run "git clone --mirror git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin-redmine.git"
+#       run "chmod -R g+rwX capsaicin-redmine.git"
+#     fi
+#     ;;
+# esac
 
 #------------------------------------------------------------------------------#
 # Continuous Integration Hooks:
@@ -314,20 +323,24 @@ echo "Starting CI regressions (if any)"
 echo "========================================================================"
 echo " "
 # Draco CI ------------------------------------------------------------
-draco_prs=`cat $TMPFILE_DRACO | grep -e 'refs/pull/[0-9]*/merge.*forced update' -e 'refs/pull/[0-9]*/head$' | sed -e 's/  (forced update)//' | awk '{print $NF}'`
 
-for prline in $draco_prs; do
-  $scriptdir/checkpr.sh -p draco -f $pr
+draco_prs=`cat $TMPFILE_DRACO | grep -e 'refs/pull/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
+for pr in $draco_prs; do
+  run "$scriptdir/checkpr.sh -r -p draco -f $pr"
 done
 
 # Jayenne CI ----------------------------------------------------------
-for prline in $jayenne_prs; do
-  $scriptdir/checkpr.sh -p jayenne -f $pr
+
+jayenne_prs=`cat $TMPFILE_JAYENNE | grep -e 'refs/merge-requests/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
+for pr in $jayenne_prs; do
+  run "$scriptdir/checkpr.sh -r -p jayenne -f $pr"
 done
 
 # Capsaicin CI ----------------------------------------------------------
-for prline in $capsaicin_prs; do
-  $scriptdir/checkpr.sh -p capsaicin -f $pr
+
+capsaicin_prs=`cat $TMPFILE_CAPSAICIN | grep -e 'refs/merge-requests/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
+for pr in $capsaicin_prs; do
+  run "$scriptdir/checkpr.sh -r -p capsaicin -f $pr"
 done
 
 # Wait for all subprocesses to finish before exiting this script

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -98,10 +98,7 @@ fi
 
 # Modules
 # ----------------------------------------
-result=`fn_exists module`
-if test $result -eq 0; then
-    echo 'module function is defined'
-else
+if [[ `fun_exists module` == 0 ]]; then
     echo 'module function does not exist. defining a local function ...'
     module ()
     {

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -37,7 +37,6 @@ fi
 # Environment setup
 # ----------------------------------------
 umask 0002
-run "ulimit -a"
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -55,31 +54,29 @@ export GIT_SSL_NO_VERIFY=true
 source $rscriptdir/scripts/common.sh
 
 machine=`uname -n`
-case $machine in
-tt-login[0-9]*)
+case $REGRESSION_PHASE in
+  cb) ctestparts="Configure,Build" ;;
+  t)
     ctestparts="Test"
 
     # Node type (aprun -n 1 lscpu)
-    partition=`aprun -q -n $PBS_NUM_NODES -N 1 grep -i "model name" /proc/cpuinfo | sort | uniq -c`
+    #partition=`aprun -q -n $PBS_NUM_NODES -N 1 grep -i "model name" /proc/cpuinfo | sort | uniq -c`
 
     # Force create of a new log file (don't append)
     echo "Purging ${logdir}/tt-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-t.log"
     echo "    " > ${logdir}/tt-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-t.log
     ;;
-tt-fey*)
-    if test "${REGRESSION_PHASE}" = "cb"; then
-       ctestparts="Configure,Build"
-    elif test "${REGRESSION_PHASE}" = "s"; then
-       ctestparts="Submit"
-       # Submitting to CDash requires this
-       unset http_proxy
-       unset https_proxy
-       unset HTTP_PROXY
-       unset HTTPS_PROXY
-    else
-       echo "Fatal Error, REGRESSION_PHASE = \"${REGRESSION_PHASE}\" does not match \"cb\" or \"s\"."
-       exit 1
-    fi
+  s)
+    ctestparts="Submit"
+    # Submitting to CDash requires this
+    unset http_proxy
+    unset https_proxy
+    unset HTTP_PROXY
+    unset HTTPS_PROXY
+    ;;
+  *)
+    echo "Fatal Error, REGRESSION_PHASE = \"${REGRESSION_PHASE}\" does not match \"cb\" or \"s\"."
+    exit 1
     ;;
 esac
 
@@ -89,12 +86,13 @@ echo "==========================================================================
 echo "Trinitite regression: ${ctestparts} from ${machine}."
 echo "                      ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
 echo "==========================================================================="
-if [[ ${partition} ]]; then
+if [[ ${SLURM_JOB_PARTITION} ]]; then
   echo " "
   echo "Allocation configuration:"
-  echo $partition
+  echo $SLURM_JOB_PARTITION
   echo " "
 fi
+run "ulimit -a"
 
 # Modules
 # ----------------------------------------
@@ -121,7 +119,7 @@ run "module load intel/17.0.1"
 #run "module swap cray-mpich cray-mpich/7.4.2"
 run "module unload cray-libsci gcc/6.1.0"
 run "module load craype-hugepages4M"
-run "module load cmake/3.6.2 numdiff git"
+run "module load cmake/3.7.1 numdiff git"
 run "module load gsl/2.1 random123 eospac/6.2.4 ndi"
 run "module load trilinos/12.8.1 ndi metis parmetis/4.0.3 superlu-dist/4.3"
 
@@ -132,7 +130,7 @@ export CRAYPE_LINK_TYPE=dynamic
 export OMP_NUM_THREADS=16
 comp=CC
 
-# Extra parameers
+# Extra parameters
 case $extra_params in
 knl)
     run "module swap craype-haswell craype-mic-knl"
@@ -280,7 +278,7 @@ ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctes
 if [[ ${regress_mode} == "on" ]]; then
   echo " "
   run "chgrp -R draco ${work_dir}"
-  run "chmod -R g+rwX,o-rwX ${work_dir}"
+  run "chmod -R g+rX,o-rwX ${work_dir}"
 fi
 
 echo "All done."

--- a/src/parser/Debug_Options.cc
+++ b/src/parser/Debug_Options.cc
@@ -4,8 +4,7 @@
  * \author Kent Grimmett Budge
  * \brief  Define Debug_Options parse functions.
  * \note   Copyright (C) 2014-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
 #include "Debug_Options.hh"
@@ -19,9 +18,10 @@ unsigned available = rtt_parser::DEBUG_END;
 std::map<std::string, unsigned> extended_debug_option;
 std::map<unsigned, std::string> extended_debug_back_option;
 
-bool is_bit(unsigned bit)
-// Is the bit actually a bit? That is, a power of 2?
-{
+#ifdef DBC
+
+//! Is the bit actually a bit? That is, a power of 2?
+bool is_bit(unsigned bit) {
   Require(bit > 0); // corner case won't work
 
   // Shift to first bit
@@ -31,18 +31,21 @@ bool is_bit(unsigned bit)
   // Erase that bit; see if the result is zero, as it must be for a power of 2.
   return (bit ^ 1U) == 0U;
 }
-}
+#endif
+
+} // end anonymous namespace
 
 namespace rtt_parser {
 using std::string;
 
-//---------------------------------------------------------------------------------------//
-/*! Get a debug specification.
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Get a debug specification.
  *
  * \param[in] option_name A string specifying a debug option keyword.
  *
- * \return The bitmask value assigned to the keyword, or
- * 0 if the keyword is not recognized.
+ * \return The bitmask value assigned to the keyword, or 0 if the keyword is not
+ *      recognized.
  */
 unsigned get_debug_option(string const &option_name) {
   if (option_name == "ALGORITHM") {
@@ -70,16 +73,16 @@ unsigned get_debug_option(string const &option_name) {
   }
 }
 
-//---------------------------------------------------------------------------------------//
-/*! Parse a debug specification.
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Parse a debug specification.
  *
- * \param[in,out] tokens Token stream from which to parse a debug specification. The specification
- * is a set of debug keywords, each optionally prefixed with a '!', and ends with the first
- * token that is not a recognized debug keyword.
- *
- * \param[in] parent Optional parent mask; defaults to zero. Allows a debug mask to be
- * based on a parent mask, with selected bits added or masked out.
- *
+ * \param[in,out] tokens Token stream from which to parse a debug
+ *      specification. The specification is a set of debug keywords, each
+ *      optionally prefixed with a '!', and ends with the first token that is
+ *      not a recognized debug keyword.
+ * \param[in] parent Optional parent mask; defaults to zero. Allows a debug mask
+ *      to be based on a parent mask, with selected bits added or masked out.
  * \return A debug options mask.
  */
 unsigned parse_debug_options(Token_Stream &tokens, unsigned const parent) {
@@ -111,11 +114,12 @@ unsigned parse_debug_options(Token_Stream &tokens, unsigned const parent) {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
-/*! Convert a debug mask to a string containing comma-delimited set of debug keywords.
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Convert a debug mask to a string containing comma-delimited set of
+ *      debug keywords.
  *
  * \param[in] debug_options Debug mask to be converted to a set of keywords.
- *
  * \return A string containing a comma-delimited set of debug options.
  */
 string debug_options_as_text(unsigned debug_options) {
@@ -158,12 +162,12 @@ string debug_options_as_text(unsigned debug_options) {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
-/*! Add a new debug option to the debug parser specific to an application. This version
-    assigns the next available bit.
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Add a new debug option to the debug parser specific to an
+ *      application. This version assigns the next available bit.
  *
  * \param[in] option_name Debug option keyword
- *
  * \return Bitflag value assigned to the new debug option.
  */
 unsigned add_debug_option(string const &option_name) {
@@ -178,7 +182,8 @@ unsigned add_debug_option(string const &option_name) {
     }
     if (available == 0) {
       throw std::range_error("maximum debug options exceeded");
-      // yeah, i know, if there are 4G debug options, someone has lost his mind. Still.
+      // yeah, i know, if there are 4G debug options, someone has lost his
+      // mind. Still.
     }
     extended_debug_option[option_name] = available;
     extended_debug_back_option[available] = option_name;
@@ -186,11 +191,12 @@ unsigned add_debug_option(string const &option_name) {
   }
 }
 
-//---------------------------------------------------------------------------------------//
-/*! Add a new debug option to the debug parser specific to an application. This version
- * requests a specific bit and throws an exception if has already been requested
- * elsewhere. This version will typically be called at the initial setup of an
- * application.
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Add a new debug option to the debug parser specific to an
+ *      application. This version requests a specific bit and throws an
+ *      exception if has already been requested elsewhere. This version will
+ *      typically be called at the initial setup of an application.
  *
  * \param[in] Debug option keyword
  *
@@ -215,7 +221,7 @@ void add_debug_option(string const &option_name, unsigned const bit) {
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 void flush_debug_options() {
   extended_debug_option.clear();
   extended_debug_back_option.clear();


### PR DESCRIPTION
+ Update README with basic instructions for building draco.
+ Require that C++11 features be availble.
+ Fix typo in .bashrc (extra '2' as the first character in the file).
+ Rework the alist.sh function to be more representative of the way we did things under subversion. This script provides a list of code authors based on who most recently touched each line of code.
+ No longer run nightly testing on ccscs7 for belosmods, gcc530 or bounds-checking.
+ Use the 'fn_exists' bash function in the scripts to simplify some logic.
+ Simplify some bash logic (especially if-tests).
+ Fix a bug in sync_repository.sh that prevented CI tests from starting for Jayenne and Capsaicin.
+ Modify Debug_Options.cc to prevent a build warning about an unused local-file-scope function.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (still broken)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
