### PR TITLE
Fix for 64-bit metis.

### DIFF
--- a/src/VendorChecks/test/tstMetis.cc
+++ b/src/VendorChecks/test/tstMetis.cc
@@ -3,9 +3,8 @@
  * \file   VendorChecks/test/tstMetis.cc
  * \date   Wednesday, May 11, 2016, 12:01 pm
  * \brief  Attempt to link to libmetis and run a simple problem.
- * \note   Copyright (C) 2016, Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ * \note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -17,22 +16,32 @@
 // https://gist.github.com/erikzenker/c4dc42c8d5a8c1cd3e5a
 
 void test_metis(rtt_dsxx::UnitTest &ut) {
-  int nVertices = 6;
-  int nWeights = 1;
-  int nParts = 2;
+  idx_t nVertices = 10;
+  idx_t nWeights = 1;
+  idx_t nParts = 2;
 
-  int objval(0);
-  std::vector<int> part(nVertices, 0);
+  idx_t objval(0);
+  std::vector<idx_t> part(nVertices, 0);
+
+  // here's the mesh, there is only one valid cut so the expected result (or a
+  // mirror of it) should alays be obtained
+  //
+  //  0 \       / 6
+  //  1 \       / 7
+  //  2 - 4 - 5 - 8
+  //  3 /       \ 9
 
   // Indexes of starting points in adjacent array
-  int xadj[] = {0, 2, 5, 7, 9, 12, 14};
+  idx_t xadj[] = {0, 1, 2, 3, 4, 9, 15, 16, 17, 18, 19};
 
   // Adjacent vertices in consecutive index order
-  int adjncy[] = {1, 3, 0, 4, 2, 1, 5, 0, 4, 3, 1, 5, 4, 2};
+  // conn. for:     0, 1, 2, 3, 4            , 5,               , 6, 7, 8, 9
+  // index:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 14,15,16,17,18
+  idx_t adjncy[] = {4, 4, 4, 4, 0, 1, 2, 3, 5, 4, 6, 7, 8, 9, 10, 5, 5, 5, 5};
 
   // Weights of vertices
   // if all weights are equal then can be set to NULL
-  std::vector<int> vwgt(nVertices * nWeights, 0);
+  std::vector<idx_t> vwgt(nVertices * nWeights, 0);
 
   // Partition a graph into k parts using either multilevel recursive
   // bisection or multilevel k-way partitioning.
@@ -40,14 +49,24 @@ void test_metis(rtt_dsxx::UnitTest &ut) {
       METIS_PartGraphKway(&nVertices, &nWeights, xadj, adjncy, NULL, NULL, NULL,
                           &nParts, NULL, NULL, NULL, &objval, &part[0]);
 
+  std::cout << "partition: ";
+  for (uint32_t i = 0; i < nVertices; ++i) {
+    std::cout << part[i] << " ";
+  }
+  std::cout << std::endl;
+
   if (ret == METIS_OK)
     PASSMSG("Successfully called METIS_PartGraphKway().");
   else
     FAILMSG("Call to METIS_PartGraphKway() failed.");
 
-  int expectedResult[] = {1, 1, 0, 1, 0, 0};
-  std::vector<int> vExpectedResult(expectedResult, expectedResult + 6);
-  if (part == vExpectedResult)
+  int expectedResult[] = {1, 1, 1, 1, 1, 0, 0, 0, 0, 0};
+  int mirrorExpectedResult[] = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
+  std::vector<idx_t> vExpectedResult(expectedResult,
+                                     expectedResult + nVertices);
+  std::vector<idx_t> vMirrorExpectedResult(mirrorExpectedResult,
+                                           mirrorExpectedResult + nVertices);
+  if (part == vExpectedResult || part == vMirrorExpectedResult)
     PASSMSG("Metis returned the expected result.");
   else
     FAILMSG("Metis failed to return the expected result.");

--- a/src/VendorChecks/test/tstMetis.cc
+++ b/src/VendorChecks/test/tstMetis.cc
@@ -50,7 +50,7 @@ void test_metis(rtt_dsxx::UnitTest &ut) {
                           &nParts, NULL, NULL, NULL, &objval, &part[0]);
 
   std::cout << "partition: ";
-  for (uint32_t i = 0; i < nVertices; ++i) {
+  for (int32_t i = 0; i < nVertices; ++i) {
     std::cout << part[i] << " ";
   }
   std::cout << std::endl;


### PR DESCRIPTION
+ This PR provides the metis portion of #320.  This should fix the failing tstMetis test when Metis expects 64-bit integers.
+ PR #320 is showing some MPI related failures, so I decided to provide the metis portion of it in this PR.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco) (2 new UMRs - it is hard to see how this would be an issue with our code.)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation (written by Alex, reviewed by KT)
