### PR TITLE
Minor cleanup for the fpe-trap feature

### DIFF
--- a/src/ds++/fpe_trap.cc
+++ b/src/ds++/fpe_trap.cc
@@ -11,7 +11,7 @@
  * Copyright (C) 1990-1994  The Boeing Company.
  *
  * See COPYING file for more copyright information.  This code is based
- * substantially on fpe/i686-pc-linux-gnu.c from algae-4.3.6, which is 
+ * substantially on fpe/i686-pc-linux-gnu.c from algae-4.3.6, which is
  * available at http://algae.sourceforge.net/.
  */
 //---------------------------------------------------------------------------//
@@ -75,7 +75,7 @@ extern "C" void catch_sigfpe(int sig, siginfo_t *psSiginfo,
 namespace rtt_dsxx {
 
 //---------------------------------------------------------------------------//
-/*! 
+/*!
  * \brief Enable trapping fpe signals.
  * \return \b true if trapping is enabled, \b false otherwise.
  *

--- a/src/ds++/test/do_exception.cc
+++ b/src/ds++/test/do_exception.cc
@@ -80,7 +80,7 @@ void run_test(int /*argc*/, char *argv[]) {
   case 0:
     // Should not throw a IEEE floating point exception.
     cout << "- Case zero: this operation should not throw a SIGFPE."
-         << " The result should be 2..." << endl;;
+         << " The result should be 2..." << endl;
     result = 1.0 + zero + sqrt(-neg);
     cout << "  result = " << result << endl;
     break;

--- a/src/ds++/test/do_exception.cc
+++ b/src/ds++/test/do_exception.cc
@@ -22,22 +22,30 @@ using namespace std;
 
 //---------------------------------------------------------------------------//
 /*
- * Usage: do_exception test
+ * Usage: 'do_exception <integer_value>'
  *
- * If test is 0, then simple floating point operations are done which should not
- * cause an error.
+ * <integer_value> must be 0, 1, 2 or 3.
  *
- * Otherwise, other test values should cause an exception.  Specifically, valid
- * test values are
+ * If the required argument is 0, then simple floating point operations are done
+ * which should not cause any errors.
  *
- * Otherwise, other test values should cause an exception.
+ * If the provided integral value is 1,2, or 3, then one of the test case listed
+ * below will be run. Each of these test cases should cause an IEEE floating
+ * point exception.
  *
- * Specifically, valid test values are
- *    1: test double division by zero
- *    2: test sqrt(-1)
- *    3: test overflow
+ * Test
+ * case    Description (type of IEEE exception)
+ * ----    --------------------------------------
+ *    1    test double division by zero
+ *    2    test sqrt(-1)
+ *    3    test overflow
  *
- * The file output.dat documents what happened during all tests.
+ * If \c 'DRACO_DIAGNOSTICS && 0100' is non-zero (e.g.: \c DRACO_DIAGNOSTICS=7),
+ * then Draco's fpe_trap shoud convert the IEEE FPE into a C++ exception and
+ * print a stack trace.
+ *
+ * When run through via \c ctest, the output from these tests is captured in the
+ * files \c do_exception_[0-9]+.out and \c do_exception_[0-9]+.err.
  */
 void run_test(int /*argc*/, char *argv[]) {
 
@@ -68,7 +76,8 @@ void run_test(int /*argc*/, char *argv[]) {
   // Certain tests may be optimized away by the compiler, by recogonizing the
   // constants set above and precomputing the results below.  So do something
   // here to hopefully avoid this.  This tricks the optimizer, at least for gnu
-  // and KCC.
+  // and KCC. [2018-02-09 KT -- some web posts hint that marking zero and neg as
+  // 'volitile' may also prevent removal of logic due to optimization.]
 
   if (test < -100) { // this should never happen
     Insist(0, "Something is very wrong.");

--- a/src/ds++/test/do_exception.cc
+++ b/src/ds++/test/do_exception.cc
@@ -22,33 +22,34 @@ using namespace std;
 
 //---------------------------------------------------------------------------//
 /*
-  Usage: do_exception test
-
-  If test is 0, then simple floating point operations are done which should not
-  cause an error.
-
-  Otherwise, other test values should cause an exception.  Specifically, valid
-  test values are
-
-  Otherwise, other test values should cause an exception.
-  Specifically, valid test values are
-     1: test double division by zero
-     2: test sqrt(-1)
-     3: test overflow
-
-  The file output.dat documents what happened during all tests.
-*/
+ * Usage: do_exception test
+ *
+ * If test is 0, then simple floating point operations are done which should not
+ * cause an error.
+ *
+ * Otherwise, other test values should cause an exception.  Specifically, valid
+ * test values are
+ *
+ * Otherwise, other test values should cause an exception.
+ *
+ * Specifically, valid test values are
+ *    1: test double division by zero
+ *    2: test sqrt(-1)
+ *    3: test overflow
+ *
+ * The file output.dat documents what happened during all tests.
+ */
 void run_test(int /*argc*/, char *argv[]) {
 
   bool const abortWithInsist(true);
   rtt_dsxx::fpe_trap fpet(abortWithInsist);
   if (fpet.enable()) {
-    // Platform supported.
+    // Platform is supported.
     cout << "\n- fpe_trap: This platform is supported.\n";
     if (!fpet.active())
       cout << "- fpe_trap: active flag set to false was not expected.\n";
   } else {
-    // Platform not supported.
+    // Platform is not supported.
     cout << "\n- fpe_trap: This platform is not supported\n";
     if (fpet.active())
       cout << "- fpe_trap: active flag set to true was not expected.\n";
@@ -79,23 +80,23 @@ void run_test(int /*argc*/, char *argv[]) {
   case 0:
     // Should not throw a IEEE floating point exception.
     cout << "- Case zero: this operation should not throw a SIGFPE."
-         << " The result should be 2...\n";
+         << " The result should be 2..." << endl;;
     result = 1.0 + zero + sqrt(-neg);
     cout << "  result = " << result << endl;
     break;
   case 1:
-    cout << "- Case one: trying a div_by_zero operation...\n";
+    cout << "- Case one: trying a div_by_zero operation..." << endl;
     result = 1.0 / zero; // should fail here
     cout << "  result = " << 1.0 * result;
     break;
   case 2:
     // http://en.cppreference.com/w/cpp/numeric/math/sqrt
-    cout << "- Case two: trying to evaluate sqrt(-1.0)...\n";
+    cout << "\n- Case two: trying to evaluate sqrt(-1.0)..." << endl;
     result = std::sqrt(neg); // should fail here
     cout << "  result = " << result;
     break;
   case 3:
-    cout << "- Case three: trying to cause an overflow condition...\n";
+    cout << "- Case three: trying to cause an overflow condition..." << endl;
     result = 2.0;
     std::vector<double> data;
     for (size_t i = 0; i < 100; i++) {

--- a/src/ds++/test/test_fpe_trap.py
+++ b/src/ds++/test/test_fpe_trap.py
@@ -66,20 +66,17 @@ try:
     if any(platform.win32_ver()):
       # Signaling error: A SIGFPE was detected!
       string_found = tFpeTrap.output_contains("A SIGFPE was detected!")
-    else:
+    if( not string_found ):
       # Signaling error: SIGFPE (Floating point divide by zero)
       string_found = tFpeTrap.output_contains("Floating point divide by zero")
+    if( not string_found ):
+      # Signaling error: runtime error: division by zero
+      string_found = tFpeTrap.output_contains("runtime error: division by zero")
 
     if( string_found ):
       tFpeTrap.passmsg("Caught SIGFPE (Floating point divide by zero)")
     else:
-      # 2nd chance: try the error stream
-      string_found = tFpeTrap.error_contains("Floating point divide by zero")
-      if( string_found):
-        tFpeTrap.passmsg("Caught SIGFPE (Floating point divide by zero)")
-      else:
-        tFpeTrap.failmsg("Failed to catch SIGFPE (Floating point divide by zero)")
-
+      tFpeTrap.failmsg("Failed to catch SIGFPE (Floating point divide by zero)")
 
       print("Standard out:")
       with open(tFpeTrap.outfile) as f:


### PR DESCRIPTION
### Background

* fpe_trap is failing to work on some systems.

### Description of changes

+ In a few places, replace newline with `std::endl` to force the buffer to flush to screen before continuing. For the previous implementation, on some systems messages that the python test is looking for don't print before the exception is thrown.
+ Cleanup python logic a bit
+ Clean up documentation and formatting a bit.

### Issues not fixed by this PR

+ On WLS with gcc-5.4.0, fpe_trap cases 2 and 3 still fail and case 3 is still failing on KNL.  I think these failures are limitations of the underlying environment but more investigation is needed.

### Status

* Reference:
  * **NOTE**: This PR accidentally includes changes found in #359.  Those changes need to be merged and then this must be rebased before it is merged.
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
