### PR TITLE
vim formatting to set a warning line at 80 columns

### DIFF
--- a/environment/vim/.vimrc
+++ b/environment/vim/.vimrc
@@ -25,3 +25,11 @@ endfun
 
 " fix trailing spaces when you write a file
 autocmd BufWritePre * :call RemoveTrailing()
+
+" sets a gray warning line at 81 columns
+if exists('+colorcolumn')
+  highlight ColorColumn ctermbg=gray
+  set colorcolumn=81
+else
+  au BufWinEnter * let w:m2=matchadd('ErrorMsg', '\%>80v.\+', -1)
+endif


### PR DESCRIPTION
* This pull requests adds an 80 column warning line to the vim format file
  * Technically the line is set at 81 columns so you can write all the way to the line

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
