### PR TITLE
Update Compton test registration from serial to one-proc parallel.

### DIFF
--- a/src/compton/test/CMakeLists.txt
+++ b/src/compton/test/CMakeLists.txt
@@ -30,8 +30,9 @@ include_directories(
 # Build Unit tests
 # ---------------------------------------------------------------------------- #
 
-add_scalar_tests(
+add_parallel_tests(
   SOURCES "${test_sources}"
+  PE_LIST "1"
   DEPS    "Lib_compton"
   LABEL   "nomemcheck"
   MPI_PLUS_OMP )


### PR DESCRIPTION
* Purpose of Pull Request
  * Quick fix -- I updated the Compton test in my last PR so I could query the MPI rank ID, but forgot to change the test registration to be parallel (the test has somehow been running/passing anyway).
 
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
