### PR TITLE
More regression fixes.

### DIFF
--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -1238,6 +1238,52 @@
    fun:orterun
    fun:main
 }
+{
+   openmpi/211/e0001
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:orte_dt_copy_sig
+   ...
+   fun:opal_libevent2022_event_base_loop
+}
+{
+   openmpi/211/e0002
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   fun:pmix_bfrop_buffer_extend
+...
+   fun:opal_libevent2022_event_base_loop
+}
+{
+   openmpi211/e0003
+   Memcheck:Cond
+   fun:opal_value_unload
+   fun:ompi_proc_complete_init
+   fun:ompi_mpi_init
+   fun:PMPI_Init
+   ...
+}
+{
+   openmpi211/e0004
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:opal_hash_table_init2
+   ...
+   fun:PMPI_Init
+   ...
+}
+{
+   openmpi211/e0005
+   Memcheck:Cond
+   fun:opal_value_unload
+   fun:ompi_proc_complete_init
+   fun:ompi_mpi_init
+   fun:PMPI_Init_thread
+   ...
+}
 
 #------------------------------------------------------------------------------#
 # Python 2.7


### PR DESCRIPTION
+ Suppress a new valgrind warning issued by openmpi/2.1.1.
+ Do a better job of detecting when draco/develop is updated and force draco to rebuild before the next jayenne or capsaicin PR testing.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
