### PR TITLE
Fix LLVM build warnings.

### DIFF
--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -1284,6 +1284,17 @@
    fun:PMPI_Init_thread
    ...
 }
+{
+   openmpi211/e0006
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:opal_proc_table_set_value
+   ...
+   fun:PMPI_Init
+   ...
+}
+
 
 #------------------------------------------------------------------------------#
 # Python 2.7

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -25,7 +25,7 @@
 #pragma warning disable 11
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #define GNUC_VERSION                                                           \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
@@ -59,7 +59,8 @@
 #endif
 
 /* #if (GNUC_VERSION >= 40600) */
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
+/* && (GNUC_VERSION >= 70000) */
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -70,7 +70,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // encourage developers to copy it and modify it for their own
 // use.  We invite comments and improvements.
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #define GNUC_VERSION                                                           \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if (GNUC_VERSION >= 70000)
@@ -220,14 +220,14 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
 // assignment may contain values that are not known at comile time (not constexpr).  We don't want to spend to much time debugging
 // this issue because the code is essentially vendor owned (Random123).
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
 #endif
 
     R123_CONSTEXPR int ex_nowarn = (excess >= 0) ? excess : 0;
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -241,7 +241,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
 
 } // namespace r123
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
+ When using LLVM clang to compile Draco on ccs-net machines, the CPP macro `#ifdef __GNUC__` was true (in addition to `#ifdef __clang__`).  This caused a logic error for the CPP macros that push, suppress warnings and pop for GCC and clang.  This problem was fixed by changing the `#ifdef __GNUC__` checks to `#if defined(__GNUC__) && !defined(__clang__)`.
+ Also suppress another valgrind warning for a TPL.
+ References #306
+ Fixes #309
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
