### PR TITLE
Allow tstSuperludist.cc to link to superlu-dist-5+

### DIFF
--- a/src/VendorChecks/test/tstSuperludist.cc
+++ b/src/VendorChecks/test/tstSuperludist.cc
@@ -52,9 +52,12 @@ int main(int argc, char *argv[]) {
  *   5. Release the process grid and terminate the MPI environment
  */
 void test_superludist(rtt_c4::ParallelUnitTest &ut) {
-  // If we are using suprelu-dist@5:, then we need
-  //   superlu_dist_options_t options;
+// SUPERLU_DIST_MAJOR_VERSION is defined in superlu_defs.h
+#if SUPERLU_DIST_MAJOR_VERSION > 4
+  superlu_dist_options_t options;
+#else
   superlu_options_t options;
+#endif
   SuperLUStat_t stat;
   SuperMatrix A;
   ScalePermstruct_t ScalePermstruct;

--- a/src/VendorChecks/test/tstSuperludist.cc
+++ b/src/VendorChecks/test/tstSuperludist.cc
@@ -52,8 +52,9 @@ int main(int argc, char *argv[]) {
  *   5. Release the process grid and terminate the MPI environment
  */
 void test_superludist(rtt_c4::ParallelUnitTest &ut) {
-// SUPERLU_DIST_MAJOR_VERSION is defined in superlu_defs.h
-#if SUPERLU_DIST_MAJOR_VERSION > 4
+// for superlu-dist > version 4, SUPERLU_DIST_MAJOR_VERSION is defined in
+// superlu_defs.h
+#ifdef SUPERLU_DIST_MAJOR_VERSION
   superlu_dist_options_t options;
 #else
   superlu_options_t options;


### PR DESCRIPTION
* The API in SuperLU-DIST changed between version 4 and 5.  Update the Draco unit test `tstSuperludist.cc` to work with either version of SuperLU-DIST.
* Also tell git to ignore `.nfs*` files found in the source tree.
* Fixes #275
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
