### PR TITLE
Here are four small tweaks to Draco.

### DIFF
--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -35,56 +35,17 @@ fi
 add_to_path ${VENDOR_DIR}/bin PATH
 
 #------------------------------------------------------------------------------#
-# Setup Modules (Lmod or TCL)
-
-# Is the module function available?
-function setup_tcl_modules ()
-{
-  found=`declare -f module | wc -l`
-  # Module is provided by the system:
-  if test ${found} == 0; then
-    if test -f /usr/share/Modules/init/bash; then
-      source /usr/share/Modules/init/bash
-    elif test -f /ccs/opt/x86_64/modules/Modules/3.2.10/init/bash; then
-      # CCS workstations (e.g.: gondolin)
-      # 2015-10-09 Kent's workstation still requires this!
-      source /ccs/opt/x86_64/modules/Modules/3.2.10/init/bash
-    fi
-  fi
-}
-
-function setup_lmod_modules()
-{
-  local do_lmod_setup=0
-  if [[ `fn_exists module` == 1 ]]; then
-    if [[ `declare -f module | grep -c LMOD` == 0 ]]; then
-      # we have tcl modules
-      module purge
-      unset dracomodules
-      unset NoModules
-      unset _LMFILES_
-      unset MODULEPATH
-      unset LOADEDMODULES
-      unset MODULESHOME
-
-      # If TCL modulefiles, switch to Lmod
-      do_lmod_setup=1
-    fi
-  else
-    do_lmod_setup=1
-  fi
-
-  if [[ $do_lmod_setup ]]; then
-    export MODULE_HOME=/scratch/vendors/spack.20170502/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/lmod-7.4.8-oytncsoih2sa4jdogz2ojvwly6mwle4n
-    source $MODULE_HOME/lmod/lmod/init/bash || die "Can't find /mod/init/bash"
-    module use /scratch/vendors/spack.20170502/share/spack/lmod/linux-rhel7-x86_64/Core
-  fi
-}
+# Setup Modules
 
 target=`uname -n`
 case $target in
   ccscs[1-9]*)
-    setup_lmod_modules
+    if [[ -d /scratch/vendors/Modules.core ]]; then
+      # spack generated "core" modulefils
+      export MODULEPATH=/scratch/vendors/Modules.core
+    fi
+
+    # hand-written modulefiles for non spack tools.
     module use --append /scratch/vendors/Modules.lmod
     if [[ -d $HOME/privatemodules ]]; then
       module use --append $HOME/privatemodules

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -57,16 +57,34 @@ function establish_permissions
   # Permissions - new files should be marked u+rwx,g+rwx,o+rx
   # Group is set to $1 or draco
   umask 0002
-  if [[ `groups | grep -c othello` = 1 ]]; then
-    install_group="othello"
-    install_permissions="g+rwX,o-rwX"
-  elif [[ `groups | grep -c dacodes` = 1 ]]; then
-    install_group="dacodes"
-    install_permissions="g+rwX,o-rwX"
-  else
-    install_group="draco"
-    install_permissions="g+rwX,o-rwX"
+
+  # Different permissions for jayenne/capsaicin vs. draco.  Trigger based on
+  # value of $package.
+  if ! [[ $package ]]; then
+    die "env(package) must be set before calling establish_permissions."
   fi
+
+  case $package in
+    draco)
+      # Draco is open source - allow anyone to read.
+      install_group="draco"
+      install_permissions="g+rwX,o=g-w"
+      ;;
+    capsaicin | jayenne)
+      # Export controlled sources - limit access
+      if [[ `groups | grep -c ccsrad` = 1 ]]; then
+        install_group="ccsrad"
+        install_permissions="g+rwX,o-rwX"
+      elif [[ `groups | grep -c dacodes` = 1 ]]; then
+        install_group="dacodes"
+        install_permissions="g+rwX,o-rwX"
+      else
+        install_group="jayenne"
+        install_permissions="g+rwX,o-rwX"
+      fi
+      ;;
+  esac
+
   build_group="$USER"
   build_permissions="g+rwX,o-rwX"
 }
@@ -506,6 +524,7 @@ function publish_release()
     if test -d $install_prefix; then
       run "chgrp -R ${install_group} $source_prefix"
       run "chmod -R $install_permissions $source_prefix"
+      run "find $source_prefix -type d -exec chmod g+s {} +"
     fi
   fi
 }

--- a/src/ds++/UnitTest.hh
+++ b/src/ds++/UnitTest.hh
@@ -240,6 +240,12 @@ protected:
 #define UT_CHECK(ut, m) ut.check(m, #m);
 #define ITFAILS ut.failure(__LINE__, __FILE__)
 #define FAILURE ut.failure(__LINE__, __FILE__);
+#define FAIL_IF_NOT(c)                                                         \
+  if (!(c))                                                                    \
+  ITFAILS
+#define FAIL_IF(c)                                                             \
+  if ((c))                                                                     \
+  ITFAILS
 #define UT_EPILOG(foo)                                                         \
   catch (rtt_dsxx::assertion & err) {                                          \
     std::cout << "DRACO ERROR: While testing " << foo.getTestName() << ", "    \

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -224,6 +224,8 @@
     #define NOMINMAX
     /* We want to use M_PI from math.h */
     #define _USE_MATH_DEFINES
+    /* MSVC's __FUNCSIG__ is similar to GNU's __PRETTY_FUNCTION__ */
+    #define  __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
 #ifdef APPLE


### PR DESCRIPTION
+ Update `.bashrc_linux64` to take advantage of the fact that LMOD modulefiles are now the default on ccs-net machines (thanks to Dan Pruitt). This simplifies the logic needed to make available the tools available at `/scratch/vendors` via the module system.
+ Update the install scripts to use the group `ccsrad` when installing Jayenne and Capsaicin. Only members of this group will be able to access installed sources and libraries. If `ccsrad` isn't available, the script will try to use the group `dacodes` and then `jayenne`. Draco will still be installed as group `draco` with world read permissions.
+ Provide new CPP macro helpers that can be used in our Unit Tests:
  - `FAIL_IF(c)`
  - `FAIL_IF_NOT(c)`
+ When building on Win32, define `__PRETTY_FUNCTION__` in a way that produces similar output to that macro's behavior on Linux systems.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
