### PR TITLE
Enable compiler flags `-Wfloat-equal -Wunused-macros`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,13 @@ macro( add_dir_if_exists package )
   endif()
 endmacro()
 
+# Extra 'draco-only' flags (don't pass these to Capsaicin).
+if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
+    toggle_compiler_flag( TRUE "-Wfloat-equal -Wunused-macros" "CXX;C" "DEBUG")
+  endif()
+endif()
+
 # Level 1
 message(" ")
 message( STATUS "Configuring Level 1 packages --" )

--- a/src/ds++/test/tstFMA2.cc
+++ b/src/ds++/test/tstFMA2.cc
@@ -36,6 +36,10 @@ void test_fma2(rtt_dsxx::UnitTest &ut) {
 
   std::cout << "Hardware FMA is available.\n";
 
+#if FP_ACCURATE_FMA > 0
+  FAILMSG("This test requires FP_ACCURATE_FMA=0.");
+#endif
+
 #ifdef FP_FAST_FMA
   std::cout << "\t#define FMA(a,b,c) fma(a,b,c)\n" << std::endl;
 

--- a/src/quadrature/Galerkin_Ordinate_Space.cc
+++ b/src/quadrature/Galerkin_Ordinate_Space.cc
@@ -1,24 +1,18 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   quadrature/Galerkin_Ordinate_Space.cc
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Define methods of class Galerkin_Ordinate_Space
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Galerkin_Ordinate_Space.cc 6855 2012-11-06 16:39:27Z kellyt $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #include "Galerkin_Ordinate_Space.hh"
 #include "special_functions/Ylm.hh"
 #include "units/PhysicalConstants.hh"
-
-// Vendor software
 #include <gsl/gsl_blas.h>
 #include <gsl/gsl_linalg.h>
-
 #include <iomanip>
 #include <iostream>
 
@@ -46,7 +40,8 @@
 //         for( unsigned j=0; j<dims[0]-1; ++j )
 //             cout << std::setprecision(10) << x[j+dims[0]*i] << ", ";
 
-//         cout << std::setprecision(10) << x[dims[0]-1+dims[0]*i] << " }." << endl;
+//         cout << std::setprecision(10) << x[dims[0]-1+dims[0]*i] << " }."
+//              << endl;
 //     }
 //     cout << endl;
 //     return;
@@ -56,7 +51,7 @@ using namespace rtt_units;
 
 namespace rtt_quadrature {
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 vector<Moment> Galerkin_Ordinate_Space::compute_n2lk_1D_(Quadrature_Class,
                                                          unsigned const N) {
   vector<Moment> result;
@@ -70,7 +65,7 @@ vector<Moment> Galerkin_Ordinate_Space::compute_n2lk_1D_(Quadrature_Class,
   return result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 vector<Moment> Galerkin_Ordinate_Space::compute_n2lk_1Da_(Quadrature_Class,
                                                           unsigned const N) {
   std::vector<Moment> result;
@@ -163,31 +158,32 @@ vector<Moment> Galerkin_Ordinate_Space::compute_n2lk_3D_(Quadrature_Class,
   return result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  *
  * \param dimension Dimension of the physical problem space (1, 2, or 3)
  *
  * \param geometry Geometry of the physical problem space (spherical,
- * axisymmetric, Cartesian)
+ *             axisymmetric, Cartesian)
  *
  * \param ordinates Set of ordinate directions
  *
- * \param quadrature_class Class of the quadrature used to generate the
- * ordinate set. At presente, only TRIANGLE_QUADRATURE is supported.
+ * \param quadrature_class Class of the quadrature used to generate the ordinate
+ *             set. At presente, only TRIANGLE_QUADRATURE is supported.
  *
  * \param sn_order Order of the quadrature. This is equal to the number of
- * levels for triangular and square quadratures.
+ *             levels for triangular and square quadratures.
  *
  * \param expansion_order Expansion order of the desired scattering moment
- * space.
+ *             space.
  *
- * \param extra_starting_directions Add extra directions to each level set. In most
- * geometries, an additional ordinate is added that is opposite in direction
- * to the starting direction. This is used to implement reflection exactly in
- * curvilinear coordinates. In 1D spherical, that means an additional angle is
- * added at mu=1. In axisymmetric, that means additional angles are added that
- * are oriented opposite to the incoming starting direction on each level.
+ * \param extra_starting_directions Add extra directions to each level set. In
+ *             most geometries, an additional ordinate is added that is opposite
+ *             in direction to the starting direction. This is used to implement
+ *             reflection exactly in curvilinear coordinates. In 1D spherical,
+ *             that means an additional angle is added at mu=1. In axisymmetric,
+ *             that means additional angles are added that are oriented opposite
+ *             to the incoming starting direction on each level.
  *
  * \param ordering Ordering into which to sort the ordinates.
  */
@@ -218,25 +214,24 @@ Galerkin_Ordinate_Space::Galerkin_Ordinate_Space(
   Ensure(check_class_invariants());
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 bool Galerkin_Ordinate_Space::check_class_invariants() const {
   return D_.size() == ordinates().size() * this->moments().size() &&
          M_.size() == ordinates().size() * this->moments().size();
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 QIM Galerkin_Ordinate_Space::quadrature_interpolation_model() const {
   Check(method_ == GQ1 || method_ == GQ2 || method_ == GQF);
   return method_;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * In the future, this function will allow the client to specify the maximum
- * order to include, but for now, we include all full orders, leaving
- * out any Galerkin augments.
+ * order to include, but for now, we include all full orders, leaving out any
+ * Galerkin augments.
  */
-
 vector<double> Galerkin_Ordinate_Space::D() const {
   unsigned const number_of_ordinates = ordinates().size();
   unsigned const number_of_moments = this->number_of_moments();
@@ -250,11 +245,11 @@ vector<double> Galerkin_Ordinate_Space::D() const {
   }
   return Result;
 }
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * In the future, this function will allow the client to specify the maximum
- * order to include, but for now, we include all full orders, leaving
- * out any Galerkin augments.
+ * order to include, but for now, we include all full orders, leaving out any
+ * Galerkin augments.
  */
 vector<double> Galerkin_Ordinate_Space::M() const {
   unsigned const number_of_ordinates = ordinates().size();
@@ -271,7 +266,7 @@ vector<double> Galerkin_Ordinate_Space::M() const {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 void Galerkin_Ordinate_Space::compute_operators() {
 
   rtt_mesh_element::Geometry const geometry(this->geometry());
@@ -285,7 +280,8 @@ void Galerkin_Ordinate_Space::compute_operators() {
   // fill cartesian_ordinates
   unsigned count(0);
   for (unsigned i = 0; i < numOrdinates; ++i) {
-    if (ordinates[i].wt() != 0) {
+    if (std::abs(ordinates[i].wt()) >
+        std::numeric_limits<decltype(ordinates[i].wt())>::min()) {
       cartesian_ordinates.push_back(ordinates[i]);
       indexes.push_back(count++);
     } else
@@ -302,9 +298,10 @@ void Galerkin_Ordinate_Space::compute_operators() {
   vector<double> cartesian_D;
 
   if (method_ == 1 || method_ == 3) {
-    // -----------------------------------------------------------------------------------------
-    // invert the (m x n) moment-to-discrete matrix M to compute the discrete-to-moment matrix D
-    // -----------------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // invert the (m x n) moment-to-discrete matrix M to compute the
+    // discrete-to-moment matrix D
+    // ------------------------------------------------------------------------
 
     cartesian_M.swap(cartesian_M_SN);
     cartesian_D =
@@ -322,15 +319,15 @@ void Galerkin_Ordinate_Space::compute_operators() {
 
     vector<Ordinate> &ordinates(this->ordinates());
     for (unsigned i = 0; i < numOrdinates; ++i) {
-      if (ordinates[i].wt() != 0) {
+      if (std::abs(ordinates[i].wt()) >
+          std::numeric_limits<decltype(ordinates[i].wt())>::min()) {
         ordinates[i].set_wt(
             cartesian_D[indexes[i] + 0 * numCartesianOrdinates]);
-        //std::cout << " setting weight to " << this->ordinates()[i].wt() << std::endl;
       }
     }
   } else if (method_ == 2) {
-    // first get new ordinate weights from the usual GQ method,
-    // needed to accurately integrate all moments
+    // first get new ordinate weights from the usual GQ method, needed to
+    // accurately integrate all moments
 
     // compute a D matrix by inverting M
     vector<double> temp_D(
@@ -348,9 +345,9 @@ void Galerkin_Ordinate_Space::compute_operators() {
 
     vector<Ordinate> &ordinates(this->ordinates());
     for (unsigned i = 0; i < numOrdinates; ++i) {
-      if (ordinates[i].wt() != 0) {
+      if (std::abs(ordinates[i].wt()) >
+          std::numeric_limits<decltype(ordinates[i].wt())>::min()) {
         ordinates[i].set_wt(temp_D[indexes[i] + 0 * numCartesianOrdinates]);
-        //std::cout << " setting weight to " << this->ordinates()[i].wt() << std::endl;
       }
     }
 
@@ -358,9 +355,10 @@ void Galerkin_Ordinate_Space::compute_operators() {
 
     vector<double> temp_M = compute_M_SN(cartesian_ordinates);
 
-    // -----------------------------------------------------------------------------------------
-    // invert the (n x m) discrete-to-moment D to compute the moment-to-discrete matrix M
-    // -----------------------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // invert the (n x m) discrete-to-moment D to compute the moment-to-discrete
+    // matrix M
+    // -------------------------------------------------------------------------
 
     cartesian_D = compute_D_SN(cartesian_ordinates, temp_M);
     cartesian_M =
@@ -373,7 +371,8 @@ void Galerkin_Ordinate_Space::compute_operators() {
   if (geometry == rtt_mesh_element::CARTESIAN) {
     M_ = cartesian_M;
     D_ = cartesian_D;
-  } else // augment the cartesian operators for the zero-weight starting directions then store
+  } else // augment the cartesian operators for the zero-weight starting
+         // directions then store
   {
     M_ = augment_M(indexes, cartesian_M);
     D_ = augment_D(indexes, numCartesianOrdinates, cartesian_D);
@@ -411,7 +410,7 @@ void Galerkin_Ordinate_Space::compute_operators() {
 */
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // Augment the matrix for curvilinear coordinates
 vector<double>
 Galerkin_Ordinate_Space::augment_D(vector<unsigned> const &indexes,
@@ -428,7 +427,8 @@ Galerkin_Ordinate_Space::augment_D(vector<unsigned> const &indexes,
 
   for (unsigned m = 0; m < numOrdinates; ++m) {
     for (unsigned n = 0; n < numMoments; ++n) {
-      if (ordinates[m].wt() != 0) {
+      if (std::abs(ordinates[m].wt()) >
+          std::numeric_limits<decltype(ordinates[m].wt())>::min()) {
         D_new[m + n * numOrdinates] = D[indexes[m] + n * numCartesianOrdinates];
       }
     }
@@ -436,7 +436,7 @@ Galerkin_Ordinate_Space::augment_D(vector<unsigned> const &indexes,
   return D_new;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // Augment the matrix for curvilinear coordinates
 vector<double>
 Galerkin_Ordinate_Space::augment_M(vector<unsigned> const &indexes,
@@ -460,7 +460,8 @@ Galerkin_Ordinate_Space::augment_M(vector<unsigned> const &indexes,
     int const k(n2lk[n].M());
 
     for (unsigned m = 0; m < numOrdinates; ++m) {
-      if (ordinates[m].wt() != 0) {
+      if (std::abs(ordinates[m].wt()) >
+          std::numeric_limits<decltype(ordinates[m].wt())>::min()) {
         M_new[n + m * numMoments] = M[n + indexes[m] * numMoments];
       } else {
         double mu(ordinates[m].mu());
@@ -475,7 +476,7 @@ Galerkin_Ordinate_Space::augment_M(vector<unsigned> const &indexes,
   return M_new;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 vector<double>
 Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
@@ -514,15 +515,15 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
         if (geometry == rtt_mesh_element::AXISYMMETRIC) {
           // R-Z coordinate system
           //
-          // It is important to remember here that the positive mu axis points to the
-          // left and the positive eta axis points up, when the unit sphere is
-          // projected on the plane of the mu- and eta-axis in R-Z. In this case, phi is
-          // measured from the mu-axis counterclockwise.
+          // It is important to remember here that the positive mu axis points
+          // to the left and the positive eta axis points up, when the unit
+          // sphere is projected on the plane of the mu- and eta-axis in R-Z. In
+          // this case, phi is measured from the mu-axis counterclockwise.
           //
           // This accounts for the fact that the aziumuthal angle is discretized
-          // on levels of the xi-axis, making the computation of the azimuthal angle
-          // here consistent with the discretization by using the eta and mu
-          // ordinates to define phi.
+          // on levels of the xi-axis, making the computation of the azimuthal
+          // angle here consistent with the discretization by using the eta and
+          // mu ordinates to define phi.
 
           double phi(compute_azimuthalAngle(mu, xi));
           M[n + m * numMoments] = Ylm(ell, k, eta, phi, sumwt);
@@ -532,8 +533,9 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
         } else if (geometry == rtt_mesh_element::CARTESIAN) {
           // X-Y coordinate system
           //
-          // In order to make the harmonic trial space is correctly oriented with
-          // respect to the moments chosen, the value of xi and eta are swapped.
+          // In order to make the harmonic trial space is correctly oriented
+          // with respect to the moments chosen, the value of xi and eta are
+          // swapped.
 
           double phi(compute_azimuthalAngle(mu, eta));
           M[n + m * numMoments] = Ylm(ell, k, xi, phi, sumwt);
@@ -551,7 +553,8 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
                               << "   " << ordinates[m].xi()
                               << "   " << ordinates[m].wt()
                               << "   " << polar
-                              << "   " << azimuthal*180.0/3.141592653589793238462643383279
+                              << "   "
+                         << azimuthal*180.0/3.141592653589793238462643383279
                               << std::endl;
 */
 
@@ -561,7 +564,7 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
   return M;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! This computation uses an existing moment-to-discrete matrix M and ordinate
  *  weights W to compute a discrete-to-moment matrix D = M^{T} W
  */
@@ -606,7 +609,7 @@ Galerkin_Ordinate_Space::compute_D_SN(vector<Ordinate> const &ordinates,
 
   return D;
 }
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 vector<double>
 Galerkin_Ordinate_Space::compute_inverse(unsigned const m, unsigned const n,
@@ -633,21 +636,20 @@ Galerkin_Ordinate_Space::compute_inverse(unsigned const m, unsigned const n,
   // Store information aobut sign changes in this variable.
   int signum(0);
 
-  // Factorize the square matrix M into the LU decomposition PM = LU.  On
-  // output the diagonal and upper triangular part of the input matrix M
-  // contain the matrix U.  The lower triangular part of the input matrix
-  // (excluding the diagonal) contains L. The diagonal elements of L are
-  // unity, and are not stored.
+  // Factorize the square matrix M into the LU decomposition PM = LU.  On output
+  // the diagonal and upper triangular part of the input matrix M contain the
+  // matrix U.  The lower triangular part of the input matrix (excluding the
+  // diagonal) contains L. The diagonal elements of L are unity, and are not
+  // stored.
   //
-  // The permutation matrix P is encoded in the permutation p.  The j-th
-  // column of the matrix P is given by the k-th column of the identity,
-  // where k=p[j] thej-th element of the permutation vector.  The sign of
-  // the permutation is given by signum.  It has the value \f$ (-1)^n \f$,
-  // where n is the number of interchanges in the permutation.
+  // The permutation matrix P is encoded in the permutation p.  The j-th column
+  // of the matrix P is given by the k-th column of the identity, where k=p[j]
+  // thej-th element of the permutation vector.  The sign of the permutation is
+  // given by signum.  It has the value \f$ (-1)^n \f$, where n is the number of
+  // interchanges in the permutation.
   //
   // The algorithm used in the decomposition is Gaussian Elimination with
-  // partial pivoting (Golub & Van Loan, Matrix Computations, Algorithm
-  // 3.4.1).
+  // partial pivoting (Golub & Van Loan, Matrix Computations, Algorithm 3.4.1).
 
   // Store the LU decomposition in the matrix A.
   Remember(int result =) gsl_linalg_LU_decomp(&gsl_A.matrix, p, &signum);
@@ -655,8 +657,8 @@ Galerkin_Ordinate_Space::compute_inverse(unsigned const m, unsigned const n,
   // Check( diagonal_not_zero( M, n, m ) );
 
   // Compute the inverse of the matrix LU from its LU decomposition (LU,p),
-  // storing the results in the matrix B.  The inverse is computed by
-  // solving the system (LU) x = b for each column of the identity matrix.
+  // storing the results in the matrix B.  The inverse is computed by solving
+  // the system (LU) x = b for each column of the identity matrix.
 
   Remember(result =) gsl_linalg_LU_invert(&gsl_A.matrix, p, &gsl_B.matrix);
 
@@ -670,6 +672,6 @@ Galerkin_Ordinate_Space::compute_inverse(unsigned const m, unsigned const n,
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//                 end of Galerkin_Ordinate_Space.cc
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
+// end of Galerkin_Ordinate_Space.cc
+//----------------------------------------------------------------------------//


### PR DESCRIPTION
+ For GCC 5.0 or later, Debug builds, enforce the compiler options `-Wfloat-equal -Wunused-macros` to prevent reintroduction of direct floating point number comparisons or unused macros.
+ These flags will only apply to Draco.  They will not be inherited by Jayenne or Capsaicin.
+ Remove an unused macro from `tstFMA.cc` and some direct comparisons of floating point numbers in a quadrature test (also fix formatting of comment blocks).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
