### PR TITLE
Minor Dev/Regression environment updates.

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -43,7 +43,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
 
 # Suppress warnings about typeid() called with function as an argument. In this
 # case, the function might not be called if the type can be deduced.
-   set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS} -stdlib=libc++ -Wno-potentially-evaluated-expression" ) #  -std=c++11" )
+   set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS} -stdlib=libc++ -Wno-potentially-evaluated-expression" )
    if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8 )
      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
    endif()

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -5,12 +5,9 @@
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 
-# History
-# ----------------------------------------
-# 6/13/2016  - IPO settings moved to compilerEnv.cmake
-#              (CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON). As of cmake/3.7, this
-#              only turns on IPO for Intel, so we still add -flto for release
-#              builds.
+# Note: In config/compilerEnv.cmake, the build system sets flags for
+# 1) the language standard (C++14, C99, etc)
+# 2) interprocedural optimization.
 
 # Notes:
 # ----------------------------------------
@@ -20,12 +17,6 @@
 # http://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 # https://gcc.gnu.org/gcc-5/changes.html
 # http://stackoverflow.com/questions/3375697/useful-gcc-flags-for-c
-
-# Require GCC-4.7 or later
-if( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7 )
-  message( FATAL_ERROR "Draco requires GNU compilers v.4.7 or later.
-This requirement is tied to support of the C++11 standard.")
-endif()
 
 #
 # Declare CMake options related to GCC

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -46,7 +46,7 @@ case $target in
     if [[ -d $HOME/privatemodules ]]; then
       module use --append $HOME/privatemodules
     fi
-    dm_core="eospac git tk ndi python doxygen ccache numdiff totalview \
+    dm_core="eospac git tk ndi python doxygen numdiff totalview \
 dia graphviz ack"
     dm_gcc="gcc/7.2.0 cmake netlib-lapack gsl metis random123 csk qt"
     dm_openmpi="openmpi parmetis superlu-dist trilinos valgrind"

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -36,7 +36,6 @@
 #------------------------------------------------------------------------------#
 
 # intel-18.0.1 + openmpi-2.1.2
-# compiler segfault when building suite-sparse -> no trilinos -> omit capsaicin.
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e newtools
 
 # gcc-6.4.0 + openmpi-2.1.2

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -26,7 +26,7 @@
 
 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\"
 
-01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \" jayenne capsaicin\" -e vtest
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne capsaicin\" -e vtest
 
 # --------------------
 # KNL


### PR DESCRIPTION
+ No longer load _ccache_ automatically on ccs-net machines.  _ccache_ has been causing trouble for a couple of developers.  You can always load it in your own `.bashrc` or manually.
+ Remove error check for _gcc_ version < 4.8.  This is no longer needed since we require c++14 and CMake will fire an assertion if _gcc_ is too old.
+ Clean up some comment blocks.
* [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation

  
  