### PR TITLE
Modify regression settings to support slurm on knl.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -595,8 +595,9 @@ macro( setupMPILibrariesUnix )
       # Set DRACO_C4 and other variables
       setupDracoMPIVars()
 
-      # Find the version
-      if( NOT "${MPIEXEC}" MATCHES "aprun" )
+      # Find the mpirun version (skip this on Cray because this command seems to
+      # occasionally hang).
+      if( NOT CRAY_PE )
         execute_process( COMMAND ${MPIEXEC} --version
           OUTPUT_VARIABLE DBS_MPI_VER_OUT
           ERROR_VARIABLE DBS_MPI_VER_ERR)


### PR DESCRIPTION
Along with the transition of MOAB to Slurm on trinitite, the consultants have also changed the way jobs are bound to KNL processors and have turned on hyperthreading on the KNL nodes.  This was causing our regressions to crash because 272 MPI ranks worth of tests were starting simultaneously.  Too many jobs running simultaneously and the fact that srun is not distributing the work correctly is causing many tests to time out.

This commit does not fix the underlying problem but it does provide a temporary work around.

1. Avoid a possible hang during the configure step related to 'discovering' MPI.
2. When on the KNL, only run 8 MPI ranks worth of tests simultaneously.

[Refs #903 (Redmine)](https://rtt.lanl.gov/redmine/issues/903)

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
