### PR TITLE
Updates to allow compilation under Visual Studio 2017

### DIFF
--- a/src/ds++/ScalarUnitTest.hh
+++ b/src/ds++/ScalarUnitTest.hh
@@ -5,10 +5,7 @@
  * \date   Thu May 18 17:08:54 2006
  * \brief  Provide services for scalar unit tests
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef dsxx_ScalarUnitTest_hh

--- a/src/ds++/UnitTest.hh
+++ b/src/ds++/UnitTest.hh
@@ -5,10 +5,7 @@
  * \date   Thu May 18 15:46:19 2006
  * \brief  Provide some common functions for unit testing within Draco
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef dsxx_UnitTest_hh

--- a/src/ds++/fpe_trap.cc
+++ b/src/ds++/fpe_trap.cc
@@ -135,7 +135,7 @@ void fpe_trap::disable(void) {
   return;
 }
 
-} // end namespace rtt_shared_lib
+} // namespace rtt_dsxx
 
 #endif // FPETRAP_LINUX_X86
 
@@ -197,9 +197,9 @@ void fpe_trap::disable(void) {
 
 #include <Windows.h> // defines STATUS_FLOAT_...
 #include <float.h>   // defines _controlfp_s
+#include <intrin.h>  // _ReturnAddress
 #include <new.h>     // _set_new_handler
 #include <signal.h>  // SIGABRT
-#include <intrin.h>  // _ReturnAddress
 
 // typdef ignored on left...
 #pragma warning(push)
@@ -724,7 +724,7 @@ void fpe_trap::disable(void) {
   return;
 }
 
-} // end namespace rtt_shared_lib
+} // namespace rtt_dsxx
 
 #endif // FPETRAP_DARWIN_INTEL
 
@@ -800,7 +800,7 @@ void fpe_trap::disable(void) {
   return;
 }
 
-} // end namespace rtt_shared_lib
+} // namespace rtt_dsxx
 
 #endif // FPETRAP_DARWIN_PPC
 

--- a/src/ds++/fpe_trap.cc
+++ b/src/ds++/fpe_trap.cc
@@ -199,6 +199,7 @@ void fpe_trap::disable(void) {
 #include <float.h>   // defines _controlfp_s
 #include <new.h>     // _set_new_handler
 #include <signal.h>  // SIGABRT
+#include <intrin.h>  // _ReturnAddress
 
 // typdef ignored on left...
 #pragma warning(push)

--- a/src/ds++/test/CMakeLists.txt
+++ b/src/ds++/test/CMakeLists.txt
@@ -73,7 +73,9 @@ if( PYTHONINTERP_FOUND )
   # create the do_exception execurtable.
   add_executable( Exe_do_exception ${PROJECT_SOURCE_DIR}/do_exception.cc )
   target_link_libraries( Exe_do_exception Lib_dsxx )
-  set_target_properties( Exe_do_exception PROPERTIES OUTPUT_NAME do_exception )
+  set_target_properties( Exe_do_exception PROPERTIES 
+    FOLDER dsxx_test
+    OUTPUT_NAME do_exception )
 
   include( ApplicationUnitTest )
   add_app_unit_test(

--- a/src/ds++/test/cxx11example_move_semantics.cc
+++ b/src/ds++/test/cxx11example_move_semantics.cc
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   ds++/test/cxx11example_move_sematics.cc
  * \author Tim M. Kelley <tkelley@lanl.gov>, Kelly G. Thompson <kgt@lanl.gov>
@@ -9,7 +9,7 @@
  *
  * \sa http://blog.smartbear.com/c-plus-plus/c11-tutorial-introducing-the-move-constructor-and-the-move-assignment-operator/
  */
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
@@ -31,7 +31,6 @@ void report_memory_locations(std::vector<double> const &v,
  * \brief Improper use of move semantics in constructor.
  */
 //============================================================================//
-
 struct A {
 
 public:
@@ -55,7 +54,6 @@ public:
  * \brief Proper use of move semantics in constructor.
  */
 //============================================================================//
-
 struct B {
 
   /*!
@@ -181,14 +179,21 @@ void move_semantics_example(rtt_dsxx::UnitTest &ut) {
 void report_memory_locations(std::vector<double> const &v,
                              std::string const &name) {
   using namespace std;
-  cout << name << " @ " << &v << ", " << name << " data @ " << &v[0] << endl;
+  cout << name << " @ " << &v << ", " << name << " data @ ";
+  if (v.size() > 0)
+    cout << &v[0] << endl;
+  else
+    cout << "nullptr" << endl;
   cout << name << " = {";
-  copy(v.begin(), v.end(), ostream_iterator<double>(cout, ","));
+  if (!v.empty()) {
+    copy(v.begin(), prev(v.end()), ostream_iterator<double>(cout, ","));
+    cout << v.back();
+  }
   cout << "}" << endl;
   return;
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {
@@ -197,6 +202,6 @@ int main(int argc, char *argv[]) {
   UT_EPILOG(ut);
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of cxx11example_move_semantics.cc
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/ds++/test/tstAssert.cc
+++ b/src/ds++/test/tstAssert.cc
@@ -10,7 +10,6 @@
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
-// #include <cmath>
 
 using namespace std;
 


### PR DESCRIPTION
Motivation:

+ Previously, we tested with VS2013.  However, the older version didn't have complete C++11 support.
+ Moving to the newer version requires a few tweaks to existing code and I haven't worked through issues related to linking against libraries generated with gfortran yet.

Implementation:

+ `fpe_trap.cc` needs a new include directive to ensure that `_ReturnAddress` is defined.
+ Update the `dsxx/test/CMakeLists.txt` to ensure that the build target for `do_exception` is associated with the `dsxx_test` solution folder.
+ In `cxx11example_move_semantics.cc`, eliminate the use of `&v[0]` for empty vectors.  Also, update the memory location function to eliminate the trailing comma that was printed at the end of a list of a vector's values.
+ Refs #225 (GitHub)

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
