### PR TITLE
Minor tweaks to the developer environment for ccs-net machines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ TAGS
 GPATH
 GTAGS
 GRTAGS
+.nfs*

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -40,20 +40,16 @@ add_to_path ${VENDOR_DIR}/bin PATH
 target=`uname -n`
 case $target in
   ccscs[1-9]*)
-    if [[ -d /scratch/vendors/Modules.core ]]; then
-      # spack generated "core" modulefils
-      export MODULEPATH=/scratch/vendors/Modules.core
-    fi
-
-    # hand-written modulefiles for non spack tools.
-    module use --append /scratch/vendors/Modules.lmod
+    # Add /scratch/vendors/Modules.lmod (totalview, ddt, etc.)
+    # Add /scratch/vendors/Modules.core (spack generated modules).
+    module load user_contrib
     if [[ -d $HOME/privatemodules ]]; then
       module use --append $HOME/privatemodules
     fi
     dm_core="cmake eospac git tk ndi python doxygen ccache numdiff totalview \
 dia graphviz ack"
     dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
-    dm_openmpi="openmpi parmetis superlu-dist/4.3-netlib trilinos valgrind"
+    dm_openmpi="openmpi parmetis superlu-dist trilinos valgrind"
     export dracomodules="$dm_core $dm_gcc $dm_openmpi"
     ;;
   ccsnet3*)

--- a/environment/elisp/draco-mode.el
+++ b/environment/elisp/draco-mode.el
@@ -237,7 +237,8 @@ to anything else will generate errors."
    ;; DRACO Unit testing - One shot keywords that take no arguments
    (list
     ;; Match single keyword
-    "\\(FAILMSG\\|ITFAILS\\|PASSMSG\\)\\>"
+    "\\(FAILMSG\\|FAIL_IF\\|FAIL_IF_NOT\\|ITFAILS\\|PASSMSG\\)\\>"
+;;    "\\(FAILMSG\\|FAIL_IF\\|FAIL_IF_NOT\\|ITFAILS\\|PASSMSG\\)\\>"
     '(0 font-lock-preprocessor-face prepend))
 
    ;; Draco extra C++ typenames


### PR DESCRIPTION
+ Tell git to ignore temporary `.nfs*` files.
+ Add new keywords `FAIL_IF` and `FAIL_IF_NOT` to emacs colorization list.
+ Make use of ccs-net's `user_contrib` module to point to `/scratch/vendors/Modules.lmod` and `/scratch/vendors/Modules.core`.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
