### PR TITLE
Eliminate direct comparison of floating point types (RTT_Format_Reade…

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -110,7 +110,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
     #             the correct dynamic type.
     string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=float-divide-by-zero")
     string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=float-cast-overflow")
-    string( APPEND CMAKE_C_FLAGS_DEBUG " -fdiagnostics-color=always")
+    string( APPEND CMAKE_C_FLAGS_DEBUG " -fdiagnostics-color=auto")
 #    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=vptr")
 #    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=object-size")
 #    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=alignment")

--- a/src/RTT_Format_Reader/test/TestRTTFormatReader.cc
+++ b/src/RTT_Format_Reader/test/TestRTTFormatReader.cc
@@ -13,6 +13,7 @@
 #include "RTT_Format_Reader/RTT_Mesh_Reader.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
+#include "ds++/Soft_Equivalence.hh"
 #include "ds++/path.hh"
 #include <sstream>
 
@@ -166,7 +167,7 @@ bool check_header(RTT_Format_Reader const &mesh, Meshes const &meshtype,
     all_passed = false;
   }
   // Check time.
-  if (mesh.get_header_time() != time) {
+  if (!rtt_dsxx::soft_equiv(mesh.get_header_time(), time)) {
     FAILMSG("Header time not obtained.");
     all_passed = false;
   }
@@ -1269,7 +1270,7 @@ bool check_nodes(RTT_Format_Reader const &mesh, Meshes const &meshtype,
   bool got_node_coord = true;
   for (size_t i = 0; i < mesh.get_dims_nnodes(); i++) {
     for (size_t d = 0; d < mesh.get_dims_ndim(); d++)
-      if (coords[i][d] != mesh.get_nodes_coords(i, d))
+      if (!rtt_dsxx::soft_equiv(coords[i][d], mesh.get_nodes_coords(i, d)))
         got_node_coord = false;
   }
   if (!got_node_coord) {
@@ -1544,7 +1545,7 @@ bool check_node_data(RTT_Format_Reader const &mesh, Meshes const &meshtype,
   bool got_node_data = true;
   for (size_t i = 0; i < mesh.get_dims_nnodes(); i++) {
     for (size_t d = 0; d < mesh.get_dims_nnode_data(); d++)
-      if (data[i][d] != mesh.get_node_data(i, d))
+      if (!rtt_dsxx::soft_equiv(data[i][d], mesh.get_node_data(i, d)))
         got_node_data = false;
   }
   if (!got_node_data) {
@@ -1605,7 +1606,7 @@ bool check_side_data(RTT_Format_Reader const &mesh, Meshes const &meshtype,
   bool got_side_data = true;
   for (size_t i = 0; i < mesh.get_dims_nsides(); i++) {
     for (size_t d = 0; d < mesh.get_dims_nside_data(); d++)
-      if (data[i][d] != mesh.get_side_data(i, d))
+      if (!rtt_dsxx::soft_equiv(data[i][d], mesh.get_side_data(i, d)))
         got_side_data = false;
   }
   if (!got_side_data) {
@@ -1664,7 +1665,7 @@ bool check_cell_data(RTT_Format_Reader const &mesh, Meshes const &meshtype,
   bool got_cell_data = true;
   for (size_t i = 0; i < mesh.get_dims_ncells(); i++) {
     for (size_t d = 0; d < mesh.get_dims_ncell_data(); d++)
-      if (data[i][d] != mesh.get_cell_data(i, d))
+      if (!rtt_dsxx::soft_equiv(data[i][d], mesh.get_cell_data(i, d)))
         got_cell_data = false;
   }
   if (!got_cell_data) {

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -10,6 +10,7 @@
 
 #include "CDI.hh"
 #include "ds++/Safe_Divide.hh"
+#include "ds++/Soft_Equivalence.hh"
 #include <iostream>
 #include <limits>
 #include <numeric>
@@ -267,7 +268,7 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 
   planck.resize(groups, 0.0);
 
-  if (T == 0)
+  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
     return;
 
   double scaled_frequency;
@@ -317,7 +318,7 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
 
   rosseland.resize(groups, 0.0);
 
-  if (T == 0.0)
+  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
     return;
 
   double scaled_frequency;
@@ -378,7 +379,7 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
   planck.resize(groups, 0.0);
   rosseland.resize(groups, 0.0);
 
-  if (T == 0.0)
+  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
     return;
 
   double scaled_frequency;

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -268,7 +268,7 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 
   planck.resize(groups, 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
+  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
     return;
 
   double scaled_frequency;
@@ -318,7 +318,7 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
 
   rosseland.resize(groups, 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
+  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
     return;
 
   double scaled_frequency;
@@ -379,7 +379,7 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
   planck.resize(groups, 0.0);
   rosseland.resize(groups, 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
+  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
     return;
 
   double scaled_frequency;
@@ -582,7 +582,7 @@ double CDI::collapseMultigroupOpacitiesRosseland(
   Require(rosselandSpectrum.size() == groupBounds.size() - 1);
 
   // If all opacities are zero, then the Rosseland mean will also be zero.
-  double const eps(1.0e-16);
+  double const eps(std::numeric_limits<double>::epsilon());
   double const opacity_sum =
       std::accumulate(opacity.begin(), opacity.end(), 0.0);
   if (rtt_dsxx::soft_equiv(opacity_sum, 0.0, eps)) {

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -197,8 +197,8 @@ static double polylog_series_minus_one_planck(double const x,
  *
  * This helper function is used by CDI::integrate_planck_rosseland
  * (also in this file).
- * 
- * ==> The underlying function x^4/(exp(x) - 1) can be difficult to evaluate 
+ *
+ * ==> The underlying function x^4/(exp(x) - 1) can be difficult to evaluate
  *     with double precision when x is very small. Instead, when x < 1.e-5,
  *     we use the first 2 terms in the expansion x^4/(exp(x) - 1) ~ x^3(1-x/2),
  *     remaining terms are x^5/12 + O(x^7).
@@ -207,11 +207,11 @@ static double polylog_series_minus_one_planck(double const x,
  *     1-exp(-x) suffers when x is large. However, std::expm1 should improve
  *     the accuracy of that evaluation.
  * ==> The large x fix might be able to be changed in the future if bug listed
- *     in man page is corrected. 
- * 
- * \param  freq The frequency for the upper limit of the integrand. 
+ *     in man page is corrected.
+ *
+ * \param  freq The frequency for the upper limit of the integrand.
  * \param  exp_freq exp(-freq)
- * \return The difference between the integrated Planck and Rosseland 
+ * \return The difference between the integrated Planck and Rosseland
  * curves over \f$ (0,\nu) \f$.
  */
 static double Planck2Rosseland(double const freq, double const exp_freq) {
@@ -378,8 +378,6 @@ namespace rtt_cdi {
  * function.  When both frequency bounds reside above the Planckian peak
  * (above 2.822 T), we skip the Taylor series calculations and use the
  * polylogarithmic series minus one (the minus one is for roundoff control).
- *
- *
  *
  * This Rosseland functions integrate the normalized Rosseland that is defined:
  * \f[

--- a/src/cdi/CDI_Integrate_Rosseland_Planckian_Spectrum.cc
+++ b/src/cdi/CDI_Integrate_Rosseland_Planckian_Spectrum.cc
@@ -5,15 +5,13 @@
  * \date   Thu Jun 22 16:22:07 2000
  * \brief  CDI class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: CDI.cc 7388 2015-01-22 16:02:07Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "CDI.hh"
 
 namespace rtt_cdi {
+
 //---------------------------------------------------------------------------//
 // Rosseland Spectrum Integrators
 //---------------------------------------------------------------------------//
@@ -53,7 +51,7 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(double low, double high,
   Require(high >= low);
   Require(T >= 0.0);
 
-  if (T == 0.0) {
+  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16)) {
     planck = 0.0;
     rosseland = 0.0;
     return;

--- a/src/cdi/CDI_Integrate_Rosseland_Planckian_Spectrum.cc
+++ b/src/cdi/CDI_Integrate_Rosseland_Planckian_Spectrum.cc
@@ -51,7 +51,7 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(double low, double high,
   Require(high >= low);
   Require(T >= 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16)) {
+  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon())) {
     planck = 0.0;
     rosseland = 0.0;
     return;

--- a/src/cdi/CDI_collapseOdfmgOpacitiesRosseland.cc
+++ b/src/cdi/CDI_collapseOdfmgOpacitiesRosseland.cc
@@ -5,10 +5,7 @@
  * \date   Thu Jun 22 16:22:07 2000
  * \brief  CDI class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: CDI.cc 7388 2015-01-22 16:02:07Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "CDI.hh"
@@ -20,7 +17,7 @@ namespace rtt_cdi {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Collapse a multigroup-multiband opacity set into a single
- * representative value weighted by the Rosseland function.
+ *        representative value weighted by the Rosseland function.
  *
  * \param groupBounds The vector of group boundaries. Size n+1
  * \param T         The material temperature.
@@ -30,16 +27,15 @@ namespace rtt_cdi {
  *                  CDI::integrate_Rosseland_Planckian_Sectrum(...).
  * \return A single interval Rosseland weighted opacity value.
  *
- * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain rosselandSpectrum. 
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain rosselandSpectrum.
  *
  * There are 2 special cases that we check for:
  * 1. All opacities are zero - just return 0.0;
  * 2. The Rosseland Integral is very small (or zero).  In this case, perform a
  *    modified calculation that does not depend on the Rosseland integral.
  *
- * If neither of the special cases are in effect, then do the normal
- * evaluation. 
+ * If neither of the special cases are in effect, then do the normal evaluation.
  */
 double CDI::collapseOdfmgOpacitiesRosseland(
     std::vector<double> const &groupBounds,
@@ -52,7 +48,7 @@ double CDI::collapseOdfmgOpacitiesRosseland(
   Require(rosselandSpectrum.size() == groupBounds.size() - 1);
 
   // If all opacities are zero, then the Rosseland mean will also be zero.
-  double const eps(1.0e-16);
+  double const eps(std::numeric_limits<double>::epsilon());
   double opacity_sum(0.0);
   for (size_t g = 1; g < groupBounds.size(); ++g)
     opacity_sum +=
@@ -70,11 +66,11 @@ double CDI::collapseOdfmgOpacitiesRosseland(
   double const rosseland_integral =
       std::accumulate(rosselandSpectrum.begin(), rosselandSpectrum.end(), 0.0);
 
-  // If the group bounds are well outside the Rosseland Spectrum at the
-  // current temperature, our algorithm may return a value that is within
-  // machine precision of zero.  In this case, we assume that this occurs
-  // when the temperature -> 0, so that limit(T->0) dB/dT = \delta(\nu).
-  // In this case we have:
+  // If the group bounds are well outside the Rosseland Spectrum at the current
+  // temperature, our algorithm may return a value that is within machine
+  // precision of zero.  In this case, we assume that this occurs when the
+  // temperature -> 0, so that limit(T->0) dB/dT = \delta(\nu).  In this case we
+  // have:
   //
   // sigma_R = sigma(g=0)
 

--- a/src/cdi/CDI_integratePlanckSpectrum.cc
+++ b/src/cdi/CDI_integratePlanckSpectrum.cc
@@ -5,10 +5,7 @@
  * \date   Thu Jun 22 16:22:07 2000
  * \brief  CDI class implementation file.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: CDI.cc 7388 2015-01-22 16:02:07Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "CDI.hh"
@@ -18,18 +15,17 @@ namespace rtt_cdi {
 /*!
  * \brief Integrate the Planckian spectrum over a frequency range.
  *
- * The arguments to this function must all be in consistent units. For
- * example, if low and high are expressed in keV, then the temperature must
- * also be expressed in keV. If low and high are in Hz and temperature is in
- * K, then low and high must first be multiplied by Planck's constant and
- * temperature by Boltzmann's constant before they are passed to this function.
+ * The arguments to this function must all be in consistent units. For example,
+ * if low and high are expressed in keV, then the temperature must also be
+ * expressed in keV. If low and high are in Hz and temperature is in K, then low
+ * and high must first be multiplied by Planck's constant and temperature by
+ * Boltzmann's constant before they are passed to this function.
  *
  * \param low lower frequency bound.
  * \param high higher frequency bound.
  * \param T the temperature (must be greater than 0.0)
- * 
- * \return integrated normalized Plankian from low to high
  *
+ * \return integrated normalized Plankian from low to high
  */
 double CDI::integratePlanckSpectrum(double low, double high, const double T) {
   Require(low >= 0.0);
@@ -37,7 +33,7 @@ double CDI::integratePlanckSpectrum(double low, double high, const double T) {
   Require(T >= 0.0);
 
   // return 0 if temperature is a hard zero
-  if (T == 0.0)
+  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
     return 0.0;
 
   // Sale the frequencies by temperature

--- a/src/cdi/CDI_integratePlanckSpectrum.cc
+++ b/src/cdi/CDI_integratePlanckSpectrum.cc
@@ -33,7 +33,7 @@ double CDI::integratePlanckSpectrum(double low, double high, const double T) {
   Require(T >= 0.0);
 
   // return 0 if temperature is a hard zero
-  if (rtt_dsxx::soft_equiv(T, 0.0, 1.0e-16))
+  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
     return 0.0;
 
   // Sale the frequencies by temperature

--- a/src/cdi_analytic/Pseudo_Line_Base.cc
+++ b/src/cdi_analytic/Pseudo_Line_Base.cc
@@ -232,7 +232,7 @@ double Pseudo_Line_Base::monoOpacity(double const x, double const T) const {
     for (int i = 0; i < number_of_lines; ++i) {
       double const nu0 = center_[i];
       double const d = (x - nu0) / (width * nu0);
-      //        Result += peak*exp(-d*d);
+      // Result += peak*exp(-d*d);
       Result += peak / (1 + d * d);
     }
   } else {
@@ -249,7 +249,8 @@ double Pseudo_Line_Base::monoOpacity(double const x, double const T) const {
       Result += edge_factor_[i] * cube(nu0 / x);
     }
   }
-  if (Tpow_ != 0.0) {
+  if (!rtt_dsxx::soft_equiv(Tpow_, 0.0,
+                            std::numeric_limits<double>::epsilon())) {
     Result = Result * pow(T / Tref_, Tpow_);
   }
   return Result;

--- a/src/cdi_analytic/test/tstAnalytic_EoS.cc
+++ b/src/cdi_analytic/test/tstAnalytic_EoS.cc
@@ -54,22 +54,21 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
     double Ui = 0.2 * T;
 
     // specific heats
-    if (analytic.getElectronHeatCapacity(T, rho) != Cve)
+    if (!soft_equiv(analytic.getElectronHeatCapacity(T, rho), Cve))
       ITFAILS;
-    if (analytic.getIonHeatCapacity(T, rho) != Cvi)
+    if (!soft_equiv(analytic.getIonHeatCapacity(T, rho), Cvi))
       ITFAILS;
 
     // specific internal energies
     if (!soft_equiv(analytic.getSpecificElectronInternalEnergy(T, rho), Ue))
       ITFAILS;
-
     if (!soft_equiv(analytic.getSpecificIonInternalEnergy(T, rho), Ui))
       ITFAILS;
 
     // everything else is zero
-    if (analytic.getNumFreeElectronsPerIon(T, rho) != 0.0)
+    if (!soft_equiv(analytic.getNumFreeElectronsPerIon(T, rho), 0.0))
       ITFAILS;
-    if (analytic.getElectronThermalConductivity(T, rho) != 0.0)
+    if (!soft_equiv(analytic.getElectronThermalConductivity(T, rho), 0.0))
       ITFAILS;
   }
 
@@ -90,16 +89,8 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
 
   // field check
   {
-    vector<double> T(6);
+    vector<double> T = {0.993, 0.882, 0.590, 0.112, 0.051, 0.001};
     vector<double> rho(6);
-
-    T[0] = .993;
-    T[1] = .882;
-    T[2] = .590;
-    T[3] = .112;
-    T[4] = .051;
-    T[5] = .001;
-
     std::fill(rho.begin(), rho.end(), 3.0);
     rho[3] = 2.5;
 
@@ -142,9 +133,9 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
         ITFAILS;
 
       // all else are zero
-      if (nfe[i] != 0.0)
+      if (!soft_equiv(nfe[i], 0.0))
         ITFAILS;
-      if (etc[i] != 0.0)
+      if (!soft_equiv(etc[i], 0.0))
         ITFAILS;
     }
   }
@@ -255,7 +246,6 @@ void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
 }
 
 //---------------------------------------------------------------------------//
-
 void CDI_test(rtt_dsxx::UnitTest &ut) {
   typedef Polynomial_Specific_Heat_Analytic_EoS_Model Polynomial_Model;
 
@@ -282,16 +272,8 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
     FAILMSG("Can't reference EoS smart pointer");
 
   // make temperature and density fields
-  vector<double> T(6);
+  vector<double> T = {0.993, 0.882, 0.590, 0.112, 0.051, 0.001};
   vector<double> rho(6);
-
-  T[0] = .993;
-  T[1] = .882;
-  T[2] = .590;
-  T[3] = .112;
-  T[4] = .051;
-  T[5] = .001;
-
   std::fill(rho.begin(), rho.end(), 3.0);
   rho[3] = 2.5;
 
@@ -335,13 +317,13 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
         ITFAILS;
 
       // all else are zero
-      if (Cvi[i] != 0.0)
+      if (!soft_equiv(Cvi[i], 0.0))
         ITFAILS;
-      if (iie[i] != 0.0)
+      if (!soft_equiv(iie[i], 0.0))
         ITFAILS;
-      if (nfe[i] != 0.0)
+      if (!soft_equiv(nfe[i], 0.0))
         ITFAILS;
-      if (etc[i] != 0.0)
+      if (!soft_equiv(etc[i], 0.0))
         ITFAILS;
     }
   }
@@ -401,13 +383,13 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
         ITFAILS;
 
       // all else are zero
-      if (Cvi[i] != 0.0)
+      if (!soft_equiv(Cvi[i], 0.0))
         ITFAILS;
-      if (iie[i] != 0.0)
+      if (!soft_equiv(iie[i], 0.0))
         ITFAILS;
-      if (nfe[i] != 0.0)
+      if (!soft_equiv(nfe[i], 0.0))
         ITFAILS;
-      if (etc[i] != 0.0)
+      if (!soft_equiv(etc[i], 0.0))
         ITFAILS;
     }
   }
@@ -416,7 +398,6 @@ void CDI_test(rtt_dsxx::UnitTest &ut) {
 }
 
 //---------------------------------------------------------------------------//
-
 void packing_test(rtt_dsxx::UnitTest &ut) {
   typedef Polynomial_Specific_Heat_Analytic_EoS_Model Polynomial_Model;
 
@@ -447,9 +428,9 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
     double Ui = 0.2 * T;
 
     // specific heats
-    if (neos.getElectronHeatCapacity(T, rho) != Cve)
+    if (!soft_equiv(neos.getElectronHeatCapacity(T, rho), Cve))
       ITFAILS;
-    if (neos.getIonHeatCapacity(T, rho) != Cvi)
+    if (!soft_equiv(neos.getIonHeatCapacity(T, rho), Cvi))
       ITFAILS;
 
     // specific internal energies
@@ -460,9 +441,9 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
       ITFAILS;
 
     // everything else is zero
-    if (neos.getNumFreeElectronsPerIon(T, rho) != 0.0)
+    if (!soft_equiv(neos.getNumFreeElectronsPerIon(T, rho), 0.0))
       ITFAILS;
-    if (neos.getElectronThermalConductivity(T, rho) != 0.0)
+    if (!soft_equiv(neos.getElectronThermalConductivity(T, rho), 0.0))
       ITFAILS;
   }
 

--- a/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
@@ -82,7 +82,8 @@ void constant_test(rtt_dsxx::UnitTest &ut) {
     T[i] = 0.1 + i / 100.0;
     rho[i] = 1.0 + i / 10.0;
 
-    if (grayp->getOpacity(T[i], rho[i]) != constant_opacity)
+    if (!rtt_dsxx::soft_equiv(grayp->getOpacity(T[i], rho[i]),
+                              constant_opacity))
       ITFAILS;
   }
 

--- a/src/cdi_ipcress/test/ReadOdfIpcressFile.cc
+++ b/src/cdi_ipcress/test/ReadOdfIpcressFile.cc
@@ -3,8 +3,7 @@
  * \file   cdi_ipcress/test/ReadOdfIpcressFile.cc
  * \author Seth R. Johnson
  * \date   Thu July 10 2008
- * \brief
- * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ * \note   Copyright (C) 2008-2017 Los Alamos National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
@@ -260,7 +259,8 @@ int main(int argc, char *argv[]) {
 
   switch (actionToTake) {
   case 0:
-    if (temperature == 0 || density == 0) {
+    if (rtt_dsxx::soft_equiv(temperature, 0.0) ||
+        rtt_dsxx::soft_equiv(density, 0.0)) {
       printGrid(spGandOpacity);
       askTempDens(temperature, density, is_unittest);
     }
@@ -270,21 +270,24 @@ int main(int argc, char *argv[]) {
     analyzeData(spGandOpacity);
     break;
   case 2:
-    if (temperature == 0 || density == 0) {
+    if (rtt_dsxx::soft_equiv(temperature, 0.0) ||
+        rtt_dsxx::soft_equiv(density, 0.0)) {
       printGrid(spGandOpacity);
       askTempDens(temperature, density, is_unittest);
     }
     printCData(spGandOpacity, temperature, density);
     break;
   case 3:
-    if (temperature == 0 || density == 0) {
+    if (rtt_dsxx::soft_equiv(temperature, 0.0) ||
+        rtt_dsxx::soft_equiv(density, 0.0)) {
       printGrid(spGandOpacity);
       askTempDens(temperature, density, is_unittest);
     }
     collapseOpacities(spGandOpacity, temperature, density);
     break;
   case 4:
-    if (temperature == 0 || density == 0) {
+    if (rtt_dsxx::soft_equiv(temperature, 0.0) ||
+        rtt_dsxx::soft_equiv(density, 0.0)) {
       printGrid(spGandOpacity);
       askTempDens(temperature, density, is_unittest);
     }
@@ -432,7 +435,7 @@ void collapseOpacities(SP_Goo spGandOpacity, double temperature,
       for (int band = numBands - 1; band >= 0; band--) {
         collapsedOpacity += bandWidths[band] / multiBandOpacities[group][band];
       }
-      if (collapsedOpacity != 0.0)
+      if (!rtt_dsxx::soft_equiv(collapsedOpacity, 0.0))
         collapsedOpacity = 1 / collapsedOpacity;
     } else // arithmetic average for planckian
     {
@@ -529,12 +532,12 @@ void printCData(SP_Goo spGandOpacity, double temperature, double density) {
   cout << "};" << endl;
 
   // print opacity data
-  cout << "const double opacities[numGroups][numBands] = {" << endl;
+  cout << "const double opacities[numGroups][numBands] = {\n";
 
   vec2_d multiBandOpacities = spGandOpacity->getOpacity(temperature, density);
 
   for (int group = 0; group < numGroups; group++) {
-    cout << "{" << endl;
+    cout << "{\n";
     // print data for each band
     for (int band = 0; band < numBands; band++) {
       printf("\t%#25.16g", multiBandOpacities[group][band]);
@@ -544,14 +547,14 @@ void printCData(SP_Goo spGandOpacity, double temperature, double density) {
 
       printf("\t\t// group %d band %d", group + 1, band + 1);
 
-      cout << endl;
+      cout << "\n";
     }
 
     cout << "}";
     if (group != numGroups - 1)
       cout << ",";
 
-    cout << endl;
+    cout << "\n";
   }
   cout << "};" << endl;
 }
@@ -566,9 +569,9 @@ void printData(SP_Goo spGandOpacity, double temperature, double density) {
   const vec_d groupBoundaries = spGandOpacity->getGroupBoundaries();
   const vec_d bandBoundaries = spGandOpacity->getBandBoundaries();
 
-  cout << "=============================================" << endl;
+  cout << "=============================================\n";
   cout << "Printing band data at " << temperature << " keV, "
-       << "rho = " << density << endl;
+       << "rho = " << density << "\n";
 
   vec2_d multiBandOpacities = spGandOpacity->getOpacity(temperature, density);
 
@@ -579,10 +582,8 @@ void printData(SP_Goo spGandOpacity, double temperature, double density) {
     double currentRatio = 0.0;
 
     cout << "=== Group " << group + 1 << " has energy range ["
-         << groupBoundaries[group] << "," << groupBoundaries[group + 1]
-         << "]\n";
-
-    cout << "Group Band  Width        Opacity  Ratio to first" << std::endl;
+         << groupBoundaries[group] << "," << groupBoundaries[group + 1] << "]\n"
+         << "Group Band  Width        Opacity  Ratio to first\n";
 
     // print data for each band
     for (int band = 0; band < numBands; band++) {
@@ -601,12 +602,12 @@ void printData(SP_Goo spGandOpacity, double temperature, double density) {
     }
   }
 
-  cout << "=============================================" << endl;
-  cout << "At " << temperature << " keV, "
-       << "rho = " << density << endl;
-  cout << "Best odf was in group " << maxGroup << " which had a high-to-low "
-       << "ratio of " << maxRatio << "." << endl;
-  cout << "=============================================" << endl;
+  cout << "=============================================\n"
+       << "At " << temperature << " keV, "
+       << "rho = " << density << "\n"
+       << "Best odf was in group " << maxGroup << " which had a high-to-low "
+       << "ratio of " << maxRatio << ".\n"
+       << "=============================================" << endl;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
+ To improve code reproducibility between machines, I am attempting to eliminate direct comparisons of floating point types.
+ I built Draco with user provided C_FLAGS='-Wfloat-equal -Werror' CXX_FLAGS='-Wfloat-equal -Werror' compiler options (GCC) to discover all of the cases where Draco did a direct comparison of two floating point values. I replaced such implementations with a safer comparison.
+ Also in this changeset:
  - When using GCC, add the `-Wunreachable-code` flag.
  - Cleaned up comment blocks.
  - Added const qualifiers in a few places.
  - Use C++11 uniform initialization in a few places.
+ This is the same as #245, but broken into smaller chunks for review.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
