### PR TITLE
Clean up the scripts that run on ccs-net machines.

### DIFF
--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -7,7 +7,7 @@
 01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh
 
 # Send a copy of our repositories to the Red.
-00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /scratch/regress/logs/push_repositories_xf.log
+00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh
 
 # Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
 */20 * * * * /scratch/regress/draco/regression/sync_repository.sh
@@ -18,7 +18,7 @@
 04 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
 
 #------------------------------------------------------------------------------#
-# Regressions with system default compiler (gcc-4.8.5)
+# Regressions:
 # -a build autodoc
 # -r use regress account
 # -b build_type: Release|Debug
@@ -27,7 +27,7 @@
 # -e extra args:
 #    coverage        - build bullseyecoverage data and send it to cdash
 #    clang
-#    gcc610
+#    valgrind
 #------------------------------------------------------------------------------#
 
 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p "draco jayenne capsaicin"

--- a/regression/ccscs-job-launch.sh
+++ b/regression/ccscs-job-launch.sh
@@ -57,7 +57,7 @@ done
 
 if ! test -d $logdir; then
   mkdir -p $logdir
-  chgrp draco $logdir
+  chgrp ccsrad $logdir
   chmod g+rwX $logdir
   chmod g+s $logdir
 fi

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -36,7 +36,7 @@ fi
 
 # Environment setup
 # ----------------------------------------
-umask 0002
+umask 0007
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -114,6 +114,7 @@ if [[ `fn_exists module` == 1 ]]; then
     run "module avail"
     run "module list"
     run "module purge"
+    run "module load user_contrib"
     run "module list"
   fi
 else
@@ -198,7 +199,7 @@ comp=$comp-$featurebranch
 if test "$USER" == "kellyt"; then
   MYHOSTNAME="`uname -n`"
   keychain=keychain-2.8.2
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+  run "$VENDOR_DIR/$keychain/keychain $HOME/.ssh/id_rsa"
   if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
   else
@@ -319,10 +320,10 @@ if test "${bounds_checking:-off}" = "on"; then
 fi
 
 # Environment
-echo " "
-echo "--------------------(environment)------------------------------"
-set
-echo "--------------------(end environment)--------------------------"
+#echo " "
+#echo "--------------------(environment)------------------------------"
+#set
+#echo "--------------------(end environment)--------------------------"
 
 echo ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}

--- a/regression/ccscs6-crontab
+++ b/regression/ccscs6-crontab
@@ -1,0 +1,31 @@
+# crontab for ccscs6
+
+# Update the regression scripts.
+01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh
+
+# Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
+*/20 * * * * /scratch/regress/draco/regression/sync_repository.sh
+
+#------------------------------------------------------------------------------#
+# Regressions:
+# -a build autodoc
+# -r use regress account
+# -b build_type: Release|Debug
+# -d dashboard:  Nightly|Experimental
+# -p projects:
+# -e extra args:
+#    coverage        - build bullseyecoverage data and send it to cdash
+#    clang
+#    valgrind
+#------------------------------------------------------------------------------#
+
+# 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind
+
+# |    |    |    |    |   |
+# |    |    |    |    |   +- command
+# |    |    |    |    +----- day of week (0 - 6) (Sunday=0)
+# |    |    |    +---------- month (1 - 12)
+# |    |    +--------------- day of month (1 - 31)
+# |    +-------------------- hour (0 - 23)
+# +------------------------- min (0 - 59)
+#

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -97,14 +97,14 @@ case $project in
 esac
 
 # Restrict the use of ccscs7.
-case $target in
-  ccscs7*)
-    if ! [[ $LOGNAME == "kellyt" ]]; then
-      echo ""; echo "FATAL ERROR: Please use ccscs6 for manual use of checkpr.sh."
-      exit 1
-    fi
-    ;;
-esac
+# case $target in
+#   ccscs7*)
+#     if ! [[ $LOGNAME == "kellyt" ]]; then
+#       echo ""; echo "FATAL ERROR: Please use ccscs6 for manual use of checkpr.sh."
+#       exit 1
+#     fi
+#     ;;
+# esac
 
 if [[ $regress_mode == "on" ]]; then
   if ! [[ $LOGNAME == "kellyt" ]]; then
@@ -227,22 +227,19 @@ esac
 echo " "
 case $target in
   # CCS-NET: Release
-  ccscs2*)
-    startCI ${project} Release na $pr
-    ;;
+  ccscs2*) startCI ${project} Release na $pr ;;
 
-  # CCS-NET: Coverage (Debug) & Valgrind (Debug)
-  ccscs7*)
-    startCI ${project} Debug coverage $pr
-    startCI ${project} Debug valgrind $pr
-    ;;
+  # CCS-NET: Valgrind (Debug)
+  ccscs6*) startCI ${project} Debug valgrind $pr ;;
+
+  # CCS-NET: Coverage (Debug)
+  ccscs7*) startCI ${project} Debug coverage $pr ;;
 
   # Moonlight: Fulldiagnostics (Debug)
-  ml-fey*) startCI ${project} Debug $pr ;;
+  ml-fey*) startCI ${project} Debug na $pr ;;
 
   # Snow: Debug
   sn-fe*)
-    startCI ${project} Debug na $pr
     startCI ${project} Release na $pr
     startCI ${project} Debug fulldiagnostics $pr
     ;;

--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -23,7 +23,7 @@
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin"
 
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin"
+# 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ml-job-launch.sh
+++ b/regression/ml-job-launch.sh
@@ -86,7 +86,7 @@ logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra
 if [[ -f $logfile ]]; then
   rm $logfile
 fi
-cmd="$MSUB ${access_queue} -o ${logfile} -t 4:00:00 ${rscriptdir}/ml-regress.msub"
+cmd="$MSUB ${access_queue} -o ${logfile} -J ${subproj:0:5}-${featurebranch} -t 4:00:00 ${rscriptdir}/ml-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 # trim extra whitespace from number

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -36,7 +36,7 @@ fi
 
 # Environment setup
 # ----------------------------------------
-umask 0002
+umask 0007
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -347,8 +347,8 @@ if [[ `jobs -p | wc -l` -gt 0 ]]; then
 fi
 
 # set permissions
-chgrp -R draco ${logdir} &> /dev/null
-chmod -R g+rX ${logdir} &> /dev/null
+chgrp -R ccsrad ${logdir} &> /dev/null
+chmod -R g+rX,o-rwX ${logdir} &> /dev/null
 
 echo " "
 echo "All done"

--- a/regression/sn-job-launch.sh
+++ b/regression/sn-job-launch.sh
@@ -47,7 +47,7 @@ fi
 job_launch_sanity_checks
 
 available_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\)|.*/\1/' | sed -e 's/|.*//'`
-case $avail_queues in
+case $available_queues in
   *access*) access_queue="-A access --qos=access" ;;
   *dev*)    access_queue="--qos=dev" ;;
 esac

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -7,6 +7,49 @@
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
+# switch to group 'ccsrad' and set umask
+if [[ $(id -gn) != ccsrad ]]; then
+  exec sg ccsrad "$0 $*"
+fi
+umask 0007
+
+# Locate the directory that this script is located in:
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+target="`uname -n | sed -e s/[.].*//`"
+
+# Prevent multiple copies of this script from running at the same time:
+lockfile=/var/tmp/sync_repository_$target.lock
+[ "${FLOCKER}" != "${lockfile}" ] && exec env FLOCKER="${lockfile}" flock -en "${lockfile}" "${0}" "$@" || :
+
+
+# All output will be saved to this log file.  This is also the lockfile for flock.
+timestamp=`date +%Y%m%d-%H%M`
+logdir="$( cd $scriptdir/../../logs && pwd )"
+logfile=$logdir/sync_repository_${target}_${timestamp}.log
+
+# Debug stuff
+verbose=off
+if [[ ${verbose:-off} == "on" ]]; then
+  echo "looking for locks..."
+  echo "   FLOCKER     = ${FLOCKER}"
+  echo "   lockfile    = $lockfile"
+  echo "   logfile     = $logfile"
+  echo "   script name = ${0}"
+  echo "   script args = $@"
+fi
+
+# Redirect all future output to the logfile.
+exec > $logfile
+exec 2>&1
+
+# import some bash functions
+source $scriptdir/scripts/common.sh
+
+echo -e "Executing $0 $*...\n"
+echo "Group: `id -gn`"
+echo -e "umask: `umask`\n"
+
+#------------------------------------------------------------------------------#
 # This script is used for 2 similar but distinct operations:
 #
 # 1. It mirrors git@github.com/lanl/Draco.git,
@@ -23,42 +66,6 @@
 #    is found in the mirrored repository, continuous integration testing is
 #    started.
 
-target="`uname -n | sed -e s/[.].*//`"
-verbose=off
-
-# Locate the directory that this script is located in:
-scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-# All output will be saved to this log file.  This is also the lockfile for flock.
-logdir="$( cd $scriptdir/../../logs && pwd )"
-timestamp=`date +%Y%m%d-%H%M`
-logfile=$logdir/sync_repository_${target}_${timestamp}.log
-lockfile=/var/tmp/sync_repository_$target.lock
-
-if [[ ${verbose:-off} == "on" ]]; then
-  echo "looking for locks..."
-  echo "   FLOCKER     = ${FLOCKER}"
-  echo "   lockfile    = $lockfile"
-  echo "   logfile     = $logfile"
-  echo "   script name = ${0}"
-  echo "   script args = $@"
-fi
-
-# Prevent multiple copies of this script from running at the same time:
-[ "${FLOCKER}" != "${lockfile}" ] && exec env FLOCKER="${lockfile}" flock -en "${lockfile}" "${0}" "$@" || :
-
-if [[ ${verbose:-off} == "on" ]]; then
-  echo "running..."
-  echo "redirecting output to $logfile"
-fi
-
-# Redirect all future output to the logfile.
-exec > $logfile
-exec 2>&1
-
-# import some bash functions
-source $scriptdir/scripts/common.sh
-
 #
 # MODULES
 #
@@ -67,13 +74,16 @@ source $scriptdir/scripts/common.sh
 if [[ `fn_exists module` == 0 ]]; then
   case ${target} in
     tt-fey*) module_init_dir=/opt/cray/pe/modules/3.2.10.4/init/bash ;;
-    # snow (Toss3)
+    # snow (Toss3, lmod)
     sn-fey*) module_init_dir=/usr/share/lmod/lmod/init/profile ;;
-    # ccs-net, darwin, ml
+    # ccs-net (lmod)
+    ccscs*)  module_init_dir=/usr/share/lmod/lmod/init/bash ;;
+    # darwin, ml
     *)       module_init_dir=/usr/share/Modules/init/bash ;;
   esac
   if [[ -f ${module_init_dir} ]]; then
-    source ${module_init_dir}
+    echo "Module environment not found, trying to init the module environment."
+    run "source ${module_init_dir}"
   else
     echo "ERROR: The module command was not found. No modules will be loaded."
   fi
@@ -87,21 +97,12 @@ fi
 # Environment
 #
 
-# Ensure that the permissions are correct
-run "umask 0002"
-
 case ${target} in
-  ccscs2*)
-    run "module load user_contrib subversion git"
-    regdir=/scratch/regress
-    gitroot=/ccs/codes/radtran/git.ccscs2
-    VENDOR_DIR=/scratch/vendors
-    keychain=keychain-2.8.2
-    ;;
   ccscs*)
+    run "module use /usr/share/lmod/lmod/modulefiles/Core"
     run "module load user_contrib subversion git"
     regdir=/scratch/regress
-    gitroot=/ccs/codes/radtran/git
+    gitroot=/ccs/codes/radtran/git.${target}
     VENDOR_DIR=/scratch/vendors
     keychain=keychain-2.8.2
     ;;
@@ -142,14 +143,14 @@ case ${target} in
 esac
 
 if ! [[ -d $regdir ]]; then
-  mkdir -p $regdir
+  run "mkdir -p $regdir"
 fi
 
 # Credentials via Keychain (SSH)
 # http://www.cyberciti.biz/faq/ssh-passwordless-login-with-keychain-for-scripts
-if [[ -f $HOME/.ssh/cmake_rsa ]]; then
+if [[ -f $HOME/.ssh/id_rsa ]]; then
   MYHOSTNAME="`uname -n`"
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+  run "$VENDOR_DIR/$keychain/keychain $HOME/.ssh/id_rsa"
   if [[ -f $HOME/.keychain/$MYHOSTNAME-sh ]]; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
   else
@@ -249,69 +250,33 @@ fi
 # Mirror git repository for redmine integration
 #------------------------------------------------------------------------------#
 
-case ${target} in
-  ccscs7*)
-    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-    # PRs since this seems to confuse Redmine.
-    echo " "
-    echo "(Redmine) Copy Draco git repository to the local file system..."
-    if test -d $gitroot/Draco-redmine.git; then
-      run "cd $gitroot/Draco-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-      run "chmod -R g+rwX,o-rwX Draco-redmine.git"
-    else
-      run "mkdir -p $gitroot"
-      run "cd $gitroot"
-      run "git clone --mirror git@github.com:lanl/Draco.git Draco-redmine.git"
-      run "chmod -R g+rwX,o-rwX Draco-redmine.git"
-      run "chmod g+s Draco-redmine.git"
-    fi
-    ;;
-esac
+if [[ ${target} == "ccscs7" ]]; then
 
-case ${target} in
-  ccscs7*)
-    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-    # PRs since this seems to confuse Redmine.
-    echo " "
-    echo "(Redmine) Copy Jayenne git repository to the local file system..."
-    if test -d $gitroot/jayenne-redmine.git; then
-      run "cd $gitroot/jayenne-redmine.git"
+  # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+  # PRs since this seems to confuse Redmine.
+  projects="jayenne capsaicin"
+  for p in $projects; do
+    echo -e "\n(Redmine) Copy ${p} git repository to the local file system..."
+    if [[ -d $gitroot/${p}-redmine.git ]]; then
+      run "cd $gitroot/${p}-redmine.git"
       run "git fetch origin +refs/heads/*:refs/heads/*"
       run "git reset --soft"
-      # run "chgrp -R draco $gitroot/jayenne-redmine.git"
-      run "chmod -R g+rwX,o-rwX $gitroot/jayenne-redmine.git"
+      run "cd $gitroot"
+      run "chmod -R g+rwX,o-rwX $gitroot/${p}-redmine.git"
     else
       run "mkdir -p $gitroot"
       run "cd $gitroot"
-      run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne-redmine.git"
-      run "chmod -R g+rwX,o-rwX jayenne-redmine.git"
-      run "chmod g+s jayenne-redmine.git"
+      if [[ ${p} == "Draco" ]]; then
+        run "git clone --bare git@github.com:lanl/${p}.git ${p}-redmine.git"
+      else
+        run "git clone --bare git@gitlab.lanl.gov:${p}/${p}.git ${p}-redmine.git"
+      fi
+      run "chmod -R g+rwX,o-rwX ${p}-redmine.git"
+      run "chmod g+s ${p}-redmine.git"
     fi
-    ;;
-esac
+  done
 
-case ${target} in
-  ccscs7*)
-    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
-    # PRs since this seems to confuse Redmine.
-    echo " "
-    echo "(Redmine) Copy Capsaicin git repository to the local file system..."
-    if test -d $gitroot/capsaicin-redmine.git; then
-      run "cd $gitroot/capsaicin-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-      run "chmod -R g+rwX,o-rwX $gitroot/capsaicin-redmine.git"
-    else
-      run "mkdir -p $gitroot"
-      run "cd $gitroot"
-      run "git clone --mirror git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin-redmine.git"
-      run "chmod -R g+rwX,o-rwX capsaicin-redmine.git"
-      run "chmod g+s capsaicin-redmine.git"
-    fi
-    ;;
-esac
+fi
 
 #------------------------------------------------------------------------------#
 # Continuous Integration Hooks:

--- a/regression/sync_vendors.sh
+++ b/regression/sync_vendors.sh
@@ -7,6 +7,37 @@
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
+# switch to group 'ccsrad' and set umask
+if [[ $(id -gn) != ccsrad ]]; then
+  exec sg ccsrad "$0 $*"
+fi
+umask 0002
+
+# Locate the directory that this script is located in:
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+target="`uname -n | sed -e s/[.].*//`"
+
+# Prevent multiple copies of this script from running at the same time:
+lockfile=/var/tmp/sync_vendors_$target.lock
+[ "${FLOCKER}" != "${lockfile}" ] && exec env FLOCKER="${lockfile}" flock -en "${lockfile}" "${0}" "$@" || :
+
+# All output will be saved to this log file.  This is also the lockfile for flock.
+timestamp=`date +%Y%m%d-%H%M`
+logdir="$( cd $scriptdir/../../logs && pwd )"
+logfile=$logdir/sync_vendors-$target-$timestamp.log
+
+# Redirect all output to a log file.
+exec > $logfile
+exec 2>&1
+
+# import some bash functions
+source $scriptdir/scripts/common.sh
+
+echo -e "Executing $0 $*...\n"
+echo "Group: `id -gn`"
+echo "umask: `umask`"
+
+#------------------------------------------------------------------------------#
 # Run from ccscs7:
 #   - Mirror ccscs7:/scratch/vendors -> /ccs/codes/radtran/vendors/rhel72
 #     Do not mirror the ndi directory (300+ GB)
@@ -18,34 +49,13 @@ vdir=/scratch/vendors
 # To dir
 r72v=/ccs/codes/radtran/vendors/rhel72vendors
 # To machines (cccs[234568]:/scratch/vendors)
-ccs_servers="ccscs2 ccscs3 ccscs4 ccscs5 ccscs6 ccscs8"
-
-target="`uname -n | sed -e s/[.].*//`"
-
-# Locate the directory that this script is located in:
-scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-# All output will be saved to this log file.  This is also the lockfile for flock.
-logdir="$( cd $scriptdir/../../logs && pwd )"
-logfile=$logdir/sync_vendors_$target.log
-lockfile=/var/tmp/sync_vendors_$target.lock
-
-# Prevent multiple copies of this script from running at the same time:
-[ "${FLOCKER}" != "${lockfile}" ] && exec env FLOCKER="${lockfile}" flock -en "${lockfile}" "${0}" "$@" || :
-
-# Redirect all output to a log file.
-exec > $logfile
-exec 2>&1
-
-# import some bash functions
-source $scriptdir/scripts/common.sh
-
-# Ensure that the permissions are correct
-run "umask 0002"
+# omit ccscs5 (scratch is too full)
+ccs_servers="ccscs2 ccscs3 ccscs4 ccscs6 ccscs8"
 
 # Credentials via Keychain (SSH)
 # http://www.cyberciti.biz/faq/ssh-passwordless-login-with-keychain-for-scripts
-$vdir/keychain-2.8.2/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+#$vdir/keychain-2.8.2/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+$vdir/keychain-2.8.2/keychain $HOME/.ssh/id_rsa
 if test -f $HOME/.keychain/$HOSTNAME-sh; then
   run "source $HOME/.keychain/$HOSTNAME-sh"
 else
@@ -65,9 +75,9 @@ fi
 # Make a backup copy of vendors to $r72v
 echo " "
 echo "Clean up permissions on source files..."
-run "chgrp -R draco $vdir"
-run "chmod -R g+rwX,o=g-w $vdir"
-run "chmod -R o-rwX $vdir/ndi* $vdir/csk* $vdir/cubit* $vdir/eospac*"
+run "chgrp -R draco $vdir &> /dev/null"
+run "chmod -R g+rwX,o=g-w $vdir &> /dev/null"
+run "chmod -R o-rwX $vdir/ndi* $vdir/csk* $vdir/cubit* $vdir/eospac* &> /dev/null"
 
 echo " "
 echo "Save a copy of /scratch/vendors to $r72v..."
@@ -97,8 +107,9 @@ echo " "
 echo "Cleaning up..."
 run "rm $lockfile"
 
-echo " "
+echo -e "\n--------------------------------------------------------------------------------"
 echo "All done."
+echo "--------------------------------------------------------------------------------"
 
 #------------------------------------------------------------------------------#
 # End sync_vendors.sh

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -45,7 +45,7 @@ fi
 
 # Environment setup
 # ----------------------------------------
-umask 0002
+umask 0007
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -236,28 +236,11 @@ if [[ ${setup_dirs} ]]; then
    if ! test -d ${work_dir}/source; then
       run "mkdir -p ${work_dir}/source"
    fi
-   # See notes above where scratch_dir is set concerning why these are soft
-   # links.
-   if test "${regress_mode}" = "on"; then
-     if ! test -d ${scratch_dir}/build; then
-       run "mkdir -p ${scratch_dir}/build"
-     fi
-     if ! test -d ${work_dir}/build; then
-       run "ln -s ${scratch_dir}/build ${work_dir}/build"
-     fi
-     if ! test -d ${scratch_dir}/target; then
-       run "mkdir -p ${scratch_dir}/target"
-     fi
-     if ! test -d ${work_dir}/target; then
-       run "ln -s ${scratch_dir}/target ${work_dir}/target"
-     fi
-   else
-     if ! test -d ${work_dir}/build; then
-       run "mkdir -p ${work_dir}/build"
-     fi
-     if ! test -d ${work_dir}/target; then
-       run "mkdir -p ${scratch_dir}/target"
-     fi
+   if ! test -d ${work_dir}/build; then
+     run "mkdir -p ${work_dir}/build"
+   fi
+   if ! test -d ${work_dir}/target; then
+     run "mkdir -p ${scratch_dir}/target"
    fi
 
    # clean the installation directory to remove any files that might no longer
@@ -272,18 +255,19 @@ fi
 
 # Environment
 echo " "
-echo "--------------------(environment)------------------------------"
-set
-echo "--------------------(end environment)--------------------------"
+#echo "--------------------(environment)------------------------------"
+#set
+#echo "--------------------(end environment)--------------------------"
 
 date
+echo " "
 echo ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 echo " "
 ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 
 if [[ ${regress_mode} == "on" ]]; then
   echo " "
-  run "chgrp -R draco ${work_dir}"
+  run "chgrp -R ccsrad ${work_dir}"
   run "chmod -R g+rX,o-rwX ${work_dir}"
 fi
 

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -7,20 +7,31 @@
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
+# switch to group 'ccsrad' and set umask
+if [[ $(id -gn) != ccsrad ]]; then
+  exec sg ccsrad "$0 $*"
+fi
 umask 0002
 
 # Locate the directory that this script is located in:
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Redirect all output to a log file.
+timestamp=`date +%Y%m%d-%H%M`
 target="`uname -n | sed -e s/[.].*//`"
 logdir="$( cd $scriptdir/../../logs && pwd )"
-logfile=$logdir/update_regression_scripts_$target.log
+logfile=$logdir/update_regression_scripts-$target-$timestamp.log
 exec > $logfile
 exec 2>&1
 
 # import some bash functions
 source $scriptdir/scripts/common.sh
+
+echo -e "Executing $0 $*...\n"
+echo "Group: `id -gn`"
+echo -e "umask: `umask` \n"
+
+#------------------------------------------------------------------------------#
 
 # Per machine setup
 case ${target} in
@@ -41,9 +52,6 @@ case ${target} in
     REGDIR=/scratch/regress
     VENDOR_DIR=/scratch/vendors
     keychain=keychain-2.8.2
-    if ! [[ $MODULESHOME ]]; then
-       source /usr/share/Modules/init/bash
-    fi
     ;;
   ml-*)
     REGDIR=/usr/projects/jayenne/regress
@@ -56,29 +64,19 @@ case ${target} in
 esac
 
 # Load some identities used for accessing gitlab.
-MYHOSTNAME="`uname -n`"
-$VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
-if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
+if [[ -f $HOME/.ssh/id_rsa ]]; then
+  MYHOSTNAME="`uname -n`"
+  run "$VENDOR_DIR/$keychain/keychain $HOME/.ssh/id_rsa"
+  if [[ -f $HOME/.keychain/$MYHOSTNAME-sh ]]; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
-else
+  else
     echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+  fi
 fi
 
 # ---------------------------------------------------------------------------- #
 # Update the regression script directories
 # ---------------------------------------------------------------------------- #
-
-# Draco
-echo " "
-echo "Updating $REGDIR/draco..."
-if ! test -d $REGDIR; then
-  run "mkdir -p ${REGDIR}"
-fi
-if test -d ${REGDIR}/draco; then
-  run "cd ${REGDIR}/draco; git pull"
-else
-  run "cd ${REGDIR}; git clone https://github.com/lanl/Draco.git draco"
-fi
 
 # Deal with proxy stuff on darwin
 case ${target} in
@@ -92,38 +90,50 @@ case ${target} in
   ;;
 esac
 
-# Jayenne
-echo " "
-echo "Updating $REGDIR/jayenne..."
-if test -d ${REGDIR}/jayenne; then
-  run "cd ${REGDIR}/jayenne; git pull"
-else
-  run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:jayenne/jayenne.git"
+# Setup
+if ! [[ -d $REGDIR ]]; then
+  run "mkdir -p ${REGDIR}"
+  run "chmod g+rwX,o-rwX ${REGDIR}"
+  run "chmod g+s ${REGDIR}"
 fi
-# Capsaicin
-echo " "
-echo "Updating $REGDIR/capsaicin..."
-if test -d ${REGDIR}/capsaicin; then
-  run "cd ${REGDIR}/capsaicin; git pull"
-else
-  run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:capsaicin/capsaicin.git"
-fi
+
+# Draco/Jayenne/Capsaicin
+projects="draco jayenne capsaicin"
+for p in $projects; do
+  echo -e "\nUpdating $REGDIR/$p..."
+  if test -d ${REGDIR}/$p; then
+    run "cd ${REGDIR}/$p; git pull"
+  else
+    case $p in
+      draco)
+        run "cd ${REGDIR}; git clone git@github.com:lanl/Draco.git $p"
+        ;;
+      *)
+        run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:${p}/${p}.git"
+        ;;
+    esac
+  fi
+done
 
 #------------------------------------------------------------------------------#
 # Cleanup old files and directories
 #------------------------------------------------------------------------------#
 if [[ -d $logdir ]]; then
-  echo "Cleaning up old log files."
+  echo -e "\nCleaning up old log files."
   run "cd $logdir"
   run "find . -mtime +14 -type f"
   run "find . -mtime +14 -type f -delete"
 fi
 if [[ -d $REGDIR/cdash ]]; then
-  echo "Cleaning up old builds."
+  echo -e "\nCleaning up old builds."
   run "cd $REGDIR/cdash"
   run "find . -maxdepth 3 -mtime +14 -name 'Experimental*-pr*' -type d"
   run "find . -maxdepth 3 -mtime +14 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
 fi
+
+echo -e "\n--------------------------------------------------------------------------------"
+echo "All done."
+echo "--------------------------------------------------------------------------------"
 
 ##---------------------------------------------------------------------------##
 ## End update_regression_scripts.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ macro( add_dir_if_exists package )
 endmacro()
 
 # Extra 'draco-only' flags (don't pass these to Capsaicin).
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
     toggle_compiler_flag( TRUE "-Wfloat-equal -Wunused-macros" "CXX;C" "DEBUG")
   endif()


### PR DESCRIPTION
+ Update `push_repositories_xf.sh` to force its output to go to a specific log file.
+ Begin marking source code with group 'ccsrad'
+ Start running valgrind on ccscs6 and coverage on ccscs7 to distribute the test load.
+ Allow anyone to run `checkpr.sh` on ccscs7.  This was blocked to reserve the machine for `checkpr.sh` testing. Fixes #281 (github).
+ Force the scripts to 'newgrp ccsrad' since I can no longer 'chgrp ccsrad'  (18th group).
+ Use new ssh keys for regression.
+ Reduce some code duplication.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (2 week DST)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
