### PR TITLE
Fix a bug in Draco's .bashrc.

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -111,6 +111,14 @@ esac
 
 # Bash functions are not inherited by subshells.
 if [[ ${INTERACTIVE} ]]; then
+
+  # Attempt to find DRACO
+  if ! [[ $DRACO_SRC_DIR ]]; then
+    _BINDIR=`dirname "$BASH_ARGV"`
+    export DRACO_SRC_DIR=`(cd $_BINDIR/../..;pwd)`
+    export DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment
+  fi
+
   # Common bash functions and alias definitions
   source ${DRACO_ENV_DIR}/bin/bash_functions.sh
   source ${DRACO_ENV_DIR}/../regression/scripts/common.sh
@@ -121,15 +129,6 @@ fi
 ##---------------------------------------------------------------------------##
 
 if test ${DRACO_BASHRC_DONE:-no} = no && test ${INTERACTIVE} = true; then
-
-  # Attempt to find DRACO
-  if test -z "$DRACO_SRC_DIR"; then
-    _BINDIR=`dirname "$BASH_ARGV"`
-    export DRACO_SRC_DIR=`(cd $_BINDIR/../..;pwd)`
-  fi
-  if test -z "$DRACO_ENV_DIR"; then
-    export DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment
-  fi
 
   # Clean up the default path to remove duplicates
   tmpifs=$IFS


### PR DESCRIPTION
+ Things work better if we set the environment variable `DRACO_ENV_DIR` before we try to use it.  Kodos to Jae for finding this bug.
+ [Ticket-913](Refs https://rtt.lanl.gov/redmine/issues/913)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
