### PR TITLE
Update Travis to use newer tools.

### DIFF
--- a/.travis-install-dependencies.sh
+++ b/.travis-install-dependencies.sh
@@ -19,10 +19,10 @@ topdir=`pwd` # /home/travis/build/lanl/Draco
 # USER = travis
 # GROUP = travis
 RANDOM123_VER=1.09
-CMAKE_VERSION=3.6.2-Linux-x86_64
+CMAKE_VERSION=3.8.2-Linux-x86_64
 NUMDIFF_VER=5.8.1
 CLANG_FORMAT_VER=3.9
-OPENMPI_VER=1.10.3
+OPENMPI_VER=1.10.5
 
 # Return integer > 0 if 'develop' branch is found.
 function find_dev_branch
@@ -99,6 +99,7 @@ else
   run "tar -zxf openmpi-${OPENMPI_VER}.tar.gz > build-openmpi.log"
   run "cd openmpi-${OPENMPI_VER}"
   run "./configure --enable-mpi-thread-multiple --quiet >> build-openmpi.log 2>&1"
+  # run "travis_wait 20 make"
   run "make >> build-openmpi.log 2>&1"
   run "sudo make install"
   run "sudo sh -c 'echo \"/usr/local/lib\n/usr/local/lib/openmpi\" > /etc/ld.so.conf.d/openmpi.conf'"

--- a/.travis-run-tests.sh
+++ b/.travis-run-tests.sh
@@ -18,10 +18,14 @@ topdir=`pwd` # /home/travis/build/lanl/Draco
 # USER = travis
 # GROUP = travis
 RANDOM123_VER=1.09
-CMAKE_VERSION=3.6.2-Linux-x86_64
+CMAKE_VERSION=3.8.2-Linux-x86_64
 NUMDIFF_VER=5.8.1
 CLANG_FORMAT_VER=3.9
-OPENMPI_VER=1.10.3
+OPENMPI_VER=1.10.5
+GCCVER=6
+export CXX=`which g++-${GCCVER}`
+export CC=`which gcc-${GCCVER}`
+export FC=`which gfortran-${GCCVER}`
 
 if [[ ${STYLE} ]]; then
   regression/check_style.sh -t

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ dist: trusty
 env:
   global:
     - BLAS_blas_LIBRARY=/usr/lib/libblas.a
-    - CC=gcc-5
+    - CC=gcc-6
     - CCACHE_CPP2=yes
-    - CMAKE=$HOME/cmake-3.6.2-Linux-x86_64/bin/cmake
-    - CTEST=$HOME/cmake-3.6.2-Linux-x86_64/bin/ctest
-    - CXX=g++-5
-    - FC=gfortran-5
+    - CMAKE=$HOME/cmake-3.8.2-Linux-x86_64/bin/cmake
+    - CTEST=$HOME/cmake-3.8.2-Linux-x86_64/bin/ctest
+    - CXX=g++-6
+    - FC=gfortran-6
     - LAPACK_LIB_DIR=/usr/lib
     - OMP_NUM_THREADS=4
     - RANDOM123_INC_DIR=$HOME/Random123-1.09/include
@@ -33,9 +33,9 @@ addons:
     packages:
       - ccache
       - libgsl0-dev
-      - gcc-5
-      - g++-5
-      - gfortran-5
+      - gcc-6
+      - g++-6
+      - gfortran-6
       - liblapack-dev
 
 before_install:
@@ -45,7 +45,7 @@ before_install:
   - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
-  - ./.travis-install-dependencies.sh
+  - travis_wait ./.travis-install-dependencies.sh
 
 before_script:
   - if [[ ${WERROR} ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} -Werror\"; done; fi
@@ -55,13 +55,13 @@ script:
   - ./.travis-run-tests.sh
 
 after_success:
-  - if [[ ${COVERAGE} ]]; then codecov --gcov-exec gcov-5; fi
+  - if [[ ${COVERAGE} ]]; then codecov --gcov-exec gcov-6; fi
 
 cache:
   - ccache
 
 compiler:
-  - gcc
+  - gcc-6
 
 git:
   depth: 3


### PR DESCRIPTION
* Update the travis control scripts to use newer tools like gcc-6 and openmpi-1.10.5.
* Fixes #282 
* Fixes #281