### PR TITLE
Fix broken nightly regressions.

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -84,7 +84,10 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
-  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wno-expansion-to-defined -Wundef -Wunreachable-code -DDEBUG")
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
+    string( APPEND CMAKE_C_FLAGS    " -Wno-expansion-to-defined" )
+  endif()
+  set( CMAKE_C_FLAGS_DEBUG          "-g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef -Wunreachable-code -DDEBUG")
   # -Wfloat-equal
   # -Werror
   # -Wconversion

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -101,7 +101,13 @@ if [[ `fn_exists module` == 1 ]]; then
     run "module list"
   fi
 else
-  die "No modules available"
+  # The nightly crontabs follow this branch!
+  echo " "
+  echo "No modules available"
+  echo "Loading Lmod modulefiles..."
+  export MODULEHOME=/usr/share/lmod/lmod
+  source $MODULE_HOME/init/bash || die "Can't find $MODULE_HOME/init/bash."
+  run "module use user_contrib"
 fi
 
 # Load default set of modules

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -76,7 +76,7 @@ print_use()
 ## Command options
 ##---------------------------------------------------------------------------##
 
-while getopts ":f:hp:r" opt; do
+while getopts ":f:hp:rt" opt; do
 case $opt in
 f)  pr=$OPTARG ;;
 h)  print_use; exit 0 ;;


### PR DESCRIPTION
+ Fix a bug that was introduced into the nightly regression suite (ref #301) that manifests as 'no modules' available.
+ Add a '-t' option to checkpr.sh (used by the regression and PR testing scripts). Adding this option will force draco to rebuild and will be invoked when a draco PR is merged.
+ A compiler option for gcc/7.2.0 used to suppress warnings about possible CPP macro issues is moved from the C_FLAGS_DEBUG to C_FLAGS.
+ Fixes #302 
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
