### PR TITLE
Make it easier to run valgrind checks.

### DIFF
--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -147,12 +147,6 @@ targets are installed." FORCE )
      set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
   endif()
 
-  # Register a valgrind suppression file
-  # ctest -D ExperimentalMemCheck -j 12 -R c4
-  set( MEMORYCHECK_SUPPRESSIONS_FILE
-    "${Draco_SOURCE_DIR}/regression/valgrind_suppress.txt" CACHE FILEPATH
-    "valgrind warning suppression file." FORCE )
-
 endmacro()
 
 ##---------------------------------------------------------------------------##

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -400,6 +400,36 @@ endmacro()
 ##---------------------------------------------------------------------------##
 macro( dbsSetupProfilerTools )
 
+  # These become variables of the form ${spt_NAME}, etc.
+  cmake_parse_arguments(
+    spt
+    ""
+    "MEMORYCHECK_SUPPRESSIONS_FILE"
+    ""
+    ${ARGV}
+    )
+
+  # Valgrind suppression file
+  # Try running 'ctest -D ExperimentalMemCheck -j 12 -R c4'
+  if( DEFINED spt_MEMORYCHECK_SUPPRESSIONS_FILE )
+    set( MEMORYCHECK_SUPPRESSIONS_FILE
+      "${spt_MEMORYCHECK_SUPPRESSIONS_FILE}" CACHE FILEPATH
+      "valgrind warning suppression file." FORCE )
+  else()
+    find_file(
+      msf
+      NAMES
+        "valgrind_suppress.txt"
+      PATHS
+        ${PROJECT_SOURCE_DIR}/regrssion
+        ${PROJECT_SOURCE_DIR}/scripts
+    )
+    if( ${msf} )
+      set( MEMORYCHECK_SUPPRESSIONS_FILE "${msf}" CACHE FILEPATH
+      "valgrind warning suppression file." FORCE )
+    endif()
+  endif()
+
   # ------------------------------------------------------------
   # Allinea MAP
   # ------------------------------------------------------------


### PR DESCRIPTION
+ This change will allow developers to run the valgrind checks with the same suppression file that the nightly DA checks use.  For example:
```
  ctest -D ExperimentalMemCheck [-j 12 -R c4]
```
+ Fixes #216
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
