### PR TITLE
Modify DBC checks to allow nullptr buffer arguments when size is zero.

### DIFF
--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -27,7 +27,7 @@ namespace rtt_c4 {
 
 template <typename T>
 DLL_PUBLIC_c4 int send(const T *buffer, int size, int destination, int tag) {
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   MPI_Send(const_cast<T *>(buffer), size, MPI_Traits<T>::element_type(),
            destination, tag, communicator);
@@ -38,7 +38,7 @@ DLL_PUBLIC_c4 int send(const T *buffer, int size, int destination, int tag) {
 
 template <typename T>
 DLL_PUBLIC_c4 int receive(T *buffer, int size, int source, int tag) {
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   // get a handle to the MPI_Status
   MPI_Status status;
@@ -58,7 +58,7 @@ DLL_PUBLIC_c4 int receive(T *buffer, int size, int source, int tag) {
 template <typename T>
 DLL_PUBLIC_c4 int send_udt(const T *buffer, int size, int destination,
                            C4_Datatype &data_type, int tag) {
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   MPI_Send(const_cast<T *>(buffer), size, data_type, destination, tag,
            communicator);
@@ -70,7 +70,7 @@ DLL_PUBLIC_c4 int send_udt(const T *buffer, int size, int destination,
 template <typename T>
 DLL_PUBLIC_c4 int receive_udt(T *buffer, int size, int source,
                               C4_Datatype &data_type, int tag) {
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   // get a handle to the MPI_Status
   MPI_Status status;
@@ -89,8 +89,8 @@ template <typename TS, typename TR>
 DLL_PUBLIC_c4 int send_receive(TS *sendbuf, int sendcount, int destination,
                                TR *recvbuf, int recvcount, int source,
                                int sendtag, int recvtag) {
-  Require(sendbuf != nullptr);
-  Require(recvbuf != nullptr);
+  Require(sendcount == 0 || sendbuf != nullptr);
+  Require(recvcount == 0 || recvbuf != nullptr);
   // buffers must not overlap
   Require(recvbuf + recvcount <= sendbuf || recvbuf >= sendbuf + sendcount);
 
@@ -108,7 +108,7 @@ DLL_PUBLIC_c4 int send_receive(TS *sendbuf, int sendcount, int destination,
 template <typename T>
 DLL_PUBLIC_c4 C4_Req send_async(const T *buffer, int size, int destination,
                                 int tag) {
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   // make a c4 request handle
   C4_Req request;
@@ -130,7 +130,7 @@ template <typename T>
 DLL_PUBLIC_c4 void send_async(C4_Req &request, const T *buffer, int size,
                               int destination, int tag) {
   Require(!request.inuse());
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   // set the request
   request.set();
@@ -146,7 +146,7 @@ template <typename T>
 DLL_PUBLIC_c4 void send_is(C4_Req &request, const T *buffer, int size,
                            int destination, int tag) {
   Require(!request.inuse());
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   // set the request
   request.set();
@@ -164,7 +164,7 @@ DLL_PUBLIC_c4 void send_is(C4_Req &request, const T *buffer, int size,
 template <typename T>
 C4_Req receive_async(T *buffer, int size, int source, int tag) {
 
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
 
   // make a c4 request handle
   C4_Req request;
@@ -185,7 +185,7 @@ C4_Req receive_async(T *buffer, int size, int source, int tag) {
 template <typename T>
 DLL_PUBLIC_c4 void receive_async(C4_Req &request, T *buffer, int size,
                                  int source, int tag) {
-  Require(buffer != nullptr);
+  Require(size == 0 || buffer != nullptr);
   Require(!request.inuse());
 
   // set the request


### PR DESCRIPTION
This is an important use case for Capsaicin. We fail numerous tests with the current checks.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
