### PR TITLE
Fix a memory error in the metis test

### DIFF
--- a/src/VendorChecks/test/tstMetis.cc
+++ b/src/VendorChecks/test/tstMetis.cc
@@ -32,12 +32,12 @@ void test_metis(rtt_dsxx::UnitTest &ut) {
   //  3 /       \ 9
 
   // Indexes of starting points in adjacent array
-  idx_t xadj[] = {0, 1, 2, 3, 4, 9, 15, 16, 17, 18, 19};
+  idx_t xadj[] = {0, 1, 2, 3, 4, 9, 14, 15, 16, 17, 18};
 
   // Adjacent vertices in consecutive index order
-  // conn. for:     0, 1, 2, 3, 4            , 5,               , 6, 7, 8, 9
-  // index:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 14,15,16,17,18
-  idx_t adjncy[] = {4, 4, 4, 4, 0, 1, 2, 3, 5, 4, 6, 7, 8, 9, 10, 5, 5, 5, 5};
+  // conn. for:     0, 1, 2, 3, 4            , 5,            ,6, 7, 8, 9
+  // index:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 14,15,16,17
+  idx_t adjncy[] = {4, 4, 4, 4, 0, 1, 2, 3, 5, 4, 6, 7, 8, 9, 5, 5, 5, 5};
 
   // Weights of vertices
   // if all weights are equal then can be set to NULL


### PR DESCRIPTION
* Purpose of Pull Request
  * Fix a memory error I introduced by making one array too long.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
