### PR TITLE
Fix build errors and warnings reported by VS 2017.

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -48,18 +48,8 @@
 # supports installation of the external project binaries during "make install".
 
 #=============================================================================
-# Copyright 2011-2012 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the License for more
-# information.
-#
-# =============================================================================
-# (To distribute this file outside of CMake, substitute the full License text for the
-#  above reference.)
+# This is a heavily modified version of CMakeAddFortranSubdirectory.cmake that is
+# distributed with CMake - Copyright 2011-2012 Kitware, Inc.
 
 set(_CAFS_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
 include(CheckLanguage)

--- a/src/FortranChecks/CMakeLists.txt
+++ b/src/FortranChecks/CMakeLists.txt
@@ -3,10 +3,8 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for FortranChecks.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
-# $Id$
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
 project( FortranChecks CXX )
@@ -50,9 +48,10 @@ set_target_properties( Lib_FC_Derived_Type PROPERTIES FOLDER FortranChecks )
 if( BUILD_TESTING )
 
   if( HAVE_Fortran )
-    # For Unix, this will simply run add_subdirectory(f90sub). For MVSE or
-    # XCode, an ExternalProject will be created that uses an alternate gfortran
-    # via Makefiles to generate the library external to the main project.
+    # For Unix, this will simply run add_subdirectory(f90sub). For Visual Studio
+    # or XCode, an ExternalProject will be created that uses an alternate
+    # gfortran via Makefiles to generate the library external to the main
+    # project.
     include(CMakeAddFortranSubdirectory)
 
     # CMake does not support storing a list of lists when sending data to a

--- a/src/FortranChecks/f90sub/CMakeLists.txt
+++ b/src/FortranChecks/f90sub/CMakeLists.txt
@@ -3,15 +3,15 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2013 June 24
 # brief  Generate build project files for fortran.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
 project( FortranChecks_f90sub Fortran )
 
 # ---------------------------------------------------------------------------- #
-# Setup - For Generators other than "Unix Makefiles", this folder is
-# parsed independent of parent folders, so we need  some basic setup.
+# Setup - For Generators other than "Unix Makefiles", this folder is parsed
+# independent of parent folders, so we need some basic setup.
 # ---------------------------------------------------------------------------- #
 # Build system configuration files are located here.
 if( NOT EXISTS ${draco_DIR} )
@@ -28,11 +28,11 @@ include( component_macros )
 # ---------------------------------------------------------------------------- #
 
 # If we are using cmake_add_fortran_subdirectory to include this package, the
-# library targets Lib_dsxx and Lib_FC_derived_typ will not be defined.
-# We must manually find these libraries.
+# library targets Lib_dsxx and Lib_FC_derived_typ will not be defined.  We must
+# manually find these libraries.
 #
-# Note: A more complex example of CMakeAddFortranSubdirectory can be
-# found in jayenne/src/wedgehog/ftest.
+# Note: A more complex example of CMakeAddFortranSubdirectory can be found in
+# jayenne/src/wedgehog/ftest.
 
 if(NOT TARGET Lib_dsxx)
   # Rebuild the list Draco_TPL_INCLUDE_DIRS from the packed list (see
@@ -95,8 +95,13 @@ if(NOT TARGET Lib_dsxx)
         "${MPI_Fortran_LIBRARIES}" MATCHES "msmpi.lib" )
       # should be located in ENV{PATH} at c:/Program Files/Microsoft MPI/Bin/
       find_file( MPI_gfortran_LIBRARIES NAMES "libmsmpi.a" )
-      set( MPI_Fortran_LIBRARIES ${MPI_gfortran_LIBRARIES} CACHE FILEPATH
-        "msmpi for gfortran" FORCE )
+      if( MPI_gfortran_LIBRARIES )
+        set( MPI_Fortran_LIBRARIES ${MPI_gfortran_LIBRARIES} CACHE FILEPATH
+          "msmpi for gfortran" FORCE )
+      else()
+        message( FATAL_ERROR "Unable to find libmsmpi.a. This library must"
+        " be created from msmpi.dll and saved as a MinGW library. ")
+      endif()
     endif()
   endif()
 

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -95,12 +95,18 @@ tokenize(std::string const &str, std::string const &delimiters = " ",
 template <typename T> auto parse_number_impl(std::string const &str) -> T;
 
 // specializations for these types are devined in DracoStrings.cc
-template <> auto parse_number_impl<int>(std::string const &str) -> int;
-template <> auto parse_number_impl<long>(std::string const &str) -> long;
 template <>
-auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long;
-template <> auto parse_number_impl<float>(std::string const &str) -> float;
-template <> auto parse_number_impl<double>(std::string const &str) -> double;
+DLL_PUBLIC_dsxx auto parse_number_impl<int>(std::string const &str) -> int;
+template <>
+DLL_PUBLIC_dsxx auto parse_number_impl<long>(std::string const &str) -> long;
+template <>
+DLL_PUBLIC_dsxx auto parse_number_impl<unsigned long>(std::string const &str)
+    -> unsigned long;
+template <>
+DLL_PUBLIC_dsxx auto parse_number_impl<float>(std::string const &str) -> float;
+template <>
+DLL_PUBLIC_dsxx auto parse_number_impl<double>(std::string const &str)
+    -> double;
 
 //----------------------------------------------------------------------------//
 /*!
@@ -167,10 +173,9 @@ auto parse_number(std::string const &str, bool verbose = true) -> T;
  * std::vector<double> bar = { 1.0, 2.0, 3.0 }
  */
 template <typename T>
-DLL_PUBLIC_dsxx std::vector<T>
-string_to_numvec(std::string const &str,
-                 std::string const &range_symbols = "{}",
-                 std::string const &delimiters = ",");
+std::vector<T> string_to_numvec(std::string const &str,
+                                std::string const &range_symbols = "{}",
+                                std::string const &delimiters = ",");
 
 //----------------------------------------------------------------------------//
 /*!

--- a/src/parser/Parallel_File_Token_Stream.cc
+++ b/src/parser/Parallel_File_Token_Stream.cc
@@ -133,7 +133,7 @@ void Parallel_File_Token_Stream::open_() {
     }
   }
   rtt_c4::broadcast(&at_error_, 1, 0);
-  if (at_error_ > 0) {
+  if (at_error_) {
     ostringstream errmsg;
     errmsg << "Cannot construct Parallel_File_Token_Stream.\n"
            << "The file specified could not be found.\n"


### PR DESCRIPTION
+ Fix `DLL_PUBLIC` decoration of functions in `DracoStrings.hh`.
+ Fix invalid comparison of a bool: `if (b > 0)` in `Parallel_File_Token_Stream.cc`.
+ Provide better error reporting for Visual Studio builds that link to a MINGW version of the MPI library.
+ Documentation cleanup.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
