### PR TITLE
Tweaks to fix broken builds for C4_SCALAR.

### DIFF
--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -3,9 +3,8 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for c4
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2018, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
 project( c4 CXX )

--- a/src/c4/Invert_Comm_Map.cc
+++ b/src/c4/Invert_Comm_Map.cc
@@ -5,8 +5,7 @@
  * \date   Mon Nov 19 10:09:11 2007
  * \brief  Implementation of Invert_Comm_Map
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Invert_Comm_Map.hh"

--- a/src/c4/Invert_Comm_Map.hh
+++ b/src/c4/Invert_Comm_Map.hh
@@ -5,8 +5,7 @@
  * \date   Mon Nov 19 10:09:10 2007
  * \brief  Implementation of Invert_Comm_Map
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef c4_Invert_Comm_Map_hh

--- a/src/c4/MPI_Traits.hh
+++ b/src/c4/MPI_Traits.hh
@@ -5,10 +5,7 @@
  * \date   Thu Mar 21 11:07:40 2002
  * \brief  Traits classes for MPI types.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef c4_MPI_Traits_hh
@@ -23,21 +20,22 @@ namespace rtt_c4 {
  * \struct MPI_Traits
  *
  * \brief Provide a generic way to get MPI_Datatype arguments for MPI function
- * calls. 
+ *        calls.
  *
  * This struct provides a generic programming--common way to get MPI_Datatype
  * arguments for MPI function calls. The static function, element_type(),
- * returns an argument of type MPI_Datatype that matches a C++ datatype with
- * an MPI_Datatype.
- *
+ * returns an argument of type MPI_Datatype that matches a C++ datatype with an
+ * MPI_Datatype.
  */
 //===========================================================================//
 
-template <class T> struct MPI_Traits {};
+template <typename T> struct MPI_Traits {};
 
 //---------------------------------------------------------------------------//
 // SPECIALIZATIONS OF MPI_Traits FOR DIFFERENT TYPES
 //---------------------------------------------------------------------------//
+
+#ifdef C4_MPI
 
 template <> struct MPI_Traits<bool> {
   static MPI_Datatype element_type() { return MPI_C_BOOL; }
@@ -94,6 +92,8 @@ template <> struct MPI_Traits<double> {
 template <> struct MPI_Traits<long double> {
   static MPI_Datatype element_type() { return MPI_LONG_DOUBLE; }
 };
+
+#endif
 
 } // end namespace rtt_c4
 

--- a/src/c4/c4_mpi.h
+++ b/src/c4/c4_mpi.h
@@ -13,8 +13,10 @@
 
 #include "c4/config.h"
 
-/* defined in ac_vendors.m4, location of <mpi.h> */
+/* defined in config/setupMPI.cmake */
+#ifdef C4_MPI
 #include <mpi.h>
+#endif
 
 #ifndef DRACO_MAX_PROCESSOR_NAME
 #ifdef MPI_MAX_PROCESSOR_NAME


### PR DESCRIPTION
### Background

* Draco fails to compile if `<mpi.h>` isn't found, even when `C4_SCALAR` is enabled.

### Description of changes

+ Add some ifdefs to allow configure and compile of Draco on a
  system that does not have MPI installed.
+ Also tweak ds++'s CMakeLists.txt.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
