### PR TITLE
Updates to regression scripts

### DIFF
--- a/regression/ccscs-options.sh
+++ b/regression/ccscs-options.sh
@@ -12,6 +12,8 @@
 ##---------------------------------------------------------------------------##
 
 # Main Options
+export machine_class="ccscs"
+export machine_name_short="ccscs"
 export machine_name_long="Linux64 on CCS LAN"
 platform_extra_params="clang coverage fulldiagnostics gcc630 nr perfbench scalar static valgrind vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`

--- a/regression/cts1-job-launch.sh
+++ b/regression/cts1-job-launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##---------------------------------------------------------------------------##
-## File  : regression/sn-job-launch.sh
+## File  : regression/cts1-job-launch.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
 ## Note  : Copyright (C) 2016-2018, Los Alamos National Security, LLC.
@@ -75,7 +75,7 @@ fi
 # Configure on the front end
 echo "Configure:"
 export REGRESSION_PHASE=c
-cmd="${rscriptdir}/sn-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log"
+cmd="${rscriptdir}/cts1-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log"
 echo "${cmd}"
 eval "${cmd}"
 
@@ -87,7 +87,7 @@ logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra
 if [[ -f $logfile ]]; then
   rm $logfile
 fi
-cmd="$MSUB ${access_queue} -o ${logfile} -J ${subproj:0:5}-${featurebranch} -t 4:00:00 ${rscriptdir}/sn-regress.msub"
+cmd="$MSUB ${access_queue} -o ${logfile} -J ${subproj:0:5}-${featurebranch} -t 4:00:00 ${rscriptdir}/${machine_class}-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 # trim extra whitespace from number
@@ -106,12 +106,12 @@ echo " "
 echo "Submit:"
 export REGRESSION_PHASE=s
 echo "Jobs done, now submitting ${build_type} results from ${host}."
-cmd="${rscriptdir}/sn-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-s.log"
+cmd="${rscriptdir}/cts1-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-s.log"
 echo "${cmd}"
 eval "${cmd}"
 
 echo "All done."
 
 ##---------------------------------------------------------------------------##
-## End of sn-job-launch.sh
+## End of ba-job-launch.sh
 ##---------------------------------------------------------------------------##

--- a/regression/cts1-options.sh
+++ b/regression/cts1-options.sh
@@ -1,21 +1,36 @@
 #!/bin/bash
 ## -*- Mode: sh -*-
 ##---------------------------------------------------------------------------##
-## File  : regression/sripts/sn-options.sh
+## File  : regression/sripts/cts1-options.sh
 ## Date  : Tuesday, May 16, 2017, 21:42 pm
 ## Author: Kelly Thompson
 ## Note  : Copyright (C) 2017, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 ##
-## Summary: Capture sn-specific features that plug into regression-master.sh.
+## Summary: Capture cts1-specific features that plug into regression-master.sh.
 ##---------------------------------------------------------------------------##
 
 # Main Options
-export machine_name_long="Snow"
+machine=`uname -n`
+export machine_class="cts1"
+case $machine in
+ba*)
+    export machine_name_short="ba"
+    export machine_name_long="Badger" ;;
+sn*)
+    export machine_name_short="sn"
+    export machine_name_long="Snow" ;;
+ic*)
+    export machine_name_short="ic"
+    export machine_name_long="Ice" ;;
+fi*)
+    export machine_name_short="fi"
+    export machine_name_long="Fire" ;;
+esac
 platform_extra_params="fulldiagnostics gcc610 gcc640 newtools nr perfbench valgrind vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
 
 ##---------------------------------------------------------------------------##
-## End sn-options.sh
+## End cts1-options.sh
 ##---------------------------------------------------------------------------##

--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -1,11 +1,19 @@
 #!/bin/bash -l
 ##---------------------------------------------------------------------------##
-## File  : regression/sn-regression.sh
+## File  : regression/cts1-regress.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
 ## Note  : Copyright (C) 2016-2018, Los Alamos National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
+
+# Under cron, a basic environment might not be loaded yet.
+#if [[ `which srun 2>/dev/null | grep -c srun` == 0 ]]; then
+#  source /etc/bash.bashrc.local
+#fi
+
+# Allow variable as case condition
+shopt -s extglob
 
 #----------------------------------------------------------------------#
 # The script starts here
@@ -13,25 +21,28 @@
 
 # Sanity Check
 # ----------------------------------------
-if [[ ! ${subproj} ]]; then
-   echo "Fatal Error, subproj not found in environment."
-   exit 1
-fi
-if [[ ! ${regdir} ]]; then
-   echo "Fatal Error, regdir not found in environment."
-   exit 1
-fi
 if [[ ! ${rscriptdir} ]]; then
    echo "Fatal Error, rscriptdir not found in environment."
    exit 1
 fi
+
+# import some bash functions
+source $rscriptdir/scripts/common.sh
+
+if [[ ! ${subproj} ]]; then
+  die "Fatal Error, subproj not found in environment."
+fi
+if [[ ! ${regdir} ]]; then
+  die "Fatal Error, regdir not found in environment."
+fi
 if [[ ! ${build_type} ]]; then
-   echo "Fatal Error, build_type not found in environment."
-   exit 1
+  die "Fatal Error, build_type not found in environment."
 fi
 if [[ ! ${logdir} ]]; then
-   echo "Fatal Error, logdir not found in environment."
-   exit 1
+  die "Fatal Error, logdir not found in environment."
+fi
+if [[ `which srun 2>/dev/null | grep -c srun` == 0 ]]; then
+  die "Cannot find srun.  Possibly bad environment or machine issue."
 fi
 
 # Environment setup
@@ -54,9 +65,6 @@ export VENDOR_DIR=/usr/projects/draco/vendors
 # gitlab.lanl.gov has an unkown certificate, disable checking
 export GIT_SSL_NO_VERIFY=true
 
-# import some bash functions
-source $rscriptdir/scripts/common.sh
-
 case $REGRESSION_PHASE in
 c) ctestparts=Configure;;
 bt) ctestparts=Build,Test;;
@@ -68,16 +76,31 @@ s)
     unset HTTP_PROXY
     unset HTTPS_PROXY
     ;;
+  *)
+    echo "Fatal Error, REGRESSION_PHASE = \"${REGRESSION_PHASE}\" does not match \"c\", \"b\", \"t\" or \"s\"."
+    exit 1
+    ;;
 esac
+
+# Host based variables
+# ----------------------------------------
+machine=`uname -n`
+export host=`uname -n | sed -e 's/[.].*//g'`
+platform_extra_params=`echo $platform_extra_params | sed -e 's/ / | /g'`
+source $rscriptdir/cts1-options.sh
 
 # Header
 # ----------------------------------------
-machine=`uname -n`
 echo "==========================================================================="
-echo "Snow regression: ${ctestparts} from ${machine}."
-echo "                 ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
+echo "${machine_name_long} regression: ${ctestparts} from ${machine}."
+echo "                      ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
 echo "==========================================================================="
-
+if [[ ${SLURM_JOB_PARTITION} ]]; then
+  echo " "
+  echo "Allocation configuration:"
+  echo $SLURM_JOB_PARTITION
+  echo " "
+fi
 run "ulimit -a"
 
 # Modules
@@ -155,10 +178,20 @@ nr)
 perfbench)
     # no-op
     ;;
+vtest)
+    # no-op
+    ;;
+@($pem_match) )
+    # found in tt-options.sh but no rule found here
+    echo "FATAL ERROR"
+    echo "Extra parameter = ${extra_param} requested and known by ${machine_name_short}-options.sh,"
+    echo "but ${0##*/} doesn't know about this option."
+    exit 1
+    ;;
 *)
     echo "FATAL ERROR"
     echo "Extra parameter = ${extra_param} requested but is unknown to"
-    echo "the regression system (edit sn-regress.msub)."
+    echo "the regression system (edit ${0##*/})."
     exit 1
     ;;
 esac
@@ -173,13 +206,12 @@ comp=$comp-$featurebranch
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
-  MYHOSTNAME="`uname -n`"
   keychain=keychain-2.7.1
   $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
-  if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
-    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+  if test -f $HOME/.keychain/$machine-sh; then
+    run "source $HOME/.keychain/$machine-sh"
   else
-    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+    echo "Error: could not find $HOME/.keychain/$machine-sh"
   fi
 fi
 
@@ -206,18 +238,18 @@ if [[ ! ${base_dir} ]]; then
       echo "  Have the names/locations of scratch space changed?"
       exit 1
    fi
-   scratchdir=$scratchdir/$LOGNAME/cdash/sn
-   base_dir=$regdir/cdash/sn
+   scratchdir=$scratchdir/$LOGNAME/cdash/${machine_name_short}
+   base_dir=${regdir}/cdash/${machine_name_short}
 fi
 
 echo " "
-echo "sn-regress.msub: dashboard_type = $dashboard_type"
-echo "sn-regress.msub: base_dir       = $base_dir"
-echo "sn-regress.msub: build_type     = $build_type"
-echo "sn-regress.msub: comp           = $comp"
-echo "sn-regress.msub: machine        = $machine"
-echo "sn-regress.msub: subproj        = $subproj"
-echo "sn-regress.msub: regdir         = $regdir"
+echo "${0##*/}: dashboard_type = $dashboard_type"
+echo "${0##*/}: base_dir       = $base_dir"
+echo "${0##*/}: build_type     = $build_type"
+echo "${0##*/}: comp           = $comp"
+echo "${0##*/}: machine        = $machine"
+echo "${0##*/}: subproj        = $subproj"
+echo "${0##*/}: regdir         = $regdir"
 
 #----------------------------------------------------------------------#
 # CTest
@@ -242,8 +274,8 @@ fi
 export work_dir=${base_dir}/${subproj}/${dashboard_type}_${comp}/${build_type}
 export scratch_dir=${scratchdir}/${subproj}/${dashboard_type}_${comp}/${build_type}
 
-echo "sn-regress.msub: work_dir       = ${work_dir}"
-echo "sn-regress.msub: scratch_dir    = ${scratch_dir}"
+echo "${0##*/}: work_dir       = ${work_dir}"
+echo "${0##*/}: scratch_dir    = ${scratch_dir}"
 echo " "
 setup_dirs=`echo $ctestparts | grep Configure`
 if [[ ${setup_dirs} ]]; then
@@ -294,13 +326,14 @@ fi
 # echo "--------------------(end environment)--------------------------"
 
 date
+echo " "
 echo ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 echo " "
 ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 
 if [[ ${regress_mode} == "on" ]]; then
   echo " "
-  run "chgrp -R draco ${work_dir}"
+  run "chgrp -R ccsrad ${work_dir}"
   run "chmod -R g+rX,o-rwX ${work_dir}"
 fi
 

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -796,26 +796,30 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   # Assume that draco_work_dir is parallel to our current location, but only
   # replace the directory name preceeding the dashboard name.
   file( TO_CMAKE_PATH "$ENV{work_dir}" work_dir )
-  string( REGEX REPLACE "${this_pkg}[/\\](Nightly|Experimental|Continuous)" "${dep_pkg}/\\1"
-    ${dep_pkg}_work_dir ${work_dir} )
+  string( REGEX REPLACE "${this_pkg}[/\\](Nightly|Experimental|Continuous)"
+    "${dep_pkg}/\\1" ${dep_pkg}_work_dir ${work_dir} )
 
   # If this is a special build, link to the normal Debug/Release Draco files:
+  #
+  # J/C directory       Draco directory
+  # --------------      -----------------
+  # *-nr-*              *-*
+  # *-vtest-*           *-*
+  # *-perfbench-*       *-*
+
   if( "${dep_pkg}" MATCHES "draco" )
-    # coverage  build -> debug   version of Draco
-    # nr        build -> release version of Draco
-    # perfbench build -> release version of Draco
-    # string( REPLACE "Coverage" "Debug"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    string( REPLACE "intel-nr"        "intel" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    string( REPLACE "intel-perfbench" "intel" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    string( REPLACE "intel-vtest"     "intel" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    string( REPLACE "gcc-perfbench"   "gcc"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    string( REPLACE "gcc-vtest"       "gcc"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+    # not any ${extraparam} since many map to draco builds that have the same
+    # ${extraparam}.  For example: *-newtools-*.
+    foreach( extraparam nr perfbench vtest )
+      string( REPLACE "-${extraparam}-" "-" ${dep_pkg}_work_dir
+        ${${dep_pkg}_work_dir} )
+    endforeach()
 
     if( "${this_pkg}" MATCHES "jayenne" OR "${this_pkg}" MATCHES "capsaicin")
       # If this is jayenne, we might be building a pull request. Replace the PR
       # number in the path with '-develop' before looking for draco.
-      string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/" "\\1_\\2-develop/"
-        ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+      string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/"
+        "\\1_\\2-develop/" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     endif()
   endif()
 

--- a/regression/metrics_report.sh
+++ b/regression/metrics_report.sh
@@ -45,8 +45,8 @@ print_use()
 # fi
 
 mach=`uname -n`
-if test "$mach" != "ccscs7.lanl.gov"; then
-   echo "FATAL ERROR: This script must be run from ccscs7 (or the machine that"
+if test "$mach" != "ccscs2.lanl.gov"; then
+   echo "FATAL ERROR: This script must be run from ccscs2 (or the machine that"
    echo "             has the regression log files)."
    exit 1
 fi

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -44,18 +44,16 @@ else
 fi
 
 # Host based variables
+platform_extra_params=`echo $platform_extra_params | sed -e 's/ / | /g'`
 export host=`uname -n | sed -e 's/[.].*//g'`
 case $host in
-  ccscs*) machine_name_short=ccscs ;;
-  sn*)    machine_name_short=sn ;;
-  tt*)    machine_name_short=tt ;;
+  ba*|sn*) source $rscriptdir/cts1-options.sh ;;
+  ccscs*)  source $rscriptdir/ccscs-options.sh ;;
+  tt*)     source $rscriptdir/tt-options.sh ;;
   *)
     echo "FATAL ERROR: I don't know how to run regression on host = ${host}."
     print_use;  exit 1 ;;
 esac
-
-platform_extra_params=`echo $platform_extra_params | sed -e 's/ / | /g'`
-source $rscriptdir/$machine_name_short-options.sh
 
 ##---------------------------------------------------------------------------##
 ## Support functions
@@ -220,7 +218,9 @@ mkdir -p $logdir || die "Could not create a directory for log files."
 # Redirect output to logfile.
 timestamp=`date +%Y%m%d-%H%M`
 logfile=$logdir/${machine_name_short}-${build_type}-master-$timestamp.log
-# echo "Redirecting output to $logfile"
+case $regress_mode in
+  off) echo "Redirecting output to $logfile" ;;
+esac
 exec > $logfile
 exec 2>&1
 
@@ -286,15 +286,15 @@ ifb=0
 # do any real work until both draco and clubimc have completed.
 
 # More sanity checks
-if ! [[ -x ${rscriptdir}/${machine_name_short}-job-launch.sh ]]; then
-   echo "FATAL ERROR: I cannot find ${rscriptdir}/${machine_name_short}-job-launch.sh."
+if ! [[ -x ${rscriptdir}/${machine_class}-job-launch.sh ]]; then
+   echo "FATAL ERROR: I cannot find ${rscriptdir}/${machine_class}-job-launch.sh."
    exit 1
 fi
 
 export subproj=draco
 if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
-  cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
+  cmd="${rscriptdir}/${machine_class}-job-launch.sh"
   cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-joblaunch.log"
   echo "${subproj}: $cmd"
   eval "${cmd} &"
@@ -307,7 +307,7 @@ export subproj=jayenne
 if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
   # Run the *-job-launch.sh script (special for each platform).
-  cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
+  cmd="${rscriptdir}/${machine_class}-job-launch.sh"
   # Spin until $draco_jobid disappears (indicates that draco has been
   # built and installed)
   cmd+=" ${draco_jobid}"
@@ -323,7 +323,7 @@ fi
 export subproj=capsaicin
 if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
-  cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
+  cmd="${rscriptdir}/${machine_class}-job-launch.sh"
   # Wait for draco regressions to finish
   case $extra_params in
   coverage)

--- a/regression/tt-options.sh
+++ b/regression/tt-options.sh
@@ -12,6 +12,8 @@
 ##---------------------------------------------------------------------------##
 
 # Main Options
+export machine_class="tt"
+export machine_name_short="tt"
 export machine_name_long="Trinitite"
 platform_extra_params="fulldiagnostics knl  nr perfbench vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -12,6 +12,9 @@ if [[ `which srun 2>/dev/null | grep -c srun` == 0 ]]; then
   source /etc/bash.bashrc.local
 fi
 
+# Allow variable as case condition
+shopt -s extglob
+
 #----------------------------------------------------------------------#
 # The script starts here
 #----------------------------------------------------------------------#
@@ -44,7 +47,7 @@ fi
 
 # Environment setup
 # ----------------------------------------
-umask 0007
+umask 0002
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -58,7 +61,6 @@ export VENDOR_DIR=/usr/projects/draco/vendors
 # gitlab.lanl.gov has an unkown certificate, disable checking
 export GIT_SSL_NO_VERIFY=true
 
-machine=`uname -n`
 case $REGRESSION_PHASE in
   c) ctestparts="Configure" ;;
   b)
@@ -79,10 +81,17 @@ case $REGRESSION_PHASE in
     ;;
 esac
 
+# Host based variables
+# ----------------------------------------
+machine=`uname -n`
+export host=`uname -n | sed -e 's/[.].*//g'`
+platform_extra_params=`echo $platform_extra_params | sed -e 's/ / | /g'`
+source $rscriptdir/tt-options.sh
+
 # Header
 # ----------------------------------------
 echo "==========================================================================="
-echo "Trinitite regression: ${ctestparts} from ${machine}."
+echo "${machine_name_long} regression: ${ctestparts} from ${machine}."
 echo "                      ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
 echo "==========================================================================="
 if [[ ${SLURM_JOB_PARTITION} ]]; then
@@ -136,17 +145,27 @@ comp=CC
 
 # Extra parameters
 case $extra_params in
+"")
+    # no-op
+    ;;
 knl)
     run "module swap craype-haswell craype-mic-knl"
     export OMP_NUM_THREADS=17
     ;;
-"")
+vtest)
     # no-op
+    ;;
+@($pem_match) )
+    # found in tt-options.sh but no rule found here
+    echo "FATAL ERROR"
+    echo "Extra parameter = ${extra_param} requested and known by ${machine_name_short}-options.sh,"
+    echo "but ${0##*/} doesn't know about this option."
+    exit 1
     ;;
 *)
     echo "FATAL ERROR"
     echo "Extra parameter = ${extra_param} requested but is unknown to"
-    echo "the regression system (edit tt-regress.msub)."
+    echo "the regression system (edit ${0##*/})."
     exit 1
     ;;
 esac
@@ -163,10 +182,10 @@ if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
   keychain=keychain-2.8.2
   $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
-  if test -f $HOME/.keychain/$HOSTNAME-sh; then
-    run "source $HOME/.keychain/$HOSTNAME-sh"
+  if test -f $HOME/.keychain/$machine-sh; then
+    run "source $HOME/.keychain/$machine-sh"
   else
-    echo "Error: could not find $HOME/.keychain/$HOSTNAME-sh"
+    echo "Error: could not find $HOME/.keychain/$machine-sh"
   fi
 fi
 
@@ -185,26 +204,26 @@ fi
 # Build type     : Release, Debug
 
 if [[ ! ${dashboard_type} ]]; then
-  dashboard_type=Experimental
+   dashboard_type=Experimental
 fi
 if [[ ! ${base_dir} ]]; then
-  if ! test -d ${scratchdir}; then
-    echo "Fatal Error, scratchdir=${scratchdir} not found.."
-    exit 1
-  fi
-  scratchdir=$scratchdir/$LOGNAME/cdash/tt
-  base_dir=${regdir}/cdash/tt
-  # base_dir=/usr/projects/ccsrad/regress/cdash/tt
+   if ! [[ -d ${scratchdir} ]]; then
+      echo "FATAL ERROR, scratchdir=${scratchdir} not found."
+      echo "  Have the names/locations of scratch space changed?"
+      exit 1
+   fi
+   scratchdir=$scratchdir/$LOGNAME/cdash/${machine_name_short}
+   base_dir=${regdir}/cdash/${machine_name_short}
 fi
 
 echo " "
-echo "tt-regress.msub: dashboard_type = $dashboard_type"
-echo "tt-regress.msub: base_dir       = $base_dir"
-echo "tt-regress.msub: build_type     = $build_type"
-echo "tt-regress.msub: comp           = $comp"
-echo "tt-regress.msub: machine        = $machine"
-echo "tt-regress.msub: subproj        = $subproj"
-echo "tt-regress.msub: regdir         = $regdir"
+echo "${0##*/}: dashboard_type = $dashboard_type"
+echo "${0##*/}: base_dir       = $base_dir"
+echo "${0##*/}: build_type     = $build_type"
+echo "${0##*/}: comp           = $comp"
+echo "${0##*/}: machine        = $machine"
+echo "${0##*/}: subproj        = $subproj"
+echo "${0##*/}: regdir         = $regdir"
 
 #----------------------------------------------------------------------#
 # CTest
@@ -229,8 +248,8 @@ fi
 export work_dir=${base_dir}/${subproj}/${dashboard_type}_${comp}/${build_type}
 export scratch_dir=${scratchdir}/${subproj}/${dashboard_type}_${comp}/${build_type}
 
-echo "tt-regress.msub: work_dir       = ${work_dir}"
-echo "tt-regress.msub: scratch_dir    = ${scratch_dir}"
+echo "${0##*/}: work_dir       = ${work_dir}"
+echo "${0##*/}: scratch_dir    = ${scratch_dir}"
 echo " "
 setup_dirs=`echo $ctestparts | grep Configure`
 if [[ ${setup_dirs} ]]; then
@@ -275,10 +294,10 @@ if [[ ${setup_dirs} ]]; then
 fi
 
 # Environment
-#echo " "
-#echo "--------------------(environment)------------------------------"
-#set
-#echo "--------------------(end environment)--------------------------"
+# echo " "
+# echo "--------------------(environment)------------------------------"
+# set
+# echo "--------------------(end environment)--------------------------"
 
 date
 echo " "


### PR DESCRIPTION
### Background

* The scripts for snow work equally well for Badger.  Because snow was down for 2 days, I made the scripts more generic so I could run them on Badger.

### Description of changes

* Updates allow the renamed _cts1_ regression scripts to run on either snow or badger (and probably fire and ice, but this hasn't been tested).
* The `*-job-launch.sh` scripts are more generic now. They use more information found in the `*-options.sh` files.
* Regression scripts for trinitite were updated to look more like the cts1 scripts.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
