### PR TITLE
Disable IPO for Win32 builds.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -108,8 +108,11 @@ macro(dbsSetupCompilers)
   check_ipo_supported(RESULT USE_IPO)
 
   # 2017-09-15 KT - eliminate configure warning in Win32 nightly regressions:
-  # "CMake doesn't support IPO for current compiler"
-  if( ${CMAKE_GENERATOR} MATCHES "NMake Makefiles")
+  #                 "CMake doesn't support IPO for current compiler"
+  # 2017-11-13 KT - This also breaks linking MinGW gfortran libraries into 
+  #                 MSVC applications, so just disable it for all Win32 builds.
+  if( WIN32 )
+  # if( ${CMAKE_GENERATOR} MATCHES "NMake Makefiles" )
     set( USE_IPO OFF CACHE BOOL
       "Enable Interprocedureal Optimization for Release builds." FORCE )
   endif()


### PR DESCRIPTION
* I think IPO is causing link-time issues when an executable created with Visual Studio attempts to link to a library created by MinGW gfortran. Disable IPO on Win32 platforms for now.  Even if this doesn't fix the compilation issue, it will make the failure easier to track down.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
