### PR TITLE
Tighten up the Draco parser code.

### DIFF
--- a/src/parser/Parse_Table.cc
+++ b/src/parser/Parse_Table.cc
@@ -60,9 +60,13 @@ Parse_Table::Parse_Table(Keyword const *const table, size_t const count,
  * tables as static C arrays.  This justifies a low-level interface in place
  * of, say, vector<Keyword>.
  */
-void Parse_Table::add(Keyword const *const table, size_t const count) {
+void Parse_Table::add(Keyword const *const table,
+                      size_t const count) noexcept(false) {
   Require(count == 0 || table != nullptr);
   // Additional precondition checked in loop below
+
+  // Preallocate storage.
+  vec.reserve(vec.size() + count);
 
   // Add the new keywords.
 
@@ -104,7 +108,10 @@ void Parse_Table::remove(char const *moniker) {
  * \throw invalid_argument If the keyword table is ill-formed or
  * ambiguous.
  */
-void Parse_Table::add(Parse_Table const &source) {
+void Parse_Table::add(Parse_Table const &source) noexcept(false) {
+  // Preallocate storage.
+  vec.reserve(vec.size() + source.vec.size());
+
   // Add the new keywords.
 
   for (auto i = source.vec.begin(); i != source.vec.end(); ++i) {
@@ -118,7 +125,9 @@ void Parse_Table::add(Parse_Table const &source) {
 
 //---------------------------------------------------------------------------------------//
 /* private */
-void Parse_Table::sort_table_() {
+void Parse_Table::sort_table_() noexcept(
+    false) // apparently std::sort can throw
+{
   if (vec.size() == 0)
     return;
 
@@ -585,14 +594,15 @@ int Parse_Table::Keyword_Compare_::kk_comparison(char const *m1,
  */
 
 bool Parse_Table::Keyword_Compare_::operator()(Keyword const &k1,
-                                               Token const &k2) const {
+                                               Token const &k2) const noexcept {
   Require(k1.moniker != nullptr);
 
   return kt_comparison(k1.moniker, k2.text().c_str()) < 0;
 }
 
 int Parse_Table::Keyword_Compare_::kt_comparison(char const *m1,
-                                                 char const *m2) const {
+                                                 char const *m2) const
+    noexcept {
   using namespace std;
 
   Require(m1 != nullptr);

--- a/src/parser/Parse_Table.hh
+++ b/src/parser/Parse_Table.hh
@@ -171,10 +171,10 @@ public:
   // MANIPULATORS
 
   //! Add keywords to the table.
-  void add(Keyword const *table, size_t count);
+  void add(Keyword const *table, size_t count) noexcept(false);
 
   //! Add the keywords from another Parse_Table
-  void add(Parse_Table const &);
+  void add(Parse_Table const &) noexcept(false);
 
   //! Remove a keyword from the table.
   void remove(char const *);
@@ -223,10 +223,10 @@ private:
 
     bool operator()(Keyword const &k1, Keyword const &k2) const;
 
-    bool operator()(Keyword const &keyword, Token const &token) const;
+    bool operator()(Keyword const &keyword, Token const &token) const noexcept;
 
     int kk_comparison(char const *, char const *) const;
-    int kt_comparison(char const *, char const *) const;
+    int kt_comparison(char const *, char const *) const noexcept;
 
   private:
     unsigned char flags_;
@@ -235,7 +235,7 @@ private:
   // IMPLEMENTATION
 
   //! Sort and check the table following the addition of new keywords
-  void sort_table_();
+  void sort_table_() noexcept(false);
 
   // DATA
 

--- a/src/parser/String_Token_Stream.cc
+++ b/src/parser/String_Token_Stream.cc
@@ -91,9 +91,6 @@ String_Token_Stream::String_Token_Stream(string const &text,
  */
 
 string String_Token_Stream::location_() const {
-  ostringstream Result;
-  Result << "near\n";
-
   // search backwards four endlines
   unsigned begin;
   unsigned count = 0;
@@ -104,15 +101,20 @@ string String_Token_Stream::location_() const {
     }
   }
   unsigned const end = text_.size();
-  for (unsigned i = begin; i < end; ++i) {
+  unsigned i;
+  for (i = begin; i < end; ++i) {
     char const c = text_[i];
     if (i >= pos_ && c == '\n') {
       break;
     }
-    Result.put(c);
   }
-  Result.put('\n');
-  return Result.str();
+  // This kruftiness is to create the location string with a single allocation.
+  string Result;
+  Result.reserve(6 + i - begin);
+  Result.insert(0U, "near\n", 5U);
+  Result.insert(Result.end(), text_.begin() + begin, text_.begin() + i);
+  Result.insert(Result.end(), 1U, '\n');
+  return Result;
 }
 
 //-------------------------------------------------------------------------------------//

--- a/src/parser/Text_Token_Stream.cc
+++ b/src/parser/Text_Token_Stream.cc
@@ -19,6 +19,15 @@ namespace rtt_parser {
 using namespace std;
 
 //----------------------------------------------------------------------------//
+// Helper function to allow a string && argument to take over storage of a
+// string.
+static string give(string &source) {
+  string Result;
+  Result.swap(source);
+  return Result;
+}
+
+//----------------------------------------------------------------------------//
 char const default_ws_string[] = "=:;,";
 
 set<char> const Text_Token_Stream::default_whitespace(
@@ -100,22 +109,45 @@ Token Text_Token_Stream::fill_() {
 
   string token_location = location_();
 
-  Token returnValue(END, token_location);
-
   if (c == '\0') {
     // Sentinel value for error or end of file.
     if (end_()) {
       Ensure(check_class_invariants());
-      returnValue = Token(EXIT, token_location);
+      return {EXIT, token_location};
     } else {
       Ensure(check_class_invariants());
-      returnValue = Token(rtt_parser::ERROR, token_location);
+      return {rtt_parser::ERROR, token_location};
     }
   } else {
     if (isalpha(c) || c == '_')
     // Beginning of a keyword or END token
     {
-      string text(1, c);
+      unsigned cc = 1;
+      unsigned ci = 1;
+      c = peek_(ci);
+      do {
+        // Scan a C identifier.
+        while (isalnum(c) || c == '_') {
+          cc++;
+          ci++;
+          c = peek_(ci);
+        }
+        if (!no_nonbreaking_ws_) {
+          // Replace any nonbreaking whitespace after the identifier
+          // with a single space, but ONLY if the identifier is
+          // followed by another identifer.
+          while (is_nb_whitespace(c)) {
+            ci++;
+            c = peek_(ci);
+          }
+          if (isalpha(c) || c == '_')
+            cc++;
+        }
+      } while (isalpha(c) || c == '_');
+
+      string text;
+      text.reserve(cc);
+      text += peek_(0);
       pop_char_();
       c = peek_();
       do {
@@ -140,43 +172,74 @@ Token Text_Token_Stream::fill_() {
 
       if (text == "end") {
         Ensure(check_class_invariants());
-        return Token(END, token_location);
+        return {END, give(token_location)};
       } else {
         Ensure(check_class_invariants());
-        return Token(KEYWORD, text, token_location);
+        return {KEYWORD, give(text), give(token_location)};
       }
     } else if (isdigit(c) || c == '.') {
       // A number of some kind.  Note that an initial sign ('+' or '-')
       // is tokenized independently, because it could be interpreted as
       // a binary operator in arithmetic expressions.  It is up to the
       // parser to decide if this is the correct interpretation.
-      string text;
       unsigned const float_length = scan_floating_literal_();
       unsigned const int_length = scan_integer_literal_();
+      string text;
       if (float_length > int_length) {
+        text.reserve(float_length);
         for (unsigned i = 0; i < float_length; i++) {
           c = pop_char_();
           text += c;
         }
         Ensure(check_class_invariants());
-        return Token(REAL, text, token_location);
+        return {REAL, give(text), give(token_location)};
       } else if (int_length > 0) {
+        text.reserve(int_length);
         for (unsigned i = 0; i < int_length; i++) {
           char c = pop_char_();
           text += c;
         }
         Ensure(check_class_invariants());
-        return Token(INTEGER, text, token_location);
+        return {INTEGER, give(text), give(token_location)};
       } else {
         Check(c == '.');
         pop_char_();
         Ensure(check_class_invariants());
-        return Token('.', token_location);
+        return {'.', give(token_location)};
       }
     } else if (c == '"')
     // Manifest string
     {
-      string text(1, c);
+      unsigned ci = 1;
+      c = peek_(ci);
+      for (;;) {
+        while (c != '"' && c != '\\' && c != '\n' && !end_() && !error_()) {
+          ci++;
+          c = peek_(ci);
+        }
+        if (c == '"')
+          break;
+        if (c == '\\') {
+          ci += 2;
+          c = peek_(ci);
+        } else {
+          if (end_() || error_()) {
+            report_syntax_error(Token(EXIT, give(token_location)),
+                                "unexpected end of file; "
+                                "did you forget a closing quote?");
+          } else {
+            Check(c == '\n');
+            report_syntax_error(Token(EXIT, give(token_location)),
+                                "unexpected end of line; "
+                                "did you forget a closing quote?");
+          }
+        }
+      }
+      ci++;
+
+      string text;
+      text.reserve(ci);
+      text += peek_();
       pop_char_();
       c = peek_();
       for (;;) {
@@ -195,12 +258,12 @@ Token Text_Token_Stream::fill_() {
           c = peek_();
         } else {
           if (end_() || error_()) {
-            report_syntax_error(Token(EXIT, token_location),
+            report_syntax_error(Token(EXIT, give(token_location)),
                                 "unexpected end of file; "
                                 "did you forget a closing quote?");
           } else {
             Check(c == '\n');
-            report_syntax_error(Token(EXIT, token_location),
+            report_syntax_error(Token(EXIT, give(token_location)),
                                 "unexpected end of line; "
                                 "did you forget a closing quote?");
           }
@@ -208,8 +271,9 @@ Token Text_Token_Stream::fill_() {
       }
       text += '"';
       pop_char_();
+
       Ensure(check_class_invariants());
-      return Token(STRING, text, token_location);
+      return {STRING, give(text), give(token_location)};
     } else if (c == '<')
     // Multicharacter OTHER
     {
@@ -217,10 +281,10 @@ Token Text_Token_Stream::fill_() {
       if (peek_() == '=') {
         pop_char_();
         Ensure(check_class_invariants());
-        return Token(OTHER, "<=", token_location);
+        return {OTHER, "<=", give(token_location)};
       } else {
         Ensure(check_class_invariants());
-        return Token(c, token_location);
+        return {c, give(token_location)};
       }
     } else if (c == '>')
     // Multicharacter OTHER
@@ -229,10 +293,10 @@ Token Text_Token_Stream::fill_() {
       if (peek_() == '=') {
         pop_char_();
         Ensure(check_class_invariants());
-        return Token(OTHER, ">=", token_location);
+        return {OTHER, ">=", give(token_location)};
       } else {
         Ensure(check_class_invariants());
-        return Token(c, token_location);
+        return {c, give(token_location)};
       }
     } else if (c == '&')
     // Multicharacter OTHER
@@ -241,10 +305,10 @@ Token Text_Token_Stream::fill_() {
       if (peek_() == '&') {
         pop_char_();
         Ensure(check_class_invariants());
-        return Token(OTHER, "&&", token_location);
+        return {OTHER, "&&", give(token_location)};
       } else {
         Ensure(check_class_invariants());
-        return Token(c, token_location);
+        return {c, give(token_location)};
       }
     } else if (c == '|')
     // Multicharacter OTHER
@@ -253,19 +317,18 @@ Token Text_Token_Stream::fill_() {
       if (peek_() == '|') {
         pop_char_();
         Ensure(check_class_invariants());
-        return Token(OTHER, "||", token_location);
+        return {OTHER, "||", give(token_location)};
       } else {
         Ensure(check_class_invariants());
-        return Token(c, token_location);
+        return {c, give(token_location)};
       }
     } else {
       // OTHER
       pop_char_();
       Ensure(check_class_invariants());
-      return Token(c, token_location);
+      return {c, give(token_location)};
     }
   }
-  return returnValue;
 }
 
 //----------------------------------------------------------------------------//

--- a/src/parser/Token.hh
+++ b/src/parser/Token.hh
@@ -83,6 +83,9 @@ public:
   //! Construct a Token with specified type, text, and location.
   inline Token(Token_Type ty, string const &tx, string const &loc);
 
+  //! Construct a Token with specified type, text, and location.
+  inline Token(Token_Type ty, string &&tx, string &&loc);
+
   //! Default constructor
   inline Token(/*empty*/) : type_(END), text_(), location_() { /* empty */
   }
@@ -90,7 +93,7 @@ public:
   // ACCESSORS
 
   //! Return the token type.
-  Token_Type type() const { return type_; }
+  Token_Type type() const noexcept { return type_; }
 
   //! Return the token text.
   string const &text() const { return text_; }
@@ -100,6 +103,14 @@ public:
 
   //! Check that the class invariants are satisfied.
   bool check_class_invariant() const;
+
+  // MANIPULATORS
+
+  void swap(Token &src) {
+    std::swap(type_, src.type_);
+    text_.swap(src.text_);
+    location_.swap(src.location_);
+  }
 
 private:
   Token_Type type_; //!< Type of this token
@@ -131,6 +142,34 @@ DLL_PUBLIC_parser bool operator==(Token const &, Token const &);
  */
 inline Token::Token(Token_Type const type, string const &text,
                     string const &location)
+    : type_(type), text_(text), location_(location) {
+  Require(Is_Text_Token(type));
+  Require(type != KEYWORD || Is_Keyword_Text(text.c_str()));
+  Require(type != REAL || Is_Real_Text(text.c_str()));
+  Require(type != INTEGER || Is_Integer_Text(text.c_str()));
+  Require(type != STRING || Is_String_Text(text.c_str()));
+  Require(type != OTHER || Is_Other_Text(text.c_str()));
+
+  Ensure(check_class_invariant());
+  Ensure(this->type() == type);
+  Ensure(this->text() == text);
+  Ensure(this->location() == location);
+}
+
+//-------------------------------------------------------------------------//
+/*!
+ * Move version of previous constructor.
+ *
+ * \param type
+ * Type of the Token.
+ *
+ * \param text
+ * Text of the Token.
+ *
+ * \param location
+ * The token location.
+ */
+inline Token::Token(Token_Type const type, string &&text, string &&location)
     : type_(type), text_(text), location_(location) {
   Require(Is_Text_Token(type));
   Require(type != KEYWORD || Is_Keyword_Text(text.c_str()));

--- a/src/parser/Token_Stream.cc
+++ b/src/parser/Token_Stream.cc
@@ -22,15 +22,20 @@ Syntax_Error::Syntax_Error() : runtime_error("syntax error") {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  *
- * This function returns the token at the cursor position and advance the 
+ * This function returns the token at the cursor position and advance the
  * cursor. It will, if necessary, fill() the token buffer first.
  *
  * \return <code>old lookahead()</code>
  */
 Token Token_Stream::shift() {
-  Token const Result = lookahead();
+  if (deq.size() == 0) {
+    deq.push_back(fill_());
+  }
+
+  Token Result;
+  Result.swap(deq[0]);
   deq.pop_front();
 
   Ensure(check_class_invariants());
@@ -40,7 +45,7 @@ Token Token_Stream::shift() {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  *
  * This function looks ahead in the token stream without changing the cursor
  * position.  It will, if necessary, fill_() the token buffer first.  If the
@@ -53,7 +58,7 @@ Token Token_Stream::shift() {
  * \return The token at the specified position relative to the
  * cursor.
  */
-Token Token_Stream::lookahead(unsigned const pos) {
+Token const &Token_Stream::lookahead(unsigned const pos) {
   while (deq.size() <= pos) {
     deq.push_back(fill_());
   }
@@ -63,7 +68,7 @@ Token Token_Stream::lookahead(unsigned const pos) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  *
  * This function pushes the specified token onto the front of the token
  * stream, so that it is now the token in the lookahead(0) position.
@@ -76,7 +81,7 @@ void Token_Stream::pushback(Token const &token) {
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  *
  * The default implementation of this function passes its message on to
  * Report_Error, then throws a Syntax_Error exception.
@@ -109,7 +114,7 @@ void Token_Stream::report_syntax_error(Token const &token,
 }
 
 //-----------------------------------------------------------------------//
-/*! 
+/*!
  *
  * The default implementation of this function passes its message on to
  * report, then throws a Syntax_Error exception.
@@ -140,7 +145,7 @@ void Token_Stream::report_syntax_error(string const &message) {
 }
 
 //--------------------------------------------------------------------------//
-/*! 
+/*!
  *
  * The default implementation of this function passes its message on to
  * report, then returns.
@@ -163,7 +168,7 @@ void Token_Stream::report_semantic_error(Token const &token,
 }
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  *
  * The default implementation of this function passes its message
  * on to report, then returns.
@@ -185,7 +190,7 @@ void Token_Stream::report_semantic_error(string const &message) {
 }
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  *
  * The default implementation of this function passes its message on to
  * report, then returns.
@@ -207,7 +212,7 @@ void Token_Stream::report_semantic_error(exception const &message) {
 }
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  * \brief Reset the token stream.
  *
  * This function is normally called by its overriding version in children of

--- a/src/parser/Token_Stream.hh
+++ b/src/parser/Token_Stream.hh
@@ -104,7 +104,8 @@ public:
   Token shift();
 
   //! Look ahead at tokens.
-  Token lookahead(unsigned pos = 0);
+  // Lookahead references should remain valid until the referenced token is shifted.
+  Token const &lookahead(unsigned pos = 0);
 
   //! Insert a token into the stream at the cursor position.
   void pushback(Token const &token);
@@ -203,7 +204,7 @@ public:
 
   //! Return the number of errors reported to the stream since it was last
   //! constructed or rewound.
-  unsigned error_count() const { return error_count_; }
+  unsigned error_count() const noexcept { return error_count_; }
 
   //! Check that all class invariants are satisfied.
   bool check_class_invariants() const { return true; }

--- a/src/quadrature/Gauss_Legendre__Parser.cc
+++ b/src/quadrature/Gauss_Legendre__Parser.cc
@@ -24,7 +24,7 @@ std::shared_ptr<Quadrature> Gauss_Legendre::parse(Token_Stream &tokens) {
   tokens.check_semantics(sn_order % 2 == 0, "order must be even");
   tokens.check_syntax(tokens.shift().type() == END, "missing end?");
 
-  return std::shared_ptr<Quadrature>(new Gauss_Legendre(sn_order));
+  return std::make_shared<Gauss_Legendre>(sn_order);
 }
 
 } // end namespace rtt_quadrature


### PR DESCRIPTION
This merge tightens up some of the parser code in Draco.

* Strings are reserved to their expected length before being constructed.
* A move constructor is provided for Token.
* A swap function is provided for Token, so that a Token can take over another Token's storage.
* The lookahead function for Token_Stream is changed to return a reference to const Token. This is safe: Token_Stream is built on std::deque, which preserves references until the referred element is popped. Thus a reference to lookahead tokens is safe until the token is shifted.
* Various parser code is modified to avoid unnecessary copies of Token or of Token::text or Token::lookahead.
* make_shared<T> is used in place of shared_ptr<T>(new T), which saves a memory allocation.

Some functions are flagged for their noexcept status.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
