### PR TITLE
Minor Compton DBC and test updates

### DIFF
--- a/src/compton/Compton.cc
+++ b/src/compton/Compton.cc
@@ -89,13 +89,13 @@ Compton::Compton(const std::string &filehandle,
   }
 
   // do quick sanity check
-  if(det_bal) {
-    // if we're enforcing detailed balance, we need induced and wt_func to 
+  if (det_bal) {
+    // if we're enforcing detailed balance, we need induced and wt_func to
     // be set to <0,"wien">||<1,"planck">; these are the only valid cases
-    Insist( ( (!induced && wt_func == std::string("wien")) ||
-              (induced && wt_func == std::string("planck")) ),
-          "Compton error: Detailed balance enforcement (det_bal = 1) \n"
-          "only valid for induced=0 w/wien -OR- induced=1 w/planck!");
+    Insist(((!induced && wt_func == std::string("wien")) ||
+            (induced && wt_func == std::string("planck"))),
+           "Compton error: Detailed balance enforcement (det_bal = 1) \n"
+           "only valid for induced=0 w/wien -OR- induced=1 w/planck!");
   }
 
   // make a group_data struct to pass to the lib builder:

--- a/src/compton/Compton.cc
+++ b/src/compton/Compton.cc
@@ -88,6 +88,16 @@ Compton::Compton(const std::string &filehandle,
               << std::endl;
   }
 
+  // do quick sanity check
+  if(det_bal) {
+    // if we're enforcing detailed balance, we need induced and wt_func to 
+    // be set to <0,"wien">||<1,"planck">; these are the only valid cases
+    Insist( ( (!induced && wt_func == std::string("wien")) ||
+              (induced && wt_func == std::string("planck")) ),
+          "Compton error: Detailed balance enforcement (det_bal = 1) \n"
+          "only valid for induced=0 w/wien -OR- induced=1 w/planck!");
+  }
+
   // make a group_data struct to pass to the lib builder:
   multigroup::Group_data grp_data = {multigroup::Library_type::EXISTING,
                                      multigroup::string_to_opac_type(opac_type),

--- a/src/compton/test/tCompton.cc
+++ b/src/compton/test/tCompton.cc
@@ -256,16 +256,17 @@ void compton_build_test(rtt_dsxx::UnitTest &ut) {
   const std::string opac_type = "jayenne";
   const std::string wt_func = "planck";
   const bool induced = false;
+  const bool det_bal = false;
 
   // set the number of angular points to retrieve (legendre or otherwise)
-  const size_t nxi = 3;
+  const size_t nxi = 5;
 
   try {
     // (This call has some output of its own, so we print some newlines around
     // it)
     std::cout << "\n\n";
     compton_test.reset(new rtt_compton::Compton(
-        filename, test_groups, opac_type, wt_func, induced, nxi));
+        filename, test_groups, opac_type, wt_func, induced, det_bal, nxi));
     std::cout << "\n\n";
   } catch (rtt_dsxx::assertion &asrt) {
     FAILMSG("Failed to construct a Compton object!");


### PR DESCRIPTION
* This PR adds a useful check to the data passed into Compton::Compton() to be sure that the set of multigroup build parameters is sensible.

* It also modifies the Compton test slightly to explicitly specify all of the variables (rather than relying on the defaults). 

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation