### PR TITLE
Global timer

### DIFF
--- a/src/c4/Global_Timer.cc
+++ b/src/c4/Global_Timer.cc
@@ -21,11 +21,11 @@ map<string, Global_Timer::timer_entry> Global_Timer::active_list_;
 
 //---------------------------------------------------------------------------------------//
 Global_Timer::Global_Timer(char const *name) : name_(name), active_(false) {
-  Require(name != NULL);
+  Require(name != nullptr);
 
   timer_entry &entry = active_list_[name];
   active_ = entry.is_active;
-  //    Check(entry.timer == NULL);
+  Check(entry.timer == nullptr); // Global_Timers must have unique names.
   entry.timer = this;
 
   Ensure(name == this->name());

--- a/src/c4/Global_Timer.hh
+++ b/src/c4/Global_Timer.hh
@@ -58,7 +58,7 @@ private:
     bool is_active; // permits activation of timers not yet constructed.
     Global_Timer *timer;
 
-    timer_entry() : is_active(false), timer(NULL) {}
+    timer_entry() : is_active(false), timer(nullptr) {}
   };
 
   typedef std::map<std::string, timer_entry> active_list_type;


### PR DESCRIPTION
Minor tweaks to design by contract for Global Timer.
    
    Eliminate use of NULL in favor of nullptr.
    Turn an assertion back on that really ought to be satisfied.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
