### PR TITLE
Add [[noreturn]] attribute to non-returning Assert.hh functions.

### DIFF
--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -169,12 +169,12 @@ public:
 //---------------------------------------------------------------------------//
 
 //! Throw a rtt_dsxx::assertion for Require, Check, Ensure.
-DLL_PUBLIC_dsxx[[noreturn]] void
+[[noreturn]] DLL_PUBLIC_dsxx void
 toss_cookies(std::string const &cond, std::string const &file, int const line);
 
-DLL_PUBLIC_dsxx[[noreturn]] void toss_cookies_ptr(char const *const cond,
-                                                  char const *const file,
-                                                  int const line);
+[[noreturn]] DLL_PUBLIC_dsxx void toss_cookies_ptr(char const *const cond,
+                                                   char const *const file,
+                                                   int const line);
 
 //! Throw a rtt_dsxx::assertion if condition fails
 DLL_PUBLIC_dsxx void check_cookies(bool cond, char const *cond_text,
@@ -184,16 +184,16 @@ DLL_PUBLIC_dsxx void check_cookies(bool cond, char const *cond_text,
 DLL_PUBLIC_dsxx void show_cookies(std::string const &cond,
                                   std::string const &file, int const line);
 //! Throw a rtt_dsxx::assertion for Insist.
-DLL_PUBLIC_dsxx[[noreturn]] void insist(std::string const &cond,
-                                        std::string const &msg,
-                                        std::string const &file,
-                                        int const line);
+[[noreturn]] DLL_PUBLIC_dsxx void insist(std::string const &cond,
+                                         std::string const &msg,
+                                         std::string const &file,
+                                         int const line);
 
 //! Pointer version of insist
-DLL_PUBLIC_dsxx[[noreturn]] void insist_ptr(char const *const cond,
-                                            char const *const msg,
-                                            char const *const file,
-                                            int const line);
+[[noreturn]] DLL_PUBLIC_dsxx void insist_ptr(char const *const cond,
+                                             char const *const msg,
+                                             char const *const file,
+                                             int const line);
 
 //! Check version of insist
 DLL_PUBLIC_dsxx void check_insist(bool cond, char const *const condstr,

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -169,11 +169,12 @@ public:
 //---------------------------------------------------------------------------//
 
 //! Throw a rtt_dsxx::assertion for Require, Check, Ensure.
-DLL_PUBLIC_dsxx void toss_cookies(std::string const &cond,
-                                  std::string const &file, int const line);
+DLL_PUBLIC_dsxx[[noreturn]] void
+toss_cookies(std::string const &cond, std::string const &file, int const line);
 
-DLL_PUBLIC_dsxx void toss_cookies_ptr(char const *const cond,
-                                      char const *const file, int const line);
+DLL_PUBLIC_dsxx[[noreturn]] void toss_cookies_ptr(char const *const cond,
+                                                  char const *const file,
+                                                  int const line);
 
 //! Throw a rtt_dsxx::assertion if condition fails
 DLL_PUBLIC_dsxx void check_cookies(bool cond, char const *cond_text,
@@ -183,12 +184,16 @@ DLL_PUBLIC_dsxx void check_cookies(bool cond, char const *cond_text,
 DLL_PUBLIC_dsxx void show_cookies(std::string const &cond,
                                   std::string const &file, int const line);
 //! Throw a rtt_dsxx::assertion for Insist.
-DLL_PUBLIC_dsxx void insist(std::string const &cond, std::string const &msg,
-                            std::string const &file, int const line);
+DLL_PUBLIC_dsxx[[noreturn]] void insist(std::string const &cond,
+                                        std::string const &msg,
+                                        std::string const &file,
+                                        int const line);
 
 //! Pointer version of insist
-DLL_PUBLIC_dsxx void insist_ptr(char const *const cond, char const *const msg,
-                                char const *const file, int const line);
+DLL_PUBLIC_dsxx[[noreturn]] void insist_ptr(char const *const cond,
+                                            char const *const msg,
+                                            char const *const file,
+                                            int const line);
 
 //! Check version of insist
 DLL_PUBLIC_dsxx void check_insist(bool cond, char const *const condstr,

--- a/src/ds++/test/tstAssert.cc
+++ b/src/ds++/test/tstAssert.cc
@@ -463,6 +463,19 @@ void tnoexcept(rtt_dsxx::UnitTest &ut) {
 }
 
 //---------------------------------------------------------------------------//
+int unused(int i) {
+  switch (i) {
+  case 0:
+    return 0;
+
+  default:
+    Insist(false, "bad case");
+    // Should not trigger a return with no value warning, because insist is
+    // flagged as a noreturn function
+  }
+}
+
+//---------------------------------------------------------------------------//
 
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);

--- a/src/ds++/test/tstAssert.cc
+++ b/src/ds++/test/tstAssert.cc
@@ -505,6 +505,10 @@ int main(int argc, char *argv[]) {
 
     // noexcept
     tnoexcept(ut);
+
+    // noreturn
+    // called only to keep code coverage good
+    unused(0);
   }
   UT_EPILOG(ut);
 }


### PR DESCRIPTION
Added the [[noreturn]] attribute to insist, insist_ptr, toss_cookies, and toss_cookies_ptr.

This potentially eliminates spurious warnings. See tstAssert.cc for an example of a function where a spurious "return with no value" warning is eliminated.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco) - 2 valgrind issues reported - but not related to this changeset.
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
