### PR TITLE
Cleanup some warnings that have crept into some of the non-CI builds.

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -20,6 +20,11 @@ query_openmp_availability()
 # http://clang.llvm.org/docs/UsersManual.html#options-to-control-error-and-warning-messages
 # -fdiagnostics-show-hotness
 #
+# valgrind like options - https://clang.llvm.org/docs/AddressSanitizer.html
+#      '-g -fsanitize=address -fno-omit-frame-pointer'
+#      must use clang++ for linking
+#      suppressions: LSAN_OPTIONS=suppressions=MyLSan.supp
+#      human readable: ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer ./a.out
 
 #
 # Compiler Flags

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -92,7 +92,7 @@ case $target in
     dm_core="cmake eospac git tk ndi python doxygen ccache numdiff totalview \
 dia graphviz ack"
     dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
-    dm_openmpi="openmpi parmetis superlu-dist trilinos valgrind"
+    dm_openmpi="openmpi parmetis superlu-dist/4.3-netlib trilinos valgrind"
     export dracomodules="$dm_core $dm_gcc $dm_openmpi"
     ;;
   ccsnet3*)

--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -1221,6 +1221,23 @@
    fun:PMPI_Win_create
    ...
 }
+{
+   openmpi210/e0020
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:pmix1_server_register_nspace
+   fun:orte_pmix_server_register_nspace
+   fun:orte_odls_base_default_construct_child_list
+   fun:orte_odls_default_launch_local_procs
+   fun:orte_daemon_recv
+   fun:orte_rml_base_process_msg
+   fun:event_process_active_single_queue
+   fun:event_process_active
+   fun:opal_libevent2022_event_base_loop
+   fun:orterun
+   fun:main
+}
 
 #------------------------------------------------------------------------------#
 # Python 2.7

--- a/src/c4/Timer.cc
+++ b/src/c4/Timer.cc
@@ -4,10 +4,7 @@
  * \author Thomas M. Evans
  * \date   Mon Mar 25 17:56:11 2002
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Timer.hh"
@@ -25,10 +22,10 @@ namespace rtt_c4 {
 
 /* Initialize static non-const data members found in the Timer class */
 
-// By default, we count up the total L2 data cache misses and hits and the
-// total number of floating point operations. These allow us to report the
-// percentage of data cache hits and the number of floating point operations
-// per cache miss.
+// By default, we count up the total L2 data cache misses and hits and the total
+// number of floating point operations. These allow us to report the percentage
+// of data cache hits and the number of floating point operations per cache
+// miss.
 int Timer::papi_events_[papi_max_counters_] = {PAPI_L2_DCM, PAPI_L2_DCH,
                                                PAPI_FP_OPS};
 
@@ -53,8 +50,8 @@ Timer::Timer()
       sum_system(0.0), sum_user(0.0), num_intervals(0) {
 #ifdef HAVE_PAPI
 
-  // Initialize the PAPI library on construction of first timer if it has
-  // not already be initialized through a call to Timer::initialize.
+  // Initialize the PAPI library on construction of first timer if it has not
+  // already be initialized through a call to Timer::initialize.
 
   papi_init_();
 
@@ -140,8 +137,8 @@ void Timer::printline(std::ostream &out, unsigned const p,
   out.setf(ios::fixed, ios::floatfield);
   out.precision(p);
 
-  // Width of first column (intervals) should be set by client before
-  // calling this function.
+  // Width of first column (intervals) should be set by client before calling
+  // this function.
   out << num_intervals << setw(w) << sum_user_cpu() << setw(w)
       << sum_system_cpu() << setw(w) << sum_wall_clock();
 
@@ -182,8 +179,8 @@ void Timer::initialize(int & /*argc*/, char * /*argv*/ [])
 #endif
 {
 // The initialize function need not be called if the default settings are
-// okay. Otherwise, initialize is called with the command line arguments
-// to allow command line control of which cache is sampled under PAPI.
+// okay. Otherwise, initialize is called with the command line arguments to
+// allow command line control of which cache is sampled under PAPI.
 //
 // At present, there are no non-PAPI options controlled by initialize.
 #ifdef HAVE_PAPI
@@ -241,7 +238,7 @@ void Timer::initialize(int & /*argc*/, char * /*argv*/ [])
 }
 
 #ifdef HAVE_PAPI
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /* static */
 void Timer::papi_init_() {
   static bool first_time = true;
@@ -284,10 +281,10 @@ void Timer::papi_init_() {
   }
 
   // At present, some platforms *lie* about how many counters they have
-  // available, reporting they have three then returning an out of
-  // counters error when you actually try to assign the three counter
-  // types listed above. Until we have a fix, hardwire to leave out the
-  // flops count, which is the least essential of the three counts.
+  // available, reporting they have three then returning an out of counters
+  // error when you actually try to assign the three counter types listed
+  // above. Until we have a fix, hardwire to leave out the flops count, which is
+  // the least essential of the three counts.
   papi_num_counters_ = 2;
 
   if (papi_num_counters_ > sizeof(papi_events_) / sizeof(int))
@@ -327,15 +324,12 @@ void Timer::pause(double const pauseSeconds) {
 /*! Print out a summary timing report for averages across MPI ranks.
  *
  * \param out Stream to which to write the report.
- *
  * \param p Precision with which to write the timing and variance numbers.
- * Defaults to 2.
- *
+ *          Defaults to 2.
  * \param w Width of the timing number fields. Defaults to each field being 13
- * characters wide.
- *
+ *          characters wide.
  * \param v Width of the variance number fields. Defaults to each field being 5
- * characters wide.
+ *          characters wide.
  */
 void Timer::printline_mean(std::ostream &out, unsigned const p,
                            unsigned const w, unsigned const v) const {
@@ -361,7 +355,11 @@ void Timer::printline_mean(std::ostream &out, unsigned const p,
   ww = buffer[6];
   ww2 = buffer[7];
 
-  unsigned mni = ni / ranks;
+  // Casting from a double to unsigned. Ensure that we aren't overflowing the
+  // unsigned or dropping a negative sign.
+  Check(ni >= 0.0);
+  Check(ni < ranks * std::numeric_limits<unsigned>::max());
+  unsigned mni = static_cast<unsigned>(ni / ranks);
   double mu = u / ranks;
   double ms = s / ranks;
   double mww = ww / ranks;
@@ -370,8 +368,8 @@ void Timer::printline_mean(std::ostream &out, unsigned const p,
     out.setf(ios::fixed, ios::floatfield);
     out.precision(p);
 
-    // Width of first column (intervals) should be set by client before
-    // calling this function.
+    // Width of first column (intervals) should be set by client before calling
+    // this function.
     out << setw(w) << mni << " +/- " << setw(v)
         << sqrt((ni2 - 2 * mni * ni + ranks * mni * mni) / ranks) << setw(w)
         << mu << " +/- " << setw(v)

--- a/src/plot2D/test/tstPlot2D.cc
+++ b/src/plot2D/test/tstPlot2D.cc
@@ -317,7 +317,8 @@ int main(int argc, char *argv[]) {
       // wait a bit before comparing the output to the gold standards.
       std::cout << "\nWaiting for Grace to finish writing files...\n"
                 << std::endl;
-      system("sleep 5");
+      bool system_call_ok = system("sleep 5") == 0;
+      Insist(system_call_ok, "system call returned an error.");
 
       // Check the created files by comparing to a gold standard.
       checkOutputFiles(std::string("plot1"));


### PR DESCRIPTION
+ On ccs-net machines, force the default draco developer environment to load `superlu-dist/4.3-netlib` instead of the default `superlu-dist`.
+ Add a valgrind suppression related to OpenMPI 2.1.0.
+ In c4's `Timer.cc`, use `static_cast` to convert from `double` to `unsigned`.  Also add DbC checks to ensure the conversion is valid.
+ In `Plot2D.cc`, collect and check the return code from `fgets` and `system`.
+ Clean up comment blocks.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
