### PR TITLE
Minor cleanup for HPC regression scripts.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -249,21 +249,29 @@ macro( setupCrayMPI )
 
   query_topology()
 
-  # srun options:
+  # salloc/sbatch options:
   # --------------------
   # -N        limit job to a single node.
+  # --gres=craynetwork:0 This option allows more than one srun to be running at
+  #           the same time on the Cray. There are 4 gres “tokens” available. If
+  #           unspecified, each srun invocation will consume all of
+  #           them. Setting the value to 0 means consume none and allow the user
+  #           to run as many concurrent jobs as there are cores available on the
+  #           node. This should only be specified on the salloc/sbatch command.
+  #           Gabe doesn't recommend this option for regression testing.
+  # --vm-overcommit=disable|enable Do not allow overcommit of heap resources.
+  # -p knl    Limit allocation to KNL nodes.
+  # srun options:
+  # --------------------
   # --cpu_bind=verbose,cores
   #           bind MPI ranks to cores
   #           print a summary of binding when run
-  # --gres=craynetwork:0 register the craynetwork as a required resource.  This
-  #           is needed for packing many parallel jobs onto one node.
-  # --exclusive This is needed for packing many parallel jobs onto one node.
-  #           The salloc or sbatch command must also use '--exclusive'
-  # --vm-overcommit=disabled Do not allow overcommit of heap resources. As of
-  #           2017-08-14 this option did not work on trinitite.
+  # --exclusive This option will keep concurrent jobs from running on the same
+  #           cores. If you want to background tasks to have them run
+  #           simultaneously, this option is required to be set or they will
+  #           stomp on the same cores.
 
-  set(postflags "-N 1 --cpu_bind=verbose,cores --gres=craynetwork:0 ")
-  # string(APPEND postflags " --vm-overcommit=disabled")
+  set(postflags "-N 1 --cpu_bind=verbose,cores ")
   string(APPEND postflags " --exclusive")
   set( MPIEXEC_POSTFLAGS ${postflags} CACHE STRING
     "extra mpirun flags (list)." FORCE)

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -174,7 +174,7 @@ if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
   MYHOSTNAME="`uname -n`"
   keychain=keychain-2.7.1
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
   if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
   else

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -152,7 +152,7 @@ if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
   MYHOSTNAME="`uname -n`"
   keychain=keychain-2.7.1
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
   if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
   else

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -56,16 +56,25 @@ for jobid in ${dep_jobids}; do
     done
 done
 
+  # srun options: (also see config/setupMPI.cmake)
+  # -------------------------------------------------
+  # -N        limit job to a single node.
+  # --gres=craynetwork:0 This option allows more than one srun to be running at
+  #           the same time on the Cray. There are 4 gres “tokens” available. If
+  #           unspecified, each srun invocation will consume all of
+  #           them. Setting the value to 0 means consume none and allow the user
+  #           to run as many concurrent jobs as there are cores available on the
+  #           node. This should only be specified on the salloc/sbatch command.
+  #           Gabe doesn't recommend this option for regression testing.
+  # --vm-overcommit=disable|enable Do not allow overcommit of heap resources.
+  # -p knl    Limit allocation to KNL nodes.
+  # -t N:NN:NN Length of allocation (e.g.: 8:00:00 hours).
 # Select haswell or knl partition
 # Optional: Use -C quad,flat to select KNL mode
 # sinfo -o "%45n %30b %65f" | cut -b 47-120 | sort | uniq -c
 case $extra_params in
-# '--gres=' - See KT's email 2017-05-30 from Paul Peltz; Hal Marshall wants a
-#             different solution (see email from same day).
-#knl) partition_options="-p knl -N 1 -t 8:00:00 --gres=craynetwork:0" ;;
-#*)   partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0" ;;
-knl) partition_options="-p knl -N 1 -t 8:00:00" ;;
-*)   partition_options="-N 1 -t 8:00:00" ;;
+knl) partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0 -p knl" ;;
+*)   partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0 " ;;
 esac
 
 # Configure, Build on front end
@@ -83,7 +92,7 @@ export REGRESSION_PHASE=t
 echo "Test from the login node..."
 echo " "
 logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
-cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} --exclusive ${partition_options} ${rscriptdir}/tt-regress.msub"
+cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} ${partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 # delete blank lines

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -161,7 +161,7 @@ comp=$comp-$featurebranch
 if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
   keychain=keychain-2.7.1
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa $HOME/.ssh/cmake_rsa
+  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
   if test -f $HOME/.keychain/$HOSTNAME-sh; then
     run "source $HOME/.keychain/$HOSTNAME-sh"
   else


### PR DESCRIPTION
+ Updated ssh-keys used by the regression system since old keys were no longer valid.
+ Update sbatch and srun options for trinitite based on recommendations from ic-platforms team. Only use `--exclusive` on the srun command and only use `--gres=craynetwork:0` for the sbatch command.
+ Update some documentation.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass (ignore small decrease in coverage)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
