### PR TITLE
Remove a bad DBC check in the Compton class

### DIFF
--- a/src/compton/Compton.cc
+++ b/src/compton/Compton.cc
@@ -34,9 +34,6 @@ namespace rtt_compton {
  */
 Compton::Compton(const std::string &filehandle) {
 
-  // Check input validity
-  Require(std::ifstream(filehandle).good());
-
   // Make a compton file object to read the multigroup data
   compton_file Cfile(false);
 


### PR DESCRIPTION
This DBC check is flawed -- it was checking the 'base' filename, when the actual library files have suffixes appended. Thus, it throws an assertion even if the library files exist.

I should add that the CSK library will still throw an assertion if the file doesn't exist, and that this is tested in tCompton.

(Thanks @attom for pointing this out! :))

* Purpose of Pull Request
  * Fix a DBC bug preventing draco Compton class from working properly

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation