### PR TITLE
Fix a bug introduced in #252 (early return if T==0).

### DIFF
--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -24,17 +24,17 @@ namespace rtt_cdi {
 /*!
  * \brief Construct a CDI object.
  *
- * Builds a CDI object.  The opacity and eos objects that this holds must
- * be loaded using the set functions.  There is no easy way to guarantee
- * that all of the set objects point to the same material.  CDI does do
- * checking that only one of each Model:Reaction pair of opacity objects
- * are assigned; however, the user can "fake" CDI with different
- * materials if he/she is malicious enough.
+ * Builds a CDI object.  The opacity and eos objects that this holds must be
+ * loaded using the set functions.  There is no easy way to guarantee that all
+ * of the set objects point to the same material.  CDI does do checking that
+ * only one of each Model:Reaction pair of opacity objects are assigned;
+ * however, the user can "fake" CDI with different materials if he/she is
+ * malicious enough.
  *
- * CDI does allow a string material ID indicator.  It is up to the client
- * to ascribe meaning to the indicator.
+ * CDI does allow a string material ID indicator.  It is up to the client to
+ * ascribe meaning to the indicator.
  *
- * \param id string material id descriptor, this is defaulted to null
+ * \param[in] id string material id descriptor, this is defaulted to null
  */
 CDI::CDI(const std_string &id)
     : grayOpacities(constants::num_Models,
@@ -68,14 +68,13 @@ std::vector<double> CDI::opacityCdfBandBoundaries = std::vector<double>();
 /*!
  * \brief Return the frequency group boundaries.
  *
- * Every multigroup opacity object held by any CDI object contains the
- * same frequency group boundaries.  This static function allows CDI
- * users to access the group boundaries without referencing a particular
- * material.
+ * Every multigroup opacity object held by any CDI object contains the same
+ * frequency group boundaries.  This static function allows CDI users to access
+ * the group boundaries without referencing a particular material.
  *
- * Note, the group boundaries are not set until a multigroup opacity
- * object is set for the first time (in any CDI object) with the
- * setMultigroupOpacity function.
+ * Note, the group boundaries are not set until a multigroup opacity object is
+ * set for the first time (in any CDI object) with the setMultigroupOpacity
+ * function.
  */
 std::vector<double> CDI::getFrequencyGroupBoundaries() {
   return frequencyGroupBoundaries;
@@ -83,14 +82,13 @@ std::vector<double> CDI::getFrequencyGroupBoundaries() {
 /*!
  * \brief Return the opacity band boundaries.
  *
- * Every multiband opacity object held by any CDI object contains the
- * same band boundaries, and also inside each group.  This static function
- * allows CDI users to access the band boundaries without referencing a
- * particular material.
+ * Every multiband opacity object held by any CDI object contains the same band
+ * boundaries, and also inside each group.  This static function allows CDI
+ * users to access the band boundaries without referencing a particular
+ * material.
  *
- * Note, the band boundaries are not set until a multigroup opacity
- * object is set for the first time (in any CDI object) with the
- * setOdfmgOpacity function.
+ * Note, the band boundaries are not set until a multigroup opacity object is
+ * set for the first time (in any CDI object) with the setOdfmgOpacity function.
  */
 std::vector<double> CDI::getOpacityCdfBandBoundaries() {
   return opacityCdfBandBoundaries;
@@ -118,8 +116,8 @@ size_t CDI::getNumberOpacityBands() {
 // Core Integrators
 /*
  * These are the most basic of the Planckian and Rosseland integration
- * functions. They are used in the implementation of integration functions
- * with friendlier interfaces.
+ * functions. They are used in the implementation of integration functions with
+ * friendlier interfaces.
  */
 //---------------------------------------------------------------------------//
 
@@ -136,11 +134,12 @@ size_t CDI::getNumberOpacityBands() {
  *
  * \brief Integrate the Planckian spectrum over a frequency group.
  *
- * \param groupIndex Index of the frequency group to integrate [1,num_groups].
- * \param T          The temperature in keV (must be greater than 0.0).
- * \return           Integrated normalized Plankian over the group specified
- *                   by groupIndex.
+ * \param[in] groupIndex Index of the frequency group to integrate
+ *                       [1,num_groups].
+ * \param[in] T          The temperature in keV (must be greater than 0.0).
  *
+ * \return Integrated normalized Plankian over the group specified by
+ *         groupIndex.
  */
 double CDI::integratePlanckSpectrum(size_t const groupIndex, double const T) {
   Insist(!frequencyGroupBoundaries.empty(), "No groups defined!");
@@ -165,7 +164,7 @@ double CDI::integratePlanckSpectrum(size_t const groupIndex, double const T) {
 //---------------------------------------------------------------------------//
 /*!
  * \brief Integrate the Planckian spectrum over all frequency groups.
- * \param T The temperature in keV (must be greater than 0.0).
+ * \param[in] T The temperature in keV (must be greater than 0.0).
  * \return Integrated normalized Plankian over all frequency groups.
  */
 double CDI::integratePlanckSpectrum(const double T) {
@@ -194,10 +193,11 @@ double CDI::integratePlanckSpectrum(const double T) {
  *
  * \brief Integrate the Rosseland spectrum over a frequency group.
  *
- * \param groupIndex index of the frequency group to integrate [1,num_groups]
- * \param T          the temperature in keV (must be greater than 0.0)
- * \return           integrated normalized Plankian over the group specified
- *                   by groupIndex.
+ * \param[in] groupIndex index of the frequency group to integrate
+ *                       [1,num_groups]
+ * \param[in] T          the temperature in keV (must be greater than 0.0)
+ * \return integrated normalized Plankian over the group specified by
+ *         groupIndex.
  */
 double CDI::integrateRosselandSpectrum(size_t const groupIndex,
                                        double const T) {
@@ -217,18 +217,16 @@ double CDI::integrateRosselandSpectrum(size_t const groupIndex,
 
 //---------------------------------------------------------------------------//
 /*!
- *
- * \brief Integrate the Planckian and Rosseland spectrum over a frequency
- * group.
+ * \brief Integrate the Planckian and Rosseland spectrum over a frequency group.
  *
  * \param groupIndex index of the frequency group to integrate [1,num_groups]
  * \param T          The temperature in keV (must be greater than 0.0)
  * \param PL         Reference argument for the Planckian integral
  * \param ROSL       Reference argument for the Rosseland integral
  *
- * \return The integrated normalized Planckian and Rosseland over the
- * requested frequency group. These are returned as references in argument PL
- * and ROSL
+ * \return The integrated normalized Planckian and Rosseland over the requested
+ *         frequency group. These are returned as references in argument PL and
+ *         ROSL
  */
 void CDI::integrate_Rosseland_Planckian_Spectrum(const size_t groupIndex,
                                                  const double T, double &planck,
@@ -251,8 +249,9 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(const size_t groupIndex,
 }
 
 //---------------------------------------------------------------------------//
-/*!\brief Integrate the Planckian Specrum over an entire a set of frequency
- * groups, returning a vector of the integrals
+/*!
+ * \brief Integrate the Planckian Specrum over an entire a set of frequency
+ *        groups, returning a vector of the integrals
  *
  * \param bounds The vector of group boundaries. Size n+1
  * \param T The temperature
@@ -268,7 +267,11 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 
   planck.resize(groups, 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
+  // max_bounds/T must be < numeric_limits<double>::max().  So, if T ~<
+  // max_bounds*min, then return early.
+  double const max_bounds_val =
+      *(std::max_element(bounds.begin(), bounds.end()));
+  if (T < max_bounds_val * std::numeric_limits<double>::min())
     return;
 
   double scaled_frequency;
@@ -301,8 +304,8 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Integrate the Rosseland Spectrum over an entire a set
- * of frequency groups, returning a vector of the integrals
+ * \brief Integrate the Rosseland Spectrum over an entire a set of frequency
+ *        groups, returning a vector of the integrals
  *
  * \param bounds    The vector of group boundaries (size n+1)
  * \param T         The temperature
@@ -318,14 +321,16 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
 
   rosseland.resize(groups, 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
+  // max_bounds/T must be < numeric_limits<double>::max().  So, if T ~<
+  // max_bounds*min, then return early.
+  double const max_bounds_val =
+      *(std::max_element(bounds.begin(), bounds.end()));
+  if (T < max_bounds_val * std::numeric_limits<double>::min())
     return;
 
   double scaled_frequency;
   double exp_scaled_frequency;
-
   Remember(double last_scaled_frequency;);
-
   double planck_value;
   double last_rosseland, rosseland_value;
 
@@ -360,8 +365,8 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Integrate the Planckian and Rosseland Specrum over an entire a set
- * of frequency groups, returning a vector of the integrals
+ * \brief Integrate the Planckian and Rosseland Specrum over an entire a set of
+ *        frequency groups, returning a vector of the integrals
  *
  * \param bounds    The vector of group boundaries. Size n+1
  * \param T         The temperature
@@ -379,7 +384,11 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
   planck.resize(groups, 0.0);
   rosseland.resize(groups, 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
+  // max_bounds/T must be < numeric_limits<double>::max().  So, if T ~<
+  // max_bounds*min, then return early.
+  double const max_bounds_val =
+      *(std::max_element(bounds.begin(), bounds.end()));
+  if (T < max_bounds_val * std::numeric_limits<double>::min())
     return;
 
   double scaled_frequency;
@@ -437,8 +446,8 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
  * \param emission_group_cdf
  * \return A single interval Planckian weighted opacity value.
  *
- * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum.
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain planckSpectrum.
  */
 double CDI::collapseMultigroupOpacitiesPlanck(
     std::vector<double> const &groupBounds,
@@ -479,9 +488,8 @@ double CDI::collapseMultigroupOpacitiesPlanck(
   if (planck_integral > 0.0)
     planck_opacity = sig_planck_sum / planck_integral;
   else {
-    // Weak check that the zero integrated Planck is due to a cold
-    // temperature whose Planckian peak is below the lowest (first) group
-    // boundary.
+    // Weak check that the zero integrated Planck is due to a cold temperature
+    // whose Planckian peak is below the lowest (first) group boundary.
     Check(rtt_dsxx::soft_equiv(sig_planck_sum, 0.0));
     // Check( T >= 0.0 );
     // Check( 3.0 * T <= groupBounds[0] );
@@ -495,8 +503,8 @@ double CDI::collapseMultigroupOpacitiesPlanck(
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Collapse a multigroup reciprocal opacity set into a single representative value
- *        weighted by the Planckian function.
+ * \brief Collapse a multigroup reciprocal opacity set into a single
+ *        representative value weighted by the Planckian function.
  *
  * \param groupBounds The vector of group boundaries.
  * \param opacity   A vector of multigroup opacity data.
@@ -505,8 +513,8 @@ double CDI::collapseMultigroupOpacitiesPlanck(
  *                  CDI::integrate_Rosseland_Planckian_Sectrum(...).
  * \return A single interval Planckian weighted reciprocal opacity value.
  *
- * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum.
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain planckSpectrum.
  */
 double CDI::collapseMultigroupReciprocalOpacitiesPlanck(
     std::vector<double> const &groupBounds, std::vector<double> const &opacity,
@@ -563,16 +571,15 @@ double CDI::collapseMultigroupReciprocalOpacitiesPlanck(
  *                  CDI::integrate_Rosseland_Planckian_Sectrum(...).
  * \return A single interval Rosseland weighted opacity value.
  *
- * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain rosselandSpectrum.
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain rosselandSpectrum.
  *
  * There are 2 special cases that we check for:
  * 1. All opacities are zero - just return 0.0;
  * 2. The Rosseland Integral is very small (or zero).  In this case, perform a
  *    modified calculation that does not depend on the Rosseland integral.
  *
- * If neither of the special cases are in effect, then do the normal
- * evaluation.
+ * If neither of the special cases are in effect, then do the normal evaluation.
  */
 double CDI::collapseMultigroupOpacitiesRosseland(
     std::vector<double> const &groupBounds, std::vector<double> const &opacity,
@@ -598,11 +605,11 @@ double CDI::collapseMultigroupOpacitiesRosseland(
   double const rosseland_integral =
       std::accumulate(rosselandSpectrum.begin(), rosselandSpectrum.end(), 0.0);
 
-  // If the group bounds are well outside the Rosseland Spectrum at the
-  // current temperature, our algorithm may return a value that is within
-  // machine precision of zero.  In this case, we assume that this occurs
-  // when the temperature -> 0, so that limit(T->0) dB/dT = \delta(\nu).
-  // In this case we have:
+  // If the group bounds are well outside the Rosseland Spectrum at the current
+  // temperature, our algorithm may return a value that is within machine
+  // precision of zero.  In this case, we assume that this occurs when the
+  // temperature -> 0, so that limit(T->0) dB/dT = \delta(\nu).  In this case we
+  // have:
   //
   // sigma_R = sigma(g=0)
 
@@ -637,7 +644,7 @@ double CDI::collapseMultigroupOpacitiesRosseland(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Collapse a multigroup-multiband opacity set into a single
- * representative value weighted by the Planckian function.
+ *        representative value weighted by the Planckian function.
  *
  * \param groupBounds The vector of group boundaries.
  * \param T         The material temperature.
@@ -648,8 +655,8 @@ double CDI::collapseMultigroupOpacitiesRosseland(
  * \param emission_group_cdf
  * \return A single interval Planckian weighted opacity value.
  *
- * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum.
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain planckSpectrum.
  */
 double CDI::collapseOdfmgOpacitiesPlanck(
     std::vector<double> const &groupBounds,
@@ -718,7 +725,7 @@ double CDI::collapseOdfmgOpacitiesPlanck(
 //---------------------------------------------------------------------------//
 /*!
  * \brief Collapse a multigroup-multiband opacity set into a single
- * representative reciprocal value weighted by the Planckian function.
+ *        representative reciprocal value weighted by the Planckian function.
  *
  * \param groupBounds The vector of group boundaries.
  * \param opacity   A vector of multigroup opacity data.
@@ -726,8 +733,8 @@ double CDI::collapseOdfmgOpacitiesPlanck(
  *                  spectrum (normally generated via
  *                  CDI::integrate_Rosseland_Planckian_Sectrum(...).
  *
- * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before
- * this function to obtain planckSpectrum.
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain planckSpectrum.
  */
 double CDI::collapseOdfmgReciprocalOpacitiesPlanck(
     std::vector<double> const &groupBounds,
@@ -818,15 +825,14 @@ void CDI::setGrayOpacity(const SP_GrayOpacity &spGOp) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Register a multigroup opacity (rtt_cdi::MultigroupOpacity) with
- * CDI.
+ * \brief Register a multigroup opacity (rtt_cdi::MultigroupOpacity) with CDI.
  *
  * This function sets a multigroup opacity object of type
  * rtt_cdi::MultigroupOpacity with the CDI object.  It stores the multigroup
- * opacity object based upon its rtt_cdi::Model and rtt_cdi::Reaction types.
- * If a MultigroupOpacity with these type has already been registered an
- * exception is thrown.  To register a new set of MultigroupOpacity objects
- * call CDI::reset() first.  You cannot overwrite registered objects with the
+ * opacity object based upon its rtt_cdi::Model and rtt_cdi::Reaction types.  If
+ * a MultigroupOpacity with these type has already been registered an exception
+ * is thrown.  To register a new set of MultigroupOpacity objects call
+ * CDI::reset() first.  You cannot overwrite registered objects with the
  * setMultigroupOpacity() function!
  *
  * \param spGOp smart pointer to a MultigroupOpacity object
@@ -843,11 +849,11 @@ void CDI::setMultigroupOpacity(const SP_MultigroupOpacity &spMGOp) {
   Insist(!multigroupOpacities[model][reaction],
          "Tried to overwrite a set MultigroupOpacity object!");
 
-  // if the frequency group boundaries have not been assigned in any CDI
-  // object, then assign them here
+  // if the frequency group boundaries have not been assigned in any CDI object,
+  // then assign them here
   if (frequencyGroupBoundaries.empty()) {
-    // copy the the group boundaries for this material to the "global"
-    // group boundaries that will be enforced for all CDI objects
+    // copy the the group boundaries for this material to the "global" group
+    // boundaries that will be enforced for all CDI objects
     frequencyGroupBoundaries = spMGOp->getGroupBoundaries();
   }
 
@@ -856,8 +862,8 @@ void CDI::setMultigroupOpacity(const SP_MultigroupOpacity &spMGOp) {
   Insist(spMGOp->getNumGroupBoundaries() == frequencyGroupBoundaries.size(),
          "Incompatible frequency groups assigned for this material");
 
-  // do a check of the actual boundary values when DBC check is on (this is
-  // more expensive so we retain the option of turning it off)
+  // do a check of the actual boundary values when DBC check is on (this is more
+  // expensive so we retain the option of turning it off)
   Remember(std::vector<double> const ref = spMGOp->getGroupBoundaries(););
   Check(soft_equiv(frequencyGroupBoundaries.begin(),
                    frequencyGroupBoundaries.end(), ref.begin(), ref.end(),
@@ -871,16 +877,14 @@ void CDI::setMultigroupOpacity(const SP_MultigroupOpacity &spMGOp) {
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Register a multigroup opacity (rtt_cdi::OdfmgOpacity) with
- * CDI.
+ * \brief Register a multigroup opacity (rtt_cdi::OdfmgOpacity) with CDI.
  *
- * This function sets a multigroup opacity object of type
- * rtt_cdi::OdfmgOpacity with the CDI object.  It stores the multigroup
- * opacity object based upon its rtt_cdi::Model and rtt_cdi::Reaction types.
- * If a OdfmgOpacity with these type has already been registered an
- * exception is thrown.  To register a new set of OdfmgOpacity objects
- * call CDI::reset() first.  You cannot overwrite registered objects with the
- * setOdfmgOpacity() function!
+ * This function sets a multigroup opacity object of type rtt_cdi::OdfmgOpacity
+ * with the CDI object.  It stores the multigroup opacity object based upon its
+ * rtt_cdi::Model and rtt_cdi::Reaction types.  If a OdfmgOpacity with these
+ * type has already been registered an exception is thrown.  To register a new
+ * set of OdfmgOpacity objects call CDI::reset() first.  You cannot overwrite
+ * registered objects with the setOdfmgOpacity() function!
  *
  * \param spGOp smart pointer to a OdfmgOpacity object
  */
@@ -896,43 +900,41 @@ void CDI::setOdfmgOpacity(const SP_OdfmgOpacity &spODFOp) {
   Insist(!odfmgOpacities[model][reaction],
          "Tried to overwrite a set odfmgOpacity object!");
 
-  // if the frequency group boundaries have not been assigned in any CDI
-  // object, then assign them here
+  // if the frequency group boundaries have not been assigned in any CDI object,
+  // then assign them here
   if (frequencyGroupBoundaries.empty()) {
-    // copy the the group boundaries for this material to the
-    // "global" group boundaries that will be enforced for all CDI
-    // objects
+    // copy the the group boundaries for this material to the "global" group
+    // boundaries that will be enforced for all CDI objects
     frequencyGroupBoundaries = spODFOp->getGroupBoundaries();
   }
 
-  // if the opacity band boundaries have not been assigned in any CDI
-  // object, then assign them here
+  // if the opacity band boundaries have not been assigned in any CDI object,
+  // then assign them here
   if (opacityCdfBandBoundaries.empty()) {
-    // copy the the band boundaries for this material to the
-    // "global" band boundaries that will be enforced for all CDI
-    // objects
+    // copy the the band boundaries for this material to the "global" band
+    // boundaries that will be enforced for all CDI objects
     opacityCdfBandBoundaries = spODFOp->getBandBoundaries();
   }
 
-  // always check that the number of frequency groups is the same for
-  // each odfmg material added to CDI
+  // always check that the number of frequency groups is the same for each odfmg
+  // material added to CDI
   Insist(spODFOp->getNumGroupBoundaries() == frequencyGroupBoundaries.size(),
          "Incompatible frequency groups assigned for this material");
 
-  // always check that the number of frequency groups is the same for
-  // each odfmg material added to CDI
+  // always check that the number of frequency groups is the same for each odfmg
+  // material added to CDI
   Insist(spODFOp->getNumBandBoundaries() == opacityCdfBandBoundaries.size(),
          "Incompatible opacity bands assigned for this material");
 
-  // do a check of the actual boundary values when DBC check is on (this
-  // is more expensive so we retain the option of turning it off)
+  // do a check of the actual boundary values when DBC check is on (this is more
+  // expensive so we retain the option of turning it off)
   Remember(std::vector<double> const refGroup = spODFOp->getGroupBoundaries(););
   Check(soft_equiv(frequencyGroupBoundaries.begin(),
                    frequencyGroupBoundaries.end(), refGroup.begin(),
                    refGroup.end(), 1.0e-6));
 
-  // do a check of the actual band boundary values when DBC check is on
-  // (this is more expensive so we retain the option of turning it off)
+  // do a check of the actual band boundary values when DBC check is on (this is
+  // more expensive so we retain the option of turning it off)
   Remember(std::vector<double> const refBand = spODFOp->getBandBoundaries(););
   Check(soft_equiv(opacityCdfBandBoundaries.begin(),
                    opacityCdfBandBoundaries.end(), refBand.begin(),
@@ -963,6 +965,7 @@ void CDI::setEoS(const SP_EoS &in_spEoS) {
  *
  * This provides the CDI with the full functionality of the interface defined in
  * GrayOpacity.hh.  For example, the host code could make the following call:
+ *
  * \code
  * double newOp = spCDI1->gray()->getOpacity( 55.3, 27.4 );
  * \endcode
@@ -978,12 +981,14 @@ CDI::SP_GrayOpacity CDI::gray(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
   return grayOpacities[m][r];
 }
 
+//----------------------------------------------------------------------------//
 /*!
  * \brief This fuction returns the MultigroupOpacity object.
  *
- * This provides the CDI with the full functionality of the interface
- * defined in MultigroupOpacity.hh.  For example, the host code could
- * make the following call:
+ * This provides the CDI with the full functionality of the interface defined in
+ * MultigroupOpacity.hh.  For example, the host code could make the following
+ * call:
+ *
  * \code
  * size_t numGroups = spCDI1->mg()->getNumGroupBoundaries();
  * \endcode
@@ -998,11 +1003,13 @@ CDI::SP_MultigroupOpacity CDI::mg(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
   return multigroupOpacities[m][r];
 }
 
+//----------------------------------------------------------------------------//
 /*!
  * \brief This fuction returns the OdfmgOpacity object.
  *
  * This provides the CDI with the full functionality of the interface defined in
  * OdfmgOpacity.hh.  For example, the host code could make the following call:
+ *
  * \code
  * size_t numGroups = spCDI1->mg()->getNumGroupBoundaries();
  * \endcode
@@ -1018,13 +1025,12 @@ CDI::SP_OdfmgOpacity CDI::odfmg(rtt_cdi::Model m, rtt_cdi::Reaction r) const {
 }
 
 //---------------------------------------------------------------------------//
-
 /*!
  * \brief This fuction returns the EoS object.
  *
- * This provides the CDI with the full functionality of the interface
- * defined in EoS.hh.  For example, the host code could make the
- * following call:
+ * This provides the CDI with the full functionality of the interface defined in
+ * EoS.hh.  For example, the host code could make the following call:
+ *
  * \code
  * double Cve = spCDI1->eos()->getElectronHeatCapacity( * density, temperature );
  * \endcode

--- a/src/cdi/CDI_Integrate_Rosseland_Planckian_Spectrum.cc
+++ b/src/cdi/CDI_Integrate_Rosseland_Planckian_Spectrum.cc
@@ -18,26 +18,22 @@ namespace rtt_cdi {
 
 //---------------------------------------------------------------------------//
 /*!
- * The arguments to this function must all be in consistent units. For
- * example, if low and high are expressed in keV, then the temperature must
- * also be expressed in keV. If low and high are in Hz and temperature is in
- * K, then low and high must first be multiplied by Planck's constant and
- * temperature by Boltzmann's constant before they are passed to this function.
+ * The arguments to this function must all be in consistent units. For example,
+ * if low and high are expressed in keV, then the temperature must also be
+ * expressed in keV. If low and high are in Hz and temperature is in K, then low
+ * and high must first be multiplied by Planck's constant and temperature by
+ * Boltzmann's constant before they are passed to this function.
  *
  * \brief Integrate the Planckian and Rosseland spectrum over a frequency
  *        range.
  *
  * \param low Lower limit of frequency range.
- *
  * \param high Higher limit of frequency range.
- *
- * \param T Temperature (must be greater than 0.0).
- *
- * \planck On return, contains the integrated normalized Planckian from
- * low to high.
- *
- * \rosseland On return, contains the integrated normalized Rosseland from
- * low to high
+ * \param[in] T Temperature (must be greater than 0.0).
+ * \param[out] planck On return, contains the integrated normalized Planckian
+ *             from low to high.
+ * \param[out] rosseland On return, contains the integrated normalized Rosseland
+ *             from low to high
  *
  * \f[
  * planck(T) = \int_{\nu_1}^{\nu_2}{B(\nu,T)d\nu}
@@ -51,7 +47,9 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(double low, double high,
   Require(high >= low);
   Require(T >= 0.0);
 
-  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon())) {
+  // high/T must be < numeric_limits<double>::max().  So, if T ~< high*min, then
+  // return early with zero values (assuming max() ~ 1/min()).
+  if (T < high * std::numeric_limits<double>::min()) {
     planck = 0.0;
     rosseland = 0.0;
     return;

--- a/src/cdi/CDI_integratePlanckSpectrum.cc
+++ b/src/cdi/CDI_integratePlanckSpectrum.cc
@@ -21,9 +21,9 @@ namespace rtt_cdi {
  * and high must first be multiplied by Planck's constant and temperature by
  * Boltzmann's constant before they are passed to this function.
  *
- * \param low lower frequency bound.
- * \param high higher frequency bound.
- * \param T the temperature (must be greater than 0.0)
+ * \param[in] low lower frequency bound.
+ * \param[in] high higher frequency bound.
+ * \param[in] T the temperature (must be greater than 0.0)
  *
  * \return integrated normalized Plankian from low to high
  */
@@ -32,8 +32,9 @@ double CDI::integratePlanckSpectrum(double low, double high, const double T) {
   Require(high >= low);
   Require(T >= 0.0);
 
-  // return 0 if temperature is a hard zero
-  if (rtt_dsxx::soft_equiv(T, 0.0, std::numeric_limits<double>::epsilon()))
+  // high/T must be < numeric_limits<double>::max().  So, if T ~< high*min, then
+  // return early with zero values (assuming max() ~ 1/min()).
+  if (T < high * std::numeric_limits<double>::min())
     return 0.0;
 
   // Sale the frequencies by temperature

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -678,6 +678,23 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
   if (!soft_equiv(int_range, 0.0345683, 3.e-5))
     ITFAILS;
 
+  // Try an extreme case 1. This should do the normal computation, but the
+  // result is zero.
+  {
+    double const integrate_range_cold =
+        CDI::integratePlanckSpectrum(0.1, 1.0, 1.0e-30);
+    if (!soft_equiv(integrate_range_cold, 0.0))
+      ITFAILS;
+  }
+  // Try an extreme case 2. T < numeric_limits<double>::min() --> follow special
+  // logic and return zero.
+  {
+    double const integrate_range_cold =
+        CDI::integratePlanckSpectrum(0.1, 1.0, 1.0e-308);
+    if (!soft_equiv(integrate_range_cold, 0.0))
+      ITFAILS;
+  }
+
   // Catch an illegal group assertion.
   CDI cdi;
   std::shared_ptr<const MultigroupOpacity> mg(

--- a/src/cdi_analytic/Pseudo_Line_Base.cc
+++ b/src/cdi_analytic/Pseudo_Line_Base.cc
@@ -211,6 +211,7 @@ vector<char> Pseudo_Line_Base::pack() const {
 
 //---------------------------------------------------------------------------//
 double Pseudo_Line_Base::monoOpacity(double const x, double const T) const {
+
   int const number_of_lines = number_of_lines_;
   double const width = line_width_;
   double const peak = line_peak_;
@@ -249,9 +250,10 @@ double Pseudo_Line_Base::monoOpacity(double const x, double const T) const {
       Result += edge_factor_[i] * cube(nu0 / x);
     }
   }
+  // if the power is ~0, then pow(a,0) == 1.0.
   if (!rtt_dsxx::soft_equiv(Tpow_, 0.0,
                             std::numeric_limits<double>::epsilon())) {
-    Result = Result * pow(T / Tref_, Tpow_);
+    Result *= pow(T / Tref_, Tpow_);
   }
   return Result;
 }


### PR DESCRIPTION
I inadvertantly introduced a bug into CDI when I replaced:
```
if (T == 0.0 )
```
with
```
if (soft_equiv(T,0.0,numeric_limits<double>::epsilon())
```
This check is needed to avoid a division by zero.  However, in CDI `T` is almost always < epsilon() because of the unit system. Thus, the Planck and Rosseland integrator functions were returning earlier than they should have.  The fix in this PR is to use the conditional
```
if ( T < max(nu) * numeric_limits<double>::min() )
```
which should guarantee that `nu/T < numeric_limits<double>::max()`.  Also add a test for very small values of T.

* Fixes #252
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
