### PR TITLE
Rework Global_Timer to be more useful in parallel runs.

### DIFF
--- a/src/c4/Global_Timer.cc
+++ b/src/c4/Global_Timer.cc
@@ -88,14 +88,14 @@ void Global_Timer::reset_all() {
 /*static*/
 void Global_Timer::report_all(ostream &out) {
   if (rtt_c4::node() == 0) {
-    for (unsigned i = 0; i < 80; ++i)
+    for (unsigned i = 0; i < 92; ++i)
       cout << '-';
     cout << endl;
     cout << "Timing report for all global timers:" << endl << endl;
-    cout
-        << "N                      user                  system                "
-           "wall"
-        << endl;
+    cout << "         N                      user                   system     "
+            "           "
+            " wall"
+         << endl;
   }
   bool deferred_not_found = false;
   for (auto const &i : active_list_) {
@@ -130,7 +130,7 @@ void Global_Timer::report_all(ostream &out) {
         }
       }
     }
-    for (unsigned i = 0; i < 80; ++i)
+    for (unsigned i = 0; i < 92; ++i)
       cout << '-';
     cout << endl;
   }

--- a/src/c4/Global_Timer.cc
+++ b/src/c4/Global_Timer.cc
@@ -88,9 +88,8 @@ void Global_Timer::reset_all() {
 /*static*/
 void Global_Timer::report_all(ostream &out) {
   if (rtt_c4::node() == 0) {
-    for (unsigned i = 0; i < 92; ++i)
-      cout << '-';
-    cout << endl;
+
+    cout << string(92U, '-') << endl;
     cout << "Timing report for all global timers:" << endl << endl;
     cout << "         N                      user                   system     "
             "           "
@@ -130,9 +129,7 @@ void Global_Timer::report_all(ostream &out) {
         }
       }
     }
-    for (unsigned i = 0; i < 92; ++i)
-      cout << '-';
-    cout << endl;
+    cout << string(92U, '-') << endl;
   }
 }
 

--- a/src/c4/Global_Timer.cc
+++ b/src/c4/Global_Timer.cc
@@ -32,43 +32,34 @@ Global_Timer::Global_Timer(char const *name) : name_(name), active_(false) {
 }
 
 //---------------------------------------------------------------------------------------//
-Global_Timer::~Global_Timer() {
-  if (active_ || global_active_) {
-    cout << endl;
-    cout << "Timing report for timer " << name_ << ':' << endl;
-    print(cout);
-    cout << endl;
-  }
-}
-
-//---------------------------------------------------------------------------------------//
 /*static*/
 void Global_Timer::set_selected_activity(set<string> const &timer_list,
                                          bool const active) {
   if (rtt_c4::node() == 0) {
-    cout << "***** Global timers selectively activated:";
-    for (set<string>::const_iterator i = timer_list.begin();
-         i != timer_list.end(); ++i) {
-      string const &name = (*i);
+    cout << "***** Global timers selectively activated:" << endl;
+    for (auto const &name : timer_list) {
       cout << " \"" << name << '\"';
       timer_entry &entry = active_list_[name];
-      entry.is_active = active;
-      if (entry.timer != NULL) {
-        entry.timer->set_activity(active);
-      } else {
+      if (entry.timer == nullptr) {
         cout << " (DEFERRED)";
       }
+      cout << endl;
     }
-    cout << endl;
+  }
+  for (auto const &name : timer_list) {
+    timer_entry &entry = active_list_[name];
+    entry.is_active = active;
+    if (entry.timer != nullptr) {
+      entry.timer->set_activity(active);
+    }
   }
 }
 
 //-----------------------------------------------------------------------------//
 /* static */
 void Global_Timer::set_global_activity(bool const active) {
+  global_active_ = active;
   if (rtt_c4::node() == 0) {
-    global_active_ = active;
-
     cout << "***** Global timers are now ";
     if (active)
       cout << "ACTIVE";
@@ -84,12 +75,11 @@ void Global_Timer::set_global_activity(bool const active) {
 void Global_Timer::reset_all() {
   if (rtt_c4::node() == 0) {
     cout << "***** Resetting all global timers" << endl;
-    for (active_list_type::const_iterator i = active_list_.begin();
-         i != active_list_.end(); ++i) {
-      timer_entry const entry = i->second;
-      if ((entry.is_active || global_active_) && entry.timer) {
-        entry.timer->reset();
-      }
+  }
+  for (auto const &i : active_list_) {
+    timer_entry const entry = i.second;
+    if ((entry.is_active || global_active_) && entry.timer) {
+      entry.timer->reset();
     }
   }
 }
@@ -102,13 +92,42 @@ void Global_Timer::report_all(ostream &out) {
       cout << '-';
     cout << endl;
     cout << "Timing report for all global timers:" << endl << endl;
-    cout << "N           user           system         wall" << endl;
-    for (active_list_type::const_iterator i = active_list_.begin();
-         i != active_list_.end(); ++i) {
-      timer_entry const entry = i->second;
-      if ((entry.is_active || global_active_) && entry.timer) {
-        out << entry.timer->name() << endl;
-        entry.timer->printline(out);
+    cout
+        << "N                      user                  system                "
+           "wall"
+        << endl;
+  }
+  bool deferred_not_found = false;
+  for (auto const &i : active_list_) {
+    timer_entry const entry = i.second;
+    if (entry.is_active || global_active_) {
+      if (entry.timer != nullptr) {
+        if (rtt_c4::node() == 0) {
+          out << entry.timer->name() << endl;
+        }
+        entry.timer->printline_mean(out);
+      } else {
+        deferred_not_found = true;
+      }
+    }
+  }
+  if (rtt_c4::node() == 0) {
+    if (!global_active_ && deferred_not_found) {
+      cout << "**** WARNING: DEFERRED timers not found:" << endl;
+      for (auto const &i : active_list_) {
+        timer_entry const entry = i.second;
+        if (entry.is_active && entry.timer == nullptr) {
+          out << i.first << endl;
+        }
+      }
+      cout << endl
+           << "Perhaps you wanted one of these timers found but not active?"
+           << endl;
+      for (auto const &i : active_list_) {
+        timer_entry const entry = i.second;
+        if (!entry.is_active && entry.timer != nullptr) {
+          out << i.first << endl;
+        }
       }
     }
     for (unsigned i = 0; i < 80; ++i)

--- a/src/c4/Global_Timer.cc
+++ b/src/c4/Global_Timer.cc
@@ -91,7 +91,7 @@ void Global_Timer::report_all(ostream &out) {
 
     cout << string(92U, '-') << endl;
     cout << "Timing report for all global timers:" << endl << endl;
-    cout << "         N                      user                   system     "
+    cout << "            N                   user                   system     "
             "           "
             " wall"
          << endl;

--- a/src/c4/Global_Timer.hh
+++ b/src/c4/Global_Timer.hh
@@ -77,8 +77,6 @@ public:
 
   explicit Global_Timer(char const *name); //! default constructor
 
-  ~Global_Timer();
-
   // Accessors
 
   char const *name() const { return name_; }

--- a/src/c4/Timer.cc
+++ b/src/c4/Timer.cc
@@ -345,28 +345,26 @@ void Timer::printline_mean(std::ostream &out, unsigned const p,
   unsigned const ranks = rtt_c4::nodes();
 
   double ni = num_intervals, ni2 = ni * ni;
-  double mni = ni / ranks;
-
   double u = sum_user_cpu(), u2 = u * u;
-  double mu = u / ranks;
-
   double s = sum_system_cpu(), s2 = s * s;
-  double ms = s / ranks;
-
   double ww = sum_wall_clock(), ww2 = ww * ww;
-  double mww = ww / ranks;
 
-  double buffer[8] = {ni, mni, u, mu, s, ms, ww, mww};
+  double buffer[8] = {ni, ni2, u, u2, s, s2, ww, ww2};
   rtt_c4::global_sum(buffer, 8);
 
   ni = buffer[0];
-  mni = buffer[1];
+  ni2 = buffer[1];
   u = buffer[2];
-  mu = buffer[3];
+  u2 = buffer[3];
   s = buffer[4];
-  ms = buffer[5];
+  s2 = buffer[5];
   ww = buffer[6];
-  mww = buffer[7];
+  ww2 = buffer[7];
+
+  double mni = ni / ranks;
+  double mu = u / ranks;
+  double ms = s / ranks;
+  double mww = ww / ranks;
 
   if (rtt_c4::node() == 0) {
     out.setf(ios::fixed, ios::floatfield);

--- a/src/c4/Timer.cc
+++ b/src/c4/Timer.cc
@@ -361,7 +361,7 @@ void Timer::printline_mean(std::ostream &out, unsigned const p,
   ww = buffer[6];
   ww2 = buffer[7];
 
-  double mni = ni / ranks;
+  unsigned mni = ni / ranks;
   double mu = u / ranks;
   double ms = s / ranks;
   double mww = ww / ranks;

--- a/src/c4/Timer.hh
+++ b/src/c4/Timer.hh
@@ -251,6 +251,9 @@ public:
 
   void printline(std::ostream &, unsigned p = 2U, unsigned width = 15U) const;
 
+  void printline_mean(std::ostream &, unsigned p = 2U,
+                      unsigned width = 13U) const;
+
   inline void merge(Timer const &);
 
   static void initialize(int &argc, char *argv[]);

--- a/src/c4/Timer.hh
+++ b/src/c4/Timer.hh
@@ -251,8 +251,8 @@ public:
 
   void printline(std::ostream &, unsigned p = 2U, unsigned width = 15U) const;
 
-  void printline_mean(std::ostream &, unsigned p = 2U,
-                      unsigned width = 13U) const;
+  void printline_mean(std::ostream &, unsigned p = 2U, unsigned w = 13U,
+                      unsigned v = 5U) const;
 
   inline void merge(Timer const &);
 


### PR DESCRIPTION
The existing implementation returned statistics only for processor 0 unless you went through gyrations that pretty much missed the whole reason for using Global_Timer rather than just Timer. The new implementation returns means and deviations for all non-PAPI statistics across processors.
    
    The new implementation also produces a warning message if timers you request to be active are never found during the run. The warning message tells you what timers were found that were not active, which can be very useful for figuring out what timer you really wanted, or where a new timer should be inserted in the code.


* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
