### PR TITLE
Implement improvements for the CI system on ccscs7

### DIFF
--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -12,10 +12,10 @@
 # Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
 */20 * * * * /scratch/regress/draco/regression/sync_repository.sh
 
-# Run the metrics report on the first monday of each month.
-00 08 1-7 * * [ "$(date '+%a')" == "Mon" ] && /scratch/regress/draco/regression/metric_report.sh -e kgt@lanl.gov -p draco
-01 08 1-7 * * [ "$(date '+%a')" == "Mon" ] && /scratch/regress/draco/regression/metric_report.sh -e kgt@lanl.gov -p jayenne
-03 08 1-7 * * [ "$(date '+%a')" == "Mon" ] && /scratch/regress/draco/regression/metric_report.sh -e kgt@lanl.gov -p capsaicin
+# Run the metrics report on the first Monday of each month.
+00 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
+02 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
+04 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
 
 #------------------------------------------------------------------------------#
 # Regressions with system default compiler (gcc-4.8.5)
@@ -32,17 +32,15 @@
 
 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p "draco jayenne capsaicin"
 
-00 01 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e coverage
+00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e coverage
 
-30 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind
+00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind
 
 #------------------------------------------------------------------------------#
 # Clang-3.8.0, gcc-6.1.0
 #------------------------------------------------------------------------------#
 
-00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang
-
-00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610
+00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs-job-launch.sh
+++ b/regression/ccscs-job-launch.sh
@@ -20,7 +20,6 @@
 args=( "$@" )
 nargs=${#args[@]}
 scriptname=${0##*/}
-host=`uname -n`
 
  # Dependencies: wait for these jobs to finish
 dep_jobids=""
@@ -28,80 +27,23 @@ for (( i=0; i < $nargs ; ++i )); do
    dep_jobids="${dep_jobids} ${args[$i]} "
 done
 
-# sanity check
-if [[ ! ${regdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
-    echo "printenv -> "
-    printenv
-    exit 1
-fi
-if [[ ! ${rscriptdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
-    echo "printenv -> "
-    printenv
-    exit 1
-fi
-if [[ ! ${subproj} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
-    echo "printenv -> "
-    printenv
-    exit 1
-fi
-if [[ ! ${build_type} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
-    echo "printenv -> "
-    printenv
-    exit 1
-fi
-if [[ ! ${logdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
-    echo "printenv -> "
-    printenv
-    exit 1
+# load some common bash functions
+export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ -f $rscriptdir/scripts/common.sh ]]; then
+  source $rscriptdir/scripts/common.sh
+else
+  echo " "
+  echo "FATAL ERROR: Unable to locate Draco's bash functions: "
+  echo "   looking for .../regression/scripts/common.sh"
+  echo "   searched rscriptdir = $rscriptdir"
+  exit 1
 fi
 
-if test $subproj == draco || test $subproj == jayenne; then
-  if [[ ! ${featurebranch} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
-    echo "printenv -> "
-    printenv
-  fi
-fi
+# sanity checks
+job_launch_sanity_checks
 
 # Banner
-echo "==========================================================================="
-echo "CCSCS Regression job launcher for ${subproj} - ${build_type} flavor."
-echo "==========================================================================="
-echo " "
-echo "Environment:"
-if [[ ${featurebranch} ]]; then
-  echo "   featurebranch  = ${featurebranch}"
-fi
-echo "   build_autodoc  = ${build_autodoc}"
-echo "   build_type     = ${build_type}"
-echo "   dashboard_type = ${dashboard_type}"
-echo "   epdash         = $epdash"
-if [[ ! ${extra_params} ]]; then
-  echo "   extra_params   = none"
-else
-  echo "   extra_params   = ${extra_params}"
-fi
-if [[ ${featurebranch} ]]; then
-  echo "   featurebranch  = ${featurebranch}"
-fi
-echo "   logdir         = ${logdir}"
-echo "   logfile        = ${logfile}"
-echo "   machine_name_long = $machine_name_long"
-echo "   prdash         = $prdash"
-echo "   projects       = \"${projects}\""
-echo "   regdir         = ${regdir}"
-echo "   regress_mode   = ${regress_mode}"
-echo "   rscriptdir     = ${rscriptdir}"
-echo "   scratchdir     = ${scratchdir}"
-echo "   subproj        = ${subproj}"
-echo " "
-echo "   ${subproj}: dep_jobids = ${dep_jobids}"
-echo " "
+print_job_launch_banner
 
 # Prerequisits:
 # Wait for all dependencies to be met before creating a new job

--- a/regression/ccscs-options.sh
+++ b/regression/ccscs-options.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+## -*- Mode: sh -*-
+##---------------------------------------------------------------------------##
+## File  : regression/sripts/ccscs-options.sh
+## Date  : Tuesday, May 16, 2017, 21:42 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
+##
+## Summary: Capture ccscs-specific features that plug into regression-master.sh.
+##---------------------------------------------------------------------------##
+
+# Main Options
+export machine_name_long="Linux64 on CCS LAN"
+platform_extra_params="clang coverage fulldiagnostics gcc630 nr perfbench valgrind"
+pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
+
+##---------------------------------------------------------------------------##
+## End ccscs-options.sh
+##---------------------------------------------------------------------------##

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 ##---------------------------------------------------------------------------##
 ## File  : regression/ccscs-regression.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
@@ -82,32 +82,75 @@ ulimit -a
 
 # Modules
 # ----------------------------------------
-if [[ `fn_exists module` == 0 ]]; then
-  echo 'module function does not exist. defining a local function ...'
-  source /usr/share/Modules/init/bash
+
+if [[ `fn_exists module` == 1 ]]; then
+  echo " "
+  if [[ `declare -f module | grep -c LMOD` == 0 ]]; then
+    # we have tcl modules
+    echo "Found Tcl modules:"
+    run "module list"
+    echo "unloading"
+    run "module purge"
+    run "module list"
+    unset dracomodules
+    unset NoModules
+    unset _LMFILES_
+    unset MODULEPATH
+    unset LOADEDMODULES
+    unset MODULESHOME
+
+    # If TCL modulefiles, switch to Lmod
+    echo " "
+    echo "Switching to Lmod modulefiles..."
+    export MODULE_HOME=/scratch/vendors/spack.20170502/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/lmod-7.4.8-oytncsoih2sa4jdogz2ojvwly6mwle4n
+    source $MODULE_HOME/lmod/lmod/init/bash || die "Can't find /mod/init/bash"
+    run "module use /scratch/vendors/spack.20170502/share/spack/lmod/linux-rhel7-x86_64/Core" || die "Can't find Lmod Core modulefiles."
+
+  else
+    # we have Lmod modules
+    echo "Found Lmod modules:"
+    run "module avail"
+    run "module list"
+    run "module purge"
+    run "module list"
+  fi
+else
+  echo " "
+  echo "No modules available"
+  echo "Loading Lmod modulefiles..."
+  export MODULE_HOME=/scratch/vendors/spack.20170502/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/lmod-7.4.8-oytncsoih2sa4jdogz2ojvwly6mwle4n
+  source $MODULE_HOME/lmod/lmod/init/bash || die "Can't find /mod/init/bash"
+  run "module use /scratch/vendors/spack.20170502/share/spack/lmod/linux-rhel7-x86_64/Core" || die "Can't find Lmod Core modulefiles."
 fi
 
-source /usr/share/Modules/init/bash
-run "module purge"
-run "module load user_contrib"
-run "module load gcc openmpi cmake git ccache"
-run "module load dracoscripts subversion random123 valgrind"
-run "module load eospac lapack gsl" # grace
-run "module load superlu-dist/4.3"
-run "module load ndi metis parmetis trilinos"
-run "module load doxygen graphviz csk" # qt
-comp=gcc
+# Establish environment via Lmod...
 
+# eospac, ndi, csk
+run "module use --append /scratch/vendors/Modules.lmod"
+
+# Load default set of modules
+dm_core="cmake eospac git ndi python graphviz doxygen ccache numdiff"
+dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
+dm_openmpi="openmpi parmetis superlu-dist trilinos"
+export dracomodules="$dm_core $dm_gcc $dm_openmpi"
+
+# use bash_functions.sh::add_to_path?
+if [ -d $VENDOR_DIR/bin ] && [[ ":${PATH}:" != *":${VENDOR_DIR}/bin:"* ]]; then
+  PATH="${PATH:+${PATH}:}${VENDOOR_DIR}/bin"
+fi
+
+# Setup for special builds (extra_params)
 case $extra_params in
   "")
-    # no-op
+    run "module load $dracomodules"
+    comp=gcc
     ;;
   coverage)
-    # comp=gcc-5.2.0
+    run "module load $dracomodules"
+    comp=gcc
     echo "Coverage option selected."
-    if ! test "${build_type}" == "Debug"; then
-      echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
-      exit 1
+    if ! [[ "${build_type}" == "Debug" ]]; then
+      die "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
     fi
     build_type=Coverage
     # Ccache breaks bullseye coverage!!!
@@ -116,63 +159,26 @@ case $extra_params in
     CXX=`which g++`
     CC=`which gcc`
     ;;
-  belosmods)
-    echo "Use special version of Trilinos (pr539)"
-    run "module swap trilinos trilinos/12.8.1-belosmods"
-    comp=$comp-belosmods
-    export buildname_append="-belosmods"
-    ;;
-  bounds_checking)
-    echo "Bounds checking option selected."
-    if ! test "${build_type}" == "Debug"; then
-      echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
-      exit 1
-    fi
-    bounds_checking=on
-    run "module swap superlu-dist superlu-dist/4.3-bc"
-    run "module swap trilinos trilinos/12.8.1-bc"
-    run "module swap metis metis/5.1.0-bc"
-    run "module swap parmetis parmetis/4.0.3-bc"
-    ;;
   clang)
-    run "module purge"
-    run "module load user_contrib"
-    run "module load llvm openmpi cmake git"
-    run "module load dracoscripts subversion random123"
-    run "module load lapack gsl" # eospac
-    run "module load superlu-dist/4.3"
-    run "module load ndi metis parmetis trilinos"
-    run "module load graphviz csk"
+    run "module load $dm_core"
+    run "module load llvm netlib-lapack gsl metis random123 csk"
+    run "module load $dm_openmpi"
     comp=clang
     ;;
   fulldiagnostics)
-    comp="intel-fulldiagnostics"
+    run "module load $dracomodules"
+    comp="gcc-fulldiagnostics"
     ;;
-  gcc530)
-    run "module purge"
-    run "module load user_contrib"
-    run "module load gcc/5.3.0 openmpi cmake git"
-    run "module load dracoscripts subversion random123"
-    run "module load lapack gsl eospac"
-    run "module load superlu-dist"
-    run "module load ndi metis parmetis trilinos csk"
-    comp=gcc-5.3.0
-    ;;
-  gcc610)
-    run "module purge"
-    run "module load user_contrib git"
-    run "module load gcc/6.1.0 openmpi cmake"
-    run "module load dracoscripts subversion random123"
-    run "module load lapack gsl eospac"
-    run "module load superlu-dist"
-    run "module load ndi metis parmetis trilinos csk"
-    comp=gcc-6.1.0
+  gcc630)
+    run "module load $dracomodules"
+    comp=gcc-6.3.0
     ;;
   valgrind)
+    run "module load $dracomodules valgrind"
+    comp=gcc
     echo "Dynamic Analysis (valgrind) option selected."
-    if ! test "${build_type}" == "Debug"; then
-      echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
-      exit 1
+    if ! [[ "${build_type}" == "Debug" ]]; then
+      die "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
     fi
     build_type=DynamicAnalysis
     ;;

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -96,6 +96,13 @@ case $project in
     print_use; exit 1 ;;
 esac
 
+
+if ! [[ $LOGNAME == "kellyt" ]]; then
+  echo ""; echo "FATAL ERROR: Please use ccscs6 for manual use of checkpr.sh."
+  exit 1
+fi
+
+
 if [[ $regress_mode == "on" ]]; then
   if ! [[ $LOGNAME == "kellyt" ]]; then
     echo ""; echo "FATAL ERROR: invalid use of -r"

--- a/regression/darwin-job-launch.sh
+++ b/regression/darwin-job-launch.sh
@@ -22,6 +22,8 @@ nargs=${#args[@]}
 scriptname=${0##*/}
 host=`uname -n`
 
+die "darwin-job-launch.sh needs to be upgraded to match other job-launch scripts."
+
 #export MOABHOMEDIR=/opt/MOAB
 export SHOWQ=/bin/squeue
 
@@ -32,59 +34,10 @@ for (( i=0; i < $nargs ; ++i )); do
 done
 
 # sanity check
-if [[ ! ${regdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
-    exit 1
-fi
-if [[ ! ${rscriptdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
-    exit 1
-fi
-if [[ ! ${subproj} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
-    exit 1
-fi
-if [[ ! ${build_type} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
-    exit 1
-fi
-if [[ ! ${logdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
-    exit 1
-fi
-
-if test $subproj == draco || test $subproj == jayenne; then
-  if [[ ! ${featurebranch} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
-    echo "printenv -> "
-    printenv
-  fi
-fi
+job_launch_sanity_checks()
 
 # Banner
-echo "==========================================================================="
-echo "Darwin Regression job launcher for ${subproj} - ${build_type} flavor."
-echo "==========================================================================="
-echo " "
-echo "Environment:"
-echo "   subproj        = ${subproj}"
-echo "   build_type     = ${build_type}"
-if [[ ! ${extra_params} ]]; then
-  echo "   extra_params   = none"
-else
-  echo "   extra_params   = ${extra_params}"
-fi
-if [[ ${featurebranch} ]]; then
-  echo "   featurebranch  = ${featurebranch}"
-fi
-echo "   regdir         = ${regdir}"
-echo "   rscriptdir     = ${rscriptdir}"
-echo "   logdir         = ${logdir}"
-echo "   dashboard_type = ${dashboard_type}"
-echo "   build_autodoc  = ${build_autodoc}"
-echo " "
-echo "   ${subproj}: dep_jobids = ${dep_jobids}"
-echo " "
+print_job_launch_banner()
 
 # Prerequisits:
 # Wait for all dependencies to be met before creating a new job

--- a/regression/metrics_report.sh
+++ b/regression/metrics_report.sh
@@ -6,7 +6,7 @@
 
 # Typical use:
 # ./metrics_report.sh -e kgt@lanl.gov -p "draco jayenne capsaicin"
-# ./metrics_report.sh -e "jsbrock@lanl.gov jomc@lanl.gov sriram@lanl.gov draco@lanl.gov" -p "draco jayenne capsaicin"
+# ./metrics_report.sh -e "jsbrock@lanl.gov jomc@lanl.gov gshipman@lanl.gov draco@lanl.gov" -p "draco jayenne capsaicin"
 
 ##---------------------------------------------------------------------------##
 ## Support functions

--- a/regression/ml-job-launch.sh
+++ b/regression/ml-job-launch.sh
@@ -20,7 +20,6 @@
 args=( "$@" )
 nargs=${#args[@]}
 scriptname=${0##*/}
-host=`uname -n`
 
 export SHOWQ=`which squeue`
 export MSUB=`which sbatch`
@@ -31,72 +30,29 @@ for (( i=0; i < $nargs ; ++i )); do
    dep_jobids="${dep_jobids} ${args[$i]} "
 done
 
-# sanity check
-if [[ ! ${regdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
-    exit 1
-fi
-if [[ ! ${rscriptdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
-    exit 1
-fi
-if [[ ! ${subproj} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
-    exit 1
-fi
-if [[ ! ${build_type} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
-    exit 1
-fi
-if [[ ! ${logdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
-    exit 1
+# load some common bash functions
+export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ -f $rscriptdir/scripts/common.sh ]]; then
+  source $rscriptdir/scripts/common.sh
+else
+  echo " "
+  echo "FATAL ERROR: Unable to locate Draco's bash functions: "
+  echo "   looking for .../regression/scripts/common.sh"
+  echo "   searched rscriptdir = $rscriptdir"
+  exit 1
 fi
 
-if test $subproj == draco || test $subproj == jayenne; then
-  if [[ ! ${featurebranch} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
-    echo "printenv -> "
-    printenv
-  fi
-fi
+# sanity checks
+job_launch_sanity_checks
 
 available_queues=`sacctmgr -np list assoc user=$LOGNAME | grep access | sed -e 's/.*|\(.*access.*\)|.*/\1/'  | sed -e 's/|.*//'`
-# snow: available_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\)|.*/\1/' | sed -e 's/|.*//'`
 case $available_queues in
   *access*) access_queue="-A access --qos=access" ;;
   *dev*) access_queue="--qos=dev" ;;
 esac
 
 # Banner
-echo "==========================================================================="
-echo "ML Regression job launcher for ${subproj} - ${build_type} flavor."
-echo "==========================================================================="
-echo " "
-echo "Environment:"
-echo "   subproj        = ${subproj}"
-echo "   build_type     = ${build_type}"
-if [[ ! ${extra_params} ]]; then
-  echo "   extra_params   = none"
-else
-  echo "   extra_params   = ${extra_params}"
-fi
-if [[ ${featurebranch} ]]; then
-  echo "   featurebranch  = ${featurebranch}"
-fi
-echo "   regdir         = ${regdir}"
-echo "   rscriptdir     = ${rscriptdir}"
-echo "   scratchdir     = ${scratchdir}"
-echo "   logdir         = ${logdir}"
-echo "   dashboard_type = ${dashboard_type}"
-echo "   build_autodoc  = ${build_autodoc}"
-echo "   access_queue   = ${access_queue}"
-echo " "
-echo "   ${subproj}: dep_jobids = ${dep_jobids}"
-echo " "
-
-echo "module purge &> /dev/null"
-module purge &> /dev/null
+print_job_launch_banner
 
 # Prerequisits:
 # Wait for all dependencies to be met before creating a new job
@@ -149,7 +105,7 @@ done
 echo " "
 echo "Submit:"
 export REGRESSION_PHASE=s
-echo "Jobs done, now submitting ${build_type} results from ${host}."
+echo "Jobs done, now submitting ${build_type} results."
 cmd="${rscriptdir}/ml-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-s.log"
 echo "${cmd}"
 eval "${cmd}"

--- a/regression/ml-options.sh
+++ b/regression/ml-options.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+## -*- Mode: sh -*-
+##---------------------------------------------------------------------------##
+## File  : regression/sripts/ml-options.sh
+## Date  : Tuesday, May 16, 2017, 21:42 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
+##
+## Summary: Capture ml-specific features that plug into regression-master.sh.
+##---------------------------------------------------------------------------##
+
+# Main Options
+machine_name_long="Moonlight"
+platform_extra_params="fulldiagnostics nr perfbench pgi valgrind"
+pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
+
+##---------------------------------------------------------------------------##
+## End ml-options.sh
+##---------------------------------------------------------------------------##

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -513,6 +513,84 @@ function allow_file_to_age
   done
 }
 
+#------------------------------------------------------------------------------#
+# Ensure environment is reasonable
+# Called from <machine>-job-launch.sh
+function job_launch_sanity_checks()
+{
+  if [[ ! ${regdir} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
+    echo "printenv -> "
+    printenv
+    exit 1
+  fi
+  if [[ ! ${rscriptdir} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
+    echo "printenv -> "
+    printenv
+    exit 1
+  fi
+  if [[ ! ${subproj} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
+    echo "printenv -> "
+    printenv
+    exit 1
+  fi
+  if [[ ! ${build_type} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
+    echo "printenv -> "
+    printenv
+    exit 1
+  fi
+  if [[ ! ${logdir} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
+    echo "printenv -> "
+    printenv
+    exit 1
+  fi
+  if [[ ! ${featurebranch} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
+    echo "printenv -> "
+    printenv
+  fi
+}
+
+#------------------------------------------------------------------------------#
+# Job Launch Banner
+function print_job_launch_banner()
+{
+echo "==========================================================================="
+echo "$machine_name_long regression job launcher for ${subproj} - ${build_type} flavor."
+echo "==========================================================================="
+echo " "
+echo "Environment:"
+echo "   build_autodoc  = ${build_autodoc}"
+echo "   build_type     = ${build_type}"
+echo "   dashboard_type = ${dashboard_type}"
+echo "   epdash         = $epdash"
+if [[ ! ${extra_params} ]]; then
+  echo "   extra_params   = none"
+else
+  echo "   extra_params   = ${extra_params}"
+fi
+if [[ ${featurebranch} ]]; then
+  echo "   featurebranch  = ${featurebranch}"
+fi
+echo "   logdir         = ${logdir}"
+echo "   logfile        = ${logfile}"
+echo "   machine_name_long = $machine_name_long"
+echo "   prdash         = $prdash"
+echo "   projects       = \"${projects}\""
+echo "   regdir         = ${regdir}"
+echo "   regress_mode   = ${regress_mode}"
+echo "   rscriptdir     = ${rscriptdir}"
+echo "   scratchdir     = ${scratchdir}"
+echo "   subproj        = ${subproj}"
+echo " "
+echo "   ${subproj}: dep_jobids = ${dep_jobids}"
+echo " "
+}
+
 ##----------------------------------------------------------------------------##
 export die
 export run
@@ -524,6 +602,7 @@ export selectscratchdir
 export npes_build
 export npes_test
 export install_versions
+export job_launch_sanity_checks
 
 ##----------------------------------------------------------------------------##
 ## End common.sh

--- a/regression/sn-job-launch.sh
+++ b/regression/sn-job-launch.sh
@@ -31,72 +31,29 @@ for (( i=0; i < $nargs ; ++i )); do
    dep_jobids="${dep_jobids} ${args[$i]} "
 done
 
+# load some common bash functions
+export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ -f $rscriptdir/scripts/common.sh ]]; then
+  source $rscriptdir/scripts/common.sh
+else
+  echo " "
+  echo "FATAL ERROR: Unable to locate Draco's bash functions: "
+  echo "   looking for .../regression/scripts/common.sh"
+  echo "   searched rscriptdir = $rscriptdir"
+  exit 1
+fi
+
 # sanity check
-if [[ ! ${regdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
-    exit 1
-fi
-if [[ ! ${rscriptdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
-    exit 1
-fi
-if [[ ! ${subproj} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
-    exit 1
-fi
-if [[ ! ${build_type} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
-    exit 1
-fi
-if [[ ! ${logdir} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
-    exit 1
-fi
+job_launch_sanity_checks
 
-if test $subproj == draco || test $subproj == jayenne; then
-  if [[ ! ${featurebranch} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
-    echo "printenv -> "
-    printenv
-  fi
-fi
-
-#moonlight: available_queues=`sacctmgr -np list assoc user=$LOGNAME | grep access | sed -e 's/.*|\(.*access.*\)|.*/\1/'  | sed -e 's/|.*//'`
 available_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\)|.*/\1/' | sed -e 's/|.*//'`
 case $avail_queues in
-  *access*) access_queue="-A access" ;;
-  *dev*) access_queue="--qos=dev" ;;
+  *access*) access_queue="-A access --qos=access" ;;
+  *dev*)    access_queue="--qos=dev" ;;
 esac
 
 # Banner
-echo "==========================================================================="
-echo "Snow regression job launcher for ${subproj} - ${build_type} flavor."
-echo "==========================================================================="
-echo " "
-echo "Environment:"
-echo "   subproj        = ${subproj}"
-echo "   build_type     = ${build_type}"
-if [[ ! ${extra_params} ]]; then
-  echo "   extra_params   = none"
-else
-  echo "   extra_params   = ${extra_params}"
-fi
-if [[ ${featurebranch} ]]; then
-  echo "   featurebranch  = ${featurebranch}"
-fi
-echo "   regdir         = ${regdir}"
-echo "   rscriptdir     = ${rscriptdir}"
-echo "   scratchdir     = ${scratchdir}"
-echo "   logdir         = ${logdir}"
-echo "   dashboard_type = ${dashboard_type}"
-echo "   build_autodoc  = ${build_autodoc}"
-echo "   access_queue   = ${access_queue}"
-echo " "
-echo "   ${subproj}: dep_jobids = ${dep_jobids}"
-echo " "
-
-echo "module purge &> /dev/null"
-module purge &> /dev/null
+print_job_launch_banner
 
 # Prerequisits:
 # Wait for all dependencies to be met before creating a new job

--- a/regression/sn-options.sh
+++ b/regression/sn-options.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+## -*- Mode: sh -*-
+##---------------------------------------------------------------------------##
+## File  : regression/sripts/sn-options.sh
+## Date  : Tuesday, May 16, 2017, 21:42 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
+##
+## Summary: Capture sn-specific features that plug into regression-master.sh.
+##---------------------------------------------------------------------------##
+
+# Main Options
+export machine_name_long="Snow"
+platform_extra_params="fulldiagnostics gcc610 newtools nr perfbench valgrind"
+pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
+
+##---------------------------------------------------------------------------##
+## End sn-options.sh
+##---------------------------------------------------------------------------##

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -320,11 +320,14 @@ fi
 echo " "
 echo "========================================================================"
 echo "Starting CI regressions (if any)"
+date
 echo "========================================================================"
 echo " "
 # Draco CI ------------------------------------------------------------
 
 draco_prs=`cat $TMPFILE_DRACO | grep -e 'refs/pull/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
+# remove any duplicates
+draco_prs=`echo $draco_prs | xargs -n1 | sort -u | xargs`
 for pr in $draco_prs; do
   run "$scriptdir/checkpr.sh -r -p draco -f $pr"
 done
@@ -332,6 +335,8 @@ done
 # Jayenne CI ----------------------------------------------------------
 
 jayenne_prs=`cat $TMPFILE_JAYENNE | grep -e 'refs/merge-requests/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
+# remove any duplicates
+jayenne_prs=`echo $jayenne_prs | xargs -n1 | sort -u | xargs`
 for pr in $jayenne_prs; do
   run "$scriptdir/checkpr.sh -r -p jayenne -f $pr"
 done
@@ -339,6 +344,8 @@ done
 # Capsaicin CI ----------------------------------------------------------
 
 capsaicin_prs=`cat $TMPFILE_CAPSAICIN | grep -e 'refs/merge-requests/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
+# remove any duplicates
+capsaicin_prs=`echo $capsaicin_prs | xargs -n1 | sort -u | xargs`
 for pr in $capsaicin_prs; do
   run "$scriptdir/checkpr.sh -r -p capsaicin -f $pr"
 done
@@ -361,6 +368,7 @@ run "rm $TMPFILE_DRACO $TMPFILE_JAYENNE $TMPFILE_CAPSAICIN"
 run "rm $lockfile"
 
 echo " "
+date
 echo "All done."
 
 #------------------------------------------------------------------------------#

--- a/regression/sync_vendors.sh
+++ b/regression/sync_vendors.sh
@@ -67,6 +67,7 @@ echo " "
 echo "Clean up permissions on source files..."
 run "chgrp -R draco $vdir"
 run "chmod -R g+rwX,o=g-w $vdir"
+run "chmod -R o-rwX $vdir/ndi* $vdir/csk* $vdir/cubit* $vdir/eospac*"
 
 echo " "
 echo "Save a copy of /scratch/vendors to $r72v..."

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -28,6 +28,7 @@ scriptname=${0##*/}
 host=`uname -n`
 
 # import some bash functions
+export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $rscriptdir/scripts/common.sh
 
 export SHOWQ=`which squeue`
@@ -39,57 +40,11 @@ for (( i=0; i < $nargs ; ++i )); do
    dep_jobids="${dep_jobids} ${args[$i]} "
 done
 
-# sanity check
-if [[ ! ${regdir} ]]; then
-  die "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
-fi
-if [[ ! ${rscriptdir} ]]; then
-  die "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
-fi
-if [[ ! ${subproj} ]]; then
-  die "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
-fi
-if [[ ! ${build_type} ]]; then
-  die "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
-fi
-if [[ ! ${logdir} ]]; then
-  die "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
-fi
-
-if test $subproj == draco || test $subproj == jayenne; then
-  if [[ ! ${featurebranch} ]]; then
-    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
-    echo "printenv -> "
-    printenv
-  fi
-fi
+# sanity checks
+job_launch_sanity_checks
 
 # Banner
-echo "==========================================================================="
-echo "Trinitite Regression job launcher for ${subproj} - ${build_type} flavor."
-echo "==========================================================================="
-echo " "
-echo "Environment:"
-echo "   subproj        = ${subproj}"
-echo "   build_type     = ${build_type}"
-if [[ ! ${extra_params} ]]; then
-  echo "   extra_params   = none"
-else
-  echo "   extra_params   = ${extra_params}"
-fi
-if [[ ${featurebranch} ]]; then
-  echo "   featurebranch  = ${featurebranch}"
-fi
-echo "   regdir         = ${regdir}"
-echo "   rscriptdir     = ${rscriptdir}"
-echo "   scratchdir     = ${scratchdir}"
-echo "   logdir         = ${logdir}"
-echo "   dashboard_type = ${dashboard_type}"
-echo "   build_autodoc  = ${build_autodoc}"
-echo "   access_queue   = ${access_queue}"
-echo " "
-echo "   ${subproj}: dep_jobids = ${dep_jobids}"
-echo " "
+print_job_launch_banner
 
 # Prerequisits:
 # Wait for all dependencies to be met before creating a new job

--- a/regression/tt-options.sh
+++ b/regression/tt-options.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+## -*- Mode: sh -*-
+##---------------------------------------------------------------------------##
+## File  : regression/sripts/tt-options.sh
+## Date  : Tuesday, May 16, 2017, 21:42 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
+##
+## Summary: Capture tt-specific features that plug into regression-master.sh.
+##---------------------------------------------------------------------------##
+
+# Main Options
+export machine_name_long="Trinitite"
+platform_extra_params="fulldiagnostics knl  nr perfbench"
+pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
+
+##---------------------------------------------------------------------------##
+## End tt-options.sh
+##---------------------------------------------------------------------------##


### PR DESCRIPTION
This pull request consists of code that is currently active in the active regression script directory on ccscs7.  These changes focus on reducing code duplication and simplifying maintenance.

+ Update crontab that runs the `metric_report.sh` monthly to fix a bug (a missing escape). Also update the comments that indicate to whom the report should be delivered.
+ Delay the start of the coverage and valgrind regressions to provide more time for the Release regressions to finish.
+ Create two new bash functions in scripts/common.sh: `job_launch_sanity_checks` and `print_job_launch_banner`.  Call these functions from the `<machine>-job-launch.sh` scripts instead of maintaining identical coding in several files.
+ Abstract out some information previously found in `regresssion-master.sh` so that the master script is more generic and easier to maintain.  Platform specific information used by this script is now archived in files of the name `<machine>-options.sh`.  This information is currently limited to:
  - `machine_name_long` - a text string description for each machine.
  - `platform_extra_params` - string names of that designate special regression builds available on the current machine.
  - `pem_match` - This string is used in as a case statement match regex.
+ `ccscs-regress.msub` script was modified to work correctly with the Lmod module system that we are currently using on ccs-net machines. Also:
  - retire regression builds `belosmods`, `bounds_checking`, `gcc530` and `gcc610`.
  - Regressions for ccs-net machines will use `gcc-6.3.0` or `llvm`.
+ We don't currently test on Darwin and the regression system has atrophied. Report an error if the regression system tries to run on Darwin.
+ Update the `sync_repository.sh` script to prevent the same PR from being started more than once.  This can occasionally occur due to the way git presents pr updates to the mirrored git repository.
+ Update the `sync_vendors.sh` script used on ccs-net machines to keep the vendor directory synchronized between machines (`ccscs7:/scratch/vendors/` is the master). This update ensures that some directories are marked with restricted access (`chmod -R o-rwX`).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
