### PR TITLE
Tweak diagnostics in expression parser.

### DIFF
--- a/src/parser/Expression.cc
+++ b/src/parser/Expression.cc
@@ -948,7 +948,8 @@ static pE parse_primary(unsigned const number_of_variables,
           }
           return pE(new Constant_Expression(number_of_variables, units));
         } else {
-          tokens.report_semantic_error("undefined variable or unit");
+          tokens.report_semantic_error("undefined variable or unit: " +
+                                       variable.text());
           return pE(new Constant_Expression(number_of_variables, 0.0));
         }
       }
@@ -1029,7 +1030,7 @@ static pE parse_additive(unsigned const number_of_variables,
       pE const Right =
           parse_multiplicative(number_of_variables, variable_map, tokens);
       if (!is_compatible(Result->units(), Right->units())) {
-        tokens.report_semantic_error("unit incompatibility for +");
+        tokens.report_semantic_error("unit incompatibility for + operator");
       } else {
         Result.reset(new Sum_Expression(Result, Right));
       }
@@ -1039,7 +1040,7 @@ static pE parse_additive(unsigned const number_of_variables,
       pE const Right =
           parse_multiplicative(number_of_variables, variable_map, tokens);
       if (!is_compatible(Result->units(), Right->units())) {
-        tokens.report_semantic_error("unit incompatibility for -");
+        tokens.report_semantic_error("unit incompatibility for - operator");
       } else {
         Result.reset(new Difference_Expression(Result, Right));
       }


### PR DESCRIPTION
When a variable is not recognized, include the variable name in the message.
Change the rather obscure "unit incompatibility for -" to "unit incompatibility for - operator" since '-' has so many meanings.

These came up when I was trying to diagnose a bad input file, and I found the diagnostic messages less useful than I would have liked for determining what was going on.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
