### PR TITLE
Eliminate direct comparison of floating point types (VendorChecks...

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -66,9 +66,7 @@ endif()
 # Compiler Flags
 #
 # Consider using these diagnostic flags for Debug builds:
-# -Wundef     - warn about CPP macros read but not defined.
 # -Wcast-qual - warn about casts that remove qualifiers like const.
-# -Wfloat-equal
 # -Wstrict-overflow=4
 # -Wwrite-strings
 # -Wunreachable-code
@@ -82,10 +80,11 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
-  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef -DDEBUG")
-  # '-Werror'
-  # -D_FORTIFY_SOURCE=2 -Wconversion -Wfloat-equal -Wunreachable-code
-  set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
+  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef -Wunreachable-code -DDEBUG")
+  # -Wfloat-equal
+  # -Werror
+  # -Wconversion
+  set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -D_FORTIFY_SOURCE=2 -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -funroll-loops" )
 

--- a/src/VendorChecks/test/tstSuperludist.cc
+++ b/src/VendorChecks/test/tstSuperludist.cc
@@ -3,7 +3,7 @@
  * \file   VendorChecks/test/tstSuperludist.cc
  * \date   Monday, May 16, 2016, 16:30 pm
  * \brief  Attempt to link to libsuperludist and run a simple problem.
- * \note   Copyright (C) 2016, Los Alamos National Security, LLC.
+ * \note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
  *         All rights reserved.
  *
  * This code is a modified version of \c pddrive.c provided in the EXAMPLES
@@ -170,7 +170,7 @@ void test_superludist(rtt_c4::ParallelUnitTest &ut) {
   // Initialize the statistics variables.
   PStatInit(&stat);
 
-  if (*stat.ops != 0)
+  if (!rtt_dsxx::soft_equiv(static_cast<double>(*stat.ops), 0.0))
     ITFAILS;
   if (stat.TinyPivots != 0)
     ITFAILS;
@@ -225,8 +225,9 @@ void test_superludist(rtt_c4::ParallelUnitTest &ut) {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Read the matrix from data file in Harwell-Boeing format, and
- * distribute it to processors in a distributed compressed row format. It also
- * generate the distributed true solution X and the right-hand side RHS.
+ *        distribute it to processors in a distributed compressed row format. It
+ *        also generate the distributed true solution X and the right-hand side
+ *        RHS.
  *
  * \param[out] A    local matrix A in NR_loc format.
  * \param[in]  nrhs number of right-hand sides.

--- a/src/diagnostics/Timing.cc
+++ b/src/diagnostics/Timing.cc
@@ -5,17 +5,12 @@
  * \date   Tue Dec 13 10:44:29 2005
  * \brief  Timing class member defininitions.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- *
- * 2010-11-29 This component was moved from clubimc/utils to
- * draco/diagnostics. 
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Timing.hh"
 #include "ds++/Assert.hh"
+#include "ds++/Soft_Equivalence.hh"
 
 namespace rtt_diagnostics {
 
@@ -25,9 +20,9 @@ namespace rtt_diagnostics {
 /*!
  * \brief Add to a specified timer.
  *
- * This functions adds value to the timer with name key.  The first time this
- * is called the value is added to zero.  The timers are all static, so
- * multiple calls to the same key will keep a running tally.  To reset, call
+ * This functions adds value to the timer with name key.  The first time this is
+ * called the value is added to zero.  The timers are all static, so multiple
+ * calls to the same key will keep a running tally.  To reset, call
  * reset_timer().
  *
  * Calling this function adds the timer with name key to the map of timers.
@@ -69,7 +64,7 @@ Timing_Diagnostics::Vec_Keys Timing_Diagnostics::timer_keys() {
  */
 void Timing_Diagnostics::reset_timer(const std::string &key) {
   timers[key] = 0.0;
-  Ensure(timers[key] == 0.0);
+  Ensure(rtt_dsxx::soft_equiv(timers[key], 0.0));
 }
 
 //---------------------------------------------------------------------------//
@@ -116,5 +111,5 @@ std::map<std::string, double> Timing_Diagnostics::timers;
 } // end namespace rtt_diagnostics
 
 //---------------------------------------------------------------------------//
-//                 end of Timing.cc
+// end of Timing.cc
 //---------------------------------------------------------------------------//

--- a/src/quadrature/Ordinate.hh
+++ b/src/quadrature/Ordinate.hh
@@ -5,10 +5,7 @@
  * \date   Tue Dec 21 14:20:03 2004
  * \brief  Declaration file for the class rtt_quadrature::Ordinate.
  * \note   Copyright (C)  2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved. 
- */
-//---------------------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved.  */
 //---------------------------------------------------------------------------------------//
 
 #ifndef quadrature_Ordinate_hh
@@ -21,14 +18,13 @@ using rtt_dsxx::soft_equiv;
 
 //=======================================================================================//
 /*!
- * \class Ordinate
- * \brief Class containing angle cosines and weights for an element of
- * an ordinate set.
+ * \class Ordinate \brief Class containing angle cosines and weights for an
+ *        element of an ordinate set.
  *
- * Provides a container that represents \f$ \mathbf\Omega_m = \mu_m \mathbf e_x +
- * \eta_m \mathbf e_y + \xi_m \mathbf e_z \f$ plus the associated point weight,
- * \f$ w_m \f$. We could represent this as a simple 4-tuple of doubles, but
- * the ordinates must satisfy certain invariants that are protected by the
+ * Provides a container that represents \f$ \mathbf\Omega_m = \mu_m \mathbf e_x
+ * + \eta_m \mathbf e_y + \xi_m \mathbf e_z \f$ plus the associated point
+ * weight, \f$ w_m \f$. We could represent this as a simple 4-tuple of doubles,
+ * but the ordinates must satisfy certain invariants that are protected by the
  * class representation.
  */
 //=======================================================================================//
@@ -37,8 +33,8 @@ class Ordinate {
 public:
   // CREATORS
 
-  //! Create an uninitialized Ordinate.  This is required by the
-  //! constructor for vector<Ordinate>.
+  //! Create an uninitialized Ordinate.  This is required by the constructor for
+  //! vector<Ordinate>.
   Ordinate() : mu_(0), eta_(0), xi_(0), wt_(0) {}
 
   //! Construct an Ordinate from the specified vector and weight.
@@ -63,8 +59,8 @@ public:
   void set_wt(double const wt) { wt_ = wt; };
 
   double const *cosines() const {
-    // This is a little krufty, but guaranteed to work according to C++
-    // object layout rules.
+    // This is a little krufty, but guaranteed to work according to C++ object
+    // layout rules.
     return &mu_;
   }
 
@@ -73,9 +69,11 @@ private:
 
   // The data must be kept private in order to protect the norm invariant.
 
-  //! Angle cosines for the ordinate.
-  // Do not change the layout of these members! They must be declared in
-  // this sequence for cosines() to work as expected!
+  /*!
+   * \brief Angle cosines for the ordinate.
+   *
+   * Do not change the layout of these members! They must be declared in this
+   * sequence for cosines() to work as expected! */
   double mu_, eta_, xi_;
 
   //! Quadrature weight for the ordinate.
@@ -85,8 +83,10 @@ private:
 //---------------------------------------------------------------------------------------//
 //! Test ordinates for equality
 inline bool operator==(Ordinate const &a, Ordinate const &b) {
-  return a.mu() == b.mu() && a.eta() == b.eta() && a.xi() == b.xi() &&
-         a.wt() == b.wt();
+  return rtt_dsxx::soft_equiv(a.mu(), b.mu()) &&
+         rtt_dsxx::soft_equiv(a.eta(), b.eta()) &&
+         rtt_dsxx::soft_equiv(a.xi(), b.xi()) &&
+         rtt_dsxx::soft_equiv(a.wt(), b.wt());
 }
 
 } // end namespace rtt_quadrature
@@ -94,5 +94,5 @@ inline bool operator==(Ordinate const &a, Ordinate const &b) {
 #endif // quadrature_Ordinate_hh
 
 //---------------------------------------------------------------------------------------//
-//              end of quadrature/Ordinate.hh
+// end of quadrature/Ordinate.hh
 //---------------------------------------------------------------------------------------//

--- a/src/quadrature/Ordinate_Space.cc
+++ b/src/quadrature/Ordinate_Space.cc
@@ -1,14 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   quadrature/Ordinate_Space.cc
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Define methods of class Ordinate_Space
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Ordinate_Space.cc 6855 2012-11-06 16:39:27Z kellyt $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #include <iostream>
 
@@ -18,14 +16,13 @@
 #include <gsl/gsl_sf_legendre.h>
 
 #include "Ordinate_Space.hh"
-
 #include "special_functions/Ylm.hh"
 #include "units/PhysicalConstants.hh"
 
 using namespace rtt_units;
 
 namespace rtt_quadrature {
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Compute the Azimuthal angle for the current quadrature direction.
  */
@@ -44,16 +41,16 @@ double Ordinate_Space::compute_azimuthalAngle(double const mu,
 
   double azimuthalAngle(std::atan2(eta, mu));
 
-  // For axisymmetric cooridnates only, the azimuthal angle is on [0, 2\pi]
-  // It is important to remember that the positive mu axis points to the
-  // left and the positive eta axis points up, when the unit sphere is
-  // projected on the plane of the mu- and eta-axis. In this case, phi is
-  // measured from the mu-axis counterclockwise.
+  // For axisymmetric cooridnates only, the azimuthal angle is on [0, 2\pi] It
+  // is important to remember that the positive mu axis points to the left and
+  // the positive eta axis points up, when the unit sphere is projected on the
+  // plane of the mu- and eta-axis. In this case, phi is measured from the
+  // mu-axis counterclockwise.
   //
-  // This accounts for the fact that the aziumuthal angle is discretized
-  // on levels of the xi-axis, making the computation of the azimuthal angle
-  // here consistent with the discretization by using the eta and mu
-  // ordinates to define phi.
+  // This accounts for the fact that the aziumuthal angle is discretized on
+  // levels of the xi-axis, making the computation of the azimuthal angle here
+  // consistent with the discretization by using the eta and mu ordinates to
+  // define phi.
 
   if (this->geometry() == rtt_mesh_element::AXISYMMETRIC &&
       azimuthalAngle < 0.0)
@@ -62,12 +59,13 @@ double Ordinate_Space::compute_azimuthalAngle(double const mu,
   return azimuthalAngle;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * The computation of the tau and alpha coefficients is described by Morel in
  * various technical notes on the treatment of the angle derivatives in the
  * streaming operator.
  */
+
 /* private */
 void Ordinate_Space::compute_angle_operator_coefficients_() {
   vector<Ordinate> const &ordinates = this->ordinates();
@@ -81,9 +79,9 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
   alpha_.resize(number_of_ordinates, 0.0);
   tau_.resize(number_of_ordinates, 1.0);
 
-  // We rely on OrdinateSet to have already sorted the ordinates and
-  // inserted the starting ordinates for each level. We assume that the
-  // starting ordinates are distinguished by zero quadrature weight.
+  // We rely on OrdinateSet to have already sorted the ordinates and inserted
+  // the starting ordinates for each level. We assume that the starting
+  // ordinates are distinguished by zero quadrature weight.
 
   levels_.resize(number_of_ordinates);
   if (geometry == rtt_mesh_element::AXISYMMETRIC) {
@@ -94,9 +92,10 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
     for (unsigned a = 0; a < number_of_ordinates; a++) {
       double const mu = ordinates[a].mu();
       double const wt = ordinates[a].wt();
-      if (wt != 0 || (wt == 0 && mu > 0))
-      // Not a starting ordinate.  Use Morel's recurrence relations
-      // to determine the next ordinate derivative coefficient.
+      if (!rtt_dsxx::soft_equiv(wt, 0.0) ||
+          (rtt_dsxx::soft_equiv(wt, 0.0) && mu > 0))
+      // Not a starting ordinate.  Use Morel's recurrence relations to determine
+      // the next ordinate derivative coefficient.
       {
         Check(a > 0);
         alpha_[a] = alpha_[a - 1] + mu * wt;
@@ -107,9 +106,8 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
       // A starting ordinate. Reinitialize the recurrence relation.
       {
         Check(a == 0 || std::fabs(alpha_[a - 1]) < 1.0e-15);
-        // Be sure that the previous level (if any) had a final alpha
-        // of zero, to within roundoff, as expected for the Morel
-        // recursion formula.
+        // Be sure that the previous level (if any) had a final alpha of zero,
+        // to within roundoff, as expected for the Morel recursion formula.
 
         if (a > 0)
           alpha_[a - 1] = 0.0;
@@ -164,7 +162,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
       double const wt = ordinates[a].wt();
       double const omm = omp;
       double const mum = mup;
-      if (wt != 0)
+      if (!rtt_dsxx::soft_equiv(wt, 0.0))
       // Not a new level.  Apply Morel's recurrence relation.
       {
         omp = omm - rtt_units::PI * C[level] * wt;
@@ -180,7 +178,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
         level++;
       }
       mup = sinth * std::cos(omp);
-      if (wt != 0) {
+      if (!rtt_dsxx::soft_equiv(wt, 0.0)) {
         tau_[a] = (mu - mum) / (mup - mum);
         //tau_[a] = 0.5;                          // old school
 
@@ -201,7 +199,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
       double const mu(ordinates[a].mu());
       double const wt(ordinates[a].wt());
 
-      if (wt != 0) {
+      if (!rtt_dsxx::soft_equiv(wt, 0.0)) {
         is_dependent_[a] = true;
         alpha_[a] = alpha_[a - 1] + 2 * wt * mu;
       } else {
@@ -223,12 +221,12 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
 
       double const mum = mup;
 
-      if (wt != 0)
+      if (!rtt_dsxx::soft_equiv(wt, 0.0))
         mup = mum + 2 * wt * rnorm;
       else
         mup = mu;
 
-      if (wt != 0) {
+      if (!rtt_dsxx::soft_equiv(wt, 0.0)) {
         tau_[a] = (mu - mum) / (2 * wt * rnorm);
 
         Check(tau_[a] > 0.0 && tau_[a] <= 1.0);
@@ -236,10 +234,10 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
     }
   } else if (geometry == rtt_mesh_element::CARTESIAN) {
     if (this->dimension() == 2 && this->ordering() == LEVEL_ORDERED) {
-      // NEW: organize quadratures for 2D into levels, even for Cartesian coordinates,
-      // but do not compute angular derivative approximation coefficients
-      // For our purposes here, the use of the first_angles_ vector is
-      // different from the use for axisymmetric coordinates; it is used to
+      // NEW: organize quadratures for 2D into levels, even for Cartesian
+      // coordinates, but do not compute angular derivative approximation
+      // coefficients For our purposes here, the use of the first_angles_ vector
+      // is different from the use for axisymmetric coordinates; it is used to
       // record find the index into the first ordinate on each level
 
       int level = 0;
@@ -277,7 +275,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
          "unexpected starting direction reflection index");
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 vector<Moment>
 Ordinate_Space::compute_n2lk_(Quadrature_Class const quadrature_class,
                               unsigned const sn_order) {
@@ -300,14 +298,13 @@ Ordinate_Space::compute_n2lk_(Quadrature_Class const quadrature_class,
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Compute the description of the moment space.
  *
  * N.B. This must not be called in the Ordinate_Space constructor, but in the
- * child class constructor, because it uses virtual functions of the child
- * class that are not set up until the child class is constructed.
+ * child class constructor, because it uses virtual functions of the child class
+ * that are not set up until the child class is constructed.
  */
-
 void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class,
                                       int const sn_order) {
   int Lmax = expansion_order_;
@@ -336,29 +333,29 @@ void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class,
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  *
  * \param dimension Dimension of the physical problem space (1, 2, or 3)
  *
  * \param geometry Geometry of the physical problem space (spherical,
- * axisymmetric, Cartesian)
+ *        axisymmetric, Cartesian)
  *
  * \param ordinates Set of ordinate directions
  *
  * \param expansion_order Expansion order of the desired scattering moment
- * space. If negative, the moment space is not needed.
+ *        space. If negative, the moment space is not needed.
  *
- * \param extra_starting_directions Add extra directions to each level set. In most
- * geometries, an additional ordinate is added that is opposite in direction
- * to the starting direction. This is used to implement reflection exactly in
- * curvilinear coordinates. In 1D spherical, that means an additional angle is
- * added at mu=1. In axisymmetric, that means additional angles are added that
- * are oriented opposite to the incoming starting direction on each level.
+ * \param extra_starting_directions Add extra directions to each level set. In
+ *        most geometries, an additional ordinate is added that is opposite in
+ *        direction to the starting direction. This is used to implement
+ *        reflection exactly in curvilinear coordinates. In 1D spherical, that
+ *        means an additional angle is added at mu=1. In axisymmetric, that
+ *        means additional angles are added that are oriented opposite to the
+ *        incoming starting direction on each level.
  *
  * \param ordering Ordering into which to sort the ordinates.
  */
-
 Ordinate_Space::Ordinate_Space(unsigned const dimension,
                                Geometry const geometry,
                                vector<Ordinate> const &ordinates,
@@ -384,10 +381,10 @@ Ordinate_Space::Ordinate_Space(unsigned const dimension,
   Ensure(has_extra_starting_directions() == extra_starting_directions);
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- * The psi coefficient is used to compute the self term in the angle
- * derivative term of the streaming operator.
+ * The psi coefficient is used to compute the self term in the angle derivative
+ * term of the streaming operator.
  */
 double Ordinate_Space::psi_coefficient(unsigned const a) const {
   Require(is_dependent(a));
@@ -399,10 +396,10 @@ double Ordinate_Space::psi_coefficient(unsigned const a) const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- * The source coefficient is used to compute the previous midpoint angle term
- * in the angle derivative term of the streaming operator.
+ * The source coefficient is used to compute the previous midpoint angle term in
+ * the angle derivative term of the streaming operator.
  */
 double Ordinate_Space::source_coefficient(unsigned const a) const {
   Require(is_dependent(a));
@@ -414,7 +411,7 @@ double Ordinate_Space::source_coefficient(unsigned const a) const {
   double const Result = (alpha_a * (1 - tau_a) / tau_a + alpha_am1) / wt;
   return Result;
 }
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * The bookkeeping coefficient is used to compute the next midpoint angle
  * specific intensity.
@@ -429,7 +426,7 @@ double Ordinate_Space::bookkeeping_coefficient(unsigned const a) const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 bool Ordinate_Space::check_class_invariants() const {
   if (geometry() == rtt_mesh_element::CARTESIAN) {
     return ((this->dimension() != 2 || this->ordering() != LEVEL_ORDERED) ||
@@ -441,22 +438,22 @@ bool Ordinate_Space::check_class_invariants() const {
     // Check that the number of levels is correct.
     unsigned levels = 0;
     for (unsigned a = 0; a < number_of_ordinates; ++a) {
-      if ((ordinates[a].wt() == 0) && (ordinates[a].mu() < 0.0)) {
+      if ((rtt_dsxx::soft_equiv(ordinates[a].wt(), 0.0)) &&
+          (ordinates[a].mu() < 0.0)) {
         ++levels;
       }
     }
     if (number_of_levels_ < levels)
       return false;
 
-    // Check that the angle derivative coefficient arrays have the correct
-    // size.
+    // Check that the angle derivative coefficient arrays have the correct size.
     return is_dependent_.size() == number_of_ordinates &&
            alpha_.size() == number_of_ordinates &&
            tau_.size() == number_of_ordinates;
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 void Ordinate_Space::compute_reflection_maps_() {
   vector<Ordinate> const &ordinates = this->ordinates();
   unsigned const number_of_ordinates = ordinates.size();
@@ -465,9 +462,9 @@ void Ordinate_Space::compute_reflection_maps_() {
   reflect_eta_.resize(number_of_ordinates);
   reflect_xi_.resize(number_of_ordinates);
 
-  // Since the ordinate set will likely never number more than a few
-  // hundred, we go ahead and do the simpleminded quadratic search to match
-  // the ordinates up.
+  // Since the ordinate set will likely never number more than a few hundred, we
+  // go ahead and do the simpleminded quadratic search to match the ordinates
+  // up.
 
   for (unsigned a = 0; a + 1 < number_of_ordinates; ++a) {
     for (unsigned ap = a + 1; ap < number_of_ordinates; ++ap) {
@@ -491,32 +488,32 @@ void Ordinate_Space::compute_reflection_maps_() {
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- * Return a mapping from the moments to the components of the astrophysical flux. The
- * astrophysical flux is defined consistently with the mean intensity as \f$ F_i =
- * \frac{1}{4 \pi}\int_{4 \pi}\Omega_i \psi d\omega\f$, that is, it is the physical flux
- * divided by \f$4 \pi\f$.
+ * Return a mapping from the moments to the components of the astrophysical
+ * flux. The astrophysical flux is defined consistently with the mean intensity
+ * as \f$ F_i = \frac{1}{4 \pi}\int_{4 \pi}\Omega_i \psi d\omega\f$, that is, it
+ * is the physical flux divided by \f$4 \pi\f$.
  *
- * The zeroth moment is presently always assumed to be equal to the mean intensity, but the
- * first order moments need not be in a basis in which they are equal to the astrophysical
- * flux components. This function returns the mapping from flux moments to astrophysical
- * flux components.
+ * The zeroth moment is presently always assumed to be equal to the mean
+ * intensity, but the first order moments need not be in a basis in which they
+ * are equal to the astrophysical flux components. This function returns the
+ * mapping from flux moments to astrophysical flux components.
  *
  * \param flux_map On return, contains the indices of the first moments
- * corresponding to each astrophysical flux component. That is, flux_map[i] is
- * the index (starting at zero) of the moment which corresponds to the ith
- * astrophysical flux component.
+ *        corresponding to each astrophysical flux component. That is,
+ *        flux_map[i] is the index (starting at zero) of the moment which
+ *        corresponds to the ith astrophysical flux component.
  *
- * \param flux_fact On return, contains the normalization factors for
- * converting the the first moments to astrophysical flux components.
+ * \param flux_fact On return, contains the normalization factors for converting
+ *        the the first moments to astrophysical flux components.
  *
- * Thus, if you are in 2-D Cartesian geometry, and phi contains the moments at a particular
- * point for a particular group, then the x-component of the astrophysical flux is equal to
- * flux_fact[0]*phi[1+flux_map[0]] and the y-component of the astrophysical flux is equal to
+ * Thus, if you are in 2-D Cartesian geometry, and phi contains the moments at a
+ * particular point for a particular group, then the x-component of the
+ * astrophysical flux is equal to flux_fact[0]*phi[1+flux_map[0]] and the
+ * y-component of the astrophysical flux is equal to
  * flux_fact[1]*phi[1+flux_map[1]].
  */
-
 void Ordinate_Space::moment_to_flux(unsigned flux_map[3],
                                     double flux_fact[3]) const {
   static double const RROOT3 = 1.0 / sqrt(3.0);
@@ -543,52 +540,52 @@ void Ordinate_Space::moment_to_flux(unsigned flux_map[3],
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- * Return a mapping from the astrophysical flux to the moments. This is the inverse of the
- * mapping returned by moment_to_flux.
+ * Return a mapping from the astrophysical flux to the moments. This is the
+ * inverse of the mapping returned by moment_to_flux.
  *
- * The zeroth moment is presently always assumed to be equal to the mean intensity, but the
- * first order moments need not be in a basis in which they are equal to the astrophysical
- * flux components. This function returns the mapping from flux moments to astrophysical
- * flux components.
+ * The zeroth moment is presently always assumed to be equal to the mean
+ * intensity, but the first order moments need not be in a basis in which they
+ * are equal to the astrophysical flux components. This function returns the
+ * mapping from flux moments to astrophysical flux components.
  *
  * \param flux_map On return, contains the indices of the astrophysical flux
- * components corresponding to each first moment. That is, flux_map[i] is the
- * index (starting at zero) of the astrophysical flux component which
- * corresponds to the ith first moment.
+ *        components corresponding to each first moment. That is, flux_map[i] is
+ *        the index (starting at zero) of the astrophysical flux component which
+ *        corresponds to the ith first moment.
  *
- * \param flux_fact On return, contains the normalization factors for
- * converting the the astrophysical flux components to first moments.
+ * \param flux_fact On return, contains the normalization factors for converting
+ *        the the astrophysical flux components to first moments.
  *
- * Thus, if you are in 2-D Cartesian geometry, and F contains the astrophysical flux at a
- * particular point for a particular group, then the ith moment is equal to
- * flux_fact[i-1]*F[flux_map[i-1]].
+ * Thus, if you are in 2-D Cartesian geometry, and F contains the astrophysical
+ * flux at a particular point for a particular group, then the ith moment is
+ * equal to flux_fact[i-1]*F[flux_map[i-1]].
  */
 void Ordinate_Space::flux_to_moment(unsigned flux_map[3],
                                     double flux_fact[3]) const {
   static double const ROOT3 = sqrt(3.0);
 
-  // We hardwire these on the optimistic assumption that the moment basis
-  // used by rtt_quadrature::Ordinate_Space will not often change.
+  // We hardwire these on the optimistic assumption that the moment basis used
+  // by rtt_quadrature::Ordinate_Space will not often change.
   if (dimension() == 1) {
     // In 1D nonaxisymmetric, the polar axis of the spherical harmonics is
     // aligned along the coordinate axis and only the k=0 harmonics are
-    // nonzero. The flux is then the Y(1,0) harmonic (times the
-    // normalization factor sqrt(3)). In 1D axisymmetric, the mu axis of
-    // the spherical harmonics is aligned along the coordinate axis for
-    // consistency with 2-D axisymmetric, and so the flux is the -Y(1,1)
-    // harmonic (times the normalization).
+    // nonzero. The flux is then the Y(1,0) harmonic (times the normalization
+    // factor sqrt(3)). In 1D axisymmetric, the mu axis of the spherical
+    // harmonics is aligned along the coordinate axis for consistency with 2-D
+    // axisymmetric, and so the flux is the -Y(1,1) harmonic (times the
+    // normalization).
     flux_map[0] = 0;
     if (geometry() != rtt_mesh_element::AXISYMMETRIC)
       flux_fact[0] = ROOT3;
     else
       flux_fact[0] = -ROOT3;
   }
-  // In 2-D and 3-D the polar axis is aligned with the second coordinate
-  // axis and the mu axis is aligned with the first coordinate. Thus the x
-  // flux corresponds to the -Y(1,1) harmonic, the y flux to the Y(1,0)
-  // harmonic, and the z flux to the -Y(1,-1) harmonic.
+  // In 2-D and 3-D the polar axis is aligned with the second coordinate axis
+  // and the mu axis is aligned with the first coordinate. Thus the x flux
+  // corresponds to the -Y(1,1) harmonic, the y flux to the Y(1,0) harmonic, and
+  // the z flux to the -Y(1,-1) harmonic.
   else if (dimension() == 2) {
     flux_map[0] = 1;
     flux_fact[0] = -ROOT3;
@@ -607,6 +604,6 @@ void Ordinate_Space::flux_to_moment(unsigned flux_map[3],
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                 end of Ordinate_Space.cc
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
+// end of Ordinate_Space.cc
+//----------------------------------------------------------------------------//

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -29,27 +29,27 @@ void test_either(UnitTest &ut,
   unsigned const dimension = ordinate_space->dimension();
 
   if (ordinate_space->moments()[0] == Moment(0, 0)) {
-    ut.passes("first moment is correct");
+    PASSMSG("first moment is correct");
   } else {
-    ut.failure("first moment is NOT correct");
+    FAILMSG("first moment is NOT correct");
   }
 
   if (number_of_ordinates == ordinate_space->alpha().size()) {
-    ut.passes("alpha size is correct");
+    PASSMSG("alpha size is correct");
   } else {
-    ut.failure("alpha size is NOT correct");
+    FAILMSG("alpha size is NOT correct");
   }
 
   if (ordinate_space->ordinates().size() == ordinate_space->tau().size()) {
-    ut.passes("tau size is correct");
+    PASSMSG("tau size is correct");
   } else {
-    ut.failure("tau size is NOT correct");
+    FAILMSG("tau size is NOT correct");
   }
 
   if (ordinate_space->expansion_order() == static_cast<int>(expansion_order)) {
-    ut.passes("expansion order is correct");
+    PASSMSG("expansion order is correct");
   } else {
-    ut.failure("expansion_order is NOT correct");
+    FAILMSG("expansion_order is NOT correct");
   }
 
   vector<unsigned> const &first_angles = ordinate_space->first_angles();
@@ -57,14 +57,14 @@ void test_either(UnitTest &ut,
 
   if (geometry == rtt_mesh_element::SPHERICAL) {
     if (first_angles.size() == 1) {
-      ut.passes("first angles is correct");
+      PASSMSG("first angles is correct");
     } else {
-      ut.failure("first angles is NOT correct");
+      FAILMSG("first angles is NOT correct");
     }
 
     if (ordinate_space->bookkeeping_coefficient(number_of_ordinates - 1) <=
         0.0) {
-      ut.failure("bookkeeping coefficient is NOT plausible");
+      FAILMSG("bookkeeping coefficient is NOT plausible");
     }
 
     ordinate_space->psi_coefficient(number_of_ordinates - 1);
@@ -73,14 +73,14 @@ void test_either(UnitTest &ut,
   } else if (geometry == rtt_mesh_element::AXISYMMETRIC) {
     if ((dimension > 1 && first_angles.size() == number_of_levels) ||
         (dimension == 1 && 2 * first_angles.size() == number_of_levels)) {
-      ut.passes("first angles is correct");
+      PASSMSG("first angles is correct");
     } else {
-      ut.failure("first angles is NOT correct");
+      FAILMSG("first angles is NOT correct");
     }
 
     if (ordinate_space->bookkeeping_coefficient(number_of_ordinates - 1) <=
         0.0) {
-      ut.failure("bookkeeping coefficient is NOT plausible");
+      FAILMSG("bookkeeping coefficient is NOT plausible");
     }
 
     ordinate_space->psi_coefficient(number_of_ordinates - 1);
@@ -89,13 +89,13 @@ void test_either(UnitTest &ut,
 
     vector<unsigned> const &levels = ordinate_space->levels();
     if (levels.size() == number_of_ordinates) {
-      ut.passes("levels size is correct");
+      PASSMSG("levels size is correct");
     } else {
-      ut.failure("levels size is NOT correct");
+      FAILMSG("levels size is NOT correct");
     }
     for (unsigned i = 0; i < number_of_ordinates; ++i) {
       if (levels[i] >= number_of_levels) {
-        ut.failure("levels is NOT in bounds");
+        FAILMSG("levels is NOT in bounds");
         return;
       }
     }
@@ -104,14 +104,14 @@ void test_either(UnitTest &ut,
         ordinate_space->moments_per_order();
 
     if (moments_per_order.size() == expansion_order + 1) {
-      ut.passes("moments_per_order size is correct");
+      PASSMSG("moments_per_order size is correct");
     } else {
-      ut.failure("moments_per_order size is NOT correct");
+      FAILMSG("moments_per_order size is NOT correct");
     }
     for (unsigned i = 0; i <= expansion_order; ++i) {
       if ((dimension == 1 && moments_per_order[i] != i / 2 + 1) ||
           (dimension > 1 && moments_per_order[i] != i + 1)) {
-        ut.failure("moments_per_order is NOT correct");
+        FAILMSG("moments_per_order is NOT correct");
         return;
       }
     }
@@ -120,31 +120,32 @@ void test_either(UnitTest &ut,
          number_of_levels == 2 * ordinate_space->number_of_levels()) ||
         (dimension > 1 &&
          number_of_levels == ordinate_space->number_of_levels())) {
-      ut.passes("number of levels is consistent");
+      PASSMSG("number of levels is consistent");
     } else {
-      ut.failure("number of levels is NOT consistent");
+      FAILMSG("number of levels is NOT consistent");
     }
   } else {
     if (ordinate_space->first_angles().size() == 0) {
-      ut.passes("first angles is correct");
+      PASSMSG("first angles is correct");
     } else {
-      ut.failure("first angles is NOT correct");
+      FAILMSG("first angles is NOT correct");
     }
   }
 
   vector<unsigned> const &reflect_mu = ordinate_space->reflect_mu();
   if (reflect_mu.size() == number_of_ordinates) {
-    ut.passes("reflect_mu is correct size");
+    PASSMSG("reflect_mu is correct size");
   } else {
-    ut.failure("reflect_mu is NOT correct size");
+    FAILMSG("reflect_mu is NOT correct size");
   }
   for (unsigned i = 0; i < number_of_ordinates; ++i) {
     if (reflect_mu[i] >= number_of_ordinates) {
-      ut.failure("reflect_mu is out of bounds");
+      FAILMSG("reflect_mu is out of bounds");
       return;
     }
-    if (ordinates[i].wt() != 0.0 && reflect_mu[reflect_mu[i]] != i) {
-      ut.failure("reflect_mu is inconsistent");
+    if (!rtt_dsxx::soft_equiv(ordinates[i].wt(), 0.0) &&
+        reflect_mu[reflect_mu[i]] != i) {
+      FAILMSG("reflect_mu is inconsistent");
       return;
     }
   }
@@ -152,17 +153,17 @@ void test_either(UnitTest &ut,
   if (dimension > 1) {
     vector<unsigned> const &reflect_eta = ordinate_space->reflect_eta();
     if (reflect_eta.size() == number_of_ordinates) {
-      ut.passes("reflect_eta is correct size");
+      PASSMSG("reflect_eta is correct size");
     } else {
-      ut.failure("reflect_eta is NOT correct size");
+      FAILMSG("reflect_eta is NOT correct size");
     }
     for (unsigned i = 0; i < number_of_ordinates; ++i) {
       if (reflect_eta[i] >= number_of_ordinates) {
-        ut.failure("reflect_eta is out of bounds");
+        FAILMSG("reflect_eta is out of bounds");
         return;
       }
       if (reflect_eta[reflect_eta[i]] != i) {
-        ut.failure("reflect_eta is inconsistent");
+        FAILMSG("reflect_eta is inconsistent");
         return;
       }
     }
@@ -170,17 +171,17 @@ void test_either(UnitTest &ut,
     if (dimension > 2) {
       vector<unsigned> const &reflect_xi = ordinate_space->reflect_xi();
       if (reflect_xi.size() == number_of_ordinates) {
-        ut.passes("reflect_xi is correct size");
+        PASSMSG("reflect_xi is correct size");
       } else {
-        ut.failure("reflect_xi is NOT correct size");
+        FAILMSG("reflect_xi is NOT correct size");
       }
       for (unsigned i = 0; i < number_of_ordinates; ++i) {
         if (reflect_xi[i] >= number_of_ordinates) {
-          ut.failure("reflect_xi is out of bounds");
+          FAILMSG("reflect_xi is out of bounds");
           return;
         }
         if (reflect_xi[reflect_xi[i]] != i) {
-          ut.failure("reflect_xi is inconsistent");
+          FAILMSG("reflect_xi is inconsistent");
           return;
         }
       }
@@ -195,17 +196,17 @@ void test_either(UnitTest &ut,
   case TRIANGLE_QUADRATURE:
     if (dimension == 1) {
       if (geometry == rtt_mesh_element::CARTESIAN && L != N)
-        ut.failure("ordinate count is wrong for triangular quadrature");
+        FAILMSG("ordinate count is wrong for triangular quadrature");
     } else if (dimension == 3) {
       if (L * (L + 2) != N)
-        ut.failure("ordinate count is wrong for triangular quadrature");
+        FAILMSG("ordinate count is wrong for triangular quadrature");
     }
     break;
 
   case SQUARE_QUADRATURE:
     if (dimension == 3) {
       if (2 * L * L != N) {
-        ut.failure("ordinate count is wrong for square quadrature");
+        FAILMSG("ordinate count is wrong for square quadrature");
       }
     }
     break;
@@ -213,7 +214,7 @@ void test_either(UnitTest &ut,
   default:
     if (dimension == 3) {
       if (4 * L > N) {
-        ut.failure("ordinate count is too small for level count");
+        FAILMSG("ordinate count is too small for level count");
       }
     }
     break;
@@ -241,46 +242,46 @@ void test_either(UnitTest &ut,
     }
 
     if (soft_equiv(J, MAGIC)) {
-      ut.passes("J okay");
+      PASSMSG("J okay");
     } else {
-      ut.failure("J NOT okay");
+      FAILMSG("J NOT okay");
     }
     if (soft_equiv(Fx, 0.0)) {
-      ut.passes("Fx okay");
+      PASSMSG("Fx okay");
     } else {
       std::cout << "Fx = " << Fx << std::endl;
-      ut.failure("Fx NOT okay");
+      FAILMSG("Fx NOT okay");
     }
     if (soft_equiv(Fx2, MAGIC / 3.0)) {
-      ut.passes("Fx2 okay");
+      PASSMSG("Fx2 okay");
     } else {
       cout << "Fx2 = " << Fx2 << ", expected " << (MAGIC / 3.0) << endl;
-      ut.failure("Fx2 NOT okay");
+      FAILMSG("Fx2 NOT okay");
     }
     if (dimension > 1) {
       if (soft_equiv(Fy, 0.0)) {
-        ut.passes("Fy okay");
+        PASSMSG("Fy okay");
       } else {
-        ut.failure("Fy NOT okay");
+        FAILMSG("Fy NOT okay");
       }
       if (soft_equiv(Fy2, MAGIC / 3.0)) {
-        ut.passes("Fy2 okay");
+        PASSMSG("Fy2 okay");
       } else {
         cout << "Fy2 = " << Fz2 << ", expected " << (MAGIC / 3.0) << endl;
-        ut.failure("Fy2 NOT okay");
+        FAILMSG("Fy2 NOT okay");
       }
     }
     if (dimension > 2) {
       if (soft_equiv(Fz, 0.0)) {
-        ut.passes("Fz okay");
+        PASSMSG("Fz okay");
       } else {
-        ut.failure("Fz NOT okay");
+        FAILMSG("Fz NOT okay");
       }
       if (soft_equiv(Fz2, MAGIC / 3.0)) {
-        ut.passes("Fz2 okay");
+        PASSMSG("Fz2 okay");
       } else {
         cout << "Fz2 = " << Fz2 << ", expected " << (MAGIC / 3.0) << endl;
-        ut.failure("Fz2 NOT okay");
+        FAILMSG("Fz2 NOT okay");
       }
     }
 
@@ -292,14 +293,14 @@ void test_either(UnitTest &ut,
     unsigned number_of_moments = ordinate_space->number_of_moments();
 
     if (M.size() == number_of_moments * number_of_ordinates) {
-      ut.passes("M has right size");
+      PASSMSG("M has right size");
     } else {
-      ut.failure("M does NOT have right size");
+      FAILMSG("M does NOT have right size");
     }
     if (D.size() == number_of_moments * number_of_ordinates) {
-      ut.passes("D has right size");
+      PASSMSG("D has right size");
     } else {
-      ut.failure("D does NOT have right size");
+      FAILMSG("D does NOT have right size");
     }
 
     if ((ordinate_space->quadrature_interpolation_model() == GQ1) ||
@@ -313,12 +314,12 @@ void test_either(UnitTest &ut,
           }
           if (m == n) {
             if (!soft_equiv(sum, 1.0)) {
-              ut.failure("diagonal element of M*D NOT 1");
+              FAILMSG("diagonal element of M*D NOT 1");
               return;
             }
           } else {
             if (!soft_equiv(sum, 0.0)) {
-              ut.failure("off-diagonal element of M*D NOT 0");
+              FAILMSG("off-diagonal element of M*D NOT 0");
               return;
             }
           }
@@ -476,7 +477,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
       if (L) {
         cout << "  Number of level sets = " << L << endl;
       } else {
-        ut.failure("no level sets are defined.");
+        FAILMSG("no level sets are defined.");
       }
     }
     break;
@@ -488,7 +489,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
       if (L) {
         cout << "  Number of level sets = " << L << endl;
       } else {
-        ut.failure("no level sets are defined.");
+        FAILMSG("no level sets are defined.");
       }
     }
     break;
@@ -504,40 +505,40 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
     break;
 
   default:
-    ut.failure("Bad value for quadrature class");
+    FAILMSG("Bad value for quadrature class");
     return;
   }
 
   // Test moment comparison.
 
   if (Moment(1, 1) == Moment(0, 0)) {
-    ut.failure("moment comparison NOT correct");
+    FAILMSG("moment comparison NOT correct");
   }
   if (Moment(1, 1) == Moment(1, 0)) {
-    ut.failure("moment comparison NOT correct");
+    FAILMSG("moment comparison NOT correct");
   }
 
   // Test default moment initialization
 
   if (Moment(1, 1) == Moment()) {
-    ut.failure("moment comparison NOT correct");
+    FAILMSG("moment comparison NOT correct");
   }
 
   // Test ordinate comparison.
 
   if (Ordinate(0.4, 0.3, sqrt(1.0 - 0.4 * 0.4 - 0.3 * 0.3), 0.5) ==
       Ordinate(0.3, 0.4, sqrt(1.0 - 0.4 * 0.4 - 0.3 * 0.3), 0.5)) {
-    ut.failure("moment comparison NOT correct");
+    FAILMSG("moment comparison NOT correct");
   }
   if (!(Ordinate(0.4, 0.3, sqrt(1.0 - 0.4 * 0.4 - 0.3 * 0.3), 0.5) ==
         Ordinate(0.4, 0.3, sqrt(1.0 - 0.4 * 0.4 - 0.3 * 0.3), 0.5))) {
-    ut.failure("moment comparison NOT correct");
+    FAILMSG("moment comparison NOT correct");
   }
 
   // Test ordinate access.
 
-  if (Ordinate(1.0, 0.0, 0.0, 0.0).cosines()[0] != 1.0) {
-    ut.failure("Ordinate::cosines NOT right");
+  if (!rtt_dsxx::soft_equiv(Ordinate(1.0, 0.0, 0.0, 0.0).cosines()[0], 1.0)) {
+    FAILMSG("Ordinate::cosines NOT right");
   }
 
   // Test textifying and parsing.
@@ -548,12 +549,12 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
       parse_class<Quadrature>(tokens);
 
   if (tokens.error_count()) {
-    ut.failure("Textification and parse did NOT succeed");
+    FAILMSG("Textification and parse did NOT succeed");
   }
 
   string text2 = parsed_quadrature->as_text("\n");
   if (text2 != text) {
-    ut.failure("Textification and parse did NOT give identical results");
+    FAILMSG("Textification and parse did NOT give identical results");
   }
 
   // ***** Test various geometry, dimensionaly, and interpolation model options.
@@ -573,15 +574,15 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
                                        Ordinate_Set::LEVEL_ORDERED);
 
     if (ordinate_set->ordinates().size() >= 2) {
-      ut.passes("Ordinate count is plausible");
+      PASSMSG("Ordinate count is plausible");
     } else {
-      ut.failure("Ordinate count is NOT plausible");
+      FAILMSG("Ordinate count is NOT plausible");
     }
 
     if (soft_equiv(ordinate_set->norm(), 1.0)) {
-      ut.passes("Ordinate norm is correct");
+      PASSMSG("Ordinate norm is correct");
     } else {
-      ut.failure("Ordinate norm is NOT correct");
+      FAILMSG("Ordinate norm is NOT correct");
     }
 
     ordinate_set->display();
@@ -637,15 +638,15 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
                                        Ordinate_Set::LEVEL_ORDERED);
 
     if (ordinate_set->ordinates().size() >= 2) {
-      ut.passes("Ordinate count is plausible");
+      PASSMSG("Ordinate count is plausible");
     } else {
-      ut.failure("Ordinate count is NOT plausible");
+      FAILMSG("Ordinate count is NOT plausible");
     }
 
     if (soft_equiv(ordinate_set->norm(), 1.0)) {
-      ut.passes("Ordinate norm is correct");
+      PASSMSG("Ordinate norm is correct");
     } else {
-      ut.failure("Ordinate norm is NOT correct");
+      FAILMSG("Ordinate norm is NOT correct");
     }
 
     ordinate_set->display();

--- a/src/units/UnitSystem.cc
+++ b/src/units/UnitSystem.cc
@@ -2,23 +2,17 @@
 /*! \file   UnitSystem.cc
  *  \author Kelly Thompson
  *  \date   Thu Oct 24 15:10:32 2003
- *  \brief
- *  \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *          All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *  \note   Copyright (C) 2003-2017 Los Alamos National Security, LLC.
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "UnitSystem.hh"
+#include "ds++/Soft_Equivalence.hh"
 #include <limits>
 
 namespace rtt_units {
 
-/*!
- * \brief Ensure that all unit conversions are valid (larger than some
- *        minimum value.)
- */
+//! Ensure that all unit conversions are valid (larger than some minimum value.)
 bool UnitSystem::validUnits() const {
   double minConversion(std::numeric_limits<double>::min());
 
@@ -43,11 +37,10 @@ bool UnitSystem::validUnits() const {
 } // end validUnits()
 
 //---------------------------------------------------------------------------//
-
-// /*!
-//  * \brief Return a new UnitSystem object whose data has the item-by-item ratio of
-//  *        two UnitSystem objects.
-//  */
+/*!
+ * \brief Return a new UnitSystem object whose data has the item-by-item ratio
+ *        of two UnitSystem objects.
+ */
 // UnitSystem operator/( UnitSystem const & op1, UnitSystem const & op2 )
 // {
 //     return UnitSystem( op1.lengthConversion      / op2.lengthConversion,
@@ -57,9 +50,9 @@ bool UnitSystem::validUnits() const {
 // }
 
 //---------------------------------------------------------------------------//
-
 /*!
  * \brief Return true if op1 and op2 are identical.
+ *
  * \return true if conversion data members are the same between op1 and
  *         op2. Otherwise return false.
  *
@@ -67,15 +60,19 @@ bool UnitSystem::validUnits() const {
  * \verbatim
  * UnitSystem UserUnits(34.0, 60.0, 0.0003, 99);
  * UnitSystem SIUnits(1.0, 1.0, 1.0 1.0 );
- * 
+ *
  * Units NewUnits = UserUnits/SIUnits
  * Ensure( NewUnits == UserUnits );
  * \endverbatim
  */
 bool operator==(UnitSystem const &op1, UnitSystem const &op2) {
-  return op1.L() == op2.L() && op1.M() == op2.M() && op1.t() == op2.t() &&
-         op1.T() == op2.T() && op1.I() == op2.I() && op1.A() == op2.A() &&
-         op1.Q() == op2.Q();
+  return rtt_dsxx::soft_equiv(op1.L(), op2.L()) &&
+         rtt_dsxx::soft_equiv(op1.M(), op2.M()) &&
+         rtt_dsxx::soft_equiv(op1.t(), op2.t()) &&
+         rtt_dsxx::soft_equiv(op1.T(), op2.T()) &&
+         rtt_dsxx::soft_equiv(op1.I(), op2.I()) &&
+         rtt_dsxx::soft_equiv(op1.A(), op2.A()) &&
+         rtt_dsxx::soft_equiv(op1.Q(), op2.Q());
 }
 
 bool operator!=(UnitSystem const &op1, UnitSystem const &op2) {


### PR DESCRIPTION
+ To improve code reproducibility between machines, I am attempting to eliminate direct comparisons of floating point types.
+ I built Draco with user provided C_FLAGS='-Wfloat-equal -Werror' CXX_FLAGS='-Wfloat-equal -Werror' compiler options (GCC) to discover all of the cases where Draco did a direct comparison of two floating point values. I replaced such implementations with a safer comparison.
+ Also in this changeset:
  - When using GCC, add the `-Wunreachable-code` flag.
  - Cleaned up comment blocks.
  - Added const qualifiers in a few places.
  - Use C++11 uniform initialization in a few places.
+ This is the same as #245, but broken into smaller chunks for review.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  