### PR TITLE
Update srun parameters for Cray+Slurm environments at LANL.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -485,7 +485,7 @@ macro( setupCrayMPI )
   #           single node.
   # set( MPIEXEC_POSTFLAGS "-q -F shared -b -m 1400m" CACHE STRING
   #   "extra mpirun flags (list)." FORCE)
-   set( MPIEXEC_POSTFLAGS "-O --exclusive"
+   set( MPIEXEC_POSTFLAGS "-N 1 --cpu_bind=cores --gres=craynetwork:0 --exclusive"
      CACHE STRING
      "extra mpirun flags (list)." FORCE)
     # Consider using 'aprun -n # -N # -S # -d # -T -cc depth ...'
@@ -500,7 +500,7 @@ macro( setupCrayMPI )
     #set( MPIEXEC_OMP_POSTFLAGS "-q -b -d $ENV{OMP_NUM_THREADS}"
     #  CACHE STRING "extra mpirun flags (list)." FORCE)
 
-    set( MPIEXEC_OMP_POSTFLAGS "-N 1 -c ${MPI_CORES_PER_CPU} --exclusive"
+    set( MPIEXEC_OMP_POSTFLAGS "${MPIEXEC_POSTFLAGS} -c ${MPI_CORES_PER_CPU}"
       CACHE STRING "extra mpirun flags (list)." FORCE)
   # Extra flags for OpenMP + MPI
 #   if( DEFINED ENV{OMP_NUM_THREADS} )

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -38,6 +38,18 @@ if [[ -n "${LESS}" ]]; then
 fi
 
 #
+# OpenMP
+#
+export OMP_PLACES=threads
+if [[ `lscpu | grep Flags | grep -c knl` == 0 ]]; then
+  export OMP_NUM_THREADS=16
+  export NRANKS_PER_NODE=32
+else
+  export OMP_NUM_THREADS=17
+  export NRANKS_PER_NODE=68
+fi
+
+#
 # MODULES
 #
 
@@ -85,8 +97,6 @@ function rmdracoenv ()
   module unload PrgEnv-intel
   module load PrgEnv-intel
 }
-
-export OMP_NUM_THREADS=16
 
 # Do not escape $ for bash completion
 shopt -s direxpand

--- a/src/ds++/UnitTest.hh
+++ b/src/ds++/UnitTest.hh
@@ -43,12 +43,12 @@ namespace rtt_dsxx {
  * Scalar UnitTests should have the following syntax.
  * \code
 
- int main(int argc, char *argv[])
- {
- rtt_utils::ScalarUnitTest ut( argc, argv, release );
- try { tstOne(ut); }
- UT_EPILOG(ut);
+ int main(int argc, char *argv[]) {
+   rtt_utils::ScalarUnitTest ut( argc, argv, release );
+   try { tstOne(ut); }
+   UT_EPILOG(ut);
  }
+
  * \endcode
  *
  * \test All of the member functions of this class are tested by
@@ -81,8 +81,9 @@ public:
   //! The assignment operator is disabled.
   UnitTest &operator=(UnitTest const &rhs);
 
-  //! Only special cases should use these (like the unit test
-  //! tstScalarUnitTest.cc).
+  /*!
+   * \brief Only special cases should use these (like the unit test
+   * tstScalarUnitTest.cc). */
   void dbcRequire(bool b) {
     m_dbcRequire = b;
     return;
@@ -106,8 +107,11 @@ public:
   DLL_PUBLIC_dsxx bool passes(std::string const &passmsg);
   DLL_PUBLIC_dsxx bool check(bool, std::string const &checkmsg,
                              bool fatal = false);
-  //! This pure virtual function must be provided by the inherited class.
-  //It should provide output concerning the status of UnitTest.
+  /*!
+   * \brief Provide a summary of the test status
+   *
+   * This pure virtual function must be provided by the inherited class.
+   * It should provide output concerning the status of UnitTest. */
   void status(void) const {
     out << resultMessage() << std::endl;
     return;
@@ -126,16 +130,16 @@ public:
   std::string getTestPath(void) const { return testPath; }
   std::string getTestName(void) const { return testName; }
   /*!
-     * \brief Returns the path of the test binary directory (useful for locating
-     * input files).
-     *
-     * This function depends on the cmake build system setting the
-     * COMPILE_DEFINITIONS target property. This should be done in
-     * config/component_macros.cmake.
-     *
-     * set_target_property( unit_test_target_name
-     *    COMPILE_DEFINITIONS PROJECT_BINARY_DIR="${PROJECT_BINARY_DIR}" )
-     */
+   * \brief Returns the path of the test binary directory (useful for locating
+   * input files).
+   *
+   * This function depends on the cmake build system setting the
+   * COMPILE_DEFINITIONS target property. This should be done in
+   * config/component_macros.cmake.
+   *
+   * set_target_property( unit_test_target_name
+   *    COMPILE_DEFINITIONS PROJECT_BINARY_DIR="${PROJECT_BINARY_DIR}" )
+   */
   static inline std::string getTestInputPath(void) {
 #ifdef PROJECT_BINARY_DIR
     std::string sourcePath(rtt_dsxx::getFilenameComponent(PROJECT_BINARY_DIR,
@@ -147,23 +151,23 @@ public:
 
     return sourcePath;
 #else
-    // We should never get here. However, when compiling ScalarUnitTest.cc,
-    // this function must be valid.  ScalarUnitTest.cc is not a unit test so
+    // We should never get here. However, when compiling ScalarUnitTest.cc, this
+    // function must be valid.  ScalarUnitTest.cc is not a unit test so
     // PROJECT_SOURCE_DIR is not defnied.
     return std::string("unknown");
 #endif
   }
   /*!
-     * \brief Returns the path of the test source directory (useful for locating
-     * input files).
-     *
-     * This function depends on the cmake build system setting the
-     * COMPILE_DEFINITIONS target property. This should be done in
-     * config/component_macros.cmake.
-     *
-     * set_target_property( unit_test_target_name
-     *    COMPILE_DEFINITIONS PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}" )
-     */
+   * \brief Returns the path of the test source directory (useful for locating
+   * input files).
+   *
+   * This function depends on the cmake build system setting the
+   * COMPILE_DEFINITIONS target property. This should be done in
+   * config/component_macros.cmake.
+   *
+   * set_target_property( unit_test_target_name
+   *    COMPILE_DEFINITIONS PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}" )
+   */
   static inline std::string getTestSourcePath(void) {
 #ifdef PROJECT_SOURCE_DIR
     std::string sourcePath(rtt_dsxx::getFilenameComponent(PROJECT_SOURCE_DIR,
@@ -175,8 +179,8 @@ public:
 
     return sourcePath;
 #else
-    // We should never get here. However, when compiling ScalarUnitTest.cc,
-    // this function must be valid.  ScalarUnitTest.cc is not a unit test so
+    // We should never get here. However, when compiling ScalarUnitTest.cc, this
+    // function must be valid.  ScalarUnitTest.cc is not a unit test so
     // PROJECT_SOURCE_DIR is not defnied.
     return std::string("unknown");
 #endif


### PR DESCRIPTION
+ Unit tests will be run on the back-end under srun with these options:  ```srun -n 4 -N 1 --cpu_bind=cores --gres=craynetwork:0 --exclusive <app>```
+ Set `OMP_NUM_THREADS` to 16 for Trinitite/Haswell and 17 for Trinitite/KNL.
+ Fix formatting issues related to comment blocks in `UnitTest.hh.`
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
