### PR TITLE
Update the 'newtools' nightly regression and reduce disk space usage.

### DIFF
--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -35,9 +35,9 @@
 # Special: NR, PerfBench and FullDiagnostics regressions.
 #------------------------------------------------------------------------------#
 
-# intel-18.0.0 + openmpi-2.1.2
-# compiler segfault when building suite-sparse -> no trilinos -> omit capsaicin.
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne\" -e newtools
+# intel-18.0.1 + openmpi-2.1.2
+# comiler segfault when building suite-sparse -> no trilinos -> omit capsaicin.
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e newtools
 
 # gcc-6.4.0 + openmpi-2.1.2
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e gcc640

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -36,7 +36,7 @@
 #------------------------------------------------------------------------------#
 
 # intel-18.0.1 + openmpi-2.1.2
-# comiler segfault when building suite-sparse -> no trilinos -> omit capsaicin.
+# compiler segfault when building suite-sparse -> no trilinos -> omit capsaicin.
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e newtools
 
 # gcc-6.4.0 + openmpi-2.1.2

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -133,8 +133,8 @@ fi
 if [[ -d /usr/projects/ccsrad/regress/cdash ]]; then
   echo -e "\nCleaning up old builds."
   run "cd /usr/projects/ccsrad/regress/cdash"
-  run "find . -maxdepth 3 -mtime +3 -name 'Experimental*-pr*' -type d"
-  run "find . -maxdepth 3 -mtime +3 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
+  run "find . -maxdepth 3 -mtime +2 -name 'Experimental*-pr*' -type d"
+  run "find . -maxdepth 3 -mtime +2 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
 fi
 
 echo -e "\n--------------------------------------------------------------------------------"


### PR DESCRIPTION
+ Add Capsaicin to the `newtools` regression. The `newtools` regression only runs on Snow.  It currently uses `intel/18.0.1` and `openmpi/2.1.2`.
+ For trinitite regressions, only keep build directories for 2 days.  This change is needed to prevent us from exceeding our disk quota at `/usr/projects/ccsrad`.  On trinitite, we must run the regressions in NFS space to work around srun defects. Regressions for other systems use lustre scratch space and we keep old build directories for 2 weeks.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
