### PR TITLE
Split RUN_VERIFICATION_TESTS away from Release regressions

### DIFF
--- a/regression/Draco_Linux64.cmake
+++ b/regression/Draco_Linux64.cmake
@@ -26,9 +26,6 @@ parse_args()
 find_tools()
 set_git_command("Draco.git")
 
-# Make machine name lower case
-string( TOLOWER "${CTEST_SITE}" CTEST_SITE )
-
 ####################################################################
 # The values in this section are optional you can either
 # have them or leave them commented out
@@ -53,6 +50,8 @@ ${INIT_CACHE_PPE_PREFIX}
 ${TOOLCHAIN_SETUP}
 # Set DRACO_DIAGNOSTICS and DRACO_TIMING:
 ${FULLDIAGNOSTICS}
+# vtest, perfbench options
+${CUSTOM_VARS}
 ${DRACO_C4}
 ${DRACO_LIBRARY_TYPE}
 ${BOUNDS_CHECKING}

--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -13,12 +13,9 @@
 */20 * * * * /scratch/regress/draco/regression/sync_repository.sh
 
 # Run the metrics report on the first Monday of each month.
-#00 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
-#02 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
-#04 07 1-7 * * [ "$(date '+\%a')" == "Mon" ] && /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
-00 07 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
-02 07 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
-04 07 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
+00 05 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p draco
+02 05 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p jayenne
+04 05 1-7 * 1 /scratch/regress/draco/regression/metrics_report.sh -e kgt@lanl.gov -p capsaicin
 
 #------------------------------------------------------------------------------#
 # Regressions:
@@ -30,21 +27,30 @@
 # -e extra args:
 #    coverage        - build bullseyecoverage data and send it to cdash
 #    clang
+#    scalar          - build w/o MPI.
+#    static          - static linking (default is dynamic/shared libs)
 #    valgrind
+#    vtest           - verification tests (long running tests)
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# gcc-7.2.0, openmpi-2.1.1
 #------------------------------------------------------------------------------#
 
 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p \"draco jayenne capsaicin\"
+
+45 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"jayenne capsaicin\" -e vtest
 
 00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e coverage
 
 00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e valgrind
 
-00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco\" -e scalar
+00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne\" -e scalar
 
-15 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco\" -e static
+15 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne\" -e static
 
 #------------------------------------------------------------------------------#
-# Clang-3.8.0, gcc-6.1.0
+# Clang-4.0.1, openmpi-2.1.1
 #------------------------------------------------------------------------------#
 
 00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e clang

--- a/regression/ccscs-options.sh
+++ b/regression/ccscs-options.sh
@@ -13,7 +13,7 @@
 
 # Main Options
 export machine_name_long="Linux64 on CCS LAN"
-platform_extra_params="clang coverage fulldiagnostics gcc630 nr perfbench scalar static valgrind"
+platform_extra_params="clang coverage fulldiagnostics gcc630 nr perfbench scalar static valgrind vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
 
 ##---------------------------------------------------------------------------##

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -106,20 +106,22 @@ dm_gcc="gcc/7.2.0 cmake netlib-lapack gsl metis random123 csk qt"
 dm_openmpi="openmpi parmetis superlu-dist trilinos"
 export dracomodules="$dm_core $dm_gcc $dm_openmpi"
 
+# default compiler
+comp=gcc
 # use bash_functions.sh::add_to_path?
 if [ -d $VENDOR_DIR/bin ] && [[ ":${PATH}:" != *":${VENDOR_DIR}/bin:"* ]]; then
   PATH="${PATH:+${PATH}:}${VENDOOR_DIR}/bin"
 fi
 
 # Setup for special builds (extra_params)
+# This variable is known by draco_regression_macros.cmake and is used for
+# setting up ctest for special builds (like static or vtest).
 case $extra_params in
   "")
     run "module load $dracomodules"
-    comp=gcc
     ;;
   coverage)
     run "module load $dracomodules"
-    comp=gcc
     echo "Coverage option selected."
     if ! [[ "${build_type}" == "Debug" ]]; then
       die "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
@@ -139,7 +141,6 @@ case $extra_params in
     ;;
   fulldiagnostics)
     run "module load $dracomodules"
-    comp="gcc-fulldiagnostics"
     ;;
 #  gcc630)
 #    run "module load $dracomodules"
@@ -147,20 +148,20 @@ case $extra_params in
 #    ;;
   scalar)
     run "module load $dracomodules"
-    comp="gcc-scalar"
     ;;
   static)
     run "module load $dracomodules"
-    comp="gcc-staticlink"
     ;;
   valgrind)
     run "module load $dracomodules valgrind"
-    comp=gcc
     echo "Dynamic Analysis (valgrind) option selected."
     if ! [[ "${build_type}" == "Debug" ]]; then
       die "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
     fi
     build_type=DynamicAnalysis
+    ;;
+  vtest)
+    run "module load $dracomodules"
     ;;
   *)
     echo "FATAL ERROR"
@@ -170,7 +171,11 @@ case $extra_params in
     ;;
 esac
 run "module list"
-comp=$comp-$featurebranch
+if [[ $extra_params ]]; then
+  comp=$comp-$extra_params-$featurebranch
+else
+  comp=$comp-$featurebranch
+fi
 
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if test "$USER" == "kellyt"; then

--- a/regression/ccscs2-crontab
+++ b/regression/ccscs2-crontab
@@ -16,9 +16,19 @@
 # -e extra args:
 #    coverage        - build bullseyecoverage data and send it to cdash
 #    clang
+#    scalar          - build w/o MPI.
+#    static          - static linking (default is dynamic/shared libs)
+#    valgrind        - memory testing
+#    vtest           - verification tests (long running tests)
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# gcc-7.2.0, openmpi-2.1.1
 #------------------------------------------------------------------------------#
 
 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"draco jayenne capsaicin\"
+
+05 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \" jayenne capsaicin\" -e vtest
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -155,6 +155,10 @@ function startCI()
   if ! [[ ${pr} == "develop" ]]; then
     pr=pr${pr}
   fi
+  if [[ ${project} == "draco" ]] && [[ ${extra} == 'vtest' ]]; then
+    # Capsaicin/Jayenne -e vtest uses Draco w/o 'vtest'
+    extra="na"
+  fi
   if [[ ${extra} == 'na' ]]; then
     extra=""
     edash=""
@@ -241,7 +245,9 @@ esac
 echo " "
 case $target in
   # CCS-NET: Release
-  ccscs2*) startCI ${project} Release na $pr ;;
+  ccscs2*)
+    startCI ${project} Release na $pr
+    startCI ${project} Release vtest $pr ;;
 
   # CCS-NET: Valgrind (Debug)
   ccscs6*) startCI ${project} Debug valgrind $pr ;;
@@ -255,12 +261,14 @@ case $target in
   # Snow: Debug
   sn-fe*)
     startCI ${project} Release na $pr
+    startCI ${project} Release vtest $pr
     startCI ${project} Debug fulldiagnostics $pr
     ;;
 
   # Trinitite: Release
   tt-fe*)
     startCI ${project} Release na $pr
+    startCI ${project} Release vtest $pr
     startCI ${project} Release knl $pr
     ;;
 

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -357,21 +357,31 @@ macro( parse_args )
     set( compiler_short_name "${compiler_short_name}-$ENV{extra_params}" )
     if( $ENV{extra_params} MATCHES "cuda" )
       set(USE_CUDA ON)
-    elseif( $ENV{extra_params} MATCHES "fulldiagnostics" )
+    endif()
+    if( $ENV{extra_params} MATCHES "fulldiagnostics" )
       set( FULLDIAGNOSTICS "DRACO_DIAGNOSTICS:STRING=7")
-      # Note 'DRACO_TIMING:STRING=2' will break milagro tests (python cannot parse output).
-    elseif( $ENV{extra_params} MATCHES "nr" )
+      # Note 'DRACO_TIMING:STRING=2' will break milagro tests (python cannot
+      # parse output).
+    endif()
+    if( $ENV{extra_params} MATCHES "nr" )
       set( RNG_NR "ENABLE_RNG_NR:BOOL=ON" )
-    elseif( $ENV{extra_params} MATCHES "scalar" )
+    endif()
+    if( $ENV{extra_params} MATCHES "scalar" )
       set( DRACO_C4 "DRACO_C4:STRING=SCALAR" )
     elseif( $ENV{extra_params} MATCHES "static" )
       set( DRACO_LIBRARY_TYPE "DRACO_LIBRARY_TYPE:STRING=STATIC" )
+    endif()
+    if( $ENV{extra_params} MATCHES "vtest" )
+      string( APPEND CUSTOM_VARS " RUN_VERIFICATION_TESTS:BOOL=ON" )
+    endif()
+    if( ${extra_params} MATCHES "perfbench" )
+      string( APPEND CUSTOM_VARS " ENABLE_PERFBENCH:BOOL=ON" )
     endif()
   endif()
 
   # Set the build name: (<platform>-<compiler>-<configuration>)
   if( WIN32 )
-    set( CTEST_BUILD_NAME "${CTEST_BUILD_CONFIGURATION}" )
+    set( CTEST_BUILD_NAME "${compiler_short_name}-${CTEST_BUILD_CONFIGURATION}" )
     # if( "$ENV{dirext}" MATCHES "x64" )
     # endif()
   elseif( APPLE ) # OS/X
@@ -428,6 +438,7 @@ CTEST_BUILD_NAME            = ${CTEST_BUILD_NAME}
 ENABLE_C_CODECOVERAGE       = ${ENABLE_C_CODECOVERAGE}
 ENABLE_DYNAMICANALYSIS      = ${ENABLE_DYNAMICANALYSIS}
 CTEST_USE_LAUNCHERS         = ${CTEST_USE_LAUNCHERS}
+CUSTOM_VARS                 = ${CUSTOM_VARS}
 ")
   endif()
 endmacro( parse_args )
@@ -481,7 +492,7 @@ macro( find_tools )
 
   if( NOT WIN32 )
     # if MAKECOMMAND is found when using "Visual Studio" as the generator,
-    # the compiler 'cl' will be found to be unable to compile a simple 
+    # the compiler 'cl' will be found to be unable to compile a simple
     # program.
     find_program( MAKECOMMAND NAMES make )
     # No memory check program on Windows for now.
@@ -793,8 +804,9 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     # string( REPLACE "Coverage" "Debug"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     string( REPLACE "intel-nr"        "intel" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     string( REPLACE "intel-perfbench" "intel" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+    string( REPLACE "intel-vtest"     "intel" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     string( REPLACE "gcc-perfbench"   "gcc"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    # string( REPLACE "-belosmods"      ""     ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+    string( REPLACE "gcc-vtest"       "gcc"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
 
     if( "${this_pkg}" MATCHES "jayenne" OR "${this_pkg}" MATCHES "capsaicin")
       # If this is jayenne, we might be building a pull request. Replace the PR

--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -15,6 +15,7 @@
 #    pgi   - build with the PGI compiler
 #    nr    - build with non-reproducible option.
 #    fulldiagnostics - build with IEEE checks enabled
+#    vtest - verification tests (long running tests)
 #------------------------------------------------------------------------------#
 
 #------------------------------------------------------------------------------#
@@ -24,6 +25,8 @@
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin\"
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
+
+02 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne capsaicin\" -e vtest
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ml-options.sh
+++ b/regression/ml-options.sh
@@ -13,7 +13,7 @@
 
 # Main Options
 machine_name_long="Moonlight"
-platform_extra_params="fulldiagnostics nr perfbench pgi valgrind"
+platform_extra_params="fulldiagnostics nr perfbench pgi valgrind vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
 
 ##---------------------------------------------------------------------------##

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -138,13 +138,13 @@ cuda)
 #     comp="${comp}-cuda"
     ;;
 fulldiagnostics)
-    comp="${comp}-fulldiagnostics"
+    # no-op
     ;;
 nr)
-    comp="${comp}-nr"
+    # no-op
     ;;
 perfbench)
-    comp="${comp}-perfbench"
+    # no-op
     ;;
 pgi)
     run "module list"
@@ -161,6 +161,9 @@ pgi)
     CC=`which pgcc`
     FC=`which pgf90`
     ;;
+vtest)
+    # no-op
+    ;;
 *)
     echo "FATAL ERROR"
     echo "Extra parameter = ${extra_param} requested but is unknown to"
@@ -171,6 +174,9 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
+if [[ $extra_params ]]; then
+  comp=$comp-$extra_params
+fi
 comp=$comp-$featurebranch
 
 # When run by crontab, use a special ssh-key to allow authentication to gitlab

--- a/regression/scripts/release_toss.sh
+++ b/regression/scripts/release_toss.sh
@@ -79,7 +79,9 @@ export draco_script_dir=`readlink -f $script_dir`
 source $draco_script_dir/common.sh
 
 # CMake options that will be included in the configuration step
-export CONFIG_BASE="-DDRACO_VERSION_PATCH=`echo $ddir | sed -e 's/.*_//'`"
+CONFIG_BASE="-DDRACO_VERSION_PATCH=`echo $ddir | sed -e 's/.*_//'`"
+CONFIG_BASE+=" -DCMAKE_VERBOSE_MAKEFILE=ON"
+export CONFIG_BASE
 
 # sets umask 0002
 # sets $install_group, $install_permissions, $build_permissions

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -18,6 +18,7 @@
 #    pgi   - build with the PGI compiler
 #    nr    - build with non-reproducible option.
 #    fulldiagnostics - build with IEEE checks enabled
+#    vtest           - verification tests (long running tests)
 #------------------------------------------------------------------------------#
 
 #------------------------------------------------------------------------------#
@@ -27,6 +28,8 @@
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin\"
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
+
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \" jayenne capsaicin\" -e vtest
 
 #------------------------------------------------------------------------------#
 # Special: NR, PerfBench and FullDiagnostics regressions.

--- a/regression/sn-options.sh
+++ b/regression/sn-options.sh
@@ -13,7 +13,7 @@
 
 # Main Options
 export machine_name_long="Snow"
-platform_extra_params="fulldiagnostics gcc610 gcc640 newtools nr perfbench valgrind"
+platform_extra_params="fulldiagnostics gcc610 gcc640 newtools nr perfbench valgrind vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
 
 ##---------------------------------------------------------------------------##

--- a/regression/sn-regress.msub
+++ b/regression/sn-regress.msub
@@ -111,7 +111,7 @@ case $extra_params in
     # no-op
     ;;
 fulldiagnostics)
-    comp="${comp}-fulldiagnostics"
+    # no-op
     ;;
 gcc610)
     run "module purge &> /dev/null"
@@ -122,7 +122,6 @@ gcc610)
     run "module load cmake/3.9.0 ndi numdiff git"
     run "module load random123 eospac/6.2.4 lapack/3.6.1"
     comp="${LCOMPILER}"
-    # ${LCOMPILERVER}
     echo "comp = $comp"
     ;;
 gcc640)
@@ -134,26 +133,23 @@ gcc640)
     run "module load cmake/3.9.0 ndi numdiff git"
     run "module load random123 eospac/6.2.4"
     comp="${LCOMPILER}"
-    # ${LCOMPILERVER}
     echo "comp = $comp"
     ;;
 newtools)
     run "module purge &> /dev/null"
     run "module list"
     run "module load user_contrib friendly-testing"
-    run "module load intel/18.0.0 openmpi/2.1.2 mkl"
+    run "module load intel/18.0.1 openmpi/2.1.2 mkl"
     run "module load superlu-dist metis parmetis"
-# Can't build suite-sparse (and thus trilinos) due to intel/18 bug.
-#    run "module load trilinos/12.10.1 superlu-dist metis parmetis"
+    run "module load trilinos/12.10.1 superlu-dist metis parmetis"
     run "module load cmake/3.9.0 ndi numdiff git"
     run "module load mkl random123 eospac/6.2.4 csk"
-    comp="${comp}-1800"
     ;;
 nr)
-    comp="${comp}-nr"
+    # no-op
     ;;
 perfbench)
-    comp="${comp}-perfbench"
+    # no-op
     ;;
 *)
     echo "FATAL ERROR"
@@ -165,6 +161,9 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
+if [[ $extra_params ]]; then
+  comp=$comp-$extra_params
+fi
 comp=$comp-$featurebranch
 
 # When run by crontab, use a special ssh-key to allow authentication to gitlab

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -15,6 +15,7 @@
 #    pgi   - build with the PGI compiler
 #    nr    - build with non-reproducible option.
 #    fulldiagnostics - build with IEEE checks enabled
+#    vtest           - verification tests (long running tests)
 #------------------------------------------------------------------------------#
 
 # --------------------
@@ -25,11 +26,16 @@
 
 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
 
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \" jayenne capsaicin\" -e vtest
+
 # --------------------
 # KNL
 # --------------------
 
 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e knl
+
+# not sure we support two extra parameters (kt)
+#01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e \"knl vtest\"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/tt-options.sh
+++ b/regression/tt-options.sh
@@ -13,7 +13,7 @@
 
 # Main Options
 export machine_name_long="Trinitite"
-platform_extra_params="fulldiagnostics knl  nr perfbench"
+platform_extra_params="fulldiagnostics knl  nr perfbench vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
 
 ##---------------------------------------------------------------------------##

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -145,7 +145,6 @@ case $extra_params in
 knl)
     run "module swap craype-haswell craype-mic-knl"
     export OMP_NUM_THREADS=17
-    comp="${comp}-knl"
     ;;
 "")
     # no-op
@@ -160,6 +159,9 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
+if [[ $extra_params ]]; then
+  comp=$comp-$extra_params
+fi
 comp=$comp-$featurebranch
 
 # When run by crontab, use a special ssh-key to allow authentication to gitlab


### PR DESCRIPTION
**Background**

Previously, *Release* regressions included long running verification tests (`RUN_VERIFICATION_TESTS=ON`). However, these regression suites were generating too much data to upload to CDash resulting in partial reports (no test results).  It also meant that *Release* regressions would take a long time to run.

This change splits the running of these long running tests into a separate regression suite (*vtest*).

**Changes**

+ Run these tests in a new regression suite 'vtest'
+ Add new 'vtest' regressions in crontab files that already run 'Release' regressions.
+ Register new 'extra_param' option 'vtest' in the regression system.
+ Ensure that the 'extra_param' string is appended to the build name.
+ [Refs #1052 (Redmine)](https://rtt.lanl.gov/redmine/issues/1052).
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
