### PR TITLE
Extend Debug_Options

### DIFF
--- a/src/parser/Debug_Options.cc
+++ b/src/parser/Debug_Options.cc
@@ -63,6 +63,8 @@ unsigned get_debug_option(string const &option_name) {
     return DEBUG_MEMORY;
   } else if (option_name == "RESET_TIMING") {
     return DEBUG_RESET_TIMING;
+  } else if (option_name == "PROBLEM") {
+    return DEBUG_PROBLEM;
   } else {
     // parse extension to debug options
     if (extended_debug_option.find(option_name) ==
@@ -147,10 +149,14 @@ string debug_options_as_text(unsigned debug_options) {
   if (debug_options & DEBUG_RESET_TIMING) {
     Result += ", RESET_TIMING";
   }
+  if (debug_options & DEBUG_PROBLEM) {
+    Result += ", PROBLEM";
+  }
   // Mask out standard options and see if any extensions are active
-  debug_options = debug_options &
-                  ~(DEBUG_ALGORITHM | DEBUG_TIMESTEP | DEBUG_TIMING |
-                    DEBUG_RESET_TIMING | DEBUG_BALANCE | DEBUG_MEMORY);
+  debug_options =
+      debug_options &
+      ~(DEBUG_ALGORITHM | DEBUG_TIMESTEP | DEBUG_TIMING | DEBUG_RESET_TIMING |
+        DEBUG_BALANCE | DEBUG_MEMORY | DEBUG_PROBLEM);
 
   if (debug_options) {
     for (const auto &i : extended_debug_option) {

--- a/src/parser/Debug_Options.hh
+++ b/src/parser/Debug_Options.hh
@@ -17,6 +17,7 @@ namespace rtt_parser {
 //! Enumeration of debug flag bits
 
 enum Debug_Options {
+  DEBUG_NONE = 0,          // For human readability; No debug options desired.
   DEBUG_ALGORITHM = 1,     // Report on behavior of the algorithm.
   DEBUG_TIMESTEP = 2,      // Report on what is limiting the time step.
   DEBUG_TIMING = 4,        // Report CPU times for various code regions.
@@ -24,8 +25,10 @@ enum Debug_Options {
   DEBUG_GMV_DUMP = 16,     // Produce a GMV dump of the solution.
   DEBUG_MEMORY = 32,       // Report on memory usage.
   DEBUG_RESET_TIMING = 64, // Reset all timings to zero.
+  DEBUG_PROBLEM = 128,     // Report on the characteristics of the posed
+                           // problem; e.g. what is its scattering fraction?
 
-  DEBUG_END = 128, // Sentinel value and first available extension.
+  DEBUG_END = 256, // Sentinel value and first available extension.
 
   DEBUG_SILENT_MASK = ~(DEBUG_RESET_TIMING)
   // Options producing no terminal output

--- a/src/parser/test/tstDebug_Options.cc
+++ b/src/parser/test/tstDebug_Options.cc
@@ -26,13 +26,13 @@ using namespace rtt_dsxx;
 //---------------------------------------------------------------------------//
 
 void debug_options_test(UnitTest &ut) {
-  for (unsigned i = 1; i < 2 * DEBUG_RESET_TIMING - 1; i++) {
+  for (unsigned i = 1; i < 2 * DEBUG_PROBLEM - 1; i++) {
     string out = debug_options_as_text(i);
     String_Token_Stream tokens(out);
     unsigned j = parse_debug_options(tokens);
     ut.check(i == j, "write/read check");
   }
-  for (unsigned i = 1; i <= DEBUG_RESET_TIMING; i <<= 1U) {
+  for (unsigned i = 1; i <= DEBUG_PROBLEM; i <<= 1U) {
     string out = debug_options_as_text(i);
     out = '!' + out.substr(1);
     String_Token_Stream mask_tokens(out);


### PR DESCRIPTION

### Background

I am planning to experiment with expert system/machine learning approaches to picking a strategy for solving a problem. For example, if I'm doing transport sweeps, I have the options of whether to use parallel block Jacobi, Gauss-Seidel, or full sweeps, and whether (and which!) preconditioners to apply. The best choice depends on the characteristics of the posed problem. I want a debug option that prints some diagnostics about the relevant characteristics of a problem as deduced by the program.

### Purpose of Pull Request

This adds a DEBUG_PROBLEM option to the Debug_Options enumeration.

### Description of changes

Add a DEBUG_PROBLEM option, which turns on code that calculates characteristics of the problem specification itself *other* than whether the problem is well-posed. For example (and this is the application I need this for) the code might estimate the minimum optical depth across a processor domain or the overall scattering fraction of a problem.

Add a DEBUG_NONE option to indicate that no debugging options are desired in a way that conveys more to a human reader than 0U does.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
