### PR TITLE
Commit changes that are *hot* in the current regress directories.

### DIFF
--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -36,6 +36,7 @@ fi
 
 # Environment setup
 # ----------------------------------------
+umask 0002
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -48,6 +49,8 @@ export NO_PROXY=$no_proxy
 export VENDOR_DIR=/scratch/vendors
 # gitlab.lanl.gov has an unkown certificate, disable checking
 export GIT_SSL_NO_VERIFY=true
+# ccscs7 has 8 cores per socket
+export OMP_NUM_THREADS=8
 
 # import some bash functions
 source $rscriptdir/scripts/common.sh
@@ -77,8 +80,7 @@ echo "CCSCS Regression: ${ctestparts} from ${machine}."
 echo "                  ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
 echo "==========================================================================="
 
-umask 0002
-ulimit -a
+run "ulimit -a"
 
 # Modules
 # ----------------------------------------
@@ -131,7 +133,7 @@ run "module use --append /scratch/vendors/Modules.lmod"
 # Load default set of modules
 dm_core="cmake eospac git ndi python graphviz doxygen ccache numdiff"
 dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
-dm_openmpi="openmpi parmetis superlu-dist trilinos"
+dm_openmpi="openmpi parmetis superlu-dist/4.3-netlib trilinos"
 export dracomodules="$dm_core $dm_gcc $dm_openmpi"
 
 # use bash_functions.sh::add_to_path?
@@ -190,6 +192,7 @@ case $extra_params in
     ;;
 esac
 run "module list"
+comp=$comp-$featurebranch
 
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if test "$USER" == "kellyt"; then
@@ -251,6 +254,9 @@ elif test "${subproj}" == jayenne; then
   script_dir=`echo ${rscriptdir} | sed -e 's/draco/jayenne/'`
   script_name=Jayenne_Linux64.cmake
 elif test "${subproj}" == capsaicin; then
+  # For now force Capsaicin to only 1 OMP thread per MPI rank to avoid
+  # oversubscribing the system.
+  export OMP_NUM_THREADS=1
   script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%capsaicin/scripts%'`
   script_name=Capsaicin_Linux64.cmake
 elif test "${subproj}" == asterisk; then

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -96,12 +96,15 @@ case $project in
     print_use; exit 1 ;;
 esac
 
-
-if ! [[ $LOGNAME == "kellyt" ]]; then
-  echo ""; echo "FATAL ERROR: Please use ccscs6 for manual use of checkpr.sh."
-  exit 1
-fi
-
+# Restrict the use of ccscs7.
+case $target in
+  ccscs7*)
+    if ! [[ $LOGNAME == "kellyt" ]]; then
+      echo ""; echo "FATAL ERROR: Please use ccscs6 for manual use of checkpr.sh."
+      exit 1
+    fi
+    ;;
+esac
 
 if [[ $regress_mode == "on" ]]; then
   if ! [[ $LOGNAME == "kellyt" ]]; then
@@ -230,10 +233,14 @@ case $target in
     ;;
 
   # Moonlight: Fulldiagnostics (Debug)
-  ml-fey*) startCI ${project} Debug fulldiagnostics $pr ;;
+  ml-fey*) startCI ${project} Debug $pr ;;
 
   # Snow: Debug
-  sn-fe*) startCI ${project} Debug na $pr ;;
+  sn-fe*)
+    startCI ${project} Debug na $pr
+    startCI ${project} Release na $pr
+    startCI ${project} Debug fulldiagnostics $pr
+    ;;
 
   # Trinitite: Release
   tt-fe*)

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -211,7 +211,7 @@ mkdir -p $logdir || die "Could not create a directory for log files."
 # Redirect output to logfile.
 timestamp=`date +%Y%m%d-%H%M`
 logfile=$logdir/${machine_name_short}-${build_type}-master-$timestamp.log
-echo "Redirecting output to $logfile"
+# echo "Redirecting output to $logfile"
 exec > $logfile
 exec 2>&1
 

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -214,6 +214,8 @@ function flavor
 # returns a path to a directory
 function selectscratchdir
 {
+  local platform=`machineName`
+
   # if df is too old this command won't work correctly, use an alternate form.
   local scratchdirs=`df --output=pcent,target 2>&1 | grep -c unrecognized`
   if [[ $scratchdirs == 0 ]]; then
@@ -222,7 +224,6 @@ function selectscratchdir
     scratchdirs=`df -a 2> /dev/null | grep net/scratch | awk '{ print $4 " "$5 }' | sort -g`
     if ! [[ $scratchdirs ]]; then
       scratchdirs=`df -a 2> /dev/null | grep lustre/scratch | awk '{ print $4 " "$5 }' | sort -g`
-
     fi
   fi
   local odd=1
@@ -238,17 +239,17 @@ function selectscratchdir
     # if this location is good (must be able to write to this location), return
     # the path.
     mkdir -p $item/$USER &> /dev/null
-    touch $item/$USER/selectscratchdir &> /dev/null
-    if [[ -f $item/$USER/selectscratchdir ]]; then
-      rm $item/$USER/selectscratchdir
+    touch $item/$USER/selectscratchdir-${platform} &> /dev/null
+    if [[ -f $item/$USER/selectscratchdir-${platform} ]]; then
+      rm $item/$USER/selectscratchdir-${platform} &> /dev/null
       echo "$item"
       return
     fi
     # might need another directory level 'yellow'
     mkdir -p $item/yellow/$USER &> /dev/null
-    touch $item/yellow/$USER/selectscratchdir &> /dev/null
-    if [[ -f $item/yellow/$USER/selectscratchdir ]]; then
-      rm $item/yellow/$USER/selectscratchdir
+    touch $item/yellow/$USER/selectscratchdir-${platform} &> /dev/null
+    if [[ -f $item/yellow/$USER/selectscratchdir-${platform} ]]; then
+      rm $item/yellow/$USER/selectscratchdir-${platform} &> /dev/null
       echo "$item/yellow"
       return
     fi
@@ -257,9 +258,9 @@ function selectscratchdir
   # if no writable scratch directory is located, then also try netscratch;
   item=/netscratch/$USER
   mkdir -p $item &> /dev/null
-  touch $item/selectscratchdir &> /dev/null
-  if [[ -f $item/selectscratchdir ]]; then
-    rm $item/selectscratchdir
+  touch $item/selectscratchdir-${platform} &> /dev/null
+  if [[ -f $item/selectscratchdir-${platform} ]]; then
+    rm $item/selectscratchdir-${platform} &> /dev/null
     echo "$item"
     return
   fi

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -214,8 +214,6 @@ function flavor
 # returns a path to a directory
 function selectscratchdir
 {
-  local platform=`machineName`
-
   # if df is too old this command won't work correctly, use an alternate form.
   local scratchdirs=`df --output=pcent,target 2>&1 | grep -c unrecognized`
   if [[ $scratchdirs == 0 ]]; then
@@ -224,6 +222,7 @@ function selectscratchdir
     scratchdirs=`df -a 2> /dev/null | grep net/scratch | awk '{ print $4 " "$5 }' | sort -g`
     if ! [[ $scratchdirs ]]; then
       scratchdirs=`df -a 2> /dev/null | grep lustre/scratch | awk '{ print $4 " "$5 }' | sort -g`
+
     fi
   fi
   local odd=1
@@ -239,17 +238,13 @@ function selectscratchdir
     # if this location is good (must be able to write to this location), return
     # the path.
     mkdir -p $item/$USER &> /dev/null
-    touch $item/$USER/selectscratchdir-${platform} &> /dev/null
-    if [[ -f $item/$USER/selectscratchdir-${platform} ]]; then
-      rm $item/$USER/selectscratchdir-${platform} &> /dev/null
+    if [[ -w $item/$USER ]]; then
       echo "$item"
       return
     fi
     # might need another directory level 'yellow'
     mkdir -p $item/yellow/$USER &> /dev/null
-    touch $item/yellow/$USER/selectscratchdir-${platform} &> /dev/null
-    if [[ -f $item/yellow/$USER/selectscratchdir-${platform} ]]; then
-      rm $item/yellow/$USER/selectscratchdir-${platform} &> /dev/null
+    if [[ -w $item/yellow/$USER ]]; then
       echo "$item/yellow"
       return
     fi
@@ -258,9 +253,7 @@ function selectscratchdir
   # if no writable scratch directory is located, then also try netscratch;
   item=/netscratch/$USER
   mkdir -p $item &> /dev/null
-  touch $item/selectscratchdir-${platform} &> /dev/null
-  if [[ -f $item/selectscratchdir-${platform} ]]; then
-    rm $item/selectscratchdir-${platform} &> /dev/null
+  if [[ -w $item ]]; then
     echo "$item"
     return
   fi

--- a/regression/sn-job-launch.sh
+++ b/regression/sn-job-launch.sh
@@ -87,7 +87,7 @@ logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra
 if [[ -f $logfile ]]; then
   rm $logfile
 fi
-cmd="$MSUB ${access_queue} -o ${logfile} -J ${subproj:0:5}-{featurebranch} -t 4:00:00 ${rscriptdir}/sn-regress.msub"
+cmd="$MSUB ${access_queue} -o ${logfile} -J ${subproj:0:5}-${featurebranch} -t 4:00:00 ${rscriptdir}/sn-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 # trim extra whitespace from number

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -241,66 +241,69 @@ fi
 # Mirror git repository for redmine integration
 #------------------------------------------------------------------------------#
 
-# Broken? - KT needs to research this.
+case ${target} in
+  ccscs7*)
+    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+    # PRs since this seems to confuse Redmine.
+    echo " "
+    echo "(Redmine) Copy Draco git repository to the local file system..."
+    if test -d $gitroot/Draco-redmine.git; then
+      run "cd $gitroot/Draco-redmine.git"
+      run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git reset --soft"
+      run "chmod -R g+rwX Draco-redmine.git"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --mirror git@github.com:lanl/Draco.git Draco-redmine.git"
+      run "chmod -R g+rwX Draco-redmine.git"
+      run "chmod g+s Draco-redmine.git"
+    fi
+    ;;
+esac
 
-# case ${target} in
-#   ccscs7*)
-#     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-#     # PRs since this seems to confuse Redmine.
-#     echo " "
-#     echo "(Redmine) Copy Draco git repository to the local file system..."
-#     if test -d $gitroot/Draco-redmine.git; then
-#       run "cd $gitroot/Draco-redmine.git"
-#       run "git fetch origin +refs/heads/*:refs/heads/*"
-#       run "git reset --soft"
-#     else
-#       run "mkdir -p $gitroot"
-#       run "cd $gitroot"
-#       run "git clone --mirror git@github.com:lanl/Draco.git Draco-redmine.git"
-#       run "chmod -R g+rwX Draco-redmine.git"
-#     fi
-#     ;;
-# esac
+case ${target} in
+  ccscs7*)
+    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+    # PRs since this seems to confuse Redmine.
+    echo " "
+    echo "(Redmine) Copy Jayenne git repository to the local file system..."
+    if test -d $gitroot/jayenne-redmine.git; then
+      run "cd $gitroot/jayenne-redmine.git"
+      run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git reset --soft"
+      # run "chgrp -R draco $gitroot/jayenne-redmine.git"
+      run "chmod -R g+rwX $gitroot/jayenne-redmine.git"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne-redmine.git"
+      run "chmod -R g+rwX jayenne-redmine.git"
+      run "chmod g+s jayenne-redmine.git"
+    fi
+    ;;
+esac
 
-# case ${target} in
-#   ccscs7*)
-#     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-#     # PRs since this seems to confuse Redmine.
-#     echo " "
-#     echo "(Redmine) Copy Jayenne git repository to the local file system..."
-#     if test -d $gitroot/jayenne-redmine.git; then
-#       run "cd $gitroot/jayenne-redmine.git"
-#       run "git fetch origin +refs/heads/*:refs/heads/*"
-#       run "git reset --soft"
-#       run "chgrp -R draco $gitroot/capsaicin.git"
-#       run "chmod -R g+rwX $gitroot/capsaicin.git"
-#     else
-#       run "mkdir -p $gitroot"
-#       run "cd $gitroot"
-#       run "git clone --mirror git@gitlab.lanl.gov:jayenne/jayenne.git jayenne-redmine.git"
-#       run "chmod -R g+rwX jayenne-redmine.git"
-#     fi
-#     ;;
-# esac
-
-# case ${target} in
-#   ccscs7*)
-#     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-#     # PRs since this seems to confuse Redmine.
-#     echo " "
-#     echo "(Redmine) Copy Capsaicin git repository to the local file system..."
-#     if test -d $gitroot/capsaicin-redmine.git; then
-#       run "cd $gitroot/capsaicin-redmine.git"
-#       run "git fetch origin +refs/heads/*:refs/heads/*"
-#       run "git reset --soft"
-#     else
-#       run "mkdir -p $gitroot"
-#       run "cd $gitroot"
-#       run "git clone --mirror git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin-redmine.git"
-#       run "chmod -R g+rwX capsaicin-redmine.git"
-#     fi
-#     ;;
-# esac
+case ${target} in
+  ccscs7*)
+    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+    # PRs since this seems to confuse Redmine.
+    echo " "
+    echo "(Redmine) Copy Capsaicin git repository to the local file system..."
+    if test -d $gitroot/capsaicin-redmine.git; then
+      run "cd $gitroot/capsaicin-redmine.git"
+      run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git reset --soft"
+      run "chmod -R g+rwX $gitroot/capsaicin-redmine.git"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --mirror git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin-redmine.git"
+      run "chmod -R g+rwX capsaicin-redmine.git"
+      run "chmod g+s capsaicin-redmine.git"
+    fi
+    ;;
+esac
 
 #------------------------------------------------------------------------------#
 # Continuous Integration Hooks:


### PR DESCRIPTION
+ `ccscs-regress.msub`:
  - On ccscs7, set `OMP_NUM_THREADS=8`
  - Force loading superlu-dist/4.3.to avoid loading 5.X.
  - Add `$featurebranch` to the build name.
+ Prevent `checkpr.sh` from running on ccscs7 unless run by the regress account. This should reduce the load on ccscs7.
+ Move *fulldiagnostics* CI build from moonlight to snow.
+ Begin running a *Release* CI build on snow.
+ Improve how `selectscratchdir` works.
+ Reactivate the repository synchronization used by Redmine.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
