### PR TITLE
Begin using Visual Studio 2017 for Win32 nightly regression testing.

### DIFF
--- a/regression/win32-regress.bat
+++ b/regression/win32-regress.bat
@@ -3,7 +3,7 @@ rem ---------------------------------------------------------------------------
 rem File  : regression/win32-regress.bat
 rem Date  : Tuesday, May 31, 2016, 14:48 pm
 rem Author: Kelly Thompson
-rem Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+rem Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 rem         All rights are reserved.
 rem ---------------------------------------------------------------------------
 
@@ -11,46 +11,14 @@ rem This file copied from c:\program files (x86)\Microsoft Visual Studio 12.0\VC
 rem It establishes a Visual Studio environment in a command prompt.  The 
 rem Windows shortcut runs the following command:
 rem
-rem %comspec% /[k|c] ""C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" x86
+rem %comspec% /[k|c] @call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86 %*
 rem
 rem This fill is called from win32-regression-master.bat so that all outpout
 rem can be captured in a log file.
 
-if "%1" == "" goto x86
-if not "%2" == "" goto usage
-
-if /i %1 == x86       goto x86
-if /i %1 == amd64     goto amd64
-if /i %1 == x64       goto amd64
-if /i %1 == arm       goto arm
-if /i %1 == x86_arm   goto x86_arm
-if /i %1 == x86_amd64 goto x86_amd64
-if /i %1 == amd64_x86 goto amd64_x86
-if /i %1 == amd64_arm goto amd64_arm
-goto usage
-
-:x86
-if not exist "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" goto missing
-call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"
-goto :SetVisualStudioVersion
-
-:SetVisualStudioVersion
-set VisualStudioVersion=12.0
-goto :vendorsetup
-
-:usage
-echo Error in script usage. The correct usage is:
-echo     %0 [option]
-echo where [option] is: x86 ^| amd64 ^| arm ^| x86_amd64 ^| x86_arm ^| amd64_x86 ^| amd64_arm
-echo:
-echo For example:
-echo     %0 x86_amd64
-goto :eof
-
-:missing
-echo The specified configuration type is missing.  The tools for the
-echo configuration might not be installed.
-goto :eof
+:setupvs17commenv
+rem 32-bit builds ==> x86
+@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86 %*
 
 rem -------------------------------------------------------------------------------------------
 rem The main regression script starts here.
@@ -58,7 +26,6 @@ rem ----------------------------------------------------------------------------
 
 :vendorsetup
 call e:\work\vendors\setupvendors.bat
-set USE_GITHUB=1
 
 :cdash
 rem set dashboard_type=Experimental

--- a/regression/win32-regression-master.bat
+++ b/regression/win32-regression-master.bat
@@ -3,17 +3,24 @@ rem ---------------------------------------------------------------------------
 rem File  : regression/win32-regression-master.bat
 rem Date  : Tuesday, May 31, 2016, 14:48 pm
 rem Author: Kelly Thompson
-rem Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+rem Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 rem         All rights are reserved.
 rem ---------------------------------------------------------------------------
 
 rem Use Task Scheduler to create a task that runs this script every night at 
 rem midnight.
 
+rem Consider using date-based log file names.
+rem c:\myscript.%date:~-4%%date:~4,2%%date:~7,2%.%time::=%.log 2>&1
+
 set logdir=e:\regress\logs
 
-%comspec% /c ""e:\regress\draco\regression\update_regression_dir.bat"" x86 > %logdir%\update_regression_dir.log 2>&1
-%comspec% /c ""e:\regress\draco\regression\win32-regress.bat"" x86 > %logdir%\regression-master.log 2>&1
-rem %comspec% /k ""e:\regress\draco\regression\win32-regress.bat"" x86
+rem Change '/c' to '/k' to keep the command window open after these commands 
+rem finish.
 
-rem c:\myscript.%date:~-4%%date:~4,2%%date:~7,2%.%time::=%.log 2>&1
+%comspec% /c ""e:\regress\draco\regression\update_regression_dir.bat"" > %logdir%\update_regression_dir.log 2>&1
+%comspec% /c ""e:\regress\draco\regression\win32-regress.bat"" > %logdir%\regression-master.log 2>&1
+
+rem ---------------------------------------------------------------------------
+rem end file regression/win32-regression-master.bat
+rem ---------------------------------------------------------------------------


### PR DESCRIPTION
**Motivation:**

+ We previously used Visual Studio 2013 for this testing.  However, VS2013 did not provide complete support for C++11 and our codes would no longer compile w/o better C++11 support.

**Implementation:**

+ Installed Visual Studio 2017 Community Edition (free for non-commercial software).
+ Update regression scripts to use the new tool set. Source the vcvarsall.bat provided by VS2017 from win32-regress.bat.
+ fixes #225

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
