### PR TITLE
Fix broken scalar builds (post pr362)

### DIFF
--- a/src/VendorChecks/test/CMakeLists.txt
+++ b/src/VendorChecks/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if( METIS_FOUND )
     DEPS    "Lib_dsxx;METIS::metis" )
 endif()
 
-if( TARGET ParMETIS::parmetis AND TARGET Lib_c4 )
+if( TARGET ParMETIS::parmetis AND ${DRACO_C4} STREQUAL "MPI" )
 
     add_parallel_tests(
       SOURCES "tstParmetis.cc"

--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -37,9 +37,12 @@ if( PAPI_LIBRARY )
   set( c4_extra_VENDORS VENDOR_LIST;PAPI;VENDOR_LIBS;${PAPI_LIBRARY} )
 endif()
 
-set( target_deps Lib_dsxx MPI::MPI_CXX MPI::MPI_C )
-if (TARGET MPI::MPI_Fortran)
-  list(APPEND target_deps MPI::MPI_Fortran )
+set( target_deps Lib_dsxx )
+if ( "${DRACO_C4}" STREQUAL "MPI")
+  list(APPEND target_deps MPI::MPI_CXX MPI::MPI_C )
+  if (TARGET MPI::MPI_Fortran)
+    list(APPEND target_deps MPI::MPI_Fortran )
+  endif()
 endif()
 
 add_component_library(

--- a/src/quadrature/ftest/CMakeLists.txt
+++ b/src/quadrature/ftest/CMakeLists.txt
@@ -43,11 +43,11 @@ if(NOT TARGET Lib_dsxx)
 
   include(CMakeAddFortranSubdirectory)
   get_filename_component( draco_BINARY_DIR ${PROJECT_BINARY_DIR}/../../.. ABSOLUTE )
-  cafs_create_imported_targets( Lib_dsxx       
+  cafs_create_imported_targets( Lib_dsxx
     "rtt_ds++"       "${draco_BINARY_DIR}/src/ds++"       CXX )
-  cafs_create_imported_targets( Lib_quadrature 
+  cafs_create_imported_targets( Lib_quadrature
     "rtt_quadrature" "${draco_BINARY_DIR}/src/quadrature" CXX )
-  cafs_create_imported_targets( Lib_quadrature_test 
+  cafs_create_imported_targets( Lib_quadrature_test
     "rtt_quadrature_test" "${draco_BINARY_DIR}/src/quadrature/test" CXX )
 
   # If we get here, we also need to use the Draco scripts to setup compiler
@@ -95,37 +95,19 @@ set( f90sources
   ${PROJECT_SOURCE_DIR}/../quadrature_interfaces.f90 )
 
 # ---------------------------------------------------------------------------- #
-# Directories to search for include directives
-# ---------------------------------------------------------------------------- #
-# if( DEFINED cafs_Draco_TPL_INCLUDE_DIRS )
-  # include_directories( "${cafs_Draco_TPL_INCLUDE_DIRS}" )
-# elseif( DEFINED MPI_Fortran_INCLUDE_PATH )
-  # # Only include directories if mpif.h is found.
-  # set( mpifh_found FALSE )
-  # foreach( dir ${MPI_Fortran_INCLUDE_PATH} )
-    # if( EXISTS ${dir}/mpif.h )
-      # set( mpifh_found TRUE )
-    # endif()
-  # endforeach()
-  # if( mpifh_found )
-    # include_directories( "${MPI_Fortran_INCLUDE_PATH}" )
-  # endif()
-# endif()
-if( "${DRACO_C4}" STREQUAL "MPI" )
-  add_definitions( -DC4_MPI )
-endif()
-
-# ---------------------------------------------------------------------------- #
 # Build library for test directory
 # ---------------------------------------------------------------------------- #
 
 # Xcode: Since cafs_create_imported_targets does not set all of the dependencies
 # between the imported libraries, we need to list them explicitly.
-set(target_deps 
+set(target_deps
     Lib_quadrature_test
     Lib_quadrature
-    Lib_dsxx
-    MPI::MPI_Fortran )
+    Lib_dsxx )
+if( "${DRACO_C4}" STREQUAL "MPI" )
+  add_definitions( -DC4_MPI )
+  list(APPEND target_deps MPI::MPI_Fortran )
+endif()
 
 add_component_library(
   TARGET       Lib_quadrature_ftest


### PR DESCRIPTION
### Background

+ #362 changed the way MPI dependencies are expressed by the build system, but didn't take into account our `SCALAR` build mode.

### Purpose of Pull Request

* SCALAR builds are failing, as tracked by [Redmine Issue #1096](https://rtt.lanl.gov/redmine/issue/1096). This PR fixes this failure mode.

### Description of changes

+ No longer link to `MPI::MPI_C` targets if `DRACO_C4=SCALAR.`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
