### PR TITLE
Miscellaneous improvements to environment, build system and scripts.

### DIFF
--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -61,7 +61,6 @@ macro( dbsSetDefaults )
   if( CMAKE_CONFIGURATION_TYPES )
     set( Draco_BUILD_TYPE "Multi-config")
   else()
-    set( Draco_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
     string( TOUPPER ${CMAKE_BUILD_TYPE} Draco_BUILD_TYPE )
   endif()
 
@@ -78,11 +77,12 @@ macro( dbsSetDefaults )
     if( NOT CMAKE_CONFIGURATION_TYPES )
       if( "${Draco_BUILD_TYPE}" MATCHES "RELEASE" )
         set( DRACO_DBC_LEVEL "0" )
-      elseif( "${CMAKE_BUILD_TYPE}" MATCHES "RELWITHDEBINFO" )
+      elseif( "${Draco_BUILD_TYPE}" MATCHES "RELWITHDEBINFO" )
         set( DRACO_DBC_LEVEL "15" )
       endif()
     endif()
-    set( DRACO_DBC_LEVEL "${DRACO_DBC_LEVEL}" CACHE STRING "Design-by-Contract (0-31)?" )
+    set( DRACO_DBC_LEVEL "${DRACO_DBC_LEVEL}" CACHE STRING
+      "Design-by-Contract (0-31)?" )
     # provide a constrained drop down menu in cmake-gui
     set_property( CACHE DRACO_DBC_LEVEL PROPERTY STRINGS
       0 1 2 3 4 5 6 7 9 10 11 12 13 14 15
@@ -92,7 +92,8 @@ macro( dbsSetDefaults )
   if( CMAKE_CONFIGURATION_TYPES )
     # This generator expression will be expanded when the project is installed
     # (CMake-3.4.0+)
-    set(DBSCFGDIR "\$<CONFIG>/" CACHE STRING "Install subdirectory for multiconfig build tools.")
+    set(DBSCFGDIR "\$<CONFIG>/" CACHE STRING
+      "Install subdirectory for multiconfig build tools.")
     # Generate a complete installation directory structure to avoid errors of
     # the form "imported target includes non-existent path" when configuring
     # Jayenne.
@@ -107,9 +108,11 @@ macro( dbsSetDefaults )
 
   # Library type to build
   # Linux: STATIC is a lib<XXX>.a
-  #        SHARED is a lib<XXX>.so (requires rpath or .so found in $LD_LIBRARY_PATH
+  #        SHARED is a lib<XXX>.so (requires rpath or .so found in
+  #               $LD_LIBRARY_PATH)
   # MSVC : STATIC is <XXX>.lib
-  #        SHARED is <XXX>.dll (requires dll to be in $PATH or in same directory as exe).
+  #        SHARED is <XXX>.dll (requires dll to be in $PATH or in same
+  #               directory as exe).
   if( NOT DEFINED DRACO_LIBRARY_TYPE )
     set( DRACO_LIBRARY_TYPE "SHARED" )
   endif()
@@ -132,8 +135,8 @@ macro( dbsSetDefaults )
 
      # Do not skip the full RPATH for the build tree
      set( CMAKE_SKIP_BUILD_RPATH OFF )
-     # When building, don't use the install RPATH already
-     # (but later on when installing)
+     # When building, don't use the install RPATH already (but later on when
+     # installing)
      set( CMAKE_BUILD_WITH_INSTALL_RPATH OFF )
 
      # For libraries created within the build tree, replace the RPATH
@@ -142,8 +145,8 @@ macro( dbsSetDefaults )
        "RPATH to embed in dynamic libraries and executables when
 targets are installed." FORCE )
 
-     # add the automatically determined parts of the RPATH
-     # which point to directories outside the build tree to the install RPATH
+     # add the automatically determined parts of the RPATH which point to
+     # directories outside the build tree to the install RPATH
      set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
   endif()
 

--- a/environment/bashrc/.bashrc_rfta
+++ b/environment/bashrc/.bashrc_rfta
@@ -21,6 +21,8 @@ if [[ ! ${VENDOR_DIR} ]]; then
    fi
 fi
 
+add_to_path $VENDOR_DIR/bin
+
 #
 # MODULES
 #
@@ -42,8 +44,16 @@ if [[ ! ${modcmd} ]]; then
    echo "ERROR: The module command was not found. No modules will be loaded."
 else
 
-  module use --append /usr/projects/packages/user_contrib/modulefiles/fta
-  module load hsi psi
+  # If modulefiles is located at $HOME, assume that the current developer wants
+  # to use his/her own checkout of user_contrib modulefiles.
+  if test -d $HOME/modulefiles; then
+    export ucmf=$HOME/modulefiles
+    module use --append $ucmf/fta
+  else
+    module load user_contrib
+  fi
+
+  export dracomodules="hsi psi svn"
 
 fi
 

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -29,6 +29,8 @@ if [[ ! ${VENDOR_DIR} ]]; then
    fi
 fi
 
+add_to_path $VENDOR_DIR/bin
+
 # If LESS is set, is should include '-R' so that git diff's color
 # displays correctly.
 if [[ -n "${LESS}" ]]; then

--- a/regression/alist.sh
+++ b/regression/alist.sh
@@ -79,26 +79,26 @@ for entry in "${entries[@]}"; do
   if [[ $current_loc == "" ]]; then current_loc=0; fi
 
   case $current_author in
-    along | Alex*  ) current_author="Alex Long" ;;
-    clevelam | *Cleveland) current_author="Matt Cleveland" ;;
-    gaber) current_author="Gabe Rockefeller" ;;
+    along | Alex*  ) current_author="Alex R. Long" ;;
+    clevelam | *Cleveland) current_author="Matt A. Cleveland" ;;
+    gaber) current_author="Gabe M. Rockefeller" ;;
     hkpark) current_author="HyeongKae Park" ;;
-    jdd) current_author="Jeff Densmore" ;;
-    jhchang | Jae* ) current_author="Jae Chang" ;;
+    jdd) current_author="Jeff D. Densmore" ;;
+    jhchang | Jae* ) current_author="Jae H. Chang" ;;
     keadyk | Kendra* ) current_author="Kendra P. Keady" ;;
-    kellyt | kgt | 107638 | Kelly*) current_author="Kelly Thompson" ;;
+    kellyt | kgt | 107638 | Kelly*) current_author="Kelly G. Thompson" ;;
     kgbudge) current_author="Kent G. Budge" ;;
-    kwang) current_author="Katherine Wang" ;;
-    lowrie | *Lowrie) current_author="Rob Lowrie" ;;
-    lpritch) current_author="Lori Pritchett-Sheats" ;;
+    kwang) current_author="Katherine J. Wang" ;;
+    lowrie | *Lowrie) current_author="Rob B. Lowrie" ;;
+    lpritch) current_author="Lori A. Pritchett-Sheats" ;;
     maxrosa) current_author="Massimiliano Rosa" ;;
     ntmyers) current_author="Nick Meyers" ;;
     pahrens) current_author="Peter Ahrens" ;;
     talbotp) current_author="Paul Talbot" ;;
-    tmonster) current_author="Todd Urbatsch" ;;
-    warsa) current_author="James Warsa" ;;
-    wollaber) current_author="Allan Wollaber" ;;
-    wollaege) current_author="Ryan Thomas Wollaeger" ;;
+    tmonster) current_author="Todd J. Urbatsch" ;;
+    warsa) current_author="James S. Warsa" ;;
+    wollaber) current_author="Allan B. Wollaber" ;;
+    wollaege | *Wollaeger) current_author="Ryan T. Wollaeger" ;;
   esac
 
   echo "$current_author:$current_loc"


### PR DESCRIPTION
+ Fix issue related to RelWithDebInfo builds (`buildEnv.cmake`).
  - inconsistent use of case (`RelWithDebInfo != RELWITHDEBINFO`) was causing some confusion.  Change build system logic to force this string to all upper case before using its value in a conditional.
+ On redcap and cray machines, add `$VENDOR_DIR/bin` to the `PATH`.
+ On redcap, if available, use `~/modulefiles` instead of `user_contrib`.
+ Minor cleanup in `alist.sh`.  No changes to logic.
+ Update the bash function `selectscratchdir` function defined in `common.sh` and used by the release scripts.
  - When trying to locate a valid scratch directory, don't use *netscratch* unless all other scratch spaces fail the checks.
  - When trying to locate a valid scratch directory, ensure the directory isn't read-only.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
