### PR TITLE
Convert Win32 nightly testing from NMake to MSBuild.

### DIFF
--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -54,6 +54,9 @@ endforeach()
 # specify maximum number of warnings to display
 # set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS "100" )
 
+set( CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE "1024" ) # bytes (1 kB)
+set( CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE "102400" ) # bytes (100 kB)
+
 ##---------------------------------------------------------------------------##
 ## Errors
 ##---------------------------------------------------------------------------##

--- a/regression/Draco_Linux64.cmake
+++ b/regression/Draco_Linux64.cmake
@@ -26,6 +26,9 @@ parse_args()
 find_tools()
 set_git_command("Draco.git")
 
+# Make machine name lower case
+string( TOLOWER "${CTEST_SITE}" CTEST_SITE )
+
 ####################################################################
 # The values in this section are optional you can either
 # have them or leave them commented out
@@ -76,6 +79,9 @@ if( ${CTEST_CONFIGURE} )
     message( "ctest_empty_binary_directory( ${CTEST_BINARY_DIRECTORY} )" )
     ctest_empty_binary_directory( ${CTEST_BINARY_DIRECTORY} )
   endif()
+  # dummy command to give the file system time to catch up before creating
+  # CMakeCache.txt.
+  # file( WRITE $ENV{TEMP}/foo.txt ${CTEST_INITIAL_CACHE} )
   file( WRITE ${CTEST_BINARY_DIRECTORY}/CMakeCache.txt ${CTEST_INITIAL_CACHE} )
 endif()
 
@@ -173,3 +179,9 @@ if( ${CTEST_SUBMIT} )
 endif()
 
 message("end of ${CTEST_SCRIPT_NAME}.")
+
+#------------------------------------------------------------------------------#
+# End Draco_Linux64.cmake
+#------------------------------------------------------------------------------#
+
+

--- a/regression/Draco_Win32.cmake
+++ b/regression/Draco_Win32.cmake
@@ -11,12 +11,12 @@
 cmake_minimum_required(VERSION 3.9.0)
 
 # Use:
-# - See draco/regression/regression_master.sh
+# - See draco/regression/win32-regression-master.bat
 # - Summary: The script must do something like this:
 #   [export work_dir=/full/path/to/working/dir]
 #   ctest [-V] [-VV] -S /path/to/this/script.cmake,\
 #     [Experimental|Nightly|Continuous],\
-#     [Debug[,Coverage]|Release|RelWithDebInfo]
+#     [Debug[,Coverage|,DynamicAnalysis]|Release|RelWithDebInfo]
 
 set( CTEST_PROJECT_NAME "Draco" )
 message("source ${CTEST_SCRIPT_DIRECTORY}/draco_regression_macros.cmake" )
@@ -24,7 +24,7 @@ include( "${CTEST_SCRIPT_DIRECTORY}/draco_regression_macros.cmake" )
 set_defaults()
 parse_args()
 find_tools()
-  set_git_command("Draco.git")
+set_git_command("Draco.git")
 
 # Make machine name lower case
 string( TOLOWER "${CTEST_SITE}" CTEST_SITE )
@@ -46,13 +46,15 @@ CTEST_TEST_TIMEOUT:STRING=${CTEST_TEST_TIMEOUT}
 
 VENDOR_DIR:PATH=${VENDOR_DIR}
 AUTODOCDIR:PATH=${AUTODOCDIR}
-
-CMAKE_MAKE_PROGRAM:FILEPATH=${MAKECOMMAND}
+# CMAKE_MAKE_PROGRAM:FILEPATH=${MAKECOMMAND}
+${TEST_PPE_BINDIR}
+USE_CUDA:BOOL=${USE_CUDA}
 
 ${INIT_CACHE_PPE_PREFIX}
 ${TOOLCHAIN_SETUP}
 # Set DRACO_DIAGNOSTICS and DRACO_TIMING:
 ${FULLDIAGNOSTICS}
+${BOUNDS_CHECKING}
 ")
 
 message("CTEST_INITIAL_CACHE =
@@ -78,7 +80,6 @@ if( ${CTEST_CONFIGURE} )
     message( "ctest_empty_binary_directory( ${CTEST_BINARY_DIRECTORY} )" )
     ctest_empty_binary_directory( ${CTEST_BINARY_DIRECTORY} )
   endif()
-
   # dummy command to give the file system time to catch up before creating
   # CMakeCache.txt.
   # file( WRITE $ENV{TEMP}/foo.txt ${CTEST_INITIAL_CACHE} )
@@ -108,7 +109,7 @@ if( ${CTEST_CONFIGURE} )
 endif()
 
 # Autodoc
-if( ${CTEST_AUTODOC} )
+if( ${CTEST_BUILD} AND ${CTEST_AUTODOC} )
   message( "ctest_build(
    TARGET autodoc
    NUMBER_ERRORS num_errors
@@ -130,9 +131,9 @@ endif()
 if( ${CTEST_BUILD} )
    message( "ctest_build(
    TARGET install
+   RETURN_VALUE res
    NUMBER_ERRORS num_errors
-   NUMBER_WARNINGS num_warnings
-   RETURN_VALUE res )" )
+   NUMBER_WARNINGS num_warnings )" )
    ctest_build(
       TARGET install
       RETURN_VALUE res
@@ -181,3 +182,4 @@ message("end of ${CTEST_SCRIPT_NAME}.")
 #------------------------------------------------------------------------------#
 # End Draco_Win32.cmake
 #------------------------------------------------------------------------------#
+

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -142,8 +142,8 @@ win32$ set work_dir=c:/full/path/to/work_dir
 
   if( WIN32 )
     # add option for "NMake Makefiles JOM"?
-    set( CTEST_CMAKE_GENERATOR "NMake Makefiles" )
-    # set( CTEST_CMAKE_GENERATOR "Visual Studio 11" )
+    # set( CTEST_CMAKE_GENERATOR "NMake Makefiles" )
+    set( CTEST_CMAKE_GENERATOR "Visual Studio 15 2017" )
   else()
     set( CTEST_CMAKE_GENERATOR "Unix Makefiles" )
   endif()
@@ -266,7 +266,7 @@ macro( parse_args )
     set( CTEST_BUILD_CONFIGURATION "RelWithDebInfo" )
   elseif( ${CTEST_SCRIPT_ARG} MATCHES MinSizeRel )
     set( CTEST_BUILD_CONFIGURATION "MinSizeRel" )
-  endif( ${CTEST_SCRIPT_ARG} MATCHES Debug )
+  endif()
 
   # Post options: SubmitOnly or NoSubmit
   set( CTEST_CONFIGURE OFF )
@@ -291,10 +291,6 @@ macro( parse_args )
   endif()
 
   # default compiler name based on platform
-  if( WIN32 )
-    set( compiler_short_name "cl" )
-  endif()
-
   unset(compiler_version)
   if( DEFINED ENV{LCOMPILERVER} )
     set( compiler_version $ENV{LCOMPILERVER} )
@@ -338,6 +334,15 @@ macro( parse_args )
       OUTPUT_STRIP_TRAILING_WHITESPACE )
     string( REGEX REPLACE "[^0-9]*([0-9]+).([0-9]+).([0-9]+).*" "\\1.\\2.\\3"
       compiler_version ${cxx_version} )
+  elseif( CTEST_CMAKE_GENERATOR MATCHES "Visual Studio" )
+    set( compiler_short_name "cl" )
+    execute_process( COMMAND cl
+      ERROR_VARIABLE cxx_version
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_QUIET
+      )
+    string( REGEX REPLACE "[^0-9]*([0-9]+).([0-9]+).([0-9]+).*" "\\1.\\2.\\3"
+      compiler_version "${cxx_version}" )
   else()
     set( compiler_short_name "unknown" )
     set( compiler_version "unknown" )
@@ -362,11 +367,9 @@ macro( parse_args )
 
   # Set the build name: (<platform>-<compiler>-<configuration>)
   if( WIN32 )
-    if( "$ENV{dirext}" MATCHES "x64" )
-      set( CTEST_BUILD_NAME "${CTEST_BUILD_CONFIGURATION}" )
-    else()
-      set( CTEST_BUILD_NAME "${CTEST_BUILD_CONFIGURATION}" )
-    endif()
+    set( CTEST_BUILD_NAME "${CTEST_BUILD_CONFIGURATION}" )
+    # if( "$ENV{dirext}" MATCHES "x64" )
+    # endif()
   elseif( APPLE ) # OS/X
     set( CTEST_BUILD_NAME "${compiler_short_name}_${CTEST_BUILD_CONFIGURATION}" )
   else() # Unix
@@ -376,6 +379,10 @@ macro( parse_args )
     endif()
     set( CTEST_BUILD_NAME "${compiler_short_name}_${CTEST_BUILD_CONFIGURATION}-$ENV{featurebranch}" )
   endif()
+
+  # I think this is only used by msbuild targets (e.g. 'ctest -j 4 -C Debug'),
+  # but I want to define it universally.
+  set( CTEST_CONFIGURATION_TYPE "${CTEST_BUILD_CONFIGURATION}" )
 
   # Default is no Coverage Analysis
   if( ${CTEST_SCRIPT_ARG} MATCHES Coverage )
@@ -410,6 +417,7 @@ macro( parse_args )
     message("
 CTEST_MODEL                 = ${CTEST_MODEL}
 CTEST_BUILD_CONFIGURATION   = ${CTEST_BUILD_CONFIGURATION}
+CTEST_CONFIGURATION_TYPE    = ${CTEST_CONFIGURATION_TYPE}
 compiler_short_name         = ${compiler_short_name}
 compiler_version            = ${compiler_version}
 CTEST_BUILD_NAME            = ${CTEST_BUILD_NAME}
@@ -467,20 +475,14 @@ macro( find_tools )
     message( FATAL_ERROR "Cound not find cmake executable." )
   endif()
 
-  find_program( MAKECOMMAND
-    NAMES nmake make
-    HINTS
-      "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/bin"
-      # NO_DEFAULT_PATH
-    )
-  if( NOT EXISTS "${MAKECOMMAND}" )
-    message( FATAL_ERROR "Cound not find make/nmake executable." )
+  if( NOT WIN32 )
+    # if MAKECOMMAND is found when using "Visual Studio" as the generator,
+    # the compiler 'cl' will be found to be unable to compile a simple 
+    # program.
+    find_program( MAKECOMMAND NAMES make )
+    # No memory check program on Windows for now.
+    find_program( CTEST_MEMORYCHECK_COMMAND NAMES valgrind )
   endif()
-
-  find_program( CTEST_MEMORYCHECK_COMMAND NAMES valgrind )
-  # --show-reachable --num-callers=50
-  # --suppressions=<filename>
-  # --gen-suppressions=all|yes|no
 
   if(ENABLE_C_CODECOVERAGE)
     find_program( COV01 NAMES cov01 )
@@ -515,7 +517,6 @@ MAKECOMMAND         = ${MAKECOMMAND}
 CTEST_MEMORYCHECK_COMMAND         = ${CTEST_MEMORYCHECK_COMMAND}
 MEMORYCHECK_SUPPRESSIONS_FILE     = ${MEMORYCHECK_SUPPRESSIONS_FILE}
 CTEST_MEMORYCHECK_COMMAND_OPTIONS = ${CTEST_MEMORYCHECK_COMMAND_OPTIONS}
-CTEST_CONFIGURE_COMMAND           = ${CTEST_CONFIGURE_COMMAND}
 
 ")
     if(ENABLE_C_CODECOVERAGE)

--- a/regression/win32-regress.bat
+++ b/regression/win32-regress.bat
@@ -32,22 +32,25 @@ rem set dashboard_type=Experimental
 set dashboard_type=Nightly
 set base_dir=e:\regress
 set comp=cl
-set script_dir=e:\regress\draco\regression
-set script_name=Draco_Win32.cmake
 set ctestparts=Configure,Build,Test,Submit
 
+rem print some information
+echo Environment:  > %logdir%\environment.log 2>&1
+rem echo .
+set > %logdir%\environment.log 2>&1
+rem echo .
+rem echo -----     -----     -----     -----     -----
+
+rem goto :jayennedebug
+
+rem -------------------------------------------------------------------------------------------
 :dracodebug
 
 set subproj=draco
 set build_type=Debug
+set script_name=Draco_Win32.cmake
+set script_dir=e:\regress\draco\regression
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
-
-rem print some information
-echo Environment:
-echo .
-set
-echo .
-echo -----     -----     -----     -----     -----
 
 rem navigate to the workdir
 if not exist %work_dir% mkdir %work_dir%
@@ -59,15 +62,44 @@ if not exist %work_dir%\build mkdir build
 if not exist %work_dir%\source mkdir source
 if not exist %work_dir%\target mkdir target
 
-rem goto :jayennerelease
-
 echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log"
-ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log
+ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log 2>&1
 
+rem goto :done
+
+rem -------------------------------------------------------------------------------------------
+:jayennedebug
+
+set subproj=jayenne
+set build_type=Debug
+set script_name=Jayenne_Win32.cmake
+set script_dir=e:\regress\jayenne\regression
+set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
+
+rem navigate to the workdir
+if not exist %work_dir% mkdir %work_dir%
+cd /d %work_dir%
+
+rem clear the build directory (need to do this here to avoid a hang).
+rem if exist %work_dir%\build rmdir /s /q build
+if not exist %work_dir%\build mkdir build
+if not exist %work_dir%\source mkdir source
+if not exist %work_dir%\target mkdir target
+
+rem run the ctest script
+
+echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log"
+ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log 2>&1
+
+rem goto :done
+
+REM rem -------------------------------------------------------------------------------------------
 :dracorelease
 
 set subproj=draco
 set build_type=Release
+set script_name=Draco_Win32.cmake
+set script_dir=e:\regress\draco\regression
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
 
 rem navigate to the workdir
@@ -83,39 +115,18 @@ if not exist %work_dir%\target mkdir target
 rem run the ctest script
 
 echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log"
-ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log
+ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log 2>&1
 
-rem --------------------------------------------------------------------------
+rem release builds are failing so stop here.
+rem goto :done
 
+REM rem --------------------------------------------------------------------------
 :jayennerelease
-
-set script_dir=e:\regress\jayenne\regression
-set script_name=Jayenne_Win32.cmake
 
 set subproj=jayenne
 set build_type=Release
-set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
-
-rem navigate to the workdir
-if not exist %work_dir% mkdir %work_dir%
-cd /d %work_dir%
-
-rem clear the build directory (need to do this here to avoid a hang).
-rem if exist %work_dir%\build rmdir /s /q build
-if not exist %work_dir%\build mkdir build
-if not exist %work_dir%\source mkdir source
-if not exist %work_dir%\target mkdir target
-
-rem goto :jayennedebug
-
-rem run the ctest script
-
-echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log"
-ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log
-
-:jayennedebug
-
-set build_type=Debug
+set script_dir=e:\regress\jayenne\regression
+set script_name=Jayenne_Win32.cmake
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
 
 rem navigate to the workdir
@@ -131,8 +142,11 @@ if not exist %work_dir%\target mkdir target
 rem run the ctest script
 
 echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log"
-ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log
+ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\%subproj%-%build_type%-cbts.log 2>&1
 
-
+rem -------------------------------------------------------------------------------------------
 :done
-echo You need to remove -k from script launch to let this window close automatically.
+rem echo You need to remove -k from script launch to let this window close automatically.
+echo All done.
+
+

--- a/regression/win32-regression-master.bat
+++ b/regression/win32-regression-master.bat
@@ -7,6 +7,8 @@ rem Note  : Copyright (C) 2016-2017, Los Alamos National Security, LLC.
 rem         All rights are reserved.
 rem ---------------------------------------------------------------------------
 
+rem Resource for batch file syntax and commands: https://ss64.com/nt/
+
 rem Use Task Scheduler to create a task that runs this script every night at 
 rem midnight.
 


### PR DESCRIPTION
**Purpose:**

+ MSBuild is faster and easier to debug with Visual Studio.
+ MSBuild works better with libraries created with MinGW's gfortran.

**Details:**

+ In `CTestCustom.cmake`, set hard limits on how much data is collected for CDash.
+ Synchronize `Draco_Linux64.cmake` and `Draco_Win32.cmake`.
+ In `draco_regression_macros.cmake`, for Win32 platforms:
  - use the *Visual Studio 15 2017* project generator instead of *NMake Makefiles*.
  - do a better job of setting the compiler name and version.
  - ensure that `CTEST_CONFIGURATION_TYPE` is set.  Because *Visual Studio 15 2017* projects don't specify the build type (multi-config builds), this value must be specified when running ctest: `ctest -j 4 -C ${CTEST_CONFIGURATION_TYPE}`
  - Ensure that `MAKECOMMAND` is not set.
+ Dump the regression environment to its own file instead of including it in the build log.
+ Rework setting of variables in the regression script to make each section more independent.

**Checks:**

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
