### PR TITLE
Extend the functionality of the cmake function provide_aux_files.

### DIFF
--- a/src/meshReaders/test/CMakeLists.txt
+++ b/src/meshReaders/test/CMakeLists.txt
@@ -1,12 +1,10 @@
 #-----------------------------*-cmake-*----------------------------------------#
-# file   config/CMakeLists.txt
+# file   meshReaders/test/CMakeLists.txt
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for meshReaders/test.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
-# $Id$
 #------------------------------------------------------------------------------#
 project( meshReaders_test CXX )
 
@@ -21,7 +19,7 @@ file( GLOB mesh_input_files *.mesh.in )
 # Directories to search for include directives
 # ---------------------------------------------------------------------------- #
 
-include_directories( 
+include_directories(
    ${PROJECT_SOURCE_DIR}      # headers for tests
    ${PROJECT_SOURCE_DIR}/..   # headers for package
 )
@@ -42,3 +40,7 @@ provide_aux_files(
    FILES    "${mesh_input_files}"
    SRC_EXT  ".mesh.in"
    DEST_EXT ".mesh" )
+
+#------------------------------------------------------------------------------#
+# End meshReaders/test/CMakeLists.txt
+#------------------------------------------------------------------------------#


### PR DESCRIPTION
**Background**:

+ This cmake function is used to copy files from the source directory to the build directory. It can rename files during the copy and replace @VAR@ type variables with values specified in the build system.
+ Capsaicin has requested a new build system feature that will rebuild applications like serrano or anaheim when `make` is run from the `test` subdirectory.

**Solution**:

+ The `provide_aux_files` cmake function can now take a new optional parameter `TARGETS` that the build system will ensure are up-to-date when `make` is executed.  An example of using this new feature can be found in `anaheim/test/CMakeLists.txt`

```
provide_aux_files(
  FILES "${aux_files}"
  TARGETS Exe_anaheim )
```

+ I also simplified some code in the function.
+ Relates to https://gitlab.lanl.gov/capsaicin/capsaicin/merge_requests/160
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
