### PR TITLE
Eliminate warnings reported by ccscs7, gcc-coverage builds.

### DIFF
--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for rng/test.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 project( rng_test C CXX )

--- a/src/rng/test/time_serial.h
+++ b/src/rng/test/time_serial.h
@@ -4,15 +4,15 @@
  * \author Gabriel M. Rockefeller
  * \date   Mon Nov 19 10:35:04 2012
  * \brief  time_serial header file.
- * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC
- */
-/*---------------------------------------------------------------------------*/
-/* $Id$ */
+ * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
+ *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
 #ifndef rng_time_serial_h
 #define rng_time_serial_h
 
+/* This is a Random123 file. Ignore advanced gcc warnings emanating from this
+ * file. */
 #ifdef __GNUC__
 #pragma GCC system_header
 #endif
@@ -25,5 +25,5 @@
 #endif /* rng_time_serial_h */
 
 /*---------------------------------------------------------------------------*/
-/*           end of rng/time_serial.h */
+/* end of rng/time_serial.h */
 /*---------------------------------------------------------------------------*/

--- a/src/rng/test/util.h
+++ b/src/rng/test/util.h
@@ -1,3 +1,4 @@
+/*----------------------------------------------------------------------------*/
 /*
 Copyright 2016, D. E. Shaw Research.
 All rights reserved.
@@ -29,6 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+/*----------------------------------------------------------------------------*/
 #ifndef UTIL_H__
 #define UTIL_H__
 
@@ -40,14 +42,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
+/* This is a Random123 file. Ignore advanced gcc warnings eminating from this
+ * file. */
+#ifdef __GNUC__
+#pragma GCC system_header
 #endif
+
 #include <Random123/features/compilerfeatures.h>
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
 extern const char *progname;
 extern int debug;
@@ -324,3 +325,7 @@ double hextod(const char *cp) {
   } while (0)
 
 #endif /* UTIL_H__ */
+
+/*----------------------------------------------------------------------------*/
+/* End util.h */
+/*----------------------------------------------------------------------------*/


### PR DESCRIPTION
+ Mark another file taken from Random123 as a "GCC system_header".  We are not interested in warnings emanating from code that we did not write.
+ Fixes #259.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
