### PR TITLE
Fix compiling against MKL when using g++.

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -99,6 +99,13 @@ macro( setupLAPACKLibrariesUnix )
         set( MKL_LIBRARY_TYPE "SHARED" )
       endif()
 
+      # should we link against libmkl_gnu_thread.so or libmkl_intel_thread.so
+      if( ${CMAKE_C_COMPILER_ID} MATCHES GNU )
+        set(tlib "mkl_gnu_thread")
+      else()
+        set(tlib "mkl_intel_thread")
+      endif()
+
       if( BLAS_FOUND )
         set( LAPACK_FOUND TRUE CACHE BOOL "lapack (MKL) found?" FORCE)
         set( lapack_FOUND TRUE CACHE BOOL "lapack (MKL) found?" FORCE)
@@ -109,7 +116,7 @@ macro( setupLAPACKLibrariesUnix )
         add_library( blas::mkl_thread  ${MKL_LIBRARY_TYPE} IMPORTED)
         add_library( blas::mkl_core    ${MKL_LIBRARY_TYPE} IMPORTED)
         set_target_properties( blas::mkl_thread PROPERTIES
-          IMPORTED_LOCATION                 "${BLAS_mkl_intel_thread_LIBRARY}"
+          IMPORTED_LOCATION                 "${BLAS_${tlib}_LIBRARY}"
           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
           IMPORTED_LINK_INTERFACE_MULTIPLICITY 20 )
         set_target_properties( blas::mkl_core PROPERTIES
@@ -120,7 +127,7 @@ macro( setupLAPACKLibrariesUnix )
         set_target_properties( blas PROPERTIES
           IMPORTED_LOCATION                 "${BLAS_mkl_intel_lp64_LIBRARY}"
           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-          IMPORTED_LINK_INTERFACE_LIBRARIES "-Wl,--start-group;${BLAS_mkl_core_LIBRARY};${BLAS_mkl_intel_thread_LIBRARY};-Wl,--end-group"
+          IMPORTED_LINK_INTERFACE_LIBRARIES "-Wl,--start-group;${BLAS_mkl_core_LIBRARY};${BLAS_${tlib}_LIBRARY};-Wl,--end-group"
           IMPORTED_LINK_INTERFACE_MULTIPLICITY 20)
         set_target_properties( lapack PROPERTIES
           IMPORTED_LOCATION                 "${BLAS_mkl_intel_lp64_LIBRARY}"


### PR DESCRIPTION
* The name of the MKL thread library should be `mkl_gnu_thread` instead of`mkl_intel_thread`.
* Fixes [Redmine 1024](https://rtt.lanl.gov/redmine/issues/1024).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
