### PR TITLE
Fix error and warning for scalar (or serial) builds.

### DIFF
--- a/src/c4/C4_Serial.hh
+++ b/src/c4/C4_Serial.hh
@@ -126,6 +126,12 @@ template <typename T> DLL_PUBLIC_c4 T prefix_sum(T const node_value) {
 }
 
 //---------------------------------------------------------------------------//
+template <typename T>
+DLL_PUBLIC_c4 void prefix_sum(T * /*buffer*/, const int32_t /*n*/) {
+  /* empty */
+}
+
+//---------------------------------------------------------------------------//
 // NON-BLOCKING SEND/RECEIVE OPERATIONS
 //---------------------------------------------------------------------------//
 

--- a/src/c4/Invert_Comm_Map.cc
+++ b/src/c4/Invert_Comm_Map.cc
@@ -55,15 +55,15 @@ int get_num_recv(Invert_Comm_Map_t::const_iterator first,
 //---------------------------------------------------------------------------//
 // SCALAR version of get_num_recv
 #elif defined(C4_SCALAR)
-int get_num_recv(Invert_Comm_Map_t::const_iterator first,
-                 Invert_Comm_Map_t::const_iterator last) {
+int get_num_recv(Invert_Comm_Map_t::const_iterator /*first*/,
+                 Invert_Comm_Map_t::const_iterator /*last*/) {
   return 0;
 }
 #else
 //---------------------------------------------------------------------------//
 // Default version of get_num_recv, which throws an error.
-int get_num_recv(Invert_Comm_Map_t::const_iterator first,
-                 Invert_Comm_Map_t::const_iterator last) {
+int get_num_recv(Invert_Comm_Map_t::const_iterator /*first*/,
+                 Invert_Comm_Map_t::const_iterator /*last*/) {
   Insist(0, "get_num_recv not implemented for this communication type!");
 }
 #endif // ifdef C4_MPI


### PR DESCRIPTION
* Purpose of Pull Request
  * An overload of the `prefix_sum` (`mpi_scan` wrapper) was missing from C4_Serial.
  * The serial version of `get_num_recv` in Invert_Comm_Map had unused arguments.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
