### PR TITLE
Turn on GCC Warning '-Wundef'

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -83,7 +83,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
 
   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
   set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef -DDEBUG")
-  # -Werror
+  # '-Werror'
   # -D_FORTIFY_SOURCE=2 -Wconversion -Wfloat-equal -Wunreachable-code
   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -82,7 +82,9 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
-  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -DDEBUG")
+  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef -DDEBUG")
+  # -Werror
+  # -D_FORTIFY_SOURCE=2 -Wconversion -Wfloat-equal -Wunreachable-code
   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -funroll-loops" )
@@ -109,6 +111,11 @@ if( NOT CXX_FLAGS_INITIALIZED )
     string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=float-divide-by-zero")
     string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=float-cast-overflow")
     string( APPEND CMAKE_C_FLAGS_DEBUG " -fdiagnostics-color=always")
+#    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=vptr")
+#    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=object-size")
+#    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=alignment")
+#    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=bounds")
+#    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=address")
     # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
   endif()
 

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -32,6 +32,8 @@ if ! [[ ${VENDOR_DIR} ]]; then
   esac
 fi
 
+add_to_path ${VENDOR_DIR}/bin PATH
+
 #------------------------------------------------------------------------------#
 # Setup Modules (Lmod or TCL)
 

--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -38,8 +38,6 @@
 ## rdde              - reload the default draco environment
 ##
 ## qrm               - quick remove (for lustre filesystems).
-##
-## switch_to_lmod    - switch module system from tcl to lmod
 ##---------------------------------------------------------------------------##
 
 ##---------------------------------------------------------------------------##
@@ -333,58 +331,6 @@ function qrm ()
     mv $dir $TMPDIR/.
 
   done
-}
-
-#------------------------------------------------------------------------------#
-# Helper for ccs-net machines while we transition to lmod
-#------------------------------------------------------------------------------#
-
-function switch_to_lmod()
-{
-  export SPACK_ROOT=/scratch/vendors/spack.20170502
-  if ! [[ -d $SPACK_ROOT ]]; then
-    echo "FATAL ERROR: spack root not found."
-    return
-  fi
-  export PATH=$SPACK_ROOT/bin:$PATH
-  # Remove any environment-modules modulefiles.
-  module purge
-  # Point to lmod application and spack's lmod modulefiles.
-  MODULE_HOME=`spack location -i lmod`
-  if [[ -f $MODULE_HOME/lmod/lmod/init/bash ]]; then
-    source $MODULE_HOME/lmod/lmod/init/bash
-    module use $SPACK_ROOT/share/spack/lmod/`spack arch`/Core
-    module unuse /usr/share/Modules/modulefiles
-  fi
-  # eospac, ndi, csk
-  module use --append /scratch/vendors/Modules.lmod
-  if [[ -d $HOME/privatemodules ]]; then
-    module use --append $HOME/privatemodules
-  fi
-
-  # Environment for default compiler (no module file)
-  # export CC=/bin/gcc
-  # export CXX=/bin/g++
-  # export FC=/bin/gfortran
-  # export F90=/bin/gfortran
-  # export F95=/bin/gfortran
-  # export LCOMPILER=gcc
-  # export LCOMPILERVER=4.8.5
-
-  # aliases
-  alias mlo='module load'
-  alias mls='module list'
-  alias mav='module avail'
-
-  # modules for draco developer environment
-  dm_core="cmake eospac git tk ndi python doxygen ccache numdiff totalview \
-dia graphviz ack"
-  dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
-  dm_openmpi="openmpi parmetis superlu-dist trilinos valgrind"
-  export dracomodules="$dm_core $dm_gcc $dm_openmpi"
-  module load $dracomodules
-
-  add_to_path $VENDOR_DIR/bin
 }
 
 #------------------------------------------------------------------------------#

--- a/src/c4/c4_mpi.h
+++ b/src/c4/c4_mpi.h
@@ -5,10 +5,7 @@
  * \date   Fri Jan  8 15:06:30 1999
  * \brief  put the right includes for MPI header files
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-/*---------------------------------------------------------------------------*/
-/* $Id$ */
+ *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
 #ifndef rtt_c4_c4_mpi_h

--- a/src/diagnostics/Procmon.cc
+++ b/src/diagnostics/Procmon.cc
@@ -6,10 +6,7 @@
  * \brief  Procmon class for printing runtime system diagnostics (free memory
  *         per node, etc).
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: Procmon.hh 5523 2010-11-30 01:12:12Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Procmon.hh"
@@ -108,7 +105,7 @@ void procmon_resource_print(std::string const &identifier, int const &mynode,
 
   MemTotal = statex.ullTotalPhys / 1024.0; // bytes -> kB.
 
-#elif APPLE
+#elif defined(APPLE)
   // can we use use 'system_profiler?'
   MemTotal = 1;
 #else

--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -33,7 +33,7 @@ DracoInfo::DracoInfo(void)
 #ifdef DRACO_SHARED_LIBS
   library_type = "Shared";
 #endif
-#if DRACO_UNAME == Linux
+#ifdef draco_isLinux
   system_type = "Linux";
 #endif
 #ifdef SITENAME

--- a/src/ds++/DracoMath.hh
+++ b/src/ds++/DracoMath.hh
@@ -243,7 +243,7 @@ inline Ordered_Group sign(Ordered_Group a, Ordered_Group b) {
 inline double linear_interpolate(double const x1, double const x2,
                                  double const y1, double const y2,
                                  double const x) {
-  Require(x2 - x1 != 0.0);
+  Require(std::abs(x2 - x1) > std::numeric_limits<double>::epsilon());
   Require(((x >= x1) && (x <= x2)) || ((x >= x2) && (x <= x1)));
 
   // return value

--- a/src/ds++/Homogeneous_New.cc
+++ b/src/ds++/Homogeneous_New.cc
@@ -4,30 +4,31 @@
  * \author Kent Budge
  * \brief  Implement methods of class Homogeneous_New
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Homogeneous_New.hh"
 #include "Assert.hh"
 #include <algorithm>
-#include <stdlib.h>
+#include <cstdlib>
 
 namespace rtt_dsxx {
+
 //---------------------------------------------------------------------------//
 Homogeneous_New::Homogeneous_New(unsigned const object_size,
                                  unsigned const default_block_size)
     : object_size_(object_size), default_block_size_(default_block_size),
       total_number_of_segments_(0), first_block_(NULL), first_segment_(NULL) {
+
   Require(object_size >= sizeof(void *));
   Require(default_block_size > sizeof(void *));
 
   if ((default_block_size_ - sizeof(void *)) % object_size != 0) {
-    unsigned count = (default_block_size_ - sizeof(void *)) / object_size;
+    unsigned count = (default_block_size_
+                      - static_cast<unsigned>(sizeof(void *))) / object_size;
     ++count;
-    default_block_size_ = count * object_size + sizeof(void *);
+    default_block_size_ = count * object_size
+                          + static_cast<unsigned>(sizeof(void *));
   }
 
   Ensure(check_class_invariants());
@@ -96,7 +97,7 @@ void Homogeneous_New::deallocate(void *const ptr) {
 void Homogeneous_New::reserve(unsigned const object_count) {
   if (object_count > total_number_of_segments_) {
     unsigned count = object_count - total_number_of_segments_;
-    count = count * object_size_ + sizeof(void *);
+    count = count * object_size_ + static_cast<unsigned>(sizeof(void *));
     count = std::max(count, default_block_size_);
     allocate_block_(count);
   }

--- a/src/ds++/Homogeneous_New.cc
+++ b/src/ds++/Homogeneous_New.cc
@@ -24,11 +24,12 @@ Homogeneous_New::Homogeneous_New(unsigned const object_size,
   Require(default_block_size > sizeof(void *));
 
   if ((default_block_size_ - sizeof(void *)) % object_size != 0) {
-    unsigned count = (default_block_size_
-                      - static_cast<unsigned>(sizeof(void *))) / object_size;
+    unsigned count =
+        (default_block_size_ - static_cast<unsigned>(sizeof(void *))) /
+        object_size;
     ++count;
-    default_block_size_ = count * object_size
-                          + static_cast<unsigned>(sizeof(void *));
+    default_block_size_ =
+        count * object_size + static_cast<unsigned>(sizeof(void *));
   }
 
   Ensure(check_class_invariants());

--- a/src/ds++/Homogeneous_New.hh
+++ b/src/ds++/Homogeneous_New.hh
@@ -5,10 +5,7 @@
  * \date   Tue Nov 28 08:27:37 2006
  * \brief  Definition of class Homogeneous_New
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef dsxx_Homogeneous_New_hh

--- a/src/ds++/Soft_Equivalence.hh
+++ b/src/ds++/Soft_Equivalence.hh
@@ -20,8 +20,8 @@
 
 #include "Assert.hh"
 #include <cmath>
-#include <iterator>
 #include <cstdint>
+#include <iterator>
 #include <vector>
 
 namespace rtt_dsxx {

--- a/src/ds++/Soft_Equivalence.hh
+++ b/src/ds++/Soft_Equivalence.hh
@@ -5,10 +5,7 @@
  * \date   Wed Nov  7 14:10:55 2001
  * \brief  Soft_Equivalence functions for floating point comparisons.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __dsxx_Soft_Equivalence_hh__
@@ -19,19 +16,12 @@
 //
 // Purpose : checks that two reals or fields of reals are within a tolerance
 // of each other.
-//
-// revision history:
-// -----------------
-// 0) original
-// 1) 01-24-02 : modified the soft_equiv function to allow using an absolute
-//               error check if the reference value is within 1.0e-14 of zero.
-//
 //===========================================================================//
 
 #include "Assert.hh"
 #include <cmath>
 #include <iterator>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace rtt_dsxx {

--- a/src/ds++/SortPermutation.hh
+++ b/src/ds++/SortPermutation.hh
@@ -5,9 +5,7 @@
  * \date   Mon Feb 14 14:18:27 2000
  * \brief  SortPermutation class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __ds_SortPermutation_hh__
@@ -27,52 +25,44 @@ namespace rtt_dsxx {
 /*!
  * \class SortPermutation
  *
- *  This class determines a permutation used to sort a sequence.
+ * This class determines a permutation used to sort a sequence.
  *
- *  This is necessary if multiple sequences need to be re-arranged, via
- *  the ordering necessary to sort a sequece of "keys".
+ * This is necessary if multiple sequences need to be re-arranged, via the
+ * ordering necessary to sort a sequece of "keys".
  *
- *  Create an object of class SortPermutation using either of the following
- *  constructors:
- *  \code
+ * Create an object of class SortPermutation using either of the following
+ * constructors:
+ * \code
  *      template<class ForwardIterator>
  *      SortPermutation(ForwardIterator first, ForwardIterator last)
  *
  *      template<class ForwardIterator, class StrictWeakOrdering>
  *      SortPermutation(ForwardIterator first, ForwardIterator last,
  *                      StrictWeakOrdering comp)
- *  \endcode
- *  The object creates a permutation that results in an ordering of
- *  elements in [first,last) into nondescending order.  This ordering
- *  is not necessarily stable.
+ * \endcode
+ * The object creates a permutation that results in an ordering of elements in
+ * [first,last) into nondescending order.  This ordering is not necessarily
+ * stable.
  *
- *  The SortPermutation object can be used to access the "index table"
- *  for the sequence via operator[](int), begin(), and end().
+ * The SortPermutation object can be used to access the "index table" for the
+ * sequence via operator[](int), begin(), and end().
  *
- *  An index table is a table of integer pointers telling which number
- *  sequence element comes first in ascending order, which second,
- *  and so on.
- *  See "Numerical Recipes" for a full discussion of an index table.
+ * An index table is a table of integer pointers telling which number sequence
+ * element comes first in ascending order, which second, and so on.  See
+ * "Numerical Recipes" for a full discussion of an index table.
  *
- *  The inverse operations on the SortPermutation object can be used
- *  to access the "rank table" for the sequence via inv(int), inv_begin(),
- *  and inv_end().
+ * The inverse operations on the SortPermutation object can be used to access
+ * the "rank table" for the sequence via inv(int), inv_begin(), and inv_end().
  *
- *  A rank table is a table telling what the numerical rank of the first
- *  sequence element, the second sequence element, and so on.
- *  See "Numerical Recipes" for a full discussion of a rank table.
+ * A rank table is a table telling what the numerical rank of the first sequence
+ * element, the second sequence element, and so on.  See "Numerical Recipes" for
+ * a full discussion of a rank table.
  */
 /*!
  * \example tstSortPermutation.cc
- * 
+ *
  * Test of rtt_dsxx::SortPermutation and isSorted.hh functions.
  */
-// revision history:
-// -----------------
-// 0) original
-// 1) 020503 : added some comments and formatting (this class is used by
-//             meshReaders-Services
-//
 //===========================================================================//
 
 class SortPermutation {
@@ -173,69 +163,53 @@ public:
   // ACCESSORS
 
   /*!
-     * \brief Returns the i'th entry into the index table.
-     * \param i The i'th entry into the sorted order.
-     * The condition, *(first + sortPerm[i+1]) < *(first + sortPerm[i]),
-     * is guaranteed to be false.
-     * 
-     * For example,
-     * \code
-     *     first = unsorted.begin();
-     *     last  = unsorted.end()
-     *     SortPermutation sortPerm(first, last);
-     *     for (int i=0; i<unsorted.size(); i++)
-     *        sorted[i] = unsorted[sortPerm[i]];
-     * \endcode
-     * results in sorted containing the sorted elements of [first, last).
-     */
+   * \brief Returns the i'th entry into the index table.
+   * \param i The i'th entry into the sorted order.  The condition, *(first +
+   *        sortPerm[i+1]) < *(first + sortPerm[i]), is guaranteed to be false.
+   *
+   * For example,
+   * \code
+   *     first = unsorted.begin();
+   *     last  = unsorted.end()
+   *     SortPermutation sortPerm(first, last);
+   *     for (int i=0; i<unsorted.size(); i++)
+   *        sorted[i] = unsorted[sortPerm[i]];
+   * \endcode
+   * results in sorted containing the sorted elements of [first, last).
+   */
 
   value_type operator[](int i) const { return indexTable_m[i]; }
 
-  /*!
-     * \brief Returns the begin const_iterator into the index table.
-     */
-
+  //! Returns the begin const_iterator into the index table.
   const_iterator begin() const { return indexTable_m.begin(); }
 
-  /*!
-     * \brief Returns the end const_iterator into the index table.
-     */
-
+  //! Returns the end const_iterator into the index table.
   const_iterator end() const { return indexTable_m.end(); }
 
   /*!
-     * \brief Returns the i'th entry into the rank table.
-     * \param i The i'th entry from the sorted order.
-     * 
-     * For example,
-     * \code 
-     *     first = unsorted.begin();
-     *     last  = unsorted.end()
-     *     SortPermutation sortPerm(first, last);
-     *     for (int i=0; i<unsorted.size(); i++)
-     *        sorted[sortPerm.inv(i)] = unsorted[i];
-     * \endcode
-     * results in sorted containing the sorted elements of [first, last).
-     */
-
+   * \brief Returns the i'th entry into the rank table.
+   * \param i The i'th entry from the sorted order.
+   *
+   * For example,
+   * \code
+   *     first = unsorted.begin();
+   *     last  = unsorted.end()
+   *     SortPermutation sortPerm(first, last);
+   *     for (int i=0; i<unsorted.size(); i++)
+   *        sorted[sortPerm.inv(i)] = unsorted[i];
+   * \endcode
+   * results in sorted containing the sorted elements of [first, last).
+   */
   value_type inv(int i) const { return rankTable_m[i]; }
 
-  /*!
-     * \brief Returns the begin const_iterator into the rank table.
-     */
-
+  //! Returns the begin const_iterator into the rank table.
   const_iterator inv_begin() const { return rankTable_m.begin(); }
 
-  /*!
-     * \brief Returns the end const_iterator into the rank table.
-     */
-
+  //! Returns the end const_iterator into the rank table.
   const_iterator inv_end() const { return rankTable_m.end(); }
 
-  /*!
-     * \brief Returns the size of the index and rank tables.
-     */
-  int size() const { return indexTable_m.size(); }
+  //! Returns the size of the index and rank tables.
+  int size() const { return static_cast<int>(indexTable_m.size()); }
 
 private:
   // IMPLEMENTATION
@@ -291,5 +265,5 @@ private:
 #endif // __ds_SortPermutation_hh__
 
 //---------------------------------------------------------------------------//
-//                              end of ds++/SortPermutation.hh
+// end of ds++/SortPermutation.hh
 //---------------------------------------------------------------------------//

--- a/src/ds++/SystemCall.cc
+++ b/src/ds++/SystemCall.cc
@@ -1,13 +1,10 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   ds++/SystemCall.cc
- * \brief  Implementation for the Draco wrapper for system calls. This
- routine attempts to hide differences between Unix/Windows system
- calls.
- * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- * \version $Id$
- */
+ * \file  ds++/SystemCall.cc
+ * \brief Implementation for the Draco wrapper for system calls. This routine
+ *        attempts to hide differences between Unix/Windows system calls.
+ * \note  Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *        All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "SystemCall.hh"
@@ -177,7 +174,7 @@ draco_getstat::draco_getstat(std::string const &fqName)
 //---------------------------------------------------------------------------//
 //! Is this a regular file?
 bool draco_getstat::isreg() {
-#if WIN32
+#ifdef WIN32
   bool b = FileInformation.dwFileAttributes & FILE_ATTRIBUTE_NORMAL;
   return filefound && b;
 #else
@@ -189,7 +186,7 @@ bool draco_getstat::isreg() {
 //---------------------------------------------------------------------------//
 //! Is this a directory?
 bool draco_getstat::isdir() {
-#if WIN32
+#ifdef WIN32
   bool b = FileInformation.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY;
   return filefound && b;
 #else
@@ -202,7 +199,7 @@ bool draco_getstat::isdir() {
 //! Is a Unix permission bit set?
 bool draco_getstat::has_permission_bit(int mask) {
   Insist(isreg(), "Can only check permission bit for regular files.");
-#if WIN32
+#ifdef WIN32
   Insist(false,
          "draco_getstat::hsa_permission_bit() not implemented for WIN32");
   return false;
@@ -242,9 +239,9 @@ void draco_mkdir(std::string const &path) {
 
   draco_getstat dirInfo(path);
   if (!dirInfo.isdir()) {
-    /*! \note If path contains the location of a directory, it cannot
-         * contain a trailing backslash. If it does, -1 will be returned and
-         * errno will be set to ENOENT. */
+    /*! \note If path contains the location of a directory, it cannot contain a
+     * trailing backslash. If it does, -1 will be returned and errno will be set
+     * to ENOENT. */
     std::string clean_fqName;
     if (path[path.size() - 1] == rtt_dsxx::WinDirSep ||
         path[path.size() - 1] == rtt_dsxx::UnixDirSep)

--- a/src/ds++/test/tstEndian.cc
+++ b/src/ds++/test/tstEndian.cc
@@ -121,7 +121,7 @@ void test_idempotence(ScalarUnitTest &ut) {
     // Use the copy-generating version to test negative numbers.
     const double neg_local = byte_swap_copy(byte_swap_copy(-value));
 
-    if ( std::abs(neg_local + value) > std::numeric_limits<double>::epsilon())
+    if (std::abs(neg_local + value) > std::numeric_limits<double>::epsilon())
       FAILMSG("byte_swap failed to reproduce original number");
   }
 

--- a/src/ds++/test/tstEndian.cc
+++ b/src/ds++/test/tstEndian.cc
@@ -3,12 +3,8 @@
  * \file   ds++/test/tstEndian.cc
  * \author Mike Buksas
  * \date   Tue Oct 23 16:20:59 2007
- * \brief
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Endian.hh"
@@ -102,12 +98,12 @@ void test_int64(ScalarUnitTest &ut) {
 void test_idempotence(ScalarUnitTest &ut) {
 
   /* This test demonstrates that two applications of byte-swap in succession
-     * return the original value.
-     *
-     * To do this, we sweep over a lot of double values. We use a non-integral
-     * multiplier for successive values to avoid small subsets of the
-     * available patterns of bits. E.g. multiples of 2.
-     */
+   * return the original value.
+   *
+   * To do this, we sweep over a lot of double values. We use a non-integral
+   * multiplier for successive values to avoid small subsets of the available
+   * patterns of bits. E.g. multiples of 2.
+   */
 
   for (double value = 1.0;
        value < std::numeric_limits<double>::max() / 4.0; // divide by 4 to
@@ -119,15 +115,14 @@ void test_idempotence(ScalarUnitTest &ut) {
     byte_swap(local);
 
     // These numbers should be identical, so I'm testing for equality.
-    if (local != value)
-      ut.failure("byte_swap failed to reproduce original number");
+    if (std::abs(local - value) > std::numeric_limits<double>::epsilon())
+      FAILMSG("byte_swap failed to reproduce original number");
 
     // Use the copy-generating version to test negative numbers.
-
     const double neg_local = byte_swap_copy(byte_swap_copy(-value));
 
-    if (neg_local != -value)
-      ut.failure("byte_swap failed to reproduce original number");
+    if ( std::abs(neg_local + value) > std::numeric_limits<double>::epsilon())
+      FAILMSG("byte_swap failed to reproduce original number");
   }
 
   return;

--- a/src/ds++/test/tstFMA.cc
+++ b/src/ds++/test/tstFMA.cc
@@ -62,7 +62,8 @@ void test_fma1(rtt_dsxx::UnitTest &ut) {
             << "\t#define FMA(a,b,c) fma(a,b,c)\n"
             << std::endl;
 
-  if (fma_result == macro_fma_result)
+  if (std::abs(fma_result - macro_fma_result)
+      < std::numeric_limits<double>::epsilon())
     PASSMSG("With FP_ACCURATE_FMA=1, a*b+c == FMA(a,b,c).");
   else
     FAILMSG("With FP_ACCURATE_FMA=1, a*b+c != FMA(a,b,c).");

--- a/src/ds++/test/tstFMA.cc
+++ b/src/ds++/test/tstFMA.cc
@@ -62,8 +62,8 @@ void test_fma1(rtt_dsxx::UnitTest &ut) {
             << "\t#define FMA(a,b,c) fma(a,b,c)\n"
             << std::endl;
 
-  if (std::abs(fma_result - macro_fma_result)
-      < std::numeric_limits<double>::epsilon())
+  if (std::abs(fma_result - macro_fma_result) <
+      std::numeric_limits<double>::epsilon())
     PASSMSG("With FP_ACCURATE_FMA=1, a*b+c == FMA(a,b,c).");
   else
     FAILMSG("With FP_ACCURATE_FMA=1, a*b+c != FMA(a,b,c).");

--- a/src/ds++/test/tstPacking_Utils.cc
+++ b/src/ds++/test/tstPacking_Utils.cc
@@ -53,7 +53,9 @@ void compute_buffer_size_test(rtt_dsxx::UnitTest &ut) {
   char const test_string[] = "test";
 
   unsigned int total_size =
-      num_vi * sizeof(int) + num_vd * sizeof(double) + sizeof(test_string);
+    num_vi * static_cast<unsigned>(sizeof(int)) + num_vd *
+    static_cast<unsigned>(sizeof(double)) +
+    static_cast<unsigned>(sizeof(test_string));
   // includes one padding byte
 
   Packer p;
@@ -176,17 +178,18 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
 
     double d = 0;
     int i = 0;
+    double eps(1.0e-16);
 
     u.set_buffer(s1, b1);
     u >> d >> i;
-    if (d != 102.45)
+    if (! soft_equiv(d, 102.45, eps) )
       ITFAILS;
     if (i != 10)
       ITFAILS;
 
     u.unpack(d);
     u.unpack(i);
-    if (d != 203.89)
+    if (! soft_equiv(d, 203.89, eps) )
       ITFAILS;
     if (i != 11)
       ITFAILS;

--- a/src/ds++/test/tstPacking_Utils.cc
+++ b/src/ds++/test/tstPacking_Utils.cc
@@ -52,10 +52,9 @@ void compute_buffer_size_test(rtt_dsxx::UnitTest &ut) {
 
   char const test_string[] = "test";
 
-  unsigned int total_size =
-    num_vi * static_cast<unsigned>(sizeof(int)) + num_vd *
-    static_cast<unsigned>(sizeof(double)) +
-    static_cast<unsigned>(sizeof(test_string));
+  unsigned int total_size = num_vi * static_cast<unsigned>(sizeof(int)) +
+                            num_vd * static_cast<unsigned>(sizeof(double)) +
+                            static_cast<unsigned>(sizeof(test_string));
   // includes one padding byte
 
   Packer p;
@@ -182,14 +181,14 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
 
     u.set_buffer(s1, b1);
     u >> d >> i;
-    if (! soft_equiv(d, 102.45, eps) )
+    if (!soft_equiv(d, 102.45, eps))
       ITFAILS;
     if (i != 10)
       ITFAILS;
 
     u.unpack(d);
     u.unpack(i);
-    if (! soft_equiv(d, 203.89, eps) )
+    if (!soft_equiv(d, 203.89, eps))
       ITFAILS;
     if (i != 11)
       ITFAILS;

--- a/src/ds++/test/tstSortPermutation.cc
+++ b/src/ds++/test/tstSortPermutation.cc
@@ -4,10 +4,7 @@
  * \author Randy M. Roberts
  * \date   Mon Feb 14 14:20:45 2000
  * \note   Copyright (c) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"

--- a/src/ds++/test/tstdbc.cc
+++ b/src/ds++/test/tstdbc.cc
@@ -34,12 +34,16 @@ void dbc_test(UnitTest &ut) {
   using rtt_dsxx::dim;
   using namespace std;
 
-  if (!(abs(5.4) == 5.4) || !(abs(-2.1) == 2.1) || !(abs(0.0) == 0.0))
+  if (abs(abs(5.4) - 5.4) > std::numeric_limits<double>::epsilon() ||
+      abs(abs(-2.1) - 2.1) > std::numeric_limits<double>::epsilon() ||
+      abs(abs(0.0) - 0.0) > std::numeric_limits<double>::epsilon() )
     FAILMSG("abs function template FAILED");
   else
     PASSMSG("abs function template ok");
 
-  if (!(dim(2, 7) == 0) || !(dim(5, -3) == 8) || !(dim(4, 4) == 0))
+  if (abs(dim(2, 7) - 0) > std::numeric_limits<int>::epsilon() ||
+      abs(dim(5, -3) - 8) > std::numeric_limits<int>::epsilon() ||
+      abs(dim(4, 4) - 0) > std::numeric_limits<int>::epsilon())
     FAILMSG("dim function template FAILED");
   else
     PASSMSG("dim function template ok");

--- a/src/ds++/test/tstdbc.cc
+++ b/src/ds++/test/tstdbc.cc
@@ -36,7 +36,7 @@ void dbc_test(UnitTest &ut) {
 
   if (abs(abs(5.4) - 5.4) > std::numeric_limits<double>::epsilon() ||
       abs(abs(-2.1) - 2.1) > std::numeric_limits<double>::epsilon() ||
-      abs(abs(0.0) - 0.0) > std::numeric_limits<double>::epsilon() )
+      abs(abs(0.0) - 0.0) > std::numeric_limits<double>::epsilon())
     FAILMSG("abs function template FAILED");
   else
     PASSMSG("abs function template ok");

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -5,8 +5,7 @@
  * \date   Fri Aug 3 16:53:23 2012
  * \brief  Declaration of class Counter_RNG.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved
- */
+ *         All rights reserved */
 //---------------------------------------------------------------------------//
 
 #ifndef Counter_RNG_hh

--- a/src/rng/Random_Inline.cc
+++ b/src/rng/Random_Inline.cc
@@ -1,10 +1,16 @@
+//----------------------------------------------------------------------------//
 /*!
-  \file    rng/Random.cc
-  \author  Paul Henning
-  \brief   Specializations of Random
-  \note    Copyright (C) 2016-2017 Los Alamos National Security, LLC. All rights reserved.
-*/
+ * \file    rng/Random_Inline.cc
+ * \author  Paul Henning
+ * \brief   Specializations of Random
+ * \note    Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *          All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #include "Random_Inline.hh"
 
 uint64_t rtt_rng::rn_stream;
+
+//----------------------------------------------------------------------------//
+// end of Random_Inline.cc
+//----------------------------------------------------------------------------//

--- a/src/rng/Random_Inline.hh
+++ b/src/rng/Random_Inline.hh
@@ -4,20 +4,18 @@
  * \author  Paul Henning
  * \brief   Header to bring in appropriate random number generators
  * \note    Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *          All rights reserved.
- */
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_rng_Random_Inline_hh
 #define rtt_rng_Random_Inline_hh
 
 #include "Rnd_Control_Inline.hh"
-//#include <stdint.h>
 
 namespace rtt_rng {
 
-/*! rn_stream is not used for anything in this library.  It is simply a global
- * variable that some applications use for holding a stream number.
+/*! \brief rn_stream is not used for anything in this library.  It is simply a
+ * global variable that some applications use for holding a stream number.
  */
 DLL_PUBLIC_rng extern uint64_t rn_stream;
 }

--- a/src/rng/test/time_initkeyctr.h
+++ b/src/rng/test/time_initkeyctr.h
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wexpansion-to-defined"
 #endif
 
-#if TRY_OTHER
+#if defined(TRY_OTHER)
 static mrg1x32_ctr_t good_mrg1x32_1 = {{0x4b2cd7ee}};
 static mt1x32_ctr_t good_mt1x32_1 = {{0x39037a7d}};
 static mtsmall1x32_ctr_t good_mtsmall1x32_1 = {{0x7afd2a98}};

--- a/src/rng/test/time_misc.h
+++ b/src/rng/test/time_misc.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * performance.  We do not distribute those RNGs or
  * their timing code.
  */
-# include "util_other.h"
+#include "util_other.h"
 #endif
 
 const char *progname;

--- a/src/rng/test/time_misc.h
+++ b/src/rng/test/time_misc.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TIME_MISC_H__ 1
 /* Miscellaneous common definitions for time_*.c */
 
-#if TRY_OTHER
+#if defined(TRY_OTHER)
 /*
  * Compare with some other conventional RNGs for timing
  * performance.  We do not distribute those RNGs or

--- a/src/rng/test/time_random123.h
+++ b/src/rng/test/time_random123.h
@@ -69,12 +69,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    unrepresentative of the kinds of optimizations that are possible in
    practice.  I.e., we could not find any "real" use of the output of
    the RNG that permitted SSE-ization of the RNG. */
-#define LOOK_AT(A, I, N) do{                                            \
-    if (N==4) if(R123_BUILTIN_EXPECT(!(A.v[N>2?3:0]^A.v[N>2?2:0]^A.v[N>1?1:0]^A.v[0]), 0)) ++I; \
-    if (N==2) if(R123_BUILTIN_EXPECT(!(A.v[N>1?1:0]^A.v[0]), 0)) ++I;   \
-    if (N==1) if(R123_BUILTIN_EXPECT(!(A.v[0]), 0)) ++I;                \
-    }while(0)
-
+#define LOOK_AT(A, I, N)                                                       \
+  do {                                                                         \
+    if (N == 4)                                                                \
+      if (R123_BUILTIN_EXPECT(!(A.v[N > 2 ? 3 : 0] ^ A.v[N > 2 ? 2 : 0] ^      \
+                                A.v[N > 1 ? 1 : 0] ^ A.v[0]),                  \
+                              0))                                              \
+        ++I;                                                                   \
+    if (N == 2)                                                                \
+      if (R123_BUILTIN_EXPECT(!(A.v[N > 1 ? 1 : 0] ^ A.v[0]), 0))              \
+        ++I;                                                                   \
+    if (N == 1)                                                                \
+      if (R123_BUILTIN_EXPECT(!(A.v[0]), 0))                                   \
+        ++I;                                                                   \
+  } while (0)
 
 /* Macro that will expand later into all the Random123 PRNGs for NxW_R */
 /* Note that making the first argument uint seems to expose some
@@ -83,30 +91,31 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    fits in 32 bits, we assign it to a 32-bit (uint) to reduce loop
    overhead.
 */
-#define TEST_TPL(NAME, N, W, R)                                         \
-KERNEL void test_##NAME##N##x##W##_##R(uint64_t n64, NAME##N##x##W##_ukey_t uk, NAME##N##x##W##_ctr_t ctrinit, MEMTYPE NAME##N##x##W##_ctr_t *ctr) \
-{                                                                       \
-    uint n = (uint)n64;                                                 \
-    unsigned tid = get_global_id(0);                                    \
-    uint i;                                                             \
-    NAME##N##x##W##_ctr_t c, v={{0}};                                   \
-    NAME##N##x##W##_key_t k=NAME##N##x##W##keyinit(uk);                 \
-    c = ctrinit;                                                        \
-    if( R == NAME##N##x##W##_rounds ){                                  \
-        for (i = 0; i < n; ++i) {                                       \
-	    v = NAME##N##x##W(c, k);                                    \
-	    LOOK_AT(v, i, N);                                           \
-            c.v[0]++;                                                   \
-        }                                                               \
-    }else {                                                             \
-        for (i = 0; i < n; ++i) {                                       \
-            v = NAME##N##x##W##_R(R, c, k);                             \
-	    LOOK_AT(v, i, N);                                           \
-            c.v[0]++;                                                   \
-        }                                                               \
-    }                                                                   \
-    ctr[tid] = v;                                                       \
-}
+#define TEST_TPL(NAME, N, W, R)                                                \
+  KERNEL void test_##NAME##N##x##W##_##R(                                      \
+      uint64_t n64, NAME##N##x##W##_ukey_t uk, NAME##N##x##W##_ctr_t ctrinit,  \
+      MEMTYPE NAME##N##x##W##_ctr_t *ctr) {                                    \
+    uint n = (uint)n64;                                                        \
+    unsigned tid = get_global_id(0);                                           \
+    uint i;                                                                    \
+    NAME##N##x##W##_ctr_t c, v = {{0}};                                        \
+    NAME##N##x##W##_key_t k = NAME##N##x##W##keyinit(uk);                      \
+    c = ctrinit;                                                               \
+    if (R == NAME##N##x##W##_rounds) {                                         \
+      for (i = 0; i < n; ++i) {                                                \
+        v = NAME##N##x##W(c, k);                                               \
+        LOOK_AT(v, i, N);                                                      \
+        c.v[0]++;                                                              \
+      }                                                                        \
+    } else {                                                                   \
+      for (i = 0; i < n; ++i) {                                                \
+        v = NAME##N##x##W##_R(R, c, k);                                        \
+        LOOK_AT(v, i, N);                                                      \
+        c.v[0]++;                                                              \
+      }                                                                        \
+    }                                                                          \
+    ctr[tid] = v;                                                              \
+  }
 
 /*
  * Hackery to time GSL and XORWOW in the same framework, they can
@@ -115,8 +124,8 @@ KERNEL void test_##NAME##N##x##W##_##R(uint64_t n64, NAME##N##x##W##_ukey_t uk, 
  * util_expandtpl.  Ugh.
  */
 #if defined(TRY_OTHER)
-# include "time_other.h"
-# define RESTORE_OTHER 1
+#include "time_other.h"
+#define RESTORE_OTHER 1
 #endif
 
 /* Now expand TEST_TPL for all the relevant RNGs */
@@ -127,9 +136,9 @@ KERNEL void test_##NAME##N##x##W##_##R(uint64_t n64, NAME##N##x##W##_ukey_t uk, 
  * expandtpl (e.g. for time_keyctrinit) will work.
  */
 #if defined(RESTORE_OTHER)
-# undef TRY_OTHER
-# define TRY_OTHER 1
-# undef RESTORE_OTHER
+#undef TRY_OTHER
+#define TRY_OTHER 1
+#undef RESTORE_OTHER
 #endif
 
 #endif /* TIME_RANDOM123_H__ */

--- a/src/rng/test/time_random123.h
+++ b/src/rng/test/time_random123.h
@@ -114,7 +114,7 @@ KERNEL void test_##NAME##N##x##W##_##R(uint64_t n64, NAME##N##x##W##_ukey_t uk, 
  * above, so we undefine TRY_OTHER before including
  * util_expandtpl.  Ugh.
  */
-#if TRY_OTHER
+#if defined(TRY_OTHER)
 # include "time_other.h"
 # define RESTORE_OTHER 1
 #endif
@@ -126,7 +126,7 @@ KERNEL void test_##NAME##N##x##W##_##R(uint64_t n64, NAME##N##x##W##_ukey_t uk, 
  * Now restore TRY_OTHER if needed to that subsequent
  * expandtpl (e.g. for time_keyctrinit) will work.
  */
-#if RESTORE_OTHER
+#if defined(RESTORE_OTHER)
 # undef TRY_OTHER
 # define TRY_OTHER 1
 # undef RESTORE_OTHER

--- a/src/rng/test/time_serial.c
+++ b/src/rng/test/time_serial.c
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * util_expandtpl.h to "templatize" over all the different permutations of RNGs
  * and NxW and R.
  */
+
 #include "util.h"
 
 #include "time_serial.h"

--- a/src/rng/test/ut_M128.cpp
+++ b/src/rng/test/ut_M128.cpp
@@ -34,119 +34,131 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <Random123/features/compilerfeatures.h>
 #if !R123_USE_SSE
 #include <stdio.h>
-int main(){ printf("No SSE.  Nothing to check.  OK\n"); return 0; }
+int main() {
+  printf("No SSE.  Nothing to check.  OK\n");
+  return 0;
+}
 #else
 
 #include "ut_M128.hh"
 #include <sstream>
 
-int main(int, char **){
-    r123m128i uninitialized;
-    __m128i zm = _mm_setzero_si128();
+int main(int, char **) {
+  r123m128i uninitialized;
+  __m128i zm = _mm_setzero_si128();
 #if defined(R123_USE_CXX1X_UNRESTRICTED_UNIONS)
-    r123m128i zM(zm);
+  r123m128i zM(zm);
 #else
-    r123m128i zM; zM.m = zm;
+  r123m128i zM;
+  zM.m = zm;
 #endif
-    uninitialized.m = _mm_setzero_si128();
+  uninitialized.m = _mm_setzero_si128();
 
-    // operator bool (or maybe void*)
-    assert(!uninitialized);
-    assert(!zM);
+  // operator bool (or maybe void*)
+  assert(!uninitialized);
+  assert(!zM);
 
-    // operator=(__m128i)
-    // conversion to __m128i
-    __m128i one = _mm_set_epi32(0, 0, 0, 1);
-    __m128i two = _mm_set_epi32(0, 0, 0, 2);
-    r123m128i One, Two;
-    One = one;
-    Two = two;
-    assert(!!One);
-    assert(!!Two);
-    r123m128i AnotherOne;
-    AnotherOne = one;
+  // operator=(__m128i)
+  // conversion to __m128i
+  __m128i one = _mm_set_epi32(0, 0, 0, 1);
+  __m128i two = _mm_set_epi32(0, 0, 0, 2);
+  r123m128i One, Two;
+  One = one;
+  Two = two;
+  assert(!!One);
+  assert(!!Two);
+  r123m128i AnotherOne;
+  AnotherOne = one;
 
-    assert( AnotherOne == One );
-    assert( Two != One );
-    __m128i m = One;
-    AnotherOne = m;
-    assert( AnotherOne ==  One );
+  assert(AnotherOne == One);
+  assert(Two != One);
+  __m128i m = One;
+  AnotherOne = m;
+  assert(AnotherOne == One);
 
-    // operator++ (prefix)
-    ++One;
-    assert( One == Two );
-    assert( One != AnotherOne );
+  // operator++ (prefix)
+  ++One;
+  assert(One == Two);
+  assert(One != AnotherOne);
 
-    // operator+=(R123_ULONG_LONG)
-    // operator==(R123_ULONG_LONG, r123m128i)
-    R123_ULONG_LONG ull = 2;
-    AnotherOne += 1;
-    for(int i=0; i<1000; ++i){
-        AnotherOne += i;
-        ull += i;
-        for(int j=0; j<i; ++j){
-            assert(One != AnotherOne);
-            ++One;
-        }
-        assert(One == AnotherOne);
-        assert(ull == AnotherOne);
+  // operator+=(R123_ULONG_LONG)
+  // operator==(R123_ULONG_LONG, r123m128i)
+  R123_ULONG_LONG ull = 2;
+  AnotherOne += 1;
+  for (int i = 0; i < 1000; ++i) {
+    AnotherOne += i;
+    ull += i;
+    for (int j = 0; j < i; ++j) {
+      assert(One != AnotherOne);
+      ++One;
     }
+    assert(One == AnotherOne);
+    assert(ull == AnotherOne);
+  }
 
-    // Do some additions that require carrying.
-    // Check the identity behavior of the streams
-    // as well
-    for(uint64_t i=0; i<1000; ++i){
-        uint64_t fff = (~((uint64_t)0)) - i;
-        AnotherOne += fff;
-        ull += fff; // will overflow
-        One += fff/2;
-        One += fff - fff/2;
-        assert(AnotherOne == One);
-        assert( !(ull == One) );
-        std::stringstream ss;
-        r123m128i YetAnother;
-        ss << AnotherOne;
-        ss >> YetAnother;
+  // Do some additions that require carrying.
+  // Check the identity behavior of the streams
+  // as well
+  for (uint64_t i = 0; i < 1000; ++i) {
+    uint64_t fff = (~((uint64_t)0)) - i;
+    AnotherOne += fff;
+    ull += fff; // will overflow
+    One += fff / 2;
+    One += fff - fff / 2;
+    assert(AnotherOne == One);
+    assert(!(ull == One));
+    std::stringstream ss;
+    r123m128i YetAnother;
+    ss << AnotherOne;
+    ss >> YetAnother;
 
-        assert( YetAnother == AnotherOne );
-    }
+    assert(YetAnother == AnotherOne);
+  }
 
-    // Sep 2011 - clang in the fink build of llvm-2.9.1 on MacOS 10.5.8
-    // fails to catch anything, and hence fails this test.  I suspect
-    // a problem with the packaging/installation rather than a bug
-    // in llvm.  However, if it shows up in other contexts, some
-    // kind of #ifndef might be appropriate.  N.B.  There's a similar
-    // exception test in ut_carray.cpp
-    rngRemember(bool caught);
-    rngRemember(caught = false);
-    bool b(false);
-    try{
-        b = One < AnotherOne;
-    }catch(std::runtime_error& ){ rngRemember(caught = true); }
-    assert(caught);
+  // Sep 2011 - clang in the fink build of llvm-2.9.1 on MacOS 10.5.8
+  // fails to catch anything, and hence fails this test.  I suspect
+  // a problem with the packaging/installation rather than a bug
+  // in llvm.  However, if it shows up in other contexts, some
+  // kind of #ifndef might be appropriate.  N.B.  There's a similar
+  // exception test in ut_carray.cpp
+  rngRemember(bool caught);
+  rngRemember(caught = false);
+  bool b(false);
+  try {
+    b = One < AnotherOne;
+  } catch (std::runtime_error &) {
+    rngRemember(caught = true);
+  }
+  assert(caught);
 
-    rngRemember(caught = false);
-    try{
-        b = One <= AnotherOne;
-    }catch(std::runtime_error& ){ rngRemember(caught = true); }
-    assert(caught);
+  rngRemember(caught = false);
+  try {
+    b = One <= AnotherOne;
+  } catch (std::runtime_error &) {
+    rngRemember(caught = true);
+  }
+  assert(caught);
 
-    rngRemember(caught = false);
-    try{
-        b = One > AnotherOne;
-    }catch(std::runtime_error& ){ rngRemember(caught = true); }
-    assert(caught);
+  rngRemember(caught = false);
+  try {
+    b = One > AnotherOne;
+  } catch (std::runtime_error &) {
+    rngRemember(caught = true);
+  }
+  assert(caught);
 
-    rngRemember(caught = false);
-    try{
-        b = One >= AnotherOne;
-    }catch(std::runtime_error& ){ rngRemember(caught = true); }
-    assert(caught);
+  rngRemember(caught = false);
+  try {
+    b = One >= AnotherOne;
+  } catch (std::runtime_error &) {
+    rngRemember(caught = true);
+  }
+  assert(caught);
 
-    // assemble_from_u32<r123m128i>
+  // assemble_from_u32<r123m128i>
 
-    std::cout << "ut_M128: OK (b=" << b << ")\n";
-    return 0;
+  std::cout << "ut_M128: OK (b=" << b << ")\n";
+  return 0;
 }
 
 #endif

--- a/src/rng/test/ut_M128.cpp
+++ b/src/rng/test/ut_M128.cpp
@@ -43,7 +43,7 @@ int main(){ printf("No SSE.  Nothing to check.  OK\n"); return 0; }
 int main(int, char **){
     r123m128i uninitialized;
     __m128i zm = _mm_setzero_si128();
-#if R123_USE_CXX1X_UNRESTRICTED_UNIONS
+#if defined(R123_USE_CXX1X_UNRESTRICTED_UNIONS)
     r123m128i zM(zm);
 #else
     r123m128i zM; zM.m = zm;

--- a/src/rng/test/util.h
+++ b/src/rng/test/util.h
@@ -32,13 +32,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTIL_H__
 #define UTIL_H__
 
+#include "rng/config.h"
+#include <assert.h>
+#include <errno.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <assert.h>
-#include <math.h>
-#include "rng/config.h"
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -56,64 +56,63 @@ extern int verbose;
 #if defined(_MSC_VER)
 #define NOMINMAX /* tells Windows.h to NOT define min() & max() */
 #include <Windows.h>
-R123_STATIC_INLINE double now(){
-    LARGE_INTEGER f; /* ticks per second */
-    LARGE_INTEGER t;
-    QueryPerformanceFrequency(&f);
-    QueryPerformanceCounter(&t); /* ticks since epoch */
-    return ((double)t.QuadPart)/((double)f.QuadPart);
+R123_STATIC_INLINE double now() {
+  LARGE_INTEGER f; /* ticks per second */
+  LARGE_INTEGER t;
+  QueryPerformanceFrequency(&f);
+  QueryPerformanceCounter(&t); /* ticks since epoch */
+  return ((double)t.QuadPart) / ((double)f.QuadPart);
 }
 #else /* _MSC_VER */
 #include <sys/time.h>
-R123_STATIC_INLINE double now(){
-    struct timeval tv;
-    gettimeofday(&tv, 0);
-    return 1.e-6*tv.tv_usec + tv.tv_sec;
+R123_STATIC_INLINE double now() {
+  struct timeval tv;
+  gettimeofday(&tv, 0);
+  return 1.e-6 * tv.tv_usec + tv.tv_sec;
 }
 #endif /* _MSC_VER */
 
 /* timer returns difference between current time and *d, also updates *d with current time. */
 R123_STATIC_INLINE double timer(double *d) {
-    double dold = *d;
-    *d = now();
-    return *d - dold;
+  double dold = *d;
+  *d = now();
+  return *d - dold;
 }
 
 #define WHITESPACE " \t\f\v\n"
-char *nameclean(char *s)
-{
-    char *cp = s, *cp2, *cpend = s + strlen(s);
-    size_t i;
+char *nameclean(char *s) {
+  char *cp = s, *cp2, *cpend = s + strlen(s);
+  size_t i;
 
-    cp2 = s;
-    while ((cp2 = strstr(cp2, "(R)")) != NULL) {
-	*cp2++ = ' ';
-	*cp2++ = ' ';
-	*cp2++ = ' ';
+  cp2 = s;
+  while ((cp2 = strstr(cp2, "(R)")) != NULL) {
+    *cp2++ = ' ';
+    *cp2++ = ' ';
+    *cp2++ = ' ';
+  }
+  cp2 = s;
+  while ((cp2 = strstr(cp2, "CPU")) != NULL) {
+    *cp2++ = ' ';
+    *cp2++ = ' ';
+    *cp2++ = ' ';
+  }
+  cp2 = s;
+  while ((cp2 = strchr(cp2, '@')) != NULL) {
+    *cp2++ = ' ';
+  }
+  while ((i = strcspn(cp, WHITESPACE)) > 0) {
+    cp += i;
+    i = strspn(cp, WHITESPACE);
+    if (i > 0) {
+      cp2 = cp + i;
+      *cp++ = ' ';
+      if (cp2 > cp) {
+        memmove(cp, cp2, cpend - cp);
+        cpend -= cp2 - cp;
+      }
     }
-    cp2 = s;
-    while ((cp2 = strstr(cp2, "CPU")) != NULL) {
-	*cp2++ = ' ';
-	*cp2++ = ' ';
-	*cp2++ = ' ';
-    }
-    cp2 = s;
-    while ((cp2 = strchr(cp2, '@')) != NULL) {
-	*cp2++ = ' ';
-    }
-    while ((i = strcspn(cp, WHITESPACE)) > 0) {
-	cp += i;
-	i = strspn(cp, WHITESPACE);
-	if (i > 0) {
-	    cp2 = cp + i;
-	    *cp++ = ' ';
-	    if (cp2 > cp) {
-		memmove(cp, cp2, cpend - cp);
-		cpend -= cp2 - cp;
-	    }
-	}
-    }
-    return s;
+  }
+  return s;
 }
 
 #undef WHITESPACE
@@ -122,10 +121,10 @@ char *nameclean(char *s)
    of the pp-symbol _XOPEN_SOURCE and other arcana.  Just
    do it ourselves.
    Mnemonic:  "ntcs" = "nul-terminated character string" */
-char *ntcsdup(const char *s){
-    char *p = (char *)malloc(strlen(s)+1);
-    strcpy(p, s);
-    return p;
+char *ntcsdup(const char *s) {
+  char *p = (char *)malloc(strlen(s) + 1);
+  strcpy(p, s);
+  return p;
 }
 
 /* MSVC doesn't know about strtoull.  Strictly speaking, strtoull
@@ -138,19 +137,19 @@ char *ntcsdup(const char *s){
 #ifdef _MSC_FULL_VER
 #define strtoull _strtoui64
 #endif
-uint32_t strtou32(const char *p, char **endp, int base){
-    uint32_t ret;
-    errno = 0;
-    ret = strtoul(p, endp, base);
-    assert(errno==0);
-    return ret;
+uint32_t strtou32(const char *p, char **endp, int base) {
+  uint32_t ret;
+  errno = 0;
+  ret = strtoul(p, endp, base);
+  assert(errno == 0);
+  return ret;
 }
-uint64_t strtou64(const char *p, char **endp, int base){
-    uint64_t ret;
-    errno = 0;
-    ret = strtoull(p, endp, base);
-    assert(errno==0);
-    return ret;
+uint64_t strtou64(const char *p, char **endp, int base) {
+  uint64_t ret;
+  errno = 0;
+  ret = strtoull(p, endp, base);
+  assert(errno == 0);
+  return ret;
 }
 
 #if defined(__cplusplus)
@@ -171,19 +170,18 @@ uint64_t strtou64(const char *p, char **endp, int base){
    <features/compilerfeatures.h>.  Hope for the best... */
 #include <iostream>
 #include <limits>
-template <typename T>
-void prtu(T val){
-    using namespace std;
-    cerr.width(std::numeric_limits<T>::digits/4);
-    char prevfill = cerr.fill('0');
-    ios_base::fmtflags prevflags = cerr.setf(ios_base::hex, ios_base::basefield);
-    cerr << val;
-    cerr.flags(prevflags);
-    cerr.fill(prevfill);
-    assert(!cerr.bad());
+template <typename T> void prtu(T val) {
+  using namespace std;
+  cerr.width(std::numeric_limits<T>::digits / 4);
+  char prevfill = cerr.fill('0');
+  ios_base::fmtflags prevflags = cerr.setf(ios_base::hex, ios_base::basefield);
+  cerr << val;
+  cerr.flags(prevflags);
+  cerr.fill(prevfill);
+  assert(!cerr.bad());
 }
-void prtu32(uint32_t v){ prtu(v); }
-void prtu64(uint64_t v){ prtu(v); }
+void prtu32(uint32_t v) { prtu(v); }
+void prtu64(uint64_t v) { prtu(v); }
 
 #else /* __cplusplus */
 /* C should be easy.  inttypes.h was standardized in 1999.  But Microsoft
@@ -194,8 +192,8 @@ void prtu64(uint64_t v){ prtu(v); }
 #else /* _MSC_FULL_VER */
 #include <inttypes.h>
 #endif /* _MSVC_FULL_VER */
-void prtu32(uint32_t v){ fprintf(stderr, "%08" PRIx32, v); }
-void prtu64(uint64_t v){ fprintf(stderr, "%016" PRIx64, v); }
+void prtu32(uint32_t v) { fprintf(stderr, "%08" PRIx32, v); }
+void prtu64(uint64_t v) { fprintf(stderr, "%016" PRIx64, v); }
 
 #endif /* __cplusplus */
 
@@ -204,97 +202,125 @@ void prtu64(uint64_t v){ fprintf(stderr, "%016" PRIx64, v); }
  * where A and B are hex integers and N is a decimal integer
  * exponent
  */
-double
-hextod(const char *cp)
-{
-    uint64_t whole = 0, frac = 0;
-    int exponent = 0, len = 0;
-    double d;
-    char *s;
-    if (cp[0] == '0' && (cp[1] == 'x'||cp[1] == 'X'))
-	cp += 2;
-    whole = strtou64(cp, &s, 16);
-    if (s[0] == '.') {
-	char *cp = ++s;
-	frac = strtou64(s, &s, 16);
-	len = s - cp;
-    }
-    if (s[0] == 'p') {
-	s++;
-	exponent = atoi(s);
-    }
-    frac += whole<<(4*len);
-    exponent -= 4*len;
-    d = frac;
-    d = ldexp(d, exponent);
-    return d;
+double hextod(const char *cp) {
+  uint64_t whole = 0, frac = 0;
+  int exponent = 0, len = 0;
+  double d;
+  char *s;
+  if (cp[0] == '0' && (cp[1] == 'x' || cp[1] == 'X'))
+    cp += 2;
+  whole = strtou64(cp, &s, 16);
+  if (s[0] == '.') {
+    char *cp = ++s;
+    frac = strtou64(s, &s, 16);
+    len = s - cp;
+  }
+  if (s[0] == 'p') {
+    s++;
+    exponent = atoi(s);
+  }
+  frac += whole << (4 * len);
+  exponent -= 4 * len;
+  d = frac;
+  d = ldexp(d, exponent);
+  return d;
 }
 
-#define CHECKNOTEQUAL(x, y)  do { if ((x) != (y)) ; else { \
-    fprintf(stderr, "%s: %s line %d error %s == %s (%s)\n", progname, __FILE__, __LINE__, #x, #y, strerror(errno)); \
-    exit(1); \
-} } while (0)
-#define CHECKEQUAL(x, y)  do { if ((x) == (y)) ; else { \
-    fprintf(stderr, "%s: %s line %d error %s != %s (%s)\n", progname, __FILE__, __LINE__, #x, #y, strerror(errno)); \
-    exit(1); \
-} } while (0)
-#define CHECKZERO(x)  CHECKEQUAL((x), 0)
-#define CHECKNOTZERO(x)  CHECKNOTEQUAL((x), 0)
+#define CHECKNOTEQUAL(x, y)                                                    \
+  do {                                                                         \
+    if ((x) != (y))                                                            \
+      ;                                                                        \
+    else {                                                                     \
+      fprintf(stderr, "%s: %s line %d error %s == %s (%s)\n", progname,        \
+              __FILE__, __LINE__, #x, #y, strerror(errno));                    \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+#define CHECKEQUAL(x, y)                                                       \
+  do {                                                                         \
+    if ((x) == (y))                                                            \
+      ;                                                                        \
+    else {                                                                     \
+      fprintf(stderr, "%s: %s line %d error %s != %s (%s)\n", progname,        \
+              __FILE__, __LINE__, #x, #y, strerror(errno));                    \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+#define CHECKZERO(x) CHECKEQUAL((x), 0)
+#define CHECKNOTZERO(x) CHECKNOTEQUAL((x), 0)
 
-#define dprintf(x) do { if (debug < 1) ; else { printf x; fflush(stdout); } } while (0)
+#define dprintf(x)                                                             \
+  do {                                                                         \
+    if (debug < 1)                                                             \
+      ;                                                                        \
+    else {                                                                     \
+      printf x;                                                                \
+      fflush(stdout);                                                          \
+    }                                                                          \
+  } while (0)
 
-#define ALLZEROS(x, K, N) \
-do { \
-    int allzeros = 1; \
-    unsigned xi, xj; \
-    for (xi = 0; xi < (unsigned)(K); xi++)      \
-	for (xj = 0; xj < (unsigned)(N); xj++)          \
-	    allzeros = allzeros & ((x)[xi].v[xj] == 0); \
-    if (allzeros) fprintf(stderr, "%s: Unexpected, all %lu elements of %ux%u had all zeros!\n", progname, (unsigned long)K, (unsigned)N, (unsigned)sizeof(x[0].v[0])); \
-} while(0)
+#define ALLZEROS(x, K, N)                                                      \
+  do {                                                                         \
+    int allzeros = 1;                                                          \
+    unsigned xi, xj;                                                           \
+    for (xi = 0; xi < (unsigned)(K); xi++)                                     \
+      for (xj = 0; xj < (unsigned)(N); xj++)                                   \
+        allzeros = allzeros & ((x)[xi].v[xj] == 0);                            \
+    if (allzeros)                                                              \
+      fprintf(stderr,                                                          \
+              "%s: Unexpected, all %lu elements of %ux%u had all zeros!\n",    \
+              progname, (unsigned long)K, (unsigned)N,                         \
+              (unsigned)sizeof(x[0].v[0]));                                    \
+  } while (0)
 
 /* Read in N words of width W into ARR */
-#define SCANFARRAY(ARR, NAME, N, W) \
-do { \
-    int xi, xj; \
-    unsigned long long xv; \
-    for (xi = 0; xi < (N); xi++) { \
-        /* Avoid any cleverness with SCNx##W because Microsoft (as of Visual Studio 10.x) silently trashes the stack by pretending that %hhx is %x). */ \
-	const char *xfmt = " %llx%n"; \
-	ret = sscanf(cp, xfmt, &xv, &xj); \
-	ARR.v[xi] = (uint##W##_t)xv; \
-	if (debug > 1) printf("line %d: xfmt for W=%d is \"%s\", got ret=%d xj=%d, %s[%d]=%llx cp=%s", linenum, W, xfmt, ret, xj, #ARR, xi, (unsigned long long) ARR.v[xi], cp); \
-	if (ret < 1) { \
-	    fprintf(stderr, "%s: ran out of words reading %s on line %d: " #NAME #N "x" #W " %2d %s", \
-		    progname, #ARR, linenum, rounds, line); \
-	    errs++; \
-	    return; \
-	} \
-	cp += xj; \
-    } \
-} while(0)
+#define SCANFARRAY(ARR, NAME, N, W)                                                                                                                   \
+  do {                                                                                                                                                \
+    int xi, xj;                                                                                                                                       \
+    unsigned long long xv;                                                                                                                            \
+    for (xi = 0; xi < (N); xi++) {                                                                                                                    \
+      /* Avoid any cleverness with SCNx##W because Microsoft (as of Visual Studio 10.x) silently trashes the stack by pretending that %hhx is %x). */ \
+      const char *xfmt = " %llx%n";                                                                                                                   \
+      ret = sscanf(cp, xfmt, &xv, &xj);                                                                                                               \
+      ARR.v[xi] = (uint##W##_t)xv;                                                                                                                    \
+      if (debug > 1)                                                                                                                                  \
+        printf("line %d: xfmt for W=%d is \"%s\", got ret=%d xj=%d, "                                                                                 \
+               "%s[%d]=%llx cp=%s",                                                                                                                   \
+               linenum, W, xfmt, ret, xj, #ARR, xi,                                                                                                   \
+               (unsigned long long)ARR.v[xi], cp);                                                                                                    \
+      if (ret < 1) {                                                                                                                                  \
+        fprintf(stderr,                                                                                                                               \
+                "%s: ran out of words reading %s on line %d: " #NAME #N "x" #W                                                                        \
+                " %2d %s",                                                                                                                            \
+                progname, #ARR, linenum, rounds, line);                                                                                               \
+        errs++;                                                                                                                                       \
+        return;                                                                                                                                       \
+      }                                                                                                                                               \
+      cp += xj;                                                                                                                                       \
+    }                                                                                                                                                 \
+  } while (0)
 
-#define PRINTARRAY(ARR, fp) \
-do { \
-    char ofmt[64]; \
-    size_t xj; \
+#define PRINTARRAY(ARR, fp)                                                                                                                                          \
+  do {                                                                                                                                                               \
+    char ofmt[64];                                                                                                                                                   \
+    size_t xj;                                                                                                                                                       \
     /* use %lu and the cast (instead of z) for portability to Microsoft, sizeof(v[0]) should fit easily in an unsigned long.  Avoid inttypes for the same reason. */ \
-    sprintf(ofmt, " %%0%lullx", (unsigned long)sizeof(ARR.v[0])*2UL); \
-    for (xj = 0; xj < sizeof(ARR.v)/sizeof(ARR.v[0]); xj++) { \
-	fprintf(fp, ofmt, (unsigned long long) ARR.v[xj]); \
-    } \
-} while(0)
+    sprintf(ofmt, " %%0%lullx", (unsigned long)sizeof(ARR.v[0]) * 2UL);                                                                                              \
+    for (xj = 0; xj < sizeof(ARR.v) / sizeof(ARR.v[0]); xj++) {                                                                                                      \
+      fprintf(fp, ofmt, (unsigned long long)ARR.v[xj]);                                                                                                              \
+    }                                                                                                                                                                \
+  } while (0)
 
-#define PRINTLINE(NAME, N, W, R, ictr, ukey, octr, fp) \
-do { \
-    fprintf(fp, "%s %d ", #NAME #N "x" #W, R); \
-    PRINTARRAY(ictr, fp); \
-    putc(' ', fp); \
-    PRINTARRAY(ukey, fp); \
-    putc(' ', fp); \
-    PRINTARRAY(octr, fp); \
-    putc('\n', fp); \
-    fflush(fp); \
-} while(0)
+#define PRINTLINE(NAME, N, W, R, ictr, ukey, octr, fp)                         \
+  do {                                                                         \
+    fprintf(fp, "%s %d ", #NAME #N "x" #W, R);                                 \
+    PRINTARRAY(ictr, fp);                                                      \
+    putc(' ', fp);                                                             \
+    PRINTARRAY(ukey, fp);                                                      \
+    putc(' ', fp);                                                             \
+    PRINTARRAY(octr, fp);                                                      \
+    putc('\n', fp);                                                            \
+    fflush(fp);                                                                \
+  } while (0)
 
 #endif /* UTIL_H__ */

--- a/src/rng/test/util.h
+++ b/src/rng/test/util.h
@@ -39,7 +39,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assert.h>
 #include <math.h>
 #include "rng/config.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
+#endif
 #include <Random123/features/compilerfeatures.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 extern const char *progname;
 extern int debug;
@@ -58,8 +66,8 @@ R123_STATIC_INLINE double now(){
 #else /* _MSC_VER */
 #include <sys/time.h>
 R123_STATIC_INLINE double now(){
-    struct timeval tv; 
-    gettimeofday(&tv, 0); 
+    struct timeval tv;
+    gettimeofday(&tv, 0);
     return 1.e-6*tv.tv_usec + tv.tv_sec;
 }
 #endif /* _MSC_VER */

--- a/src/rng/test/util_expandtpl.h
+++ b/src/rng/test/util_expandtpl.h
@@ -42,14 +42,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wexpansion-to-defined"
 #endif
 
-#if TRY_OTHER
+#if defined(TRY_OTHER)
 TEST_TPL(mrg, 1, 32, 1)
 TEST_TPL(mt, 1, 32, 1)
 TEST_TPL(mtsmall, 1, 32, 1)
 TEST_TPL(cmrg, 1, 32, 1)
 TEST_TPL(xorwow, 1, 32, 1)
 #endif
-#if TRY_PHILOX2X32
+#if defined(TRY_PHILOX2X32)
 TEST_TPL(philox, 2, 32, 7)
 TEST_TPL(philox, 2, 32, 10)
 #endif

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -76,8 +76,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <type_traits>
 #endif
 
-
-namespace r123{
+namespace r123 {
 
 #if R123_USE_CXX11_TYPE_TRAITS
 using std::make_signed;
@@ -86,13 +85,13 @@ using std::make_unsigned;
 // Sigh... We could try to find another <type_traits>, e.g., from
 // boost or TR1.  Or we can do it ourselves in the r123 namespace.
 // It's not clear which will cause less headache...
-template <typename T> struct make_signed{};
-template <typename T> struct make_unsigned{};
-#define R123_MK_SIGNED_UNSIGNED(ST, UT)                 \
-template<> struct make_signed<ST>{ typedef ST type; }; \
-template<> struct make_signed<UT>{ typedef ST type; }; \
-template<> struct make_unsigned<ST>{ typedef UT type; }; \
-template<> struct make_unsigned<UT>{ typedef UT type; }
+template <typename T> struct make_signed {};
+template <typename T> struct make_unsigned {};
+#define R123_MK_SIGNED_UNSIGNED(ST, UT)                                        \
+  template <> struct make_signed<ST> { typedef ST type; };                     \
+  template <> struct make_signed<UT> { typedef ST type; };                     \
+  template <> struct make_unsigned<ST> { typedef UT type; };                   \
+  template <> struct make_unsigned<UT> { typedef UT type; }
 
 R123_MK_SIGNED_UNSIGNED(int8_t, uint8_t);
 R123_MK_SIGNED_UNSIGNED(int16_t, uint16_t);
@@ -117,14 +116,13 @@ R123_MK_SIGNED_UNSIGNED(__int128_t, __uint128_t);
 // In both cases, we find max() by computing ~(unsigned)0 right-shifted
 // by is_signed.
 template <typename T>
-R123_CONSTEXPR R123_STATIC_INLINE R123_CUDA_DEVICE T maxTvalue(){
-    typedef typename make_unsigned<T>::type uT;
-    return (~uT(0)) >> std::numeric_limits<T>::is_signed;
- }
+R123_CONSTEXPR R123_STATIC_INLINE R123_CUDA_DEVICE T maxTvalue() {
+  typedef typename make_unsigned<T>::type uT;
+  return (~uT(0)) >> std::numeric_limits<T>::is_signed;
+}
 #else
-template <typename T>
-R123_CONSTEXPR R123_STATIC_INLINE T maxTvalue(){
-    return std::numeric_limits<T>::max();
+template <typename T> R123_CONSTEXPR R123_STATIC_INLINE T maxTvalue() {
+  return std::numeric_limits<T>::max();
 }
 #endif
 
@@ -142,14 +140,15 @@ R123_CONSTEXPR R123_STATIC_INLINE T maxTvalue(){
 //  If W>M  then the largest value retured is 1.0.
 //  If W<=M then the largest value returned is the largest Ftype less than 1.0.
 template <typename Ftype, typename Itype>
-R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01(Itype in){
-    typedef typename make_unsigned<Itype>::type Utype;
-    R123_CONSTEXPR Ftype factor = Ftype(1.)/(maxTvalue<Utype>() + Ftype(1.));
-    R123_CONSTEXPR Ftype halffactor = Ftype(0.5)*factor;
+R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01(Itype in) {
+  typedef typename make_unsigned<Itype>::type Utype;
+  R123_CONSTEXPR Ftype factor = Ftype(1.) / (maxTvalue<Utype>() + Ftype(1.));
+  R123_CONSTEXPR Ftype halffactor = Ftype(0.5) * factor;
 #ifdef R123_UNIFORM_FLOAT_STORE
-    volatile Ftype x = Utype(in)*factor; return x+halffactor;
+  volatile Ftype x = Utype(in) * factor;
+  return x + halffactor;
 #else
-    return Utype(in)*factor + halffactor;
+  return Utype(in) * factor + halffactor;
 #endif
 }
 
@@ -168,14 +167,15 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01(Itype in){
 //  If W<=M then the largest value returned is the largest Ftype less than 1.0
 //    and the smallest value returned is the smallest Ftype greater than -1.0.
 template <typename Ftype, typename Itype>
-R123_CUDA_DEVICE R123_STATIC_INLINE Ftype uneg11(Itype in){
-    typedef typename make_signed<Itype>::type Stype;
-    R123_CONSTEXPR Ftype factor = Ftype(1.)/(maxTvalue<Stype>() + Ftype(1.));
-    R123_CONSTEXPR Ftype halffactor = Ftype(0.5)*factor;
+R123_CUDA_DEVICE R123_STATIC_INLINE Ftype uneg11(Itype in) {
+  typedef typename make_signed<Itype>::type Stype;
+  R123_CONSTEXPR Ftype factor = Ftype(1.) / (maxTvalue<Stype>() + Ftype(1.));
+  R123_CONSTEXPR Ftype halffactor = Ftype(0.5) * factor;
 #ifdef R123_UNIFORM_FLOAT_STORE
-    volatile Ftype x = Stype(in)*factor; return x+halffactor;
+  volatile Ftype x = Stype(in) * factor;
+  return x + halffactor;
 #else
-    return Stype(in)*factor + halffactor;
+  return Stype(in) * factor + halffactor;
 #endif
 }
 
@@ -193,11 +193,11 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype uneg11(Itype in){
 //   - are uniformly spaced by 2^-(B-1),
 //   - are balanced around 0.5
 template <typename Ftype, typename Itype>
-R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in){
-    typedef typename make_unsigned<Itype>::type Utype;
-    R123_CONSTEXPR int excess = std::numeric_limits<Utype>::digits - std::numeric_limits<Ftype>::digits;
-    if(excess>=0)
-    {
+R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
+  typedef typename make_unsigned<Itype>::type Utype;
+  R123_CONSTEXPR int excess =
+      std::numeric_limits<Utype>::digits - std::numeric_limits<Ftype>::digits;
+  if (excess >= 0) {
 
 // 2015-09-26 KT - Suppress warnings for the following expressions (see https://rtt.lanl.gov/redmine/issues/416)
 //
@@ -216,19 +216,18 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in){
 #pragma GCC diagnostic ignored "-Wunused-value"
 #endif
 
-        R123_CONSTEXPR int ex_nowarn = (excess>=0) ? excess : 0;
+    R123_CONSTEXPR int ex_nowarn = (excess >= 0) ? excess : 0;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 
-        R123_CONSTEXPR Ftype factor = Ftype(1.)/(Ftype(1.) + ((maxTvalue<Utype>()>>ex_nowarn)));
-        return (1 | (Utype(in)>>ex_nowarn)) * factor;
-    }
-    else
-    {
-        return u01<Ftype>(in);
-    }
+    R123_CONSTEXPR Ftype factor =
+        Ftype(1.) / (Ftype(1.) + ((maxTvalue<Utype>() >> ex_nowarn)));
+    return (1 | (Utype(in) >> ex_nowarn)) * factor;
+  } else {
+    return u01<Ftype>(in);
+  }
 }
 
 } // namespace r123

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //   uneg11:  output is as dense as possible in {-1,1}, never 0.0.  May
 //     return 1.0 or -1.0 if and only if the number of output mantissa bits
 //     is less than the width of the input.
-//   u01fixedpt:  output is "fixed point", equispaced, open at both ends, 
+//   u01fixedpt:  output is "fixed point", equispaced, open at both ends,
 //      and is never 0.0, 0.5 nor 1.0.
 //
 // The behavior of u01 and uneg11 depend on the pre-processor symbol:
@@ -106,14 +106,14 @@ R123_MK_SIGNED_UNSIGNED(__int128_t, __uint128_t);
 
 #if defined(__CUDACC__) || defined(_LIBCPP_HAS_NO_CONSTEXPR)
 // Amazing! cuda thinks numeric_limits::max() is a __host__ function, so
-// we can't use it in a device function.  
+// we can't use it in a device function.
 //
 // The LIBCPP_HAS_NO_CONSTEXP test catches situations where the libc++
 // library thinks that the compiler doesn't support constexpr, but we
 // think it does.  As a consequence, the library declares
 // numeric_limits::max without constexpr.  This workaround should only
 // affect a narrow range of compiler/library pairings.
-// 
+//
 // In both cases, we find max() by computing ~(unsigned)0 right-shifted
 // by is_signed.
 template <typename T>
@@ -136,7 +136,7 @@ R123_CONSTEXPR R123_STATIC_INLINE T maxTvalue(){
 //
 //  If the input is a uniformly distributed integer, then the
 //  result is a uniformly distributed floating point number in [0, 1].
-//  The result is never exactly 0.0.  
+//  The result is never exactly 0.0.
 //  The smallest value returned is 2^-W.
 //  Let M be the number of mantissa bits in Ftype.
 //  If W>M  then the largest value retured is 1.0.
@@ -146,7 +146,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01(Itype in){
     typedef typename make_unsigned<Itype>::type Utype;
     R123_CONSTEXPR Ftype factor = Ftype(1.)/(maxTvalue<Utype>() + Ftype(1.));
     R123_CONSTEXPR Ftype halffactor = Ftype(0.5)*factor;
-#if R123_UNIFORM_FLOAT_STORE
+#ifdef R123_UNIFORM_FLOAT_STORE
     volatile Ftype x = Utype(in)*factor; return x+halffactor;
 #else
     return Utype(in)*factor + halffactor;
@@ -172,7 +172,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype uneg11(Itype in){
     typedef typename make_signed<Itype>::type Stype;
     R123_CONSTEXPR Ftype factor = Ftype(1.)/(maxTvalue<Stype>() + Ftype(1.));
     R123_CONSTEXPR Ftype halffactor = Ftype(0.5)*factor;
-#if R123_UNIFORM_FLOAT_STORE
+#ifdef R123_UNIFORM_FLOAT_STORE
     volatile Ftype x = Stype(in)*factor; return x+halffactor;
 #else
     return Stype(in)*factor + halffactor;
@@ -202,7 +202,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in){
 // 2015-09-26 KT - Suppress warnings for the following expressions (see https://rtt.lanl.gov/redmine/issues/416)
 //
 // Basically, GCC under BullseyeCoverage issues the following warning every time this file is included:
-//         
+//
 // Counter_RNG.hh:124:65:   required from here
 // uniform.hpp:200:48: warning: second operand of conditional expression has no effect [-Wunused-value]
 //         R123_CONSTEXPR int ex_nowarn = (excess>=0) ? excess : 0;
@@ -215,7 +215,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in){
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
 #endif
-        
+
         R123_CONSTEXPR int ex_nowarn = (excess>=0) ? excess : 0;
 
 #ifdef __GNUC__
@@ -234,4 +234,3 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in){
 } // namespace r123
 
 #endif
-


### PR DESCRIPTION
**Motivation**:

To improve code quality, it may be useful to increase the degree of warnings issued by the GNU compiler.  This commit updates Draco by improving the use of CPP macros.

+ Clean up CPP statements to pass new warning checks.  Change
```
    if SYMBOL
  to
    if defined(SYMBOL)
```
+ In draco_info.cc, change
```
    if DRACO_UNAME == Linux
  to
    ifdef draco_isLinux
```
+ Elminate a few cases where a double value is compared directly to another double w/o a soft_equiv.
+ Use a static cast to eliminate a warning about type conversion when using 'sizeof'.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
