### PR TITLE
Update draco environment to support Badger.

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -120,8 +120,7 @@ fi
 ## ENVIRONMENTS - once per login
 ##---------------------------------------------------------------------------##
 
-#if test ${DRACO_BASHRC_DONE:-no} = no && test ${INTERACTIVE} = true; then
-if [[ ${INTERACTIVE} = true ]]; then
+if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
 
   # Clean up the default path to remove duplicates
   tmpifs=$IFS
@@ -179,13 +178,13 @@ if [[ ${INTERACTIVE} = true ]]; then
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_darwin_fe
       ;;
 
-    # Mapache | Moonlight | Mustang | Pinto | Wolf | Luna
+    # Luna | Moonlight | Pinto | Wolf
     lu* | ml* | pi* | wf* )
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_toss22
       ;;
 
-    # Snow | Fire | Ice
-    sn* | fi* | ic* )
+    # Snow | Badger | Fire | Ice
+    sn* | ba* | fi* | ic* )
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_toss3
       ;;
 
@@ -223,31 +222,18 @@ if [[ ${INTERACTIVE} = true ]]; then
 
   esac
 
-  # Generic functions for loading/unloaded the default set of modules.
-  fn_exists=`type dracoenv 2>/dev/null | head -n 1 | grep -c 'is a function'`
-  if test $fn_exists = 0; then
-    # only define if they do not already exist...
-    function dracoenv ()
-    {
-      module load $dracomodules
-    }
-    function rmdracoenv ()
-    {
-      # unload in reverse order.
-      mods=( ${dracomodules} )
-      for ((i=${#mods[@]}-1; i>=0; i--)); do
-        loaded=`echo $LOADEDMODULES | grep -c ${mods[$i]}`
-        if test $loaded = 1; then
-          module unload ${mods[$i]}
-        fi
-      done
-    }
-  fi
+  source ${DRACO_ENV_DIR}/bashrc/bash_functions2.sh
   dracoenv
 
   # Mark that we have already done this setup
   export DRACO_BASHRC_DONE=yes
 
+fi
+
+if ! [[ ${INTERACTIVE} ]]; then
+  # provide some bash functions (dracoenv, rmdracoenv) for non-interactive
+  # sessions.
+  source ${DRACO_ENV_DIR}/bashrc/bash_functions2.sh
 fi
 
 ##---------------------------------------------------------------------------##

--- a/environment/bashrc/.bashrc_toss3
+++ b/environment/bashrc/.bashrc_toss3
@@ -57,7 +57,7 @@ else
   module load friendly-testing
   module use --append ${VENDOR_DIR}-ec/modulefiles
 
-  export dracomodules="ack cloc htop clang-format/3.9.0 \
+  export dracomodules="ack htop clang-format/3.9.0 \
 intel/17.0.4 openmpi/2.1.2 mkl \
 subversion cmake/3.9.0 numdiff git totalview trilinos/12.10.1 \
 superlu-dist/5.1.3 metis parmetis ndi random123 eospac/6.2.4 csk"

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -45,7 +45,7 @@ fi
 #
 # OpenMP
 #
-# export OMP_PLACES=threads
+# export OMP_PLACES=threads # lmdm says do not set this!
 if [[ `lscpu | grep Flags | grep -c avx512` == 0 ]]; then
   export OMP_NUM_THREADS=16
   export NRANKS_PER_NODE=32
@@ -76,8 +76,8 @@ if [[ ${SLURM_JOB_PARTITION} == "knl" ]]; then
 fi
 
 export dracomodules="cmake/3.9.0 git subversion \
-clang-format csk eospac/6.2.4 gsl/2.3 metis ndi numdiff random123 \
-parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1"
+clang-format eospac/6.2.4 gsl/2.3 metis ndi numdiff random123 \
+parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1 csk"
 
 function dracoenv ()
 {

--- a/environment/bashrc/bash_functions2.sh
+++ b/environment/bashrc/bash_functions2.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+##-*- Mode: bash -*-
+##---------------------------------------------------------------------------##
+## File  : environment/bashrc/bash_functions2.sh
+## Date  : Thursday, Dec 21, 2017, 12:14 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+##  Bash configuration file upon bash shell startup
+##---------------------------------------------------------------------------##
+
+# Generic functions for loading/unloaded the default set of modules.
+fn_exists=`type dracoenv 2>/dev/null | head -n 1 | grep -c 'is a function'`
+if test $fn_exists = 0; then
+  # only define if they do not already exist...
+  function dracoenv ()
+  {
+    module load $dracomodules
+  }
+  function rmdracoenv ()
+  {
+    # unload in reverse order.
+    mods=( ${dracomodules} )
+    for ((i=${#mods[@]}-1; i>=0; i--)); do
+      loaded=`echo $LOADEDMODULES | grep -c ${mods[$i]}`
+      if test $loaded = 1; then
+        module unload ${mods[$i]}
+      fi
+    done
+  }
+fi
+
+##---------------------------------------------------------------------------##
+## end of environment/bashrc/bash_functions2.sh
+##---------------------------------------------------------------------------##

--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -464,12 +464,15 @@ auto-mode-alist."
 	     ) auto-mode-alist))
 
     (defun draco-f90-mode-hook ()
-      "Hooks added to F90 mode"
+      "Hooks added to F90 mode. See https://jblevins.org/log/f90-mode"
       (local-set-key [(f5)]         'draco-f90-subroutine-divider)
       (local-set-key [(control f6)] 'draco-f90-insert-document)
       (local-set-key [(f6)]         'draco-f90-comment-divider)
       (draco-mode-update-menu (draco-menu-insert-comments-f90))
       (set-fill-column draco-code-comment-width)
+      (abbrev-mode 1)
+      (setq f90-font-lock-keywords f90-font-lock-keywords-3)
+      (setq f90-beginning-ampersand nil)
       (require 'fill-column-indicator)
       (fci-mode))
      ;; let .F denone Fortran and not freeze files


### PR DESCRIPTION
+ Teach the bashrc files about badger (ba-fey).
+ Move the bash functions from `bashrc/.bashrc` into a `bash_functions_2.sh`.  Bash functions are not inherited by subshells, so change the environment logic to define bash functions like `dracoenv` everytime a new shell is started.
+ Fixes [Redmine 1061](https://rtt.lanl.gov/redmine/issues/1061)

Somewhat unrelated:
+ For the Draco Emacs modes: For f90-mode (a) enable abbrev-mode, (b) disable beginning ampersand (except for strings), and (c) colorize more keywords.

* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
