### PR TITLE
Cleanup to allow Draco to build cleanly with new tools.

### DIFF
--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -97,7 +97,7 @@ endforeach()
 #------------------------------------------------------------------------------#
 # EXAMPLES FROM LAPACK
 
-# SET(CTEST_CUSTOM_WARNING_EXCEPTION ${CTEST_CUSTOM_WARNING_EXCEPTION}
+# SET(CTEST_CUSTOM_WARNING_EXCEPTION ${CTEST_CUSTOM_WARNING_EXCEPTION})
 
 # Common warning when linking ATLAS built with GNU Fortran 4.1 and building with
 # GNU Fortran 4.4.  It can be safely ignored.

--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -1,70 +1,13 @@
 #-----------------------------*-cmake-*----------------------------------------#
 # file   CTestCustom.cmake
 # brief  Custom configuration for CTest/CDash.
-# note   Copyright (C) 2016 LANS, LLC
-#------------------------------------------------------------------------------#
-# $Id$
+# note   Copyright (C) 2016-2017 Los Alamos National Laboratory, LLC.
+#        All rights reserved
 #------------------------------------------------------------------------------#
 
 # This file must be found in the root build tree.
 # http://www.vtk.org/Wiki/CMake_Testing_With_CTest
 # https://www.rad.upenn.edu/sbia/software/doxygen/basis/trunk/html/CTestCustom_8cmake_source.html
-
-
-##---------------------------------------------------------------------------##
-## Warnings
-##---------------------------------------------------------------------------##
-
-# Extra matches for warnings:
-# set( CTEST_CUSTOM_WARNING_MATCH
-#   ${CTEST_CUSTOM_WARNING_MATCH}
-#   "{standard input}:[0-9][0-9]*: [Ww]arning: "
-#   "{standard input}:[0-9][0-9]*: WARNING: "
-#   )
-
-# specialization for machines
-# if( "@CMAKE_SYSTEM@" MATCHES "OSF" )
-#   set( CTEST_CUSTOM_WARNING_EXCEPTION
-#     ${CTEST_CUSTOM_WARNING_EXCEPTION}
-#     "XdmfDOM"
-#     "XdmfExpr"
-#     )
-# endif()
-
-# examples from lapack
-# SET(CTEST_CUSTOM_WARNING_EXCEPTION
-#   ${CTEST_CUSTOM_WARNING_EXCEPTION}
-
-#   # Common warning when linking ATLAS built with GNU Fortran 4.1 and building
-#   # with GNU Fortran 4.4.  It can be safely ignored.
-#   "libgfortran.*may conflict with libgfortran"
-
-#   # Harmless warning often seen on IRIX
-#   "WARNING 84 : .*libm.* is not used for resolving any symbol"
-
-#   # Warnings caused by sun compilers when building code to only run on your
-#   # native platform
-#   "xarch=native on this architecture implies -xarch=.*which generates code that does not run"
-
-#   # Harmless warnings from the Intel compiler on Windows
-#   "ipo: warning #11010: file format not recognized for .*\\.exe\\.embed\\.manifest\\.res"
-#   "LINK : warning LNK4224: /INCREMENTAL:YES is no longer supported;  ignored"
-
-#   # Warnings caused by string truncation in the test code.  The truncation is
-#   # intentional
-#   "Character string truncated to length 1 on assignment"
-# )
-
-
-# Exceptions
-# set( CTEST_CUSTOM_WARNING_EXCEPTION
-#   ${CTEST_CUSTOM_WARNING_EXCEPTION}
-#   "tcl8.4.5/[^/]+/../[^/]+/[^.]+.c[:\"]"
-#   "Utilities/vtkmpeg2/"
-#   "warning LNK44221blahblah"
-#   "myspecial/path/to/something/"
-#   "myvendorexception"
-#   )
 
 # specialization for machines
 if( APPLE )
@@ -74,9 +17,42 @@ if( APPLE )
       )
 endif()
 
+# Add extra options by specifying MEMORYCHECK_COMMAND_OPTIONS and
+# MEMORYCHECK_SUPPRESSIONS_FILE.
+set( MEMORYCHECK_SUPPRESSIONS_FILE
+   "${CTEST_SCRIPT_DIRECTORY}/valgrind_suppress.txt"
+   CACHE FILEPATH
+  "File that contains suppressions for the memory checker" )
+
+# Files for exclusion:
+set( CTEST_CUSTOM_MEMCHECK_IGNORE ${CTEST_CUSTOM_MEMCHECK_IGNORE} )
+
+# CTEST_CUSTOM_COVERAGE_EXCLUDE is a list of regular expressions. Any file name
+# that matches any of the regular expressions in the list is excluded from the
+# reported coverage data.
+set( CTEST_CUSTOM_COVERAGE_EXCLUDE
+  ${CTEST_CUSTOM_COVERAGE_EXCLUDE}
+
+  # don't report on actual unit tests
+  "/tests/"
+  "tests.cpp"
+  "tests/tst*.cpp"
+  "/src/pkg/tests/tstXercesConfig.cpp"
+  )
+
+# @brief Specify additional files which should be considered for coverage
+# report.
+#
+# Note that the expressions here are globbing expression as interpreted by
+# CMake's file(GLOB) command, not regular expressions.
+set( CTEST_EXTRA_COVERAGE_GLOB ${CTEST_EXTRA_COVERAGE_GLOB} )
+foreach( extension IN ITEMS cc hh )
+  list (APPEND CTEST_EXTRA_COVERAGE_GLOB
+    "${PROJECT_SOURCE_DIR}/src/*\\.${extension}" )
+endforeach()
 
 # specify maximum number of warnings to display
-#set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS "100" )
+# set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS "100" )
 
 ##---------------------------------------------------------------------------##
 ## Errors
@@ -99,64 +75,79 @@ endif()
 #set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS "100" )
 
 ##---------------------------------------------------------------------------##
+## Warnings
+##---------------------------------------------------------------------------##
+
+# Extra matches for warnings:
+# set( CTEST_CUSTOM_WARNING_MATCH
+#   ${CTEST_CUSTOM_WARNING_MATCH}
+#   "{standard input}:[0-9][0-9]*: [Ww]arning: "
+#   "{standard input}:[0-9][0-9]*: WARNING: "
+#   )
+
+# specialization for machines
+# if( "@CMAKE_SYSTEM@" MATCHES "OSF" )
+#   set( CTEST_CUSTOM_WARNING_EXCEPTION
+#     ${CTEST_CUSTOM_WARNING_EXCEPTION}
+#     "XdmfDOM"
+#     "XdmfExpr"
+#     )
+# endif()
+
+#------------------------------------------------------------------------------#
+# EXAMPLES FROM LAPACK
+
+# SET(CTEST_CUSTOM_WARNING_EXCEPTION ${CTEST_CUSTOM_WARNING_EXCEPTION}
+
+# Common warning when linking ATLAS built with GNU Fortran 4.1 and building with
+# GNU Fortran 4.4.  It can be safely ignored.
+#
+# "libgfortran.*may conflict with libgfortran"
+
+# Harmless warning often seen on IRIX
+#
+# "WARNING 84 : .*libm.* is not used for resolving any symbol"
+
+# Warnings caused by sun compilers when building code to only run on your native
+# platform
+#
+# "xarch=native on this architecture implies -xarch=.*which generates code that does not run"
+
+# Harmless warnings from the Intel compiler on Windows
+#   "ipo: warning #11010: file format not recognized for .*\\.exe\\.embed\\.manifest\\.res"
+#   "LINK : warning LNK4224: /INCREMENTAL:YES is no longer supported;  ignored"
+
+# Warnings caused by string truncation in the test code.  The truncation is
+# intentional
+#
+# "Character string truncated to length 1 on assignment"
+
+# Exceptions
+# set( CTEST_CUSTOM_WARNING_EXCEPTION
+#   ${CTEST_CUSTOM_WARNING_EXCEPTION}
+#   "tcl8.4.5/[^/]+/../[^/]+/[^.]+.c[:\"]"
+#   "Utilities/vtkmpeg2/"
+#   "warning LNK44221blahblah"
+#   "myspecial/path/to/something/"
+#   "myvendorexception"
+#   )
+#------------------------------------------------------------------------------#
+
+##---------------------------------------------------------------------------##
 ## Tests
 ##---------------------------------------------------------------------------##
 
-# ## @brief Specify tests which should be ignored during the test stage.
+# @brief Specify tests which should be ignored during the test stage.
 # set( CTEST_CUSTOM_TESTS_IGNORE ${CTEST_CUSTOM_TESTS_IGNORE} "" )
 
-# ## @brief Specify command to execute before execution of any test during test stage.
+# @brief Specify command to execute before execution of any test during test stage.
 # set( CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST} "" )
 
 # ## @brief Specify command to execute at the end of the test stage.
 # set( CTEST_CUSTOM_POST_TEST ${CTEST_CUSTOM_POST_TEST} "" )
 
-
-
 ##---------------------------------------------------------------------------##
 # Code Coverage and Dynamic Analysis Settings
 #
-# http://www.vtk.org/Wiki/CMake_Testing_With_CTest#Dynamic_Analysis
+# See http://www.vtk.org/Wiki/CMake_Testing_With_CTest#Dynamic_Analysis
 ##---------------------------------------------------------------------------##
-
-
-# What tool should we use (this should be in your CMakeCache.txt):
-# MEMORYCHECK_COMMAND:FILEPATH=/home/kitware/local/bin/valgrind
-# PURIFYCOMMAND:FILEPATH=c:/Progra~1/Rational/common/purify.exe
-
-# Add extra options by specifying MEMORYCHECK_COMMAND_OPTIONS and
-# MEMORYCHECK_SUPPRESSIONS_FILE.
-set( MEMORYCHECK_SUPPRESSIONS_FILE
-   "${CTEST_SCRIPT_DIRECTORY}/valgrind_suppress.txt"
-   CACHE FILEPATH
-  "File that contains suppressions for the memory checker" )
-
-# Files for exclusion:
-set( CTEST_CUSTOM_MEMCHECK_IGNORE
-  ${CTEST_CUSTOM_MEMCHECK_IGNORE}
-#     test1
-#     tstbubbagump
-)
-
-# CTEST_CUSTOM_COVERAGE_EXCLUDE is a list of regular expressions. Any
-# file name that matches any of the regular expressions in the list is
-# excluded from the reported coverage data.
-set( CTEST_CUSTOM_COVERAGE_EXCLUDE
-  ${CTEST_CUSTOM_COVERAGE_EXCLUDE}
-
-  # don't report on actual unit tests
-  "/tests/"
-  "tests.cpp"
-  "tests/tst*.cpp"
-  "/src/pkg/tests/tstXercesConfig.cpp"
-  )
-
-## @brief Specify additional files which should be considered for coverage report.
-#
-# Note that the expressions here are globbing expression as
-# interpreted by CMake's file(GLOB) command, not regular expressions.
-set( CTEST_EXTRA_COVERAGE_GLOB ${CTEST_EXTRA_COVERAGE_GLOB} )
-foreach( extension IN ITEMS cc hh )
-  list (APPEND CTEST_EXTRA_COVERAGE_GLOB
-    "${PROJECT_SOURCE_DIR}/src/*\\.${extension}" )
-endforeach()

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ Many thanks go to Draco's [contributors](https://github.com/lanl/Draco/graphs/co
 
 Draco was originally written by staff from Los Alamos's [CCS-2 Computational Physics and Methods Group](http://www.lanl.gov/org/padste/adtsc/computer-computational-statistical-sciences/computational-physics-methods/index.php):
 
-> Kelly G. Thompson, Kent G. Budge, Tom M. Evans, B. Todd Adams,
-> Rob Lowrie, John McGhee, Mike W. Buksas, Gabriel M. Rockefeller,
-> James S. Warsa, Seth R. Johnson, Allan B. Wollaber, Randy M. Roberts,
-> Jae H. Chang, Paul W. Talbot, Katherine J. Wang, Jeff Furnish,
-> Matthew A. Cleveland, Benjamin K. Bergen, Paul J. Henning.
+> Kelly G. Thompson, James S. Warsa, Kent G. Budge, Alex R. Long,
+> Kendra P. Keady, Jae H. Chang, Rob B. Lowrie, Matt A. Cleveland,
+> Massimiliano Rosa, Daniel Holladay, Ryan T. Wollaeger,
+> Andrew T. Till, and Kris C. Garrett.
+
+> Jeff D. Densmore, Allan B. Wollaber, Lori A. Pritchett-Sheats,
+> Peter Ahrens, Katherine J. Wang, Gabriel M. Rockefeller, and
+> Paul W. Talbot.
+
 
 Release
 ----------------

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Draco was originally written by staff from Los Alamos's [CCS-2 Computational Phy
 > Kelly G. Thompson, James S. Warsa, Kent G. Budge, Alex R. Long,
 > Kendra P. Keady, Jae H. Chang, Rob B. Lowrie, Matt A. Cleveland,
 > Massimiliano Rosa, Daniel Holladay, Ryan T. Wollaeger,
-> Andrew T. Till, and Kris C. Garrett.
+> Andrew T. Till, and C. Kris Garrett.
 
 > Jeff D. Densmore, Allan B. Wollaber, Lori A. Pritchett-Sheats,
 > Peter Ahrens, Katherine J. Wang, Gabriel M. Rockefeller, and

--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -147,6 +147,12 @@ targets are installed." FORCE )
      set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
   endif()
 
+  # Register a valgrind suppression file
+  # ctest -D ExperimentalMemCheck -j 12 -R c4
+  set( MEMORYCHECK_SUPPRESSIONS_FILE
+    "${Draco_SOURCE_DIR}/regression/valgrind_suppress.txt" CACHE FILEPATH
+    "valgrind warning suppression file." FORCE )
+
 endmacro()
 
 ##---------------------------------------------------------------------------##

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -301,8 +301,8 @@ macro( setupOpenMPI )
   endif()
 
   # sanity check, these OpenMPI flags (below) require version >= 1.4
-  if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.4 )
-    message( FATAL_ERROR "OpenMPI version < 1.4 found." )
+  if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.8 )
+    message( FATAL_ERROR "OpenMPI version < 1.8 found." )
   endif()
 
   # Setting mpi_paffinity_alone to 0 allows parallel ctest to work correctly.
@@ -313,15 +313,11 @@ macro( setupOpenMPI )
 
   # This flag also shows up in jayenne/pkg_tools/run_milagro_test.py and
   # regress_funcs.py.
-  if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.7 )
-    set( MPIEXEC_POSTFLAGS "--mca mpi_paffinity_alone 0 ${runasroot}" CACHE
-      STRING "extra mpirun flags (list)." FORCE)
-  else()
-    # (2017-01-13) Bugs in openmpi-1.10.x are mostly fixed. Remove flags used
-    # to work around bugs: '-mca btl self,vader -mca timer_require_monotonic 0'
-    set( MPIEXEC_POSTFLAGS "-bind-to none ${runasroot}" CACHE STRING
-      "extra mpirun flags (list)." FORCE)
-  endif()
+
+  # (2017-01-13) Bugs in openmpi-1.10.x are mostly fixed. Remove flags used
+  # to work around bugs: '-mca btl self,vader -mca timer_require_monotonic 0'
+  set( MPIEXEC_POSTFLAGS "-bind-to none ${runasroot}" CACHE STRING
+    "extra mpirun flags (list)." FORCE)
 
   # Find cores/cpu, cpu/node, hyperthreading
   query_topology()
@@ -329,18 +325,11 @@ macro( setupOpenMPI )
   #
   # Setup for OMP plus MPI
   #
-  if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.7 )
+  if( NOT APPLE )
+    # -bind-to fails on OSX, See #691
     set( MPIEXEC_OMP_POSTFLAGS
-      "-bind-to-socket -cpus-per-proc ${MPI_CORES_PER_CPU} --report-bindings" )
-  elseif( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_GREATER 1.7 )
-    if( NOT APPLE )
-      # -bind-to fails on OSX, See #691
-      set( MPIEXEC_OMP_POSTFLAGS
-        "-bind-to socket --map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings ${runasroot}" )
-    endif()
-  else()  # Version 1.7.4
-    set( MPIEXEC_OMP_POSTFLAGS
-      "-bind-to socket --map-by socket:PPR=${MPI_CORES_PER_CPU}" )
+      "--map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings ${runasroot}" )
+      # "-bind-to socket --map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings ${runasroot}"
   endif()
 
   set( MPIEXEC_OMP_POSTFLAGS ${MPIEXEC_OMP_POSTFLAGS}

--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -16,6 +16,11 @@
 include(platform_checks)
 query_openmp_availability()
 
+# Debug flags to consider adding:
+# http://clang.llvm.org/docs/UsersManual.html#options-to-control-error-and-warning-messages
+# -fdiagnostics-show-hotness
+#
+
 #
 # Compiler Flags
 #

--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -3,7 +3,7 @@
 ## File  : environment/bin/bash_functions.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+## Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 ##

--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -380,7 +380,7 @@ function switch_to_lmod()
   dm_core="cmake eospac git tk ndi python totalview dia graphviz doxygen \
 ack ccache"
   dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
-  dm_openmpi="openmpi parmetis superlu-dist trilinos"
+  dm_openmpi="openmpi parmetis superlu-dist trilinos valgrind"
   export dracomodules="$dm_core $dm_gcc $dm_openmpi"
   module load $dracomodules
 

--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -38,6 +38,8 @@
 ## rdde              - reload the default draco environment
 ##
 ## qrm               - quick remove (for lustre filesystems).
+##
+## switch_to_lmod    - switch module system from tcl to lmod
 ##---------------------------------------------------------------------------##
 
 ##---------------------------------------------------------------------------##
@@ -208,6 +210,9 @@ function rm_from_path ()
 
 ##---------------------------------------------------------------------------##
 ## If path is a directory add it to PATH (if not already in PATH)
+##
+## Use:
+##   add_to_path <path> TEXINPUTS|BSTINPUTS|BIBINPUTS|PATH
 ##---------------------------------------------------------------------------##
 function add_to_path ()
 {
@@ -374,14 +379,12 @@ function switch_to_lmod()
   # modules for draco developer environment
   dm_core="cmake eospac git tk ndi python totalview dia graphviz doxygen \
 ack ccache"
-  dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk"
+  dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
   dm_openmpi="openmpi parmetis superlu-dist trilinos"
   export dracomodules="$dm_core $dm_gcc $dm_openmpi"
   module load $dracomodules
 
-  if [[ -d $VENDOR_DIR/bin ]]; then
-    export PATH=$PATH:$VENDOR_DIR/bin
-  fi
+  add_to_path $VENDOR_DIR/bin
 }
 
 #------------------------------------------------------------------------------#

--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -1,385 +1,70 @@
 # -*-sh-*-
 # Valgrind Suppression Instructions
-# generate these expressions by specifying 'valgrind --gen-suppressions=yes'
-
-# For help, use '--gen-suppressions=[yes|all]'
+# generate these expressions by specifying 'valgrind --gen-suppressions=all'
 
 # Example valgrind use:
+
 # valgrind -q --tool=memcheck --leak-check=full --show-reachable=yes
-#   --trace-children=yes --num-callers=50 --gen-suppressions=yes
+#   --trace-children=yes --num-callers=50 --gen-suppressions=all
 #   --suppressions="$HOME/draco/regression/valgrind_suppress.txt"
-#   /ccs/codes/mpi/openmpi/Linux64/1.6/bin/mpiexec -np 1 phw hello
+#   mpirun -np 1 phw hello
 
 # OR --------
 
-# mpirun -np 1 valgrind --leak-check=full --suppressions=/home/kellyt/draco/regression/valgrind_suppress.txt ./phw
+# ctest -D ExperimentalMemCheck -j 12 -R c4
 
 ## -------------------------------------------------------------------------- ##
-## OpenMPI-1.10
+## rhel7
 ## -------------------------------------------------------------------------- ##
 {
-   libpthread/memcheck/param/01
-   Memcheck:Param
-   write(buf)
-   obj:/lib64/libpthread-2.12.so
-   ...
-   fun:orterun
-   fun:main
-}
-{
-   libpthread/memcheck/param/02
-   Memcheck:Param
-   write(buf)
-   obj:/usr/lib64/libpthread-2.17.so
-   ...
-   fun:orterun
-   fun:main
-}
-{
-  <orterun memory leaks should be ignored>
-  Memcheck:Leak
-  ...
-  fun:orterun
-}
-
-{
-  <pmpi_init_thread>
+   rhel7/e001
    Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
+   match-leak-kinds: reachable
+   fun:realloc
    ...
-   fun:PMPI_Init_thread
-   ...
-}
-
-{
-  <pmpi_init_thread-2>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:strdup
-   ...
-   fun:PMPI_Init_thread
+   fun:gomp_realloc
    ...
 }
 {
-  <pmpi_init_thread-3>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:fetch
-   ...
-   fun:PMPI_Init_thread
-   ...
-}
-{
-  <pmpi_init_thread-4>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:store
-   ...
-   fun:PMPI_Init_thread
-}
-
-{
-   <ompi_mpi_init>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:store
-   ...
-   fun:ompi_mpi_init
-}
-{
-  <clone>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:opal_dss_copy_value
-   ...
-   fun:start_thread
-   fun:clone
-}
-{
-   clone3
+   rhel7/e002
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:malloc
-   fun:opal_class_initialize
-   fun:listen_thread
-   fun:start_thread
-   fun:clone
-}
-
-{
-  <pmpi_init_thread-5>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:df_search
    ...
-   fun:PMPI_Init_thread
+   fun:gomp_realloc
    ...
 }
 {
-  <pmpi_init_thread-6>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:df_search
-   ...
-   fun:PMPI_Init
-   ...
-}
-{
-  <clone-2>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:opal_dss_unpack_value
-   ...
-   fun:start_thread
-   fun:clone
-}
-{
-  <pmpi_init_thread-6>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:mca_bml_r2_add_procs
-   ...
-   fun:PMPI_Init_thread
-   ...
-}
-
-{
-  <pmpi_init_thread-7>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   ...
-   fun:ompi_mpi_init
-   fun:PMPI_Init_thread
-   ...
-}
-
-{
-  <pmpi_init>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:strdup
-   ...
-   fun:PMPI_Init
-   ...
-}
-{
-  <pmpi_init>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:mca_bml_r2_add_procs
-   ...
-   fun:PMPI_Init
-   ...
-}
-
-{
-  <fortran>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:strdup
-   ...
-   fun:mpi_init
-   ...
-}
-
-{
-  <fortran-2>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:mca_bml_r2_add_procs
-   ...
-   fun:mpi_init
-   ...
-}
-{
-
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:fetch
-   fun:opal_db_base_fetch
-   fun:ompi_rte_db_fetch
-   fun:ompi_modex_recv
-   fun:vader_add_procs
-   fun:mca_bml_r2_add_procs
-   fun:mca_pml_ob1_add_procs
-   fun:ompi_mpi_init
-   fun:PMPI_Init
-   fun:mpi_init
-   fun:__draco_mpi_MOD_f90_mpi_init
-}
-{
-
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:fetch
-   fun:opal_db_base_fetch
-   fun:ompi_rte_db_fetch
-   fun:ompi_modex_recv
-   fun:mca_btl_tcp_proc_create
-   fun:mca_btl_tcp_del_procs
-   fun:mca_bml_r2_add_procs
-   fun:mca_pml_ob1_add_procs
-   fun:ompi_mpi_init
-   fun:PMPI_Init
-   fun:mpi_init
-}
-{
-
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:fetch
-   fun:opal_db_base_fetch
-   fun:ompi_rte_db_fetch
-   fun:ompi_modex_recv
-   fun:mca_btl_tcp_proc_create
-   fun:mca_btl_tcp_add_procs
-   fun:mca_bml_r2_add_procs
-   fun:mca_pml_ob1_add_procs
-   fun:ompi_mpi_init
-   fun:PMPI_Init
-   fun:mpi_init
-}
-{
-  <fortran-mpi>
-   Memcheck:Leak
-   ...
-   fun:mpi_init
-   ...
-}
-{
-  <fortran-mpi>
-   Memcheck:Leak
-   ...
-   fun:mpi_init
-}
-{
-
+   rhel7/e003
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:malloc
-   fun:strdup
-   fun:hwloc__add_info
-   fun:hwloc__get_dmi_id_one_info.isra.8
-   fun:hwloc__get_dmi_id_info
-   fun:hwloc_look_linuxfs
-   fun:hwloc_discover
-   fun:hwloc_topology_load
-   fun:opal_hwloc_base_get_topology
-   fun:rte_init
-   fun:orte_init
-}
-{
-   <tstparmetis/compdup>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:ompi_comm_set_nb
    ...
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:store
-   fun:opal_db_base_store
-   fun:ompi_modex_send
-   fun:mca_btl_tcp_component_init
-   fun:mca_btl_base_select
-   fun:mca_bml_r2_component_init
-   fun:mca_bml_base_init
-   fun:mca_pml_ob1_component_init
-   fun:mca_pml_base_select
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:store
-   fun:opal_db_base_store
-   fun:ompi_modex_send
-   fun:mca_btl_base_vader_modex_send
-   fun:mca_btl_vader_component_init
-   fun:mca_btl_base_select
-   fun:mca_bml_r2_component_init
-   fun:mca_bml_base_init
-   fun:mca_pml_ob1_component_init
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:fetch
-   fun:opal_db_base_fetch
-   fun:ompi_rte_db_fetch
+   fun:gomp_malloc
    ...
-   fun:mca_pml_ob1_add_procs
-   fun:ompi_mpi_init
 }
 {
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:opal_dss_unpack_value
-   fun:opal_dss_unpack_buffer
-   fun:opal_dss_unpack
-   fun:orte_grpcomm_base_store_modex
-   fun:app_recv
-   fun:orte_rml_base_process_msg
-   fun:event_process_active_single_queue
-   fun:event_process_active
-   fun:opal_libevent2021_event_base_loop
-   fun:orte_progress_thread_engine
-   fun:start_thread
-}
-#--------------------------------------------------------
-## Python suppressions
-{
-   python_lib/memcheck/leak
-   Memcheck:Leak
-   ...
-   obj:/*/libpython2.4.so*
-}
-{
-   python_lib/memcheck/leak 
+   rhel7/e004
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:malloc
-   fun:PyObject_Malloc
+   fun:calloc
+   ...
+   fun:pthread_create@@GLIBC_2.2.5
    ...
 }
 {
-   python_lib/memcheck/leak  
+   rhel7/e005
    Memcheck:Leak
-   match-leak-kinds: possible
+   match-leak-kinds: reachable
    fun:malloc
-   obj:/usr/lib64/libpython2.7.so.1.0
+   fun:__fopen_internal
+   ...
 }
 
-#--------------------------------------------------------
-## CMake suppressions
+## -------------------------------------------------------------------------- ##
+## CMake
+## -------------------------------------------------------------------------- ##
+
 {
    ld/memcheck/leak
    Memcheck:Leak
@@ -1061,3 +746,502 @@
    fun:_ZSt9transformIN9__gnu_cxx17__normal_iteratorIPSsSt6vectorISsSaISsEEEESt20back_insert_iteratorIS3_IPcSaIS8_EEEPFS8_RKSsEET0_T_SH_SG_T1_
    ...
 }
+
+
+#------------------------------------------------------------------------------#
+# Import OpenMPI's openmpi-valgrind.supp
+# Openmpi-2.1.0
+#
+# ccs-net: /scratch/vendors/spack.20170502/opt/spack/linux-rhel7-x86_64/gcc-6.3.0/openmpi-2.1.0-vrj55htfsolpnbtjv63xzh3jnl4kly3k/share/openmpi/openmpi-valgrind.supp
+#------------------------------------------------------------------------------#
+###############################################################
+#
+# OPAL suppressions
+#
+###############################################################
+
+# weirdness in init routines on Gentoo
+{
+  linux_pthread_init
+  Memcheck:Leak
+  fun:calloc
+  fun:allocate_dtv
+  fun:_dl_allocate_tls_storage
+  fun:_dl_allocate_tls
+}
+{
+  linux_pthread_init2
+  Memcheck:Leak
+  fun:calloc
+  fun:_dl_tls_setup
+  fun:__pthread_initialize_minimal
+}
+{
+  linux_pthread_init3
+  Memcheck:Leak
+  fun:memalign
+  fun:_dl_allocate_tls_storage
+  fun:_dl_allocate_tls
+  fun:__pthread_initialize_minimal
+}
+
+# The event library leaves some blocks in use that we should clean up,
+# but it would require much changing of the event library, so it
+# really isn't worth it...
+{
+  event_lib_poll
+  Memcheck:Leak
+  fun:malloc
+  fun:realloc
+  fun:opal_realloc
+  fun:poll_dispatch
+}
+
+
+###############################################################
+#
+# ORTE suppressions
+#
+###############################################################
+
+# inet_ntoa on linux mallocs a static buffer.  We can't free
+# it, so we have to live with it
+{
+  linux_inet_ntoa
+  Memcheck:Leak
+  fun:malloc
+  fun:inet_ntoa
+}
+{
+  linux_inet_ntoa_thread
+  Memcheck:Leak
+  fun:calloc
+  fun:pthread_setspecific
+  fun:inet_ntoa
+}
+
+
+###############################################################
+#
+# OMPI suppressions
+#
+###############################################################
+{
+  tcp_send
+  Memcheck:Param
+  writev(vector[...])
+  fun:writev
+  fun:mca_btl_tcp_frag_send
+  fun:mca_btl_tcp_endpoint_send
+}
+
+###############################################################
+#
+# Suppressions for various commonly-used packages
+#
+###############################################################
+
+# Portals reference implementation has a read from invalid issue
+{
+  portals_send
+  Memcheck:Param
+  socketcall.send(msg)
+  fun:send
+  fun:utcp_sendbytes
+  fun:utcp_sendto
+  fun:utcp_msg_wait
+}
+
+#------------------------------------------------------------------------------#
+# Openmpi-2.1.0 (added by KT)
+#------------------------------------------------------------------------------#
+
+{
+   openmpi210/e001
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001a
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001aa
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001b
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:calloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001c
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001d
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:realloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001e
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e002
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e003
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:strdup
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0004
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0004a
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   ...
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0004b
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:calloc
+   ...
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0004c
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0005
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0005
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0005a
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:realloc
+   ...
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+{
+   openmpi210/e0006
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0007
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0007
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:calloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0008
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0009
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0009a
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0010
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0011
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:orterun
+   ...
+}
+{
+   openmpi210/e0012
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:PMPI_Recv
+   ...
+}
+{
+   openmpi210/e0013
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:PMPI_Send
+   ...
+}
+{
+   openmpi210/e0014
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:PMPI_Irecv
+   ...
+}
+{
+   openmpi210/e0014
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:PMPI_Gather
+   ...
+}
+{
+   openmpi210/e0015
+   Memcheck:Cond
+   ...
+   fun:orterun
+   ...
+}
+
+#------------------------------------------------------------------------------#
+# Python 2.7
+#------------------------------------------------------------------------------#
+{
+   python/e001
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:dictresize
+   ...
+}
+{
+   python/e002
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_PyObject_GC_Malloc
+   ...
+}
+{
+   python/e003
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   ...
+   fun:dlopen@@GLIBC_2.2.5
+   ...
+}
+{
+   python/e004
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:Py_Main
+   ...
+}
+{
+   python/e004a
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:Py_Main
+   ...
+}
+{
+   python/e004b
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:Py_Main
+   ...
+}
+{
+   python/e005
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:import_submodule
+   ...
+}
+{
+   python/e006
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:PyObject_Call
+   ...
+}
+{
+   python/e007
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:PyObject_Call
+   ...
+}
+{
+   python/e008
+   Memcheck:Addr4
+   fun:PyObject_Free
+   ...
+}
+{
+   python/e009
+   Memcheck:Addr4
+   fun:PyObject_Realloc
+   ...
+}
+{
+   python/e010
+   Memcheck:Value8
+   fun:PyObject_Free
+   ...
+}
+{
+   python/e010a
+   Memcheck:Value8
+   fun:PyObject_Realloc
+   ...
+}
+{
+   python/e011
+   Memcheck:Cond
+   fun:PyObject_Free
+   ...
+}
+{
+   python/e011
+   Memcheck:Cond
+   fun:PyObject_Realloc
+   ...
+}
+
+#------------------------------------------------------------------------------#
+# End valgrind_suppress.txt
+#------------------------------------------------------------------------------#

--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -1,17 +1,25 @@
 # -*-sh-*-
-# Valgrind Suppression Instructions
-# generate these expressions by specifying 'valgrind --gen-suppressions=all'
-
+#------------------------------------------------------------------------------#
+# File  : regression/valgrind_suppress.txt
+# Date  : Friday, May 19, 2017, 10:26 am
+# Author: Kelly Thompson <kgt@lanl.gov>
+# Breif : Valgrind Suppression Instructions
+# Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
+#         All rights are reserved.
+#------------------------------------------------------------------------------#
+#
 # Example valgrind use:
-
+#
 # valgrind -q --tool=memcheck --leak-check=full --show-reachable=yes
 #   --trace-children=yes --num-callers=50 --gen-suppressions=all
 #   --suppressions="$HOME/draco/regression/valgrind_suppress.txt"
 #   mpirun -np 1 phw hello
-
-# OR --------
-
+#
+# -------- OR --------
+#
 # ctest -D ExperimentalMemCheck -j 12 -R c4
+#
+#------------------------------------------------------------------------------#
 
 ## -------------------------------------------------------------------------- ##
 ## rhel7
@@ -165,6 +173,14 @@
 ## Added with upgrade to valgrind 3.6.1
 ## ---------------------------------------------------------------------- ##
 
+{
+   ld217/e001
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   obj:/usr/lib64/ld-2.17.so
+}
 {
    tstSP/condjump/ld25so
    Memcheck:Cond
@@ -444,25 +460,6 @@
    fun:__gmpn_divrem
    ...
 }
-
-{
-   numdiff/lost/01
-   Memcheck:Leak
-   fun:calloc
-   fun:process_substring
-   fun:get_separating_string
-   fun:setargs
-   fun:main
-}
-{
-   numdiff/lost/02
-   Memcheck:Leak
-   fun:calloc
-   fun:process_substring
-   fun:get_separating_string
-   fun:setargs
-   fun:main
-}
 {
    numdiff/lost/03
    Memcheck:Leak
@@ -473,6 +470,15 @@
    fun:init_mpa
    fun:init_mpa_support
    fun:main
+}
+{
+   numdiff/lost/04
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:process_substring
+   fun:get_separating_string
+   ...
 }
 
 #==================== F90 open/read/write errors ====================#
@@ -904,6 +910,15 @@
 {
    openmpi210/e001d
    Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:PMPI_Init_thread
+   ...
+}
+{
+   openmpi210/e001d
+   Memcheck:Leak
    match-leak-kinds: indirect
    fun:realloc
    ...
@@ -946,7 +961,7 @@
    ...
    fun:progress_engine
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0004a
@@ -956,7 +971,7 @@
    ...
    fun:progress_engine
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0004b
@@ -966,7 +981,7 @@
    ...
    fun:progress_engine
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0004c
@@ -975,7 +990,7 @@
    fun:malloc
    ...
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0005
@@ -985,7 +1000,7 @@
    ...
    fun:progress_engine
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0005
@@ -995,7 +1010,7 @@
    ...
    fun:progress_engine
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0005a
@@ -1005,7 +1020,7 @@
    ...
    fun:progress_engine
    fun:start_thread
-   fun:clone
+   ...
 }
 {
    openmpi210/e0006
@@ -1122,6 +1137,51 @@
    fun:orterun
    ...
 }
+{
+   openmpi210/e0016
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:PMPI_Init
+   ...
+}
+{
+   openmpi210/e0017
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:PMPI_Comm_create
+   ...
+}
+{
+   openmpi210/e0018
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:PMPI_Comm_split
+   ...
+}
+{
+   openmpi210/e0019
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:PMPI_Comm_dup
+   ...
+}
+{
+   openmpi210/e0019
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:PMPI_Win_create
+   ...
+}
 
 #------------------------------------------------------------------------------#
 # Python 2.7
@@ -1138,6 +1198,14 @@
    python/e002
    Memcheck:Leak
    match-leak-kinds: reachable
+   fun:malloc
+   fun:_PyObject_GC_Malloc
+   ...
+}
+{
+   python/e002b
+   Memcheck:Leak
+   match-leak-kinds: possible
    fun:malloc
    fun:_PyObject_GC_Malloc
    ...

--- a/src/compton/test/CMakeLists.txt
+++ b/src/compton/test/CMakeLists.txt
@@ -33,7 +33,8 @@ include_directories(
 
 add_scalar_tests(
   SOURCES "${test_sources}"
-  DEPS    "Lib_compton" )
+  DEPS    "Lib_compton"
+  LABELS  nomemcheck )
 
 #------------------------------------------------------------------------------#
 # Copy data files

--- a/src/compton/test/CMakeLists.txt
+++ b/src/compton/test/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(
 add_scalar_tests(
   SOURCES "${test_sources}"
   DEPS    "Lib_compton"
-  LABELS  nomemcheck )
+  LABEL   "nomemcheck" )
 
 #------------------------------------------------------------------------------#
 # Copy data files
@@ -43,5 +43,5 @@ add_scalar_tests(
 provide_aux_files( FILES "${compton_data}" )
 
 # ---------------------------------------------------------------------------- #
-# end of CMakeLists.txt
+# end of compton/test/ CMakeLists.txt
 # ---------------------------------------------------------------------------- #

--- a/src/parser/Debug_Options.cc
+++ b/src/parser/Debug_Options.cc
@@ -18,7 +18,7 @@ unsigned available = rtt_parser::DEBUG_END;
 std::map<std::string, unsigned> extended_debug_option;
 std::map<unsigned, std::string> extended_debug_back_option;
 
-#ifdef DBC
+#ifdef REQUIRE_ON
 
 //! Is the bit actually a bit? That is, a power of 2?
 bool is_bit(unsigned bit) {
@@ -31,6 +31,7 @@ bool is_bit(unsigned bit) {
   // Erase that bit; see if the result is zero, as it must be for a power of 2.
   return (bit ^ 1U) == 0U;
 }
+
 #endif
 
 } // end anonymous namespace

--- a/src/parser/Debug_Options.hh
+++ b/src/parser/Debug_Options.hh
@@ -4,10 +4,7 @@
  * \author Kent Grimmett Budge
  * \brief  Define the Debug_Options enumeration and declare parse functions.
  * \note   Copyright (C) 2014-2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-/*---------------------------------------------------------------------------*/
-/* $Id: template.h 7388 2014-01-22 16:02:07Z kellyt $ */
+ *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
 #ifndef parser_Debug_Options_hh

--- a/src/plot2D/test/CMakeLists.txt
+++ b/src/plot2D/test/CMakeLists.txt
@@ -1,12 +1,10 @@
 #-----------------------------*-cmake-*----------------------------------------#
-# file   config/CMakeLists.txt
+# file   plot2D/test/CMakeLists.txt
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for plot2D/test.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
-# $Id$
 #------------------------------------------------------------------------------#
 project( plot2D_test CXX )
 
@@ -20,7 +18,7 @@ file( GLOB bench_files bench/*.agr bench/*.par )
 # ---------------------------------------------------------------------------- #
 # Directories to search for include directives
 # ---------------------------------------------------------------------------- #
-include_directories( 
+include_directories(
    ${PROJECT_SOURCE_DIR}      # headers for tests
    ${PROJECT_SOURCE_DIR}/..   # headers for package
    ${PROJECT_BINARY_DIR}/..   # config.h
@@ -40,7 +38,7 @@ find_program( NUMDIFF
 if ( NOT ${NUMDIFF} MATCHES NOTFOUND )
    add_scalar_tests(
       SOURCES "${test_sources}"
-      DEPS    "${test_deps}" ) 
+      DEPS    "${test_deps}" )
    ##------------------------------------------------------------------------##
    ## This test doesn't behave correctly under valgrind (the pause
    ## doesn't work and that causes everything else to fail).
@@ -88,4 +86,6 @@ set_directory_properties(
    PROPERTIES
    ADDITIONAL_MAKE_CLEAN_FILES "${extra_clean_files}" )
 
-
+#------------------------------------------------------------------------------#
+# End plot2D/test/CMakeLists.txt
+#------------------------------------------------------------------------------#


### PR DESCRIPTION
**Motivation**:
+ New Lmod modules will provide gcc/6.3.0 and openmpi/2.1.0 as defaults. We also have a new version of valgrind. This update eliminates some warnings that show up with the new tools.
+ Other unrelated cleanup is also included in this change set.

**Implementation**:
+ Significant change to `valgrind_suppress.txt` to address false positives reported by newer versions of gcc, openmpi, python, etc.
+ Register Draco's `valgrind_suppress.txt` file with cmake.    This allows developers to easily obtain valgrind test results from their build directories.
    
      *Example:* `ctest -D ExperimentalMemCheck [-j 8 -R c4]`

+ Update author list shown on Draco's github page.
+ Retire some build system code designed for older versions of OpenMPI.  The minimum required version of OpenMPI is now 1.8 (we use MPI 3.0 features).
+ Add some notes about clang sanitizer options.  We will depend more on these going forward since we will no longer run the `bounds_checking` nightly tests.
+ Mark the Compton unit test with `nomemcheck`.  This test takes too long when running under valgrind.
+ Minor formatting and documentation changes.
+ Refs #210 (GitHub).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
