### PR TITLE
Second update to provide support for slurm on Cray machines (trinitite).

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -330,7 +330,7 @@ macro( add_component_library )
   # Find target file name and location
   get_target_property( impname ${acl_TARGET} OUTPUT_NAME )
 
-  # the above command returns the location in the build tree.  We need to 
+  # the above command returns the location in the build tree.  We need to
   # convert this to the install location.
   if( ${DRACO_SHARED_LIBS} )
     set( imploc "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${impname}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
@@ -723,11 +723,8 @@ macro( add_scalar_tests test_sources )
   # On some platforms (Trinity), even scalar tests must be run underneath
   # MPIEXEC (aprun):
   separate_arguments(MPIEXEC_POSTFLAGS)
-  if( "${MPIEXEC}" MATCHES "aprun" )
-    set( RUN_CMD ${MPIEXEC} ${MPIEXEC_POSTFLAGS} -n 1)
-    set( APT_TARGET_FILE_PREFIX "./" )
-  elseif( "${MPIEXEC}" MATCHES "srun" )
-    set( RUN_CMD ${MPIEXEC} -n 1 )
+  if( "${MPIEXEC}" MATCHES "srun" )
+    set( RUN_CMD ${MPIEXEC} ${MPIEXEC_POSTFLAGS} -n 1 )
   else()
     unset( RUN_CMD )
   endif()

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -496,7 +496,7 @@ macro( setupCrayMPI )
   #           single node.
   # set( MPIEXEC_POSTFLAGS "-q -F shared -b -m 1400m" CACHE STRING
   #   "extra mpirun flags (list)." FORCE)
-   set( MPIEXEC_POSTFLAGS "-N 1 -c 1 --mem=1400m"
+   set( MPIEXEC_POSTFLAGS "--exclusive"
      CACHE STRING
      "extra mpirun flags (list)." FORCE)
     # Consider using 'aprun -n # -N # -S # -d # -T -cc depth ...'
@@ -511,7 +511,7 @@ macro( setupCrayMPI )
     #set( MPIEXEC_OMP_POSTFLAGS "-q -b -d $ENV{OMP_NUM_THREADS}"
     #  CACHE STRING "extra mpirun flags (list)." FORCE)
 
-    set( MPIEXEC_OMP_POSTFLAGS "-N 1 -c ${MPI_CORES_PER_CPU} --mem=1400m"
+    set( MPIEXEC_OMP_POSTFLAGS "-N 1 -c ${MPI_CORES_PER_CPU} --exclusive"
       CACHE STRING "extra mpirun flags (list)." FORCE)
   # Extra flags for OpenMP + MPI
 #   if( DEFINED ENV{OMP_NUM_THREADS} )

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -82,23 +82,21 @@ win32$ set work_dir=c:/full/path/to/work_dir
   endif( NOT work_dir )
   file( TO_CMAKE_PATH ${work_dir} work_dir )
 
-  # Set the sitename, but strip any domain information
-  site_name( sitename )
-  string( REGEX REPLACE "([A-z0-9]+).*" "\\1" sitename ${sitename} )
-  if( ${sitename} MATCHES "tt" )
-     set( sitename "Trinitite" )
-  elseif( ${sitename} MATCHES "tr" )
-     set( sitename "Trinity" )
-  elseif( ${sitename} MATCHES "ml[0-9]+" OR
-      ${sitename} MATCHES "ml-fey"       OR
-      ${sitename} STREQUAL "ml")
-    set( sitename "Moonlight" )
-  elseif( ${sitename} MATCHES "cn[0-9]+" OR ${sitename} MATCHES "darwin-fe")
-     set( sitename "Darwin" )
-  elseif( ${sitename} MATCHES "sn[0-9]+" OR
-      ${sitename} MATCHES "sn-fey" OR
-      ${sitename} STREQUAL "sn")
-     set( sitename "Snow" )
+  # Set the sitename, but strip any domain information. If we are an an HPC
+  # machine, attempt to associate the backend name with the same string that is
+  # used to identify the front end. If we are on a LANL HPC machine, attempt to
+  # use the sys_name tool for this purpose.
+  if( EXISTS /usr/projects/hpcsoft/utilities/bin/sys_name )
+    execute_process( COMMAND /usr/projects/hpcsoft/utilities/bin/sys_name
+      OUTPUT_VARIABLE sitename
+      OUTPUT_STRIP_TRAILING_WHITESPACE )
+  else()
+    site_name( sitename )
+    string( REGEX REPLACE "([A-z0-9]+).*" "\\1" sitename ${sitename} )
+  endif()
+
+  if( ${sitename} MATCHES "cn[0-9]+" OR ${sitename} MATCHES "darwin-fe")
+    set( sitename "Darwin" )
   endif()
   message( "sitename = ${sitename}")
   set( CTEST_SITE ${sitename} )

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -16,6 +16,11 @@
 #    $build_type - 'Debug', 'Release'
 #    $extra_params - '', 'intel13', 'pgi', 'coverage'
 
+# Under cron, a basic environment might not be loaded yet.
+if [[ `which sbatch 2>/dev/null | grep -c sbatch` == 0 ]]; then
+  source /etc/bash.bashrc.local
+fi
+
 # command line arguments
 args=( "$@" )
 nargs=${#args[@]}
@@ -36,24 +41,19 @@ done
 
 # sanity check
 if [[ ! ${regdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
-    exit 1
+  die "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
 fi
 if [[ ! ${rscriptdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
-    exit 1
+  die "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
 fi
 if [[ ! ${subproj} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
-    exit 1
+  die "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
 fi
 if [[ ! ${build_type} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
-    exit 1
+  die "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
 fi
 if [[ ! ${logdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
-    exit 1
+  die "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
 fi
 
 if test $subproj == draco || test $subproj == jayenne; then
@@ -127,7 +127,10 @@ logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra
 cmd="$MSUB -o ${logfile} -e ${logfile} ${partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
-jobid=`echo $jobid | sed '/^$/d'`
+# delete blank lines
+#jobid=`echo $jobid | sed '/^$/d'`
+# only keep the job number
+jobid=`echo $jobid | sed -e 's/.*[ ]//'`
 echo "jobid = ${jobid}"
 
 # Wait for testing to finish

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 ##---------------------------------------------------------------------------##
 ## File  : regression/tt-regress.msub
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
@@ -7,31 +7,40 @@
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
+# Under cron, a basic environment might not be loaded yet.
+if [[ `which srun 2>/dev/null | grep -c srun` == 0 ]]; then
+  source /etc/bash.bashrc.local
+fi
+
 #----------------------------------------------------------------------#
 # The script starts here
 #----------------------------------------------------------------------#
 
 # Sanity Check
 # ----------------------------------------
-if [[ ! ${subproj} ]]; then
-   echo "Fatal Error, subproj not found in environment."
-   exit 1
-fi
-if [[ ! ${regdir} ]]; then
-   echo "Fatal Error, regdir not found in environment."
-   exit 1
-fi
 if [[ ! ${rscriptdir} ]]; then
    echo "Fatal Error, rscriptdir not found in environment."
    exit 1
 fi
+
+# import some bash functions
+source $rscriptdir/scripts/common.sh
+
+
+if [[ ! ${subproj} ]]; then
+  die "Fatal Error, subproj not found in environment."
+fi
+if [[ ! ${regdir} ]]; then
+  die "Fatal Error, regdir not found in environment."
+fi
 if [[ ! ${build_type} ]]; then
-   echo "Fatal Error, build_type not found in environment."
-   exit 1
+  die "Fatal Error, build_type not found in environment."
 fi
 if [[ ! ${logdir} ]]; then
-   echo "Fatal Error, logdir not found in environment."
-   exit 1
+  die "Fatal Error, logdir not found in environment."
+fi
+if [[ `which srun 2>/dev/null | grep -c srun` == 0 ]]; then
+  die "Cannot find srun.  Possibly bad environment or machine issue."
 fi
 
 # Environment setup
@@ -49,9 +58,6 @@ export NO_PROXY=$no_proxy
 export VENDOR_DIR=/usr/projects/draco/vendors
 # gitlab.lanl.gov has an unkown certificate, disable checking
 export GIT_SSL_NO_VERIFY=true
-
-# import some bash functions
-source $rscriptdir/scripts/common.sh
 
 machine=`uname -n`
 case $REGRESSION_PHASE in
@@ -96,11 +102,11 @@ run "ulimit -a"
 
 # Modules
 # ----------------------------------------
-if [[ `fun_exists module` == 0 ]]; then
+if [[ `fn_exists module` == 0 ]]; then
     echo 'module function does not exist. defining a local function ...'
     module ()
     {
-        eval `/opt/cray/pe/modules/3.2.10.4/bin/modulecmd bash $*`
+      eval `/opt/cray/pe/modules/3.2.10.5/bin/modulecmd bash $*`
     }
 fi
 


### PR DESCRIPTION
+ Remove some code that was specific to aprun.
+ Update commands used when registering tests.  On Cray machines, we will now use: `${MPIEXEC} ${MPIEXEC_POSTFLAGS} -n <num_tasks>`, where
   `MPIEXEC = srun`, and 
    `MPIEXEC_POSTFLAGS` is set by setupMPI.cmake.
  We are still trying to establish the correct options list provided by `MPIEXEC_POSTFLAGS`. Currently, we use `--exclusive`, but we might want to consider `-N 1 -c 1 --mem=1400m`.
+ Add some additional setup and checks in the regression system for trinitite.  It seems that shell scripts started by cron aren't getting the default set of Cray modules unless extra work is done (source /etc/bash.bashrc.local)
+ For LANL HPC, use sys_name to fill the sitename string.
+ [Refs Redmine #903](https://rtt.lanl.gov/redmine/issues/903)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
