### PR TITLE
Upgrade how the Compton TPL is discovered, presented and used.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,7 +47,7 @@ DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IncludeCategories:
-  - Regex:           '^"(c4|cdi|cdi_analytic|cdi_eospac|cdi_ipcress|device|diagnostics|ds\+\+|fit|linear|memory|mesh_element|meshReaders|min|norms|ode|parser|plot2D|quadrature|rng|roots|RTT_Format_Reader|shared_lib|special_functions|timestep|units|viz)/'
+  - Regex:           '^"(c4|cdi|cdi_analytic|cdi_eospac|cdi_ipcress|compton|device|diagnostics|ds\+\+|fit|linear|memory|mesh_element|meshReaders|min|norms|ode|parser|plot2D|quadrature|rng|roots|RTT_Format_Reader|shared_lib|special_functions|timestep|units|viz)/'
     Priority:        2
   - Regex:           '^(<|"(gtest|isl|json)/)'
     Priority:        3

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -608,7 +608,7 @@ machines."  )
 endmacro()
 
 #------------------------------------------------------------------------------
-# Setup COMPTON (https://gitlab.lanl.gov/csk)
+# Setup COMPTON (https://gitlab.lanl.gov/keadyk/CSK_generator)
 #------------------------------------------------------------------------------
 macro( setupCOMPTON )
 

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -550,9 +550,9 @@ macro( setupParMETIS )
     set_package_properties( ParMETIS PROPERTIES
       DESCRIPTION "MPI Parallel METIS"
       URL "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
-      PURPOSE "ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning
-   unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices."
-      )
+      PURPOSE "ParMETIS is an MPI-based parallel library that implements a
+variety of algorithms for partitioning unstructured graphs, meshes, and for
+computing fill-reducing orderings of sparse matrices." )
 
   endif()
 
@@ -588,20 +588,68 @@ macro( setupSuperLU_DIST )
         POSITION_INDEPENDENT_CODE
         IMPORTED_LOCATION )
 
-      save_vendor_imported_library_to_draco_config( "SuperLU_DIST::superludist" "${props}" )
+      save_vendor_imported_library_to_draco_config(
+        "SuperLU_DIST::superludist" "${props}" )
     else()
       message( STATUS "Looking for SuperLU_DIST.....not found" )
     endif()
 
-    #=============================================================================
+    #===========================================================================
     # Include some information that can be printed by the build system.
     set_package_properties( SuperLU_DIST PROPERTIES
       DESCRIPTION "SuperLU_DIST"
       URL " http://crd-legacy.lbl.gov/~xiaoye/SuperLU/"
-      PURPOSE "SuperLU is a general purpose library for the direct solution of large, sparse,
-   nonsymmetric systems of linear equations on high performance machines."
-      )
+      PURPOSE "SuperLU is a general purpose library for the direct solution of
+large, sparse, nonsymmetric systems of linear equations on high performance
+machines."  )
 
+  endif()
+
+endmacro()
+
+#------------------------------------------------------------------------------
+# Setup COMPTON (https://gitlab.lanl.gov/csk)
+#------------------------------------------------------------------------------
+macro( setupCOMPTON )
+
+  if( NOT TARGET compton::compton )
+    message( STATUS "Looking for COMPTON..." )
+
+    find_package( COMPTON QUIET )
+
+    if( COMPTON_FOUND )
+      message( STATUS "Looking for COMPTON.....found ${COMPTON_LIBRARY}" )
+
+      # Export COMPTON target information to draco-config.cmake
+      # Choose items for props list via:
+      # include(print_target_properties)
+      # print_targets_properties("COMPTON::compton")
+      set( props
+        GNUtoMS
+        IMPORTED_CONFIGURATIONS
+        IMPORTED_IMPLIB
+        IMPORTED_IMPLIB_DEBUG
+        IMPORTED_LINK_INTERFACE_LANGUAGES
+        INTERFACE_LINK_LIBRARIES
+        IMPORTED_LOCATION_DEBUG
+        IMPORTED_LOCATION_RELEASE
+        IMPORTED
+        INTERFACE_INCLUDE_DIRECTORIES
+        POSITION_INDEPENDENT_CODE
+        IMPORTED_LOCATION )
+
+      save_vendor_imported_library_to_draco_config(
+        "COMPTON::compton" "${props}" )
+    else()
+      message( STATUS "Looking for COMPTON.....not found" )
+    endif()
+
+    #===========================================================================
+    # Include some information that can be printed by the build system.
+    set_package_properties( COMPTON PROPERTIES
+      DESCRIPTION "Access multigroup Compton scattering data."
+      TYPE OPTIONAL
+      PURPOSE "Required for bulding the compton component." )
   endif()
 
 endmacro()
@@ -615,6 +663,7 @@ macro( SetupVendorLibrariesUnix )
   setupGSL()
   setupParMETIS()
   setupSuperLU_DIST()
+  setupCOMPTON()
 
   # Random123 ----------------------------------------------------------------
   message( STATUS "Looking for Random123...")

--- a/src/compton/CMakeLists.txt
+++ b/src/compton/CMakeLists.txt
@@ -9,67 +9,70 @@
 cmake_minimum_required(VERSION 3.0.0)
 project( compton CXX )
 
-##---------------------------------------------------------------------------##
-# Requires COMPTON
-##---------------------------------------------------------------------------##
-find_package( COMPTON QUIET )
-set_package_properties( COMPTON PROPERTIES
-   DESCRIPTION "Access multigroup Compton scattering data."
-   TYPE OPTIONAL
-   PURPOSE "Required for bulding the compton component."
-   )
+# This packages requires libcompton.  See draco/config/vendor_libraries.cmake
+# and draco/config/FindCOMPTON.cmake to manage how the build system discovers
+# this TPL.  If not found, only a stub header file will be installed.
 
-if( COMPTON_FOUND )
+configure_file( ${PROJECT_SOURCE_DIR}/config.h.in
+  ${PROJECT_BINARY_DIR}/config.h )
+
+set( headers
+  ${PROJECT_BINARY_DIR}/config.h
+  ${PROJECT_SOURCE_DIR}/Compton.hh )
+
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
 
-file( GLOB sources *.cc )
-file( GLOB headers *.hh )
+if( COMPTON_FOUND )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
+set( sources ${PROJECT_SOURCE_DIR}/Compton.cc )
 
-# ---------------------------------------------------------------------------- #
-# Directories to search for include directives
-# ---------------------------------------------------------------------------- #
+  # Make the header files available in the IDE.
+  if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
+    list( APPEND sources ${headers} )
+  endif()
 
-include_directories(
-   ${PROJECT_SOURCE_DIR}      # component headers
-   ${PROJECT_BINARY_DIR}      # compton/config.h
-   ${PROJECT_SOURCE_DIR}/..   # ds++ and compton header files
-   ${dsxx_BINARY_DIR}         # ds++/config.h
-   ${ode_BINARY_DIR}          # ode/config.h
-   ${COMPTON_INCLUDE_DIR}
+  # -------------------------------------------------------------------------- #
+  # Directories to search for include directives
+  # -------------------------------------------------------------------------- #
+
+  include_directories(
+    ${Draco_SOURCE_DIR}/src    # compton/Compton.hh ds++/Assert.hh
+    ${Draco_BINARY_DIR}/src    # compton/config.h
+    ${dsxx_BINARY_DIR}         # ds++/config.h
+    )
+
+  # -------------------------------------------------------------------------- #
+  # Build package library
+  # -------------------------------------------------------------------------- #
+
+  add_component_library(
+    TARGET       Lib_compton
+    TARGET_DEPS  "Lib_dsxx;COMPTON::compton"
+    LIBRARY_NAME compton
+    SOURCES      "${sources}"
+#    VENDOR_LIST "COMPTON"
+#    VENDOR_LIBS "${COMPTON_LIBRARY}"
+#    VENDOR_INCLUDE_DIRS "${COMPTON_INCLUDE_DIR}"
 )
 
-# ---------------------------------------------------------------------------- #
-# Build package library
-# ---------------------------------------------------------------------------- #
+  install( TARGETS Lib_compton  EXPORT draco-targets DESTINATION
+    ${DBSCFGDIR}lib )
 
-add_component_library(
-   TARGET       Lib_compton
-   TARGET_DEPS  Lib_dsxx
-   LIBRARY_NAME compton
-   SOURCES      "${sources}"
-   VENDOR_LIST "COMPTON"
-   VENDOR_LIBS "${COMPTON_LIBRARY}"
-   VENDOR_INCLUDE_DIRS "${COMPTON_INCLUDE_DIR}" )
+endif() # COMPTON_FOUND
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 
-install( TARGETS Lib_compton  EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/compton )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
 
-if( BUILD_TESTING )
+if( BUILD_TESTING AND COMPTON_FOUND )
   add_subdirectory( test )
 endif()
 
@@ -79,4 +82,6 @@ endif()
 
 process_autodoc_pages()
 
-endif() # COMPTON_FOUND
+#------------------------------------------------------------------------------#
+# End compton/CMakeLists.txt
+#------------------------------------------------------------------------------#

--- a/src/compton/Compton.cc
+++ b/src/compton/Compton.cc
@@ -9,7 +9,7 @@
 //---------------------------------------------------------------------------//
 
 // headers provided in draco:
-#include "Compton.hh"
+#include "compton/Compton.hh"
 #include "ds++/Assert.hh"
 // headers provided in Compton include directory:
 #include "compton_file.hh"
@@ -26,9 +26,9 @@ namespace rtt_compton {
 /*!
  * \brief Constructor for an existing multigroup libfile.
  *
- * This calls CSK_generator methods to read the data file and store everything in a
- * Compton data object, a smart pointer to which is then passed to (and held by)
- * the CSK_generator etemp_interp class.
+ * This calls CSK_generator methods to read the data file and store everything
+ * in a Compton data object, a smart pointer to which is then passed to (and
+ * held by) the CSK_generator etemp_interp class.
  *
  * \param[in] filehandle The name of the Compton multigroup file
  */

--- a/src/compton/Compton.hh
+++ b/src/compton/Compton.hh
@@ -11,13 +11,14 @@
 #ifndef __compton_Compton_hh__
 #define __compton_Compton_hh__
 
+#include "compton/config.h"
+
+#ifdef COMPTON_FOUND
+
 // C++ standard library dependencies
 #include <iostream>
 #include <memory>
 #include <vector>
-// headers provided in compton CSK_generator include directory
-#include "etemp_interp.hh"
-#include "multigroup_compton_data.hh"
 
 namespace rtt_compton {
 //===========================================================================//
@@ -25,7 +26,7 @@ namespace rtt_compton {
  * \class Compton
  *
  * \brief Provides access to relativistic Compton scattering angle and
- * multigroup frequency distributions from the CSK_generator project.
+ *        multigroup frequency distributions from the CSK_generator project.
  *
  * This interface class allows the client to:
  * 1) access (interpolate) data from existing multigroup CSK_generator libraries
@@ -38,13 +39,12 @@ namespace rtt_compton {
  * If this is not found at the CMake configure step, the lib_compton portion of
  * draco will not be built.
  *
- * <b>User's environment</b>
+ * \b User's \b environment
  *
- * Cmake searches for the CSK_generator library/include headers during the
+ * CMake searches for the CSK_generator library/include headers during the
  * configuration step. The script that does this is located at:
  *
- * /draco/config/findCOMPTON.cmake
- *
+ * \c /draco/config/FindCOMPTON.cmake
  */
 
 /*!
@@ -99,4 +99,10 @@ public:
 };
 }
 
-#endif
+#endif // COMPTON_FOUND
+
+#endif // __compton_Compton_hh__
+
+//----------------------------------------------------------------------------//
+// End compton/Compton.hh
+//----------------------------------------------------------------------------//

--- a/src/compton/config.h.in
+++ b/src/compton/config.h.in
@@ -1,0 +1,24 @@
+/*-----------------------------------*-C-*-----------------------------------*/
+/*!
+ * \file   compton/config.h
+ * \brief  CPP defines necessary for the compton packages.
+ * \note   Copyright (C) 2017 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+/*---------------------------------------------------------------------------*/
+
+#ifndef __compton_config_h__
+#define __compton_config_h__
+
+#cmakedefine COMPTON_FOUND
+
+#ifdef COMPTON_FOUND
+// headers provided in compton CSK_generator include directory
+#include "etemp_interp.hh"
+#include "multigroup_compton_data.hh"
+#endif
+
+#endif /* __compton_config_h__ */
+
+/*---------------------------------------------------------------------------*/
+/* end of compton/config.h */
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This change set upgrades CSK to a full Draco TPL and publishes it via the installed `draco-config.cmake` file.

+ Add the compton package to the `.clang-format` list of Draco packages (for sorting of header files).
+ Complete rewrite of `FindCOMPTON.cmake` makes use of target properties instead of environment and cmake variables.
+ Move the discovery of compton from `src/compton/CMakeLists.txt` to `config/vendor_libraries.cmake`
+ Always install a *compton* package when building Draco.  If the CSK library is not found, the installation will be a stubbed out `Compton.hh` file and no library.
+ A `compton/config.h` file has been added to capture the CPP macro `COMPTON_FOUND`. Include directives for CSK files were moved to this new file. This mimics the way we treat other TPLs like Random123 or Metis.
+ Updated the Lib_compton source files to make proper use of the above changes.
+ This will break Jayenne until it is updated to use this new TPL API.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass (failing due to #293)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (not tested due to 2-week outage)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
