### PR TITLE
Prepare code for gcc-7.2.0.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -107,6 +107,13 @@ macro(dbsSetupCompilers)
   include(CheckIPOSupported)
   check_ipo_supported(RESULT USE_IPO)
 
+  # 2017-09-15 KT - eliminate configure warning in Win32 nightly regressions:
+  # "CMake doesn't support IPO for current compiler"
+  if( ${CMAKE_GENERATOR} MATCHES "NMake Makefiles")
+    set( USE_IPO OFF CACHE BOOL
+      "Enable Interprocedureal Optimization for Release builds." FORCE )
+  endif()
+
 endmacro()
 
 #------------------------------------------------------------------------------#

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -75,18 +75,22 @@ endif()
 # Consider using these optimization flags:
 # -ffast-math -ftree-vectorize
 # -fno-finite-math-only -fno-associative-math -fsignaling-nans
+#
+# Added, but shouldn't be needed:
+# -Wno-expansion-to-defined - unable to use GCC diagnostic pragma to suppress
+#           warnings.
 
 if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
-  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef -Wunreachable-code -DDEBUG")
+  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wno-expansion-to-defined -Wundef -Wunreachable-code -DDEBUG")
   # -Wfloat-equal
   # -Werror
   # -Wconversion
   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -D_FORTIFY_SOURCE=2 -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
-  set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -funroll-loops" )
+  set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -Wno-expansion-to-defined -funroll-loops" )
 
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
     # LTO appears to be broken (at least for Jayenne with gcc 4 and 5 series).
@@ -116,6 +120,22 @@ if( NOT CXX_FLAGS_INITIALIZED )
 #    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=bounds")
 #    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=address")
     # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
+  endif()
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 )
+    # See https://gcc.gnu.org/gcc-6/changes.html
+    # -fsanitize=bounds-strict, which enables strict checking of array
+    #            bounds. In particular, it enables -fsanitize=bounds as well as
+    #            instrumentation of flexible array member-like arrays.
+  endif()
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
+    # See https://gcc.gnu.org/gcc-7/changes.html
+    # -fsanitize-address-use-after-scope: sanitation of variables whose address
+    #            is taken and used after a scope where the variable is
+    #            defined. On by default when -fsanitize=address.
+    # -fsanitize=signed-integer-overflow
+    # -Wduplicated-branches warns when an if-else has identical branches.
+    string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=signed-integer-overflow")
+
   endif()
 
   # [2017-04-15 KT] -march=native doesn't seem to work correctly on toolbox

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -46,9 +46,9 @@ case $target in
     if [[ -d $HOME/privatemodules ]]; then
       module use --append $HOME/privatemodules
     fi
-    dm_core="cmake eospac git tk ndi python doxygen ccache numdiff totalview \
+    dm_core="eospac git tk ndi python doxygen ccache numdiff totalview \
 dia graphviz ack"
-    dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
+    dm_gcc="gcc/7.2.0 cmake netlib-lapack gsl metis random123 csk qt"
     dm_openmpi="openmpi parmetis superlu-dist trilinos valgrind"
     export dracomodules="$dm_core $dm_gcc $dm_openmpi"
     ;;

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -88,26 +88,7 @@ run "ulimit -a"
 if [[ `fn_exists module` == 1 ]]; then
   echo " "
   if [[ `declare -f module | grep -c LMOD` == 0 ]]; then
-    # we have tcl modules
-    echo "Found Tcl modules:"
-    run "module list"
-    echo "unloading"
-    run "module purge"
-    run "module list"
-    unset dracomodules
-    unset NoModules
-    unset _LMFILES_
-    unset MODULEPATH
-    unset LOADEDMODULES
-    unset MODULESHOME
-
-    # If TCL modulefiles, switch to Lmod
-    echo " "
-    echo "Switching to Lmod modulefiles..."
-    export MODULE_HOME=/scratch/vendors/spack.20170502/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/lmod-7.4.8-oytncsoih2sa4jdogz2ojvwly6mwle4n
-    source $MODULE_HOME/lmod/lmod/init/bash || die "Can't find /mod/init/bash"
-    run "module use /scratch/vendors/spack.20170502/share/spack/lmod/linux-rhel7-x86_64/Core" || die "Can't find Lmod Core modulefiles."
-
+    die "Found Tcl modules:"
   else
     # we have Lmod modules
     echo "Found Lmod modules:"
@@ -115,26 +96,18 @@ if [[ `fn_exists module` == 1 ]]; then
     run "module list"
     run "module purge"
     run "module load user_contrib"
+    # eospac, ndi, csk
+    run "module use --append /scratch/vendors/Modules.lmod"
     run "module list"
   fi
 else
-  echo " "
-  echo "No modules available"
-  echo "Loading Lmod modulefiles..."
-  export MODULE_HOME=/scratch/vendors/spack.20170502/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/lmod-7.4.8-oytncsoih2sa4jdogz2ojvwly6mwle4n
-  source $MODULE_HOME/lmod/lmod/init/bash || die "Can't find /mod/init/bash"
-  run "module use /scratch/vendors/spack.20170502/share/spack/lmod/linux-rhel7-x86_64/Core" || die "Can't find Lmod Core modulefiles."
+  die "No modules available"
 fi
 
-# Establish environment via Lmod...
-
-# eospac, ndi, csk
-run "module use --append /scratch/vendors/Modules.lmod"
-
 # Load default set of modules
-dm_core="cmake/3.9.1 eospac git ndi python graphviz doxygen ccache numdiff"
-dm_gcc="gcc/6.3.0 netlib-lapack gsl metis random123 csk qt"
-dm_openmpi="openmpi parmetis superlu-dist/4.3-netlib trilinos"
+dm_core="eospac git ndi python graphviz doxygen ccache numdiff"
+dm_gcc="gcc/7.2.0 cmake netlib-lapack gsl metis random123 csk qt"
+dm_openmpi="openmpi parmetis superlu-dist trilinos"
 export dracomodules="$dm_core $dm_gcc $dm_openmpi"
 
 # use bash_functions.sh::add_to_path?
@@ -164,7 +137,7 @@ case $extra_params in
     ;;
   clang)
     run "module load $dm_core"
-    run "module load llvm netlib-lapack gsl metis random123 csk"
+    run "module load llvm cmake netlib-lapack gsl metis random123 csk"
     run "module load $dm_openmpi"
     comp=clang
     ;;
@@ -172,10 +145,10 @@ case $extra_params in
     run "module load $dracomodules"
     comp="gcc-fulldiagnostics"
     ;;
-  gcc630)
-    run "module load $dracomodules"
-    comp=gcc-6.3.0
-    ;;
+#  gcc630)
+#    run "module load $dracomodules"
+#    comp=gcc-6.3.0
+#    ;;
   valgrind)
     run "module load $dracomodules valgrind"
     comp=gcc

--- a/src/cdi_ipcress/test/ReadOdfIpcressFile.cc
+++ b/src/cdi_ipcress/test/ReadOdfIpcressFile.cc
@@ -154,6 +154,7 @@ int main(int argc, char *argv[]) {
         // density = std::stod(program_options.get_option_value()); // C++11
         density = atof(program_options.get_option_value().c_str());
         cerr << "Using density of " << density << endl;
+        break;
 
       case 't':
         temperature = atof(program_options.get_option_value().c_str());

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -436,6 +436,50 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
 #define NOEXCEPT_C(c) noexcept(c)
 #endif
 
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Define a macro that disables potential exception throws for optimized
+ *        (Release) code.
+ *
+ * Example:
+ *
+ * \code
+ * double get_db(Vec3 const &, Vec3 const &) const ONLY_DBC_THROWS;
+ * \endcode
+ *
+ * Issues:
+ * - C++11 - Dynamic exception specifications are deprecated until C++17 except
+ *           on lambda-declarator or on a function declarator that is the
+ *           top-level (until C++17) declarator of a function, variable, or
+ *           non-static data member, whose type is a function type, a pointer to
+ *           function type, a reference to function type, a pointer to member
+ *           function type. It may appear on the declarator of a parameter or on
+ *           the declarator of a return type.
+ *           \ref http://en.cppreference.com/w/cpp/language/except_spec
+ */
+//----------------------------------------------------------------------------//
+
+// Disable since we default to C++11 ('throw()' is deprecated)
+#if 0
+
+#if DBC
+#define ONLY_DBC_THROWS throw(rtt_dsxx::assertion)
+#else
+#define ONLY_DBC_THROWS throw()
+#endif
+
+#else
+
+#if DBC
+#define ONLY_DBC_THROWS
+#else
+#define ONLY_DBC_THROWS noexcept
+#endif
+
+#endif
+
+//----------------------------------------------------------------------------//
+
 #if defined(MSVC)
 #pragma warning(pop)
 #endif

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -452,18 +452,21 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return A;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'C':
       if (u.size() == 1)
         return C;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'F':
       if (u.size() == 1)
         return F;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'H':
       if (u.size() == 1)
@@ -472,48 +475,56 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return Hz;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'J':
       if (u.size() == 1)
         return J;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'K':
       if (u.size() == 1)
         return K;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'N':
       if (u.size() == 1)
         return N;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'P':
       if (u.size() == 2)
         return Pa;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'S':
       if (u.size() == 1)
         return S;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'T':
       if (u.size() == 1)
         return T;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'V':
       if (u.size() == 1)
         return V;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'W':
       if (u.size() == 1)
@@ -522,6 +533,7 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return Wb;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'c':
       if (token.text() == "cd")
@@ -530,12 +542,14 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return cm;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'd':
       if (token.text() == "dyne")
         return dyne;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'e':
       if (token.text() == "erg")
@@ -544,24 +558,28 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return eV;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'f':
       if (token.text() == "foot")
         return foot;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'g':
       if (u.size() == 1)
         return g;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'i':
       if (token.text() == "inch")
         return inch;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'k':
       if (token.text() == "kg")
@@ -570,6 +588,7 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return keV;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'l':
       if (token.text() == "lm")
@@ -578,6 +597,7 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return lx;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'm':
       if (u.size() == 1)
@@ -586,24 +606,28 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return mol;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'o':
       if (token.text() == "ohm")
         return ohm;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'p':
       if (token.text() == "pound")
         return pound;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 'r':
       if (token.text() == "rad")
         return rad;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     case 's':
       if (u.size() == 1)
@@ -612,6 +636,7 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         return sr;
       else
         tokens.report_syntax_error("expected a unit");
+      break;
 
     default:
       tokens.report_syntax_error("expected a unit");

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -25,14 +25,19 @@
 #pragma warning disable 11
 #endif
 
+#ifdef __GNUC__
 #define GNUC_VERSION                                                           \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+/*
 #if (GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
-#if (GNUC_VERSION >= 40600)
+*/
 #pragma GCC diagnostic push
+#if (GNUC_VERSION >= 70000)
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
@@ -46,18 +51,19 @@
 #endif
 
 #include "Random123/threefry.h"
+#include "uniform.hpp"
 
 #ifdef __clang__
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
 #endif
 
-#if (GNUC_VERSION >= 40600)
+/* #if (GNUC_VERSION >= 40600) */
+#ifdef __GNUC__
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif
 
-#include "uniform.hpp"
 #include "ds++/Data_Table.hh"
 #include <algorithm>
 

--- a/src/rng/test/time_initkeyctr.h
+++ b/src/rng/test/time_initkeyctr.h
@@ -30,6 +30,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef TIME_INITKEYCTR_H__
 #define TIME_INITKEYCTR_H__ 1
 
+#define GNUC_VERSION                                                           \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#ifdef __GNUC__
+#if (GNUC_VERSION >= 70000)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+#endif
+#endif
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wexpansion-to-defined"
@@ -140,6 +150,13 @@ static aesni4x32_ctr_t good_aesni4x32_10 = {
 #ifdef __clang__
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
+#endif
+
+#ifdef __GNUC__
+#if (GNUC_VERSION >= 70000)
+// Restore GCC diagnostics to previous state.
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #endif /* TIME_INITKEYCTR_H__ */

--- a/src/rng/test/util_expandtpl.h
+++ b/src/rng/test/util_expandtpl.h
@@ -37,9 +37,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * being the number of rounds.
  */
 
+#define GNUC_VERSION                                                           \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#if (GNUC_VERSION >= 70000)
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+#endif
 #endif
 
 #ifdef __clang__

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -70,6 +70,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // encourage developers to copy it and modify it for their own
 // use.  We invite comments and improvements.
 
+#ifdef __GNUC__
+#define GNUC_VERSION                                                           \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if (GNUC_VERSION >= 70000)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+#endif
+#endif
+
 #include <Random123/features/compilerfeatures.h>
 #include <limits>
 #if R123_USE_CXX11_TYPE_TRAITS
@@ -231,5 +240,10 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
 }
 
 } // namespace r123
+
+#ifdef __GNUC__
+// Restore GCC diagnostics to previous state.
+#pragma GCC diagnostic pop
+#endif
 
 #endif


### PR DESCRIPTION
+ Disable IPO for some CMake generators.
+ Add notes about new compiler flags and behaviors.  If GCC > 7.0, then
  - Enable `-fsanitize=signed-integer-overflow` for Debug builds.
  - Disable `-Wno-expansion-to-defined` that is now part of `-Wextra`.  These
    warnings show up in Random123 and cannot be disabled by pragmas.
+ Update `.bashrc` and regression scripts to use gcc/7.2.0.
+ Add 'break;' to case statements where control flow could fall through.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (2 week DST)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [ ] `/scratch/vendors/Modules` must point to the 20170914a spack directory.
  * [x] `#pragma GCC diagnostic ignored "-Wexpansion-to-defined"` must be protected by GCC version guards.