### PR TITLE
Tweak parser code.

### DIFF
--- a/src/parser/Token.cc
+++ b/src/parser/Token.cc
@@ -17,7 +17,7 @@
 namespace rtt_parser {
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  * Is the argument a token type that has no associated text?
  */
 
@@ -26,7 +26,7 @@ bool Is_Text_Token(Token_Type const type) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  * Is the argument a valid OTHER text?
  *
  * \return \c true if the argument points to a string of a single character
@@ -53,7 +53,7 @@ bool Is_Other_Text(char const *text) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  * Is the argument a valid keyword?
  *
  * \return \c true if the argument points to a string consisting of a
@@ -78,7 +78,7 @@ bool Is_Keyword_Text(char const *text) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  * Is the argument a valid string constant?
  *
  * \return \c true if the argument points to a string consisting of a
@@ -105,7 +105,7 @@ bool Is_String_Text(char const *text) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  *  Is the argument a valid real constant?
  *
  * \return \c true if the argument points to a string consisting of a
@@ -121,7 +121,7 @@ bool Is_Real_Text(char const *text) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  * Is the argument a valid integer constanta?
  *
  * \return \c true if the argument points to a string consisting of a
@@ -137,7 +137,7 @@ bool Is_Integer_Text(char const *text) {
 }
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  * \param a First token to compare
  * \param b Second token to compare
  *
@@ -150,16 +150,16 @@ bool operator==(Token const &a, Token const &b) {
 }
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  * The invariants all reflect the basic requirement that the token text is
  * consistent with the token type.  For example, if the type is REAL, the
  * text must be a valid C representation of a real number, which can be
  * converted to double using atof.
- * 
+ *
  * \return \c true if the invariants are all satisfied; \c false otherwise
  */
 
-bool Token::check_class_invariants() const {
+bool Token::check_class_invariant() const {
   return (Is_Text_Token(type_) || text_ == "") &&
          (type_ != KEYWORD || Is_Keyword_Text(text_.c_str())) &&
          (type_ != REAL || Is_Real_Text(text_.c_str())) &&

--- a/src/parser/Token.hh
+++ b/src/parser/Token.hh
@@ -93,13 +93,13 @@ public:
   Token_Type type() const { return type_; }
 
   //! Return the token text.
-  string text() const { return text_; }
+  string const &text() const { return text_; }
 
   //! Return the location information.
-  string location() const { return location_; }
+  string const &location() const { return location_; }
 
   //! Check that the class invariants are satisfied.
-  bool check_class_invariants() const;
+  bool check_class_invariant() const;
 
 private:
   Token_Type type_; //!< Type of this token
@@ -139,7 +139,7 @@ inline Token::Token(Token_Type const type, string const &text,
   Require(type != STRING || Is_String_Text(text.c_str()));
   Require(type != OTHER || Is_Other_Text(text.c_str()));
 
-  Ensure(check_class_invariants());
+  Ensure(check_class_invariant());
   Ensure(this->type() == type);
   Ensure(this->text() == text);
   Ensure(this->location() == location);
@@ -157,7 +157,7 @@ inline Token::Token(char const c, string const &location)
     : type_(OTHER), text_(1, c), location_(location) {
   Require(Is_Other_Text(string(1, c).c_str()));
 
-  Ensure(check_class_invariants());
+  Ensure(check_class_invariant());
   Ensure(this->type() == OTHER);
   Ensure(this->text() == string(1, c));
   Ensure(this->location() == location);
@@ -177,7 +177,7 @@ inline Token::Token(Token_Type const type, string const &location)
     : type_(type), text_(), location_(location) {
   Require(!Is_Text_Token(type));
 
-  Ensure(check_class_invariants());
+  Ensure(check_class_invariant());
   Ensure(this->type() == type);
   Ensure(this->text() == "");
   Ensure(this->location() == location);


### PR DESCRIPTION
Use return by const reference for access functions. This is more efficient and, in this context, quite safe.

Change check_class_invariants to check_class_invariant. A class really only has one invariant (the logical AND of all constraints on the internal state of the class object.)

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)(2 week DST)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
