### PR TITLE
For HPC machines, add CSK to the dev env and regression system on HPC.

### DIFF
--- a/environment/bashrc/.bashrc_toss22
+++ b/environment/bashrc/.bashrc_toss22
@@ -52,10 +52,11 @@ else
     module load user_contrib
   fi
   module load friendly-testing
+  module use --append ${VENDOR_DIR}-ec/modulefiles
 
   export dracomodules="clang-format/3.9.0 intel/17.0.1 openmpi/1.10.5 mkl \
 trilinos/12.8.1 superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3 ndi random123 \
-eospac/6.2.4 subversion cmake/3.9.0 numdiff git totalview emacs grace"
+eospac/6.2.4 subversion cmake/3.9.0 numdiff git totalview emacs grace csk"
 
 fi
 

--- a/environment/bashrc/.bashrc_toss3
+++ b/environment/bashrc/.bashrc_toss3
@@ -52,10 +52,11 @@ else
     module load user_contrib
   fi
   module load friendly-testing
+  module use --append ${VENDOR_DIR}-ec/modulefiles
 
   export dracomodules="clang-format/3.9.0 intel/17.0.1 openmpi/1.10.5 mkl \
 subversion cmake/3.9.0 numdiff git totalview trilinos/12.8.1 \
-superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3 ndi random123 eospac/6.2.4"
+superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3 ndi random123 eospac/6.2.4 csk"
 
 fi
 

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -67,13 +67,14 @@ else
   module load user_contrib
 fi
 module load friendly-testing
+module use --append ${VENDOR_DIR}-ec/modulefiles
 if [[ ${SLURM_JOB_PARTITION} == "knl" ]]; then
   module swap craype-haswell craype-mic-knl
 fi
 
 export dracomodules="clang-format metis parmetis/4.0.3 trilinos/12.8.1 \
 superlu-dist/4.3 gsl/2.1 cmake/3.9.0 numdiff ndi random123 eospac/6.2.4 \
-subversion git craype-hugepages4M"
+subversion git csk"
 
 function dracoenv ()
 {

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -103,6 +103,8 @@ run "module load subversion git"
 run "module load random123"
 run "module load eospac/6.2.4"
 run "module load grace"
+run "module use --append ${VENDOR_DIR}-ec/modulefiles"
+run "module load csk"
 comp=`basename $CXX`
 export OMP_NUM_THREADS=8
 

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -92,6 +92,8 @@ run "module load intel/17.0.1 openmpi/1.10.5"
 run "module load trilinos/12.8.1 superlu-dist metis parmetis"
 run "module load cmake/3.9.0 ndi numdiff git"
 run "module load mkl random123 eospac/6.2.4"
+run "module use --append ${VENDOR_DIR}-ec/modulefiles"
+run "module load csk"
 
 export OMP_NUM_THREADS=18
 comp=`basename $CXX`

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -127,6 +127,8 @@ run "module load craype-hugepages4M"
 run "module load cmake/3.9.0 numdiff git"
 run "module load gsl/2.1 random123 eospac/6.2.4 ndi"
 run "module load trilinos/12.8.1 ndi metis parmetis/4.0.3 superlu-dist/4.3"
+run "module use --append ${VENDOR_DIR}-ec/modulefiles"
+run "module load csk"
 
 export CC=`which cc`
 export CXX=`which CC`


### PR DESCRIPTION
+ Regression scripts updated to load csk.
+ Developer's `.bashrc` files updated to load csk:

```
module use --append ${VENDOR_DIR}-ec/modulefiles
module load csk
```

+ No longer load hugepages modulefile when developing on trinitite/trinity.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass (ignore small decrease in coverage)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
