### PR TITLE
On Cray systems, ensure that ApplicationUnitTest uses correct srun options.

### DIFF
--- a/config/ApplicationUnitTest.cmake
+++ b/config/ApplicationUnitTest.cmake
@@ -356,8 +356,8 @@ macro( add_app_unit_test )
   if( DEFINED aut_PE_LIST AND ${DRACO_C4} MATCHES "MPI" )
 
     # Parallel tests
-    if( "${MPIEXEC}" MATCHES "srun" )
-      set( RUN_CMD "srun -n" )
+    if( "${MPIEXEC}" MATCHES "aprun" )
+      set( RUN_CMD "aprun -n" )
     else()
       set( RUN_CMD "${MPIEXEC} ${MPIEXEC_POSTFLAGS} ${MPIEXEC_NUMPROC_FLAG}")
     endif()

--- a/config/ApplicationUnitTest.cmake
+++ b/config/ApplicationUnitTest.cmake
@@ -365,10 +365,8 @@ macro( add_app_unit_test )
   else()
 
     # Scalar tests
-    if( "${MPIEXEC}" MATCHES "aprun" )
+    if( "${MPIEXEC}" MATCHES "aprun" OR "${MPIEXEC}" MATCHES "srun" )
       set( RUN_CMD "${MPIEXEC} ${MPIEXEC_POSTFLAGS} ${MPIEXEC_NUMPROC_FLAG} 1" )
-    elseif( "${MPIEXEC}" MATCHES "srun" )
-      set( RUN_CMD "srun -n 1" )
     endif()
   endif()
 

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -43,7 +43,7 @@ fi
 # OpenMP
 #
 export OMP_PLACES=threads
-if [[ `lscpu | grep Flags | grep -c knl` == 0 ]]; then
+if [[ `lscpu | grep Flags | grep -c avx512` == 0 ]]; then
   export OMP_NUM_THREADS=16
   export NRANKS_PER_NODE=32
 else
@@ -67,6 +67,9 @@ else
   module load user_contrib
 fi
 module load friendly-testing
+if [[ ${SLURM_JOB_PARTITION} == "knl" ]]; then
+  module swap craype-haswell craype-mic-knl
+fi
 
 export dracomodules="clang-format metis parmetis/4.0.3 trilinos/12.8.1 \
 superlu-dist/4.3 gsl/2.1 cmake/3.6.2 numdiff ndi random123 eospac/6.2.4 \

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -83,7 +83,7 @@ export REGRESSION_PHASE=t
 echo "Test from the login node..."
 echo " "
 logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
-cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} ${partition_options} ${rscriptdir}/tt-regress.msub"
+cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} --exclusive ${partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 # delete blank lines

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -4,8 +4,6 @@
 # note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
-# $Id: CMakeLists.txt 6732 2012-09-05 22:28:18Z kellyt $
-#------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.0.0)
 project( cdi_eospac CXX )
 
@@ -89,3 +87,7 @@ endif()
 process_autodoc_pages()
 
 endif() # EOSPAC_FOUND
+
+# ---------------------------------------------------------------------------- #
+# End cdi_eospac/CMakeLists.txt
+# ---------------------------------------------------------------------------- #

--- a/src/cdi_eospac/test/CMakeLists.txt
+++ b/src/cdi_eospac/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for cdi_eospac/test.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 project( cdi_eospac_test CXX )
@@ -55,3 +55,7 @@ add_app_unit_test(
   APP    $<TARGET_FILE_DIR:Exe_QueryEospac>/$<TARGET_FILE_NAME:Exe_QueryEospac>
   TEST_ARGS "--version;--help"
 )
+
+# ---------------------------------------------------------------------------- #
+# End cdi_eospac/test/CMakeLists.txt
+# ---------------------------------------------------------------------------- #

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -3,10 +3,8 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for diagnostics.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
-# $Id$
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.0.0)
 project( diagnostics CXX )
@@ -15,7 +13,7 @@ project( diagnostics CXX )
 # Special options for this component
 ##---------------------------------------------------------------------------##
 
-# DRACO_DIAGNOSICS IS SET IN DS++ (ds++/config.h).
+# DRACO_DIAGNOSICS is set in ds++ (ds++/config.h).
 
 # From autoconf build system: "yes" --> 2, "no" --> 0
 set( DRACO_TIMING "0"

--- a/src/diagnostics/test/CMakeLists.txt
+++ b/src/diagnostics/test/CMakeLists.txt
@@ -1,12 +1,10 @@
 #-----------------------------*-cmake-*----------------------------------------#
-# file   config/CMakeLists.txt
+# file   diagnostics/test/CMakeLists.txt
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for diagnostics/test.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
-# $Id$
 #------------------------------------------------------------------------------#
 project( diagnostics_test CXX )
 
@@ -33,10 +31,13 @@ add_scalar_tests(
 
 include( ApplicationUnitTest )
 
-# Consider using the label "nomemcheck" to prevent this from running under valgrind.
 add_app_unit_test(
   DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/tDracoInfo.py
   APP    $<TARGET_FILE_DIR:Exe_draco_info>/$<TARGET_FILE_NAME:Exe_draco_info>
   TEST_ARGS "none;--version;--brief"
-#  LABELS nomemcheck
+  LABELS nomemcheck
 )
+
+# ---------------------------------------------------------------------------- #
+# End diagnostics/test/CMakeLists.txt
+# ---------------------------------------------------------------------------- #

--- a/src/diagnostics/test/tDracoInfo.py
+++ b/src/diagnostics/test/tDracoInfo.py
@@ -3,10 +3,8 @@
 # author Alex Long <along@lanl.gov>
 # date   Wednesday, September 14, 2016, 14:16 pm
 # brief  This is a CTest script that is used to test bin/draco_info.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
-# $Id: CMakeLists.txt 6721 2012-08-30 20:38:59Z gaber $
 #------------------------------------------------------------------------------#
 
 import sys


### PR DESCRIPTION
**The problem:**

When unit tests are executed on Trinitite/Trinity, all tests (including scalar) tests must be run under srun.  To enable packing multiple parallel running jobs onto a single node extra options must be provided to srun (i.e.: `--cpu_bind=cores --gres=craynetwork:0 --exclusive`).  These extra flags were not being used by auxillary programs (like numdiff) for ApplicationUnitTests.

**The fix:**

Replace logic that triggered on `$MPIEXEC == aprun` with logic that turns on for `$MPIEXEC == srun`.  Currently, this logic only applies to Trinity and Trinitite.  This new conditional code block adds $MPIEXEC_POSTFLAGS to the run command.

* Also clean up documentation in some CMakeLists.txt files and in `DracoInfo.py.`
* Refs Github #236 and [Redmine #972.](https://rtt.lanl.gov/redmine/issues/972)
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
