### PR TITLE
Add prefix sums for unsigned longs

### DIFF
--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -475,7 +475,7 @@ DLL_PUBLIC_c4 std::string get_processor_name();
  * \param node_value Current node's value of variable to be prefix summed
  * \return Sum of value over nodes up to and including this node.
  */
-template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value);
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(const T node_value);
 
 } // end namespace rtt_c4
 

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -355,7 +355,7 @@ template <typename T> DLL_PUBLIC_c4 void global_max(T *x, int n) {
 
 //---------------------------------------------------------------------------//
 
-template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value) {
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(const T node_value) {
   T prefix_sum = 0;
   MPI_Scan(&node_value, &prefix_sum, 1, MPI_Traits<T>::element_type(), MPI_SUM,
            communicator);

--- a/src/c4/C4_MPI_blocking_pt.cc
+++ b/src/c4/C4_MPI_blocking_pt.cc
@@ -104,11 +104,12 @@ template DLL_PUBLIC_c4 int send_receive(double *sendbuf, int sendcount,
                                         int recvcount, int source, int sendtag,
                                         int recvtag);
 
-template DLL_PUBLIC_c4 int prefix_sum(int &node_value);
-template DLL_PUBLIC_c4 uint32_t prefix_sum(uint32_t &node_value);
-template DLL_PUBLIC_c4 long prefix_sum(long &node_value);
-template DLL_PUBLIC_c4 float prefix_sum(float &node_value);
-template DLL_PUBLIC_c4 double prefix_sum(double &node_value);
+template DLL_PUBLIC_c4 int prefix_sum(const int node_value);
+template DLL_PUBLIC_c4 uint32_t prefix_sum(const uint32_t node_value);
+template DLL_PUBLIC_c4 long prefix_sum(const long node_value);
+template DLL_PUBLIC_c4 uint64_t prefix_sum(const uint64_t node_value);
+template DLL_PUBLIC_c4 float prefix_sum(const float node_value);
+template DLL_PUBLIC_c4 double prefix_sum(const double node_value);
 
 } // end namespace rtt_c4
 

--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -194,8 +194,8 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
 void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
 
   // Calculate prefix sums on rank ID with MPI call and by hand and compare
-  // the output. As a reminder, the prefix sum on a node includes all previos
-  // node's value and the value of the current node
+  // the output. The prefix sum on a node includes all previous node's value
+  // and the value of the current node
 
   // test ints
   int xint = rtt_c4::node();
@@ -207,7 +207,7 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
       int_answer += i + 1;
   }
 
-  std::cout << "Prefix sum on this node: " << xint_prefix_sum;
+  std::cout << "int: Prefix sum on this node: " << xint_prefix_sum;
   std::cout << " Answer: " << int_answer << std::endl;
 
   if (xint_prefix_sum != int_answer)
@@ -225,7 +225,7 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
       uint_answer += i + 1;
   }
 
-  std::cout << "Prefix sum on this node: " << xuint_prefix_sum;
+  std::cout << "uint32_t: Prefix sum on this node: " << xuint_prefix_sum;
   std::cout << " Answer: " << uint_answer << std::endl;
 
   if (xuint_prefix_sum != uint_answer)
@@ -241,10 +241,28 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
       long_answer += i + 1000;
   }
 
-  std::cout << "Prefix sum on this node: " << xlong_prefix_sum;
+  std::cout << "long: Prefix sum on this node: " << xlong_prefix_sum;
   std::cout << " Answer: " << long_answer << std::endl;
 
   if (xlong_prefix_sum != long_answer)
+    ITFAILS;
+
+  // test unsigned longs (start at max of unsigned int)
+  uint64_t xulong = rtt_c4::node();
+  if (rtt_c4::node() == 0)
+    xulong = std::numeric_limits<uint32_t>::max();
+  uint64_t xulong_prefix_sum = prefix_sum(xulong);
+
+  uint64_t ulong_answer = std::numeric_limits<uint32_t>::max();
+  for (int i = 0; i < rtt_c4::nodes(); i++) {
+    if (i < rtt_c4::node())
+      ulong_answer += i + 1;
+  }
+
+  std::cout << "uint64_t: Prefix sum on this node: " << xulong_prefix_sum;
+  std::cout << " Answer: " << ulong_answer << std::endl;
+
+  if (xulong_prefix_sum != ulong_answer)
     ITFAILS;
 
   // test floats
@@ -257,7 +275,7 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
       float_answer += static_cast<float>(i) + 0.01;
   }
 
-  std::cout << "Prefix sum on this node: " << xfloat_prefix_sum;
+  std::cout << "float: Prefix sum on this node: " << xfloat_prefix_sum;
   std::cout << " Answer: " << float_answer << std::endl;
 
   if (!soft_equiv(xfloat_prefix_sum, float_answer))
@@ -274,7 +292,7 @@ void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
   }
 
   std::cout.precision(16);
-  std::cout << "Prefix sum on this node: " << xdbl_prefix_sum;
+  std::cout << "double: Prefix sum on this node: " << xdbl_prefix_sum;
   std::cout << " Answer: " << dbl_answer << std::endl;
 
   if (!soft_equiv(xdbl_prefix_sum, dbl_answer))


### PR DESCRIPTION
* I need unsigned longs for Jayenne and I forgot to add those in the last commit
    * The type signature needs to accept const variables and does not need to be a reference so I changed the signature
    * Added a test for unsigned long in tstReduction.cc
* Purpose of Pull Request
  * Fix Jayenne issue #892 (https://rtt.lanl.gov/redmine/issues/892)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (Snow on DST)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (broken after slurm transition)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
