### PR TITLE
Update regression scripts so they run as group ccsrad.

### DIFF
--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -13,9 +13,12 @@
 */20 * * * * /scratch/regress/draco/regression/sync_repository.sh
 
 # Run the metrics report on the first Monday of each month.
-00 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
-02 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
-04 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
+#00 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
+#02 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
+#04 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
+00 07 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
+02 07 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
+04 07 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
 
 #------------------------------------------------------------------------------#
 # Regressions:
@@ -30,17 +33,17 @@
 #    valgrind
 #------------------------------------------------------------------------------#
 
-05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p "draco jayenne capsaicin"
+05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p \"draco jayenne capsaicin\"
 
-00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e coverage
+00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e coverage
 
-00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind
+00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e valgrind
 
 #------------------------------------------------------------------------------#
 # Clang-3.8.0, gcc-6.1.0
 #------------------------------------------------------------------------------#
 
-00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang
+00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e clang
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -87,27 +87,17 @@ run "ulimit -a"
 
 if [[ `fn_exists module` == 1 ]]; then
   echo " "
-  if [[ `declare -f module | grep -c LMOD` == 0 ]]; then
-    die "Found Tcl modules:"
-  else
-    # we have Lmod modules
-    echo "Found Lmod modules:"
-    run "module avail"
-    run "module list"
-    run "module purge"
-    run "module load user_contrib"
-    # eospac, ndi, csk
-    run "module use --append /scratch/vendors/Modules.lmod"
-    run "module list"
-  fi
+  # we have Lmod modules
+  echo "Found Lmod modules:"
+  run "module purge"
+  run "module load user_contrib"
 else
   # The nightly crontabs follow this branch!
   echo " "
   echo "No modules available"
-  echo "Loading Lmod modulefiles..."
-  export MODULEHOME=/usr/share/lmod/lmod
-  source $MODULE_HOME/init/bash || die "Can't find $MODULE_HOME/init/bash."
-  run "module use user_contrib"
+  echo "Trying to setup Lmod modulefiles..."
+  run "source /etc/bashrc"
+  run "module load user_contrib"
 fi
 
 # Load default set of modules

--- a/regression/ccscs2-crontab
+++ b/regression/ccscs2-crontab
@@ -18,7 +18,7 @@
 #    clang
 #------------------------------------------------------------------------------#
 
-05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p "draco jayenne capsaicin"
+05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"draco jayenne capsaicin\"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs6-crontab
+++ b/regression/ccscs6-crontab
@@ -19,7 +19,7 @@
 #    valgrind
 #------------------------------------------------------------------------------#
 
-# 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind
+# 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e valgrind
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -1,7 +1,7 @@
 # crontab for ml-fey
 
 # Sync git repositories to local FS and run CI tests
-*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
+*/20 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
 
 #------------------------------------------------------------------------------#
 # Regressions options:
@@ -21,9 +21,9 @@
 # Intel/17.0.1 and OpenMPI/1.10.5
 #------------------------------------------------------------------------------#
 
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin"
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin\"
 
-# 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin"
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -15,6 +15,16 @@
 ## Environment
 ##---------------------------------------------------------------------------##
 
+# Because of this next 'exec sg' command, the crontab must escape double quotes
+# to keep space delimited options together.  Something like:
+# 00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e clang
+
+# switch to group 'ccsrad' and set umask
+if [[ $(id -gn) != ccsrad ]]; then
+  exec sg ccsrad "$0 $*"
+fi
+umask 0007
+
 # Enable job control
 set -m
 

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -24,28 +24,28 @@
 # Intel/17.0.4 and OpenMPI/2.1.2
 #------------------------------------------------------------------------------#
 
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin"
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin\"
 
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin"
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
 
 #------------------------------------------------------------------------------#
 # Special: NR, PerfBench and FullDiagnostics regressions.
 #------------------------------------------------------------------------------#
 
 # intel-17.0.4 + Openmpi-2.1.2 (currently the default)
-# 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne" -e newtools
+# 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne\" -e newtools
 
 # gcc-6.4.0 + openmpi-2.1.2
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne" -e gcc640
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne\" -e gcc640
 
 # Floating point traps, etc.
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e fulldiagnostics -p "draco jayenne capsaicin"
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e fulldiagnostics -p \"draco jayenne capsaicin\"
 
 # non-reproducible flavor (IMC)
-01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e nr -p "jayenne"
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e nr -p \"jayenne\"
 
 # performance over time
-01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p "jayenne capsaicin"
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p \"jayenne capsaicin\"
 
 #------------------------------------------------------------------------------#
 # Periodic usage reports

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -1,7 +1,7 @@
 # crontab for tt-fey
 
 # Create a svn hotcopy of capsaicin at /usr/projects/jayenne/regress/svn
-*/15 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
+*/20 * * * * /usr/projects/jayenne/regress/draco/regression/sync_repository.sh
 
 #------------------------------------------------------------------------------#
 # Regression Options:
@@ -21,15 +21,15 @@
 # Haswell
 # --------------------
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin"
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin\"
 
-01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin"
+01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
 
 # --------------------
 # KNL
 # --------------------
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco" -e knl
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e knl
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command


### PR DESCRIPTION
+ At the top of `regression_master.sh`, force the current group to be `ccscsrad`.
+ Update all crontabs to allow the above trick to work.  That is, double quotes must be escaped.
+ Simplify logic used to setup modules for regressions running on ccs-net machines.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
