### PR TITLE
Invert_Comm_Map cleanup of warnings under optimization

### DIFF
--- a/src/c4/Invert_Comm_Map.cc
+++ b/src/c4/Invert_Comm_Map.cc
@@ -21,8 +21,8 @@ namespace rtt_c4 {
 #ifdef C4_MPI
 int get_num_recv(Invert_Comm_Map_t::const_iterator first,
                  Invert_Comm_Map_t::const_iterator last) {
-  const int myproc = rtt_c4::node();
-  const int numprocs = rtt_c4::nodes();
+  const int my_proc = rtt_c4::node();
+  Remember(const int num_procs = rtt_c4::nodes());
   const int one = 1;
   int num_recv(0); // return value
 
@@ -39,8 +39,8 @@ int get_num_recv(Invert_Comm_Map_t::const_iterator first,
   MPI_Win_fence(fence_assert, win);
   for (auto it = first; it != last; ++it) {
     Require(it->first >= 0);
-    Require(it->first < numprocs);
-    if (it->first != myproc) { // treat only non-local sends
+    Require(it->first < num_procs);
+    if (it->first != my_proc) { // treat only non-local sends
       // ...increment the remote number of receives
       MPI_Accumulate(&one, 1, MPI_Traits<int>::element_type(), it->first, 0, 1,
                      MPI_Traits<int>::element_type(), MPI_SUM, win);
@@ -49,7 +49,7 @@ int get_num_recv(Invert_Comm_Map_t::const_iterator first,
   MPI_Win_fence(fence_assert, win);
   MPI_Win_free(&win);
 
-  Ensure(num_recv >= 0 && num_recv < numprocs);
+  Ensure(num_recv >= 0 && num_recv < num_procs);
   return num_recv;
 }
 //---------------------------------------------------------------------------//
@@ -72,7 +72,7 @@ int get_num_recv(Invert_Comm_Map_t::const_iterator first,
 void invert_comm_map(Invert_Comm_Map_t const &to_map,
                      Invert_Comm_Map_t &from_map) {
   const int my_proc = rtt_c4::node();
-  const int num_procs = rtt_c4::nodes();
+  Remember(const int num_procs = rtt_c4::nodes());
 
   // number of procs we will receive data from
   const int num_recv = get_num_recv(to_map.begin(), to_map.end());

--- a/src/c4/test/tstC4_Status.cc
+++ b/src/c4/test/tstC4_Status.cc
@@ -39,7 +39,8 @@ void tst2Procs(rtt_dsxx::UnitTest &ut) {
   if (my_proc == 0) {
     std::vector<int> send_buffer(num_int);
     std::vector<double> recv_buffer(num_double);
-    rtt_c4::receive_async(request, &recv_buffer[0], num_double, 1, tag);
+    rtt_c4::receive_async(request, &recv_buffer[0], num_double,
+                          rtt_c4::any_source, tag);
     rtt_c4::send_async(&send_buffer[0], num_int, 1, tag);
     request.wait(&status);
     if (status.get_source() == 1)
@@ -57,7 +58,8 @@ void tst2Procs(rtt_dsxx::UnitTest &ut) {
   } else { // my_proc == 1
     std::vector<double> send_buffer(num_double);
     std::vector<int> recv_buffer(num_int);
-    rtt_c4::receive_async(request, &recv_buffer[0], num_int, 0, tag);
+    rtt_c4::receive_async(request, &recv_buffer[0], num_int, rtt_c4::any_source,
+                          tag);
     rtt_c4::send_async(&send_buffer[0], num_double, 0, tag);
     request.wait(&status);
     if (status.get_source() == 0)


### PR DESCRIPTION

* Cleanup of Invert_Comm_Map PR to get rid of warnings under optimization.
  * tstC4_Status now uses any_source (Alex's suggestion)

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
