### PR TITLE
Fix build post pr362 build failures on cray.

### DIFF
--- a/config/draco-config-install.cmake.in
+++ b/config/draco-config-install.cmake.in
@@ -47,6 +47,7 @@ set_package_properties( draco PROPERTIES
 set( DRACO_LIBRARY_TYPE @DRACO_LIBRARY_TYPE@ )
 # set( CXX11_FEATURE_LIST "@CXX11_FEATURE_LIST@" )
 set( GCC_ENABLE_GLIBCXX_DEBUG "@GCC_ENABLE_GLIBCXX_DEBUG@" )
+set( CRAY_PE "@CRAY_PE@" )
 
 ## ---------------------------------------------------------------------------
 ## Set library specifications and paths


### PR DESCRIPTION
### Background

* #362 changed the order that some cmake macros are called.  This inadvertently broke MPI detection and setup.

### Purpose of Pull Request

* [Fixes Redmine Issue #1095](https://rtt.lanl.gov/redmine/issue/1095)

### Description of changes

* Save the cmake variable `CRAY_PE` to `draco-config.cmake` to eliminate the order dependency for calling cmake macros.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
