### PR TITLE
Allow c4 to build when DRACO_C4=SCALAR.

### DIFF
--- a/src/c4/C4_MPI_blocking_pt.cc
+++ b/src/c4/C4_MPI_blocking_pt.cc
@@ -5,10 +5,7 @@
  * \date   Mon Mar 25 14:41:05 2002
  * \brief  C4 MPI Blocking Send/Recv instantiations.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <c4/config.h>

--- a/src/c4/C4_Req.hh
+++ b/src/c4/C4_Req.hh
@@ -5,8 +5,7 @@
  * \date   Thu Jun  2 09:54:02 2005
  * \brief  C4_Req class definition.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef c4_C4_Req_hh
@@ -27,8 +26,8 @@ namespace rtt_c4 {
  * \class C4_ReqRefRep
  * \brief Handle for non-blocking message requests.
  *
- * This class provides an encapsulator for the message requests (MPI) which
- * are produced by non blocking calls.  This class automatically waits for the
+ * This class provides an encapsulator for the message requests (MPI) which are
+ * produced by non blocking calls.  This class automatically waits for the
  * message to complete when the containing object goes out of scope, thus
  * plugging one of the easiest types of programming errors with non blocking
  * messaging.  Reference counting is used so that these may be passed by value
@@ -95,7 +94,7 @@ private:
  * without accidentally triggering a program stall.
  *
  * This class provides an interface for non-blocking request handles that
- * should be used by users.  
+ * should be used by users.
  */
 //===========================================================================//
 
@@ -131,8 +130,8 @@ private:
 
 // FRIENDSHIP
 
-// Specific friend C4 functions that may need to manipulate the
-// C4_ReqRefRep internals.
+// Specific friend C4 functions that may need to manipulate the C4_ReqRefRep
+// internals.
 
 #ifdef C4_MPI
   template <class T>

--- a/src/c4/C4_Serial.hh
+++ b/src/c4/C4_Serial.hh
@@ -5,10 +5,7 @@
  * \date   Mon Mar 25 17:06:25 2002
  * \brief  Serial implementation of C4.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __c4_C4_Serial_hh__
@@ -77,7 +74,6 @@ DLL_PUBLIC_c4 int send_receive(TS * /*sendbuf*/, int /*sendcount*/,
 }
 
 //---------------------------------------------------------------------------//
-
 template <class T>
 int receive(T * /* buffer */, int /* size */, int /* source */, int /* tag */) {
   return C4_SUCCESS;
@@ -95,7 +91,8 @@ DLL_PUBLIC_c4 int receive_udt(T * /*buffer*/, int /*size*/, int /*destination*/,
   return C4_SUCCESS;
 }
 
-template <typename T> DLL_PUBLIC_c4 T prefix_sum(T &node_value) {
+//----------------------------------------------------------------------------//
+template <typename T> DLL_PUBLIC_c4 T prefix_sum(T const node_value) {
   return node_value;
 }
 

--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -5,10 +5,7 @@
  * \date   Mon Mar 25 15:41:00 2002
  * \brief  C4 Reduction test.
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
@@ -193,9 +190,9 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
 //---------------------------------------------------------------------------//
 void test_prefix_sum(rtt_dsxx::UnitTest &ut) {
 
-  // Calculate prefix sums on rank ID with MPI call and by hand and compare
-  // the output. The prefix sum on a node includes all previous node's value
-  // and the value of the current node
+  // Calculate prefix sums on rank ID with MPI call and by hand and compare the
+  // output. The prefix sum on a node includes all previous node's value and the
+  // value of the current node
 
   // test ints
   int xint = rtt_c4::node();

--- a/src/c4/test/tstScalar.cc
+++ b/src/c4/test/tstScalar.cc
@@ -5,10 +5,7 @@
  * \date   Tue Nov  1 13:24:19 2005
  * \brief  Test functions provided by C4_Serial.cc/.hh
  * \note   Copyright (C) 2016-2017 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
@@ -102,7 +99,7 @@ void tstScalar(rtt_dsxx::UnitTest &ut) {
   request = rtt_c4::receive_async(&int3, 1, 0, 0);
   rtt_c4::send_async(request, &int3, 1, 0, 0);
 
-  if (request.inuse() == 0 && request.count() == 0) {
+  if (request.inuse() == 0 && request.complete()) {
     PASSMSG("For --with-c4=scalar, successful test of send_async(const "
             "T*,int,int,int) and receive_async( C4_Req&,T*,int,int,int).");
   } else {
@@ -116,7 +113,6 @@ void tstScalar(rtt_dsxx::UnitTest &ut) {
 }
 
 //---------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   rtt_c4::ParallelUnitTest ut(argc, argv, rtt_dsxx::release);
   try {


### PR DESCRIPTION
+ While reviewing #280, I discovered that Draco no-MPI builds were broken.  This PR fixes `develop` for no-MPI builds and should be merged before #280.
+ Update function signature for `T prefix_sum` found in `C4_Serial.hh` to use the same argument types as the function of the same name found in `C4_MPI.hh`. This fixes the build error `call of overloaded function is ambiguous`.
+ Update `tstScalar.cc` to check the value of `request.complete()` instead of `request.count()` since the later member function no longer exists.
+ Clean up comments.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
