### PR TITLE
Move special Xcode/VS code into add_component_library.

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -243,6 +243,7 @@ endmacro()
 #   TARGET_DEPS  "dep1;dep2;..."
 #   PREFIX       "ClubIMC"
 #   SOURCES      "file1.cc;file2.cc;..."
+#   HEADERS      "file1.hh;file2.hh;..."
 #   LIBRARY_NAME_PREFIX "rtt_"
 #   VENDOR_LIST  "MPI;GSL"
 #   VENDOR_LIBS  "${MPI_CXX_LIBRARIES};${GSL_LIBRARIES}"
@@ -271,7 +272,7 @@ macro( add_component_library )
     acl
     "NOEXPORT"
     "PREFIX;TARGET;LIBRARY_NAME;LIBRARY_NAME_PREFIX;LINK_LANGUAGE"
-    "SOURCES;TARGET_DEPS;VENDOR_LIST;VENDOR_LIBS;VENDOR_INCLUDE_DIRS"
+    "HEADERS;SOURCES;TARGET_DEPS;VENDOR_LIST;VENDOR_LIBS;VENDOR_INCLUDE_DIRS"
     ${ARGV}
     )
 
@@ -279,12 +280,21 @@ macro( add_component_library )
   # Defaults:
   #
   # Optional 3rd argument is the library prefix.  The default is "rtt_".
-  if( "${acl_LIBRARY_NAME_PREFIX}x" STREQUAL "x" )
+  if( NOT acl_LIBRARY_NAME_PREFIX )
     set( acl_LIBRARY_NAME_PREFIX "rtt_" )
   endif()
   # Default link language is C++
-  if( "${acl_LINK_LANGUAGE}x" STREQUAL "x" )
+  if( NOT acl_LINK_LANGUAGE )
     set( acl_LINK_LANGUAGE CXX )
+  endif()
+
+  #
+  # Add headers to Visual Studio or Xcode solutions
+  #
+  if( acl_HEADERS )
+    if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
+      list( APPEND sources ${headers} )
+    endif()
   endif()
 
   #
@@ -588,7 +598,7 @@ function( copy_dll_link_libraries_to_build_dir target )
     set( old_link_libs ${link_libs} )
     foreach( lib ${link_libs} )
       if( lverbose )
-        # message("\n  examine dependencies for lib           = ${lib}\n")        
+        # message("\n  examine dependencies for lib           = ${lib}\n")
         print_targets_properties("${lib}")
       endif()
       # $lib will either be a cmake target (e.g.: Lib_dsxx, Lib_c4) or an actual
@@ -607,7 +617,7 @@ function( copy_dll_link_libraries_to_build_dir target )
           list( APPEND link_libs ${link_libs2} )
           list( APPEND link_libs ${link_libs3} )
       endif()
-    endforeach()    
+    endforeach()
     # Loop through all current dependencies, remove static libraries
     #(they do not need to be in the run directory).
     list( REMOVE_DUPLICATES link_libs )
@@ -688,7 +698,7 @@ function( copy_dll_link_libraries_to_build_dir target )
 
     endif()
   endforeach()
-  
+
 endfunction()
 
 #----------------------------------------------------------------------#

--- a/config/generate_dll_declspec.cmake
+++ b/config/generate_dll_declspec.cmake
@@ -3,9 +3,8 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2016 Feb 13
 # brief  Generate dll_declspec.h used to define DLL_PUBLIC_<pkg> definitions.
-# note   Copyright (C) 2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2016-2018, Los Alamos National Security, LLC.
 #        All rights reserved.
-#------------------------------------------------------------------------------#
 #------------------------------------------------------------------------------#
 
 function( generate_dll_declspec dir components )

--- a/src/RTT_Format_Reader/CMakeLists.txt
+++ b/src/RTT_Format_Reader/CMakeLists.txt
@@ -16,11 +16,6 @@ project( RTT_Format_Reader CXX )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +25,7 @@ add_component_library(
    TARGET_DEPS  Lib_meshReaders
    LIBRARY_NAME RTT_Format_Reader
    SOURCES      "${sources}"
+   HEADERS      "${headers}"
    LIBRARY_NAME_PREFIX "rtt_" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -25,11 +25,6 @@ file( GLOB headers *.hh *.h)
 list( APPEND headers ${PROJECT_BINARY_DIR}/c4/config.h )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} ${template_implementations} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -50,6 +45,7 @@ add_component_library(
    TARGET_DEPS  ${target_deps}
    LIBRARY_NAME c4
    SOURCES      "${sources}"
+   HEADERS      "${headers};${template_implementations}"
    ${c4_extra_VENDORS}
    )
 target_include_directories( Lib_c4

--- a/src/cdi/CMakeLists.txt
+++ b/src/cdi/CMakeLists.txt
@@ -17,11 +17,6 @@ file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +25,7 @@ add_component_library(
    TARGET       Lib_cdi
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME cdi
+   HEADERS      "${headers}"
    SOURCES "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_analytic/CMakeLists.txt
+++ b/src/cdi_analytic/CMakeLists.txt
@@ -16,11 +16,6 @@ project( cdi_analytic CXX )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -29,7 +24,8 @@ add_component_library(
    TARGET       Lib_cdi_analytic
    TARGET_DEPS  "Lib_parser;Lib_roots;Lib_cdi"
    LIBRARY_NAME cdi_analytic
-   SOURCES      "${sources}"  )
+   HEADERS      "${headers}"
+   SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -26,11 +26,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM sources ${PROJECT_SOURCE_DIR}/QueryEospac.cc )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -40,6 +35,7 @@ add_component_library(
    TARGET_DEPS  Lib_cdi
    LIBRARY_NAME cdi_eospac
    SOURCES      "${sources}"
+   HEADERS      "${headers}"
    VENDOR_LIST "EOSPAC"
    VENDOR_LIBS "${EOSPAC_LIBRARY}" )
 target_include_directories( Lib_cdi_eospac PUBLIC ${EOSPAC_INCLUDE_DIR} )
@@ -48,8 +44,7 @@ add_component_executable(
   TARGET      Exe_QueryEospac
   TARGET_DEPS Lib_cdi_eospac
   SOURCES     ${PROJECT_SOURCE_DIR}/QueryEospac.cc
-  PREFIX       Draco
-  )
+  PREFIX       Draco )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions

--- a/src/cdi_ipcress/CMakeLists.txt
+++ b/src/cdi_ipcress/CMakeLists.txt
@@ -30,11 +30,6 @@ set( headers
    IpcressOdfmgOpacity.hh
 )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -43,7 +38,9 @@ add_component_library(
   TARGET       Lib_cdi_ipcress
   TARGET_DEPS  "Lib_cdi"
   LIBRARY_NAME ${PROJECT_NAME}
+  HEADERS      "${headers}"
   SOURCES      "${sources}" )
+
 
 add_component_executable(
   TARGET      Exe_Ipcress_Interpreter

--- a/src/compton/CMakeLists.txt
+++ b/src/compton/CMakeLists.txt
@@ -26,11 +26,6 @@ set( headers
 
 if( TARGET COMPTON::compton )
 
-  # Make the header files available in the IDE.
-  if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-    list( APPEND sources ${headers} )
-  endif()
-
   # -------------------------------------------------------------------------- #
   # Build package library
   # -------------------------------------------------------------------------- #
@@ -39,7 +34,8 @@ if( TARGET COMPTON::compton )
     TARGET       Lib_compton
     TARGET_DEPS  "Lib_c4;Lib_dsxx;COMPTON::compton"
     LIBRARY_NAME compton
-    SOURCES      "${sources}" )
+    SOURCES      "${sources}"
+    HEADERS      "${headers}" )
   # generated include directive files (config.h)
   target_include_directories( Lib_compton
     PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )

--- a/src/device/GPU_Device.cmake
+++ b/src/device/GPU_Device.cmake
@@ -9,7 +9,7 @@
 # Generate config.h (only occurs when cmake is run)
 # ---------------------------------------------------------------------------- #
 
-set( TEST_KERNEL_BINDIR ${PROJECT_BINARY_DIR}/test CACHE PATH 
+set( TEST_KERNEL_BINDIR ${PROJECT_BINARY_DIR}/test CACHE PATH
    "GPU kernel binary install location" )
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/device/config.h )
 
@@ -17,46 +17,31 @@ configure_file( config.h.in ${PROJECT_BINARY_DIR}/device/config.h )
 # Source files
 # ---------------------------------------------------------------------------- #
 
-set( sources 
+set( sources
    GPU_Device.cc
-   GPU_Module.cc
-   )
-set( headers 
+   GPU_Module.cc )
+set( headers
    GPU_Device.hh
    GPU_Module.hh
    ${PROJECT_BINARY_DIR}/device/config.h
-   device_cuda.h
-   )
-
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode)
-   list( APPEND sources ${headers} )
-endif()
-
-# ---------------------------------------------------------------------------- #
-# Directories to search for include directives
-# ---------------------------------------------------------------------------- #
-
-include_directories(
-   ${PROJECT_SOURCE_DIR}        # sources
-   ${PROJECT_BINARY_DIR}        # config.h
-   ${draco_src_dir_SOURCE_DIR}  # ds++ header files
-   ${dsxx_BINARY_DIR}           # ds++/config.h
-   )
+   device_cuda.h )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
 
-add_component_library( 
+add_component_library(
    TARGET       Lib_device
    TARGET_DEPS  Lib_dsxx
-   LIBRARY_NAME device 
+   LIBRARY_NAME device
    SOURCES      "${sources}"
+   HEADERS      "${headers}"
    VENDOR_LIST  "CUDA"
    VENDOR_LIBS  "${CUDA_CUDA_LIBRARY}"
    VENDOR_INCLUDE_DIRS "${CUDA_TOOLKIT_INCLUDE}"
    )
+target_include_directories( Lib_device
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
@@ -64,3 +49,7 @@ add_component_library(
 
 install( TARGETS Lib_device EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/device )
+
+#------------------------------------------------------------------------------#
+# End device/GPU_Device.cmake
+#------------------------------------------------------------------------------#

--- a/src/diagnostics/qt/CMakeLists.txt
+++ b/src/diagnostics/qt/CMakeLists.txt
@@ -32,11 +32,6 @@ file( GLOB headers   *.hh *.h )
 file( GLOB ui_files  *.ui )
 #file( GLOB resources *.qrc )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # Use moc to convert *.ui files into ui_*.h files:
 qt5_wrap_ui( ui_headers ${ui_files} )
 list( APPEND sources ${ui_headers} )
@@ -44,19 +39,6 @@ list( APPEND sources ${ui_headers} )
 # use rcc to convert *.qrc files into qrc_*.cpp files:
 qt5_add_resources( qrc_sources ${resources} )
 list( APPEND sources ${qrc_sources} )
-
-# ---------------------------------------------------------------------------- #
-# Directories to search for include directives
-# ---------------------------------------------------------------------------- #
-
-include_directories(
-   ${PROJECT_SOURCE_DIR}  # sources
-   ${PROJECT_BINARY_DIR}  # qt generated .h files
-   ${draco_src_dir_SOURCE_DIR} # ds++ and c4 headers
-   ${dsxx_BINARY_DIR}     # ds++/config.h
-   ${c4_BINARY_DIR}       # c4/config.h
-   ${MPI_CXX_INCLUDE_PATH}
-   )
 
 # ---------------------------------------------------------------------------- #
 # Build package library

--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -73,11 +73,6 @@ list( APPEND headers
    ${PROJECT_BINARY_DIR}/ds++/dll_declspec.h )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} ${template_implementations} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #

--- a/src/fit/CMakeLists.txt
+++ b/src/fit/CMakeLists.txt
@@ -16,11 +16,6 @@ project( fit CXX )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #

--- a/src/lapack_wrap/CMakeLists.txt
+++ b/src/lapack_wrap/CMakeLists.txt
@@ -86,11 +86,6 @@ else()
     file( GLOB headers *.hh )
     list( APPEND headers ${PROJECT_BINARY_DIR}/lapack_wrap/config.h )
 
-    # Make the header files available in the IDE.
-    if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-      list( APPEND sources ${headers} )
-    endif()
-
     # ------------------------------------------------------------------------ #
     # Installation instructions
     # ------------------------------------------------------------------------ #

--- a/src/linear/CMakeLists.txt
+++ b/src/linear/CMakeLists.txt
@@ -18,11 +18,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -31,6 +26,7 @@ add_component_library(
    TARGET       Lib_linear
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -18,11 +18,6 @@ file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -31,6 +26,7 @@ add_component_library(
    TARGET       Lib_memory
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/meshReaders/CMakeLists.txt
+++ b/src/meshReaders/CMakeLists.txt
@@ -17,11 +17,6 @@ file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
- endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +25,7 @@ add_component_library(
    TARGET       Lib_meshReaders
    TARGET_DEPS  Lib_mesh_element
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}"  )
 
 # ---------------------------------------------------------------------------- #

--- a/src/mesh_element/CMakeLists.txt
+++ b/src/mesh_element/CMakeLists.txt
@@ -17,11 +17,6 @@ file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +25,7 @@ add_component_library(
    TARGET       Lib_mesh_element
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}"  )
 
 # ---------------------------------------------------------------------------- #

--- a/src/min/CMakeLists.txt
+++ b/src/min/CMakeLists.txt
@@ -18,11 +18,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -31,6 +26,7 @@ add_component_library(
    TARGET       Lib_min
    TARGET_DEPS  Lib_linear
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/norms/CMakeLists.txt
+++ b/src/norms/CMakeLists.txt
@@ -17,11 +17,6 @@ file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +25,7 @@ add_component_library(
    TARGET       Lib_norms
    TARGET_DEPS  Lib_c4
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/ode/CMakeLists.txt
+++ b/src/ode/CMakeLists.txt
@@ -18,11 +18,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -16,11 +16,6 @@ project( parser CXX )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -29,6 +24,7 @@ add_component_library(
    TARGET       Lib_parser
    TARGET_DEPS  "Lib_c4;Lib_units"
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/plot2D/CMakeLists.txt
+++ b/src/plot2D/CMakeLists.txt
@@ -27,11 +27,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh *.h )
 list( APPEND headers ${PROJECT_BINARY_DIR}/plot2D/config.h )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} ${template_implementations} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -41,12 +36,11 @@ add_component_library(
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME plot2D
    SOURCES      "${sources}"
-   )
+   HEADERS      "${headers}" )
  target_include_directories( Lib_plot2D
    PUBLIC
      ${Grace_INCLUDE_DIR}
-     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-   )
+     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions

--- a/src/quadrature/CMakeLists.txt
+++ b/src/quadrature/CMakeLists.txt
@@ -15,12 +15,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 file( GLOB f90sources *.f90 )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-   list( APPEND sources ${f90sources} )
- endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +24,7 @@ add_component_library(
    TARGET_DEPS  "Lib_special_functions;Lib_parser;Lib_mesh_element;GSL::gsl"
    LIBRARY_NAME ${PROJECT_NAME}
    SOURCES      "${sources}"
+   HEADERS      "${headers};${f90sources}"
 )
 
 # ---------------------------------------------------------------------------- #

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for rng.
-# note   Copyright (C) 2010-2016, Los Alamos National Security, LLC.
+# note   Copyright (C) 2010-2018, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -14,22 +14,6 @@ project( rng CXX )
 # ---------------------------------------------------------------------------- #
 # default to using C++11 features of Random123.
 set( R123_USE_CXX11 1 )
-# if the current compiler doesn't support some c++11 features, disable
-# Random123's use of these extensions.
-set( required_features "cxx_explicit_conversions;cxx_static_assert;cxx_unrestricted_unions;cxx_long_long_type;cxx_constexpr;cxx_type_traits")
-foreach( feature ${required_features} )
-   list( FIND CXX11_FEATURE_LIST ${feature} featurefound )
-   if( ${featurefound} STREQUAL "-1" )
-      unset(R123_USE_CXX11)
-   endif()
-endforeach()
-
-# When also linking to CUDA, C++11 doesn't work.
-# MSVC 2013 RTM doesn't provide constexpr, even though cmake thinks it does.
-if( USE_CUDA OR WIN32 )
-   unset(R123_USE_CXX11)
-endif()
-
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/rng/config.h )
 
 # ---------------------------------------------------------------------------- #
@@ -40,11 +24,6 @@ file( GLOB sources *.cc *.c )
 file( GLOB headers *.hh *.h *.hpp)
 list( APPEND headers ${PROJECT_BINARY_DIR}/rng/config.h )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -54,11 +33,13 @@ add_component_library(
    TARGET_DEPS  "Lib_dsxx;GSL::gsl"
    LIBRARY_NAME ${PROJECT_NAME}
    SOURCES      "${sources}"
+   HEADERS      "${headers}"
    )
 target_include_directories( Lib_rng
-  PUBLIC 
+  PUBLIC
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> # config.h
-    ${RANDOM123_INCLUDE_DIR} )
+    $<BUILD_INTERFACE:${RANDOM123_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:${RANDOM123_INCLUDE_DIR}> )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -26,17 +26,15 @@
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)
-#define GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 /*
-#if (GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
 */
 #pragma GCC diagnostic push
-#if (GNUC_VERSION >= 70000)
+#if (RNG_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -58,9 +56,9 @@
 #pragma clang diagnostic pop
 #endif
 
-/* #if (GNUC_VERSION >= 40600) */
+/* #if (RNG_GNUC_VERSION >= 40600) */
 #if defined(__GNUC__) && !defined(__clang__)
-/* && (GNUC_VERSION >= 70000) */
+/* && (RNG_GNUC_VERSION >= 70000) */
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/config.h.in
+++ b/src/rng/config.h.in
@@ -20,6 +20,12 @@
 #endif
 #endif
 
+/* If GNU, then define GNU_VERSION */
+#ifdef __GNUC__
+#define RNG_GNUC_VERSION                                                           \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+
 /* Use a unique name for this Remember macro */
 #ifdef NDEBUG
 #define rngRemember(c)

--- a/src/rng/test/kat_cpp.cpp
+++ b/src/rng/test/kat_cpp.cpp
@@ -41,13 +41,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // complaint
 #pragma warning(disable : 4521)
 #endif
-#define GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if (GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
-#if (GNUC_VERSION >= 40600)
+#if (RNG_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -62,7 +60,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <utility>
 
-#if (GNUC_VERSION >= 40600)
+#if (RNG_GNUC_VERSION >= 40600)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/time_initkeyctr.h
+++ b/src/rng/test/time_initkeyctr.h
@@ -30,11 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef TIME_INITKEYCTR_H__
 #define TIME_INITKEYCTR_H__ 1
 
-#define GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
 #ifdef __GNUC__
-#if (GNUC_VERSION >= 70000)
+#if (RNG_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
@@ -153,7 +150,7 @@ static aesni4x32_ctr_t good_aesni4x32_10 = {
 #endif
 
 #ifdef __GNUC__
-#if (GNUC_VERSION >= 70000)
+#if (RNG_GNUC_VERSION >= 70000)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/ut_Engine.cpp
+++ b/src/rng/test/ut_Engine.cpp
@@ -36,6 +36,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // complaint
 #pragma warning(disable : 4521)
 #endif
+#ifdef __GNUC__
+#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+// Suppress GCC's "unused variable" warning.
+#if (RNG_GNUC_VERSION >= 40600)
+#pragma GCC diagnostic push
+#endif
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+#endif
 
 #include "ut_Engine.hh"
 
@@ -256,6 +265,13 @@ int main(int, char **) {
 #ifdef __clang__
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
+#endif
+
+#ifdef __GNUC__
+#if (RNG_GNUC_VERSION >= 40600)
+// Restore GCC diagnostics to previous state.
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 //---------------------------------------------------------------------------//

--- a/src/rng/test/ut_Engine.cpp
+++ b/src/rng/test/ut_Engine.cpp
@@ -179,7 +179,7 @@ template <typename EType> void doit() {
   e5.seed((rtype)99);
   ASSERTEQ(e4, e5);
 
-#if R123_USE_STD_RANDOM
+#ifdef R123_USE_STD_RANDOM
   // Check that we can use an EType with a std::distribution. Obviously, this
   // requires <random>
   uniform_int_distribution<int> dieroller(1, 6);

--- a/src/rng/test/ut_Engine.hh
+++ b/src/rng/test/ut_Engine.hh
@@ -3,10 +3,8 @@
  * \file   rng/test/ut_Engine.hh
  * \author Gabriel M. Rockefeller
  * \brief  ut_Engine header file.
- * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC
- */
-//---------------------------------------------------------------------------//
-
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rng_test_ut_Engine_hh
@@ -18,13 +16,12 @@
 
 #include <Random123/aes.h>
 #include <Random123/ars.h>
+#include <Random123/conventional/Engine.hpp>
 #include <Random123/philox.h>
 #include <Random123/threefry.h>
-
-#include <Random123/conventional/Engine.hpp>
 
 #endif // rng_test_ut_Engine_hh
 
 //---------------------------------------------------------------------------//
-//              end of rng/test/ut_Engine.hh
+// end of rng/test/ut_Engine.hh
 //---------------------------------------------------------------------------//

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -44,6 +44,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     no high-precicision intermediates.  See its own comments for more details.
  */
 
+#include "rng/config.h"
+
 #if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -44,13 +44,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     no high-precicision intermediates.  See its own comments for more details.
  */
 
-#define GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if (GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
-#if (GNUC_VERSION >= 40600)
+#if (RNG_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -76,7 +74,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic pop
 #endif
 
-#if (GNUC_VERSION >= 40600)
+#if (RNG_GNUC_VERSION >= 40600)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/util_expandtpl.h
+++ b/src/rng/test/util_expandtpl.h
@@ -37,13 +37,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * being the number of rounds.
  */
 
-#define GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
-#if (GNUC_VERSION >= 70000)
+#if (RNG_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
 #endif

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -70,6 +70,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // encourage developers to copy it and modify it for their own
 // use.  We invite comments and improvements.
 
+#include "rng/config.h"
+
 #if defined(__GNUC__) && !defined(__clang__)
 #if (RNG_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic push

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -71,9 +71,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // use.  We invite comments and improvements.
 
 #if defined(__GNUC__) && !defined(__clang__)
-#define GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if (GNUC_VERSION >= 70000)
+#if (RNG_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif

--- a/src/roots/CMakeLists.txt
+++ b/src/roots/CMakeLists.txt
@@ -18,11 +18,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
- endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -31,6 +26,7 @@ add_component_library(
    TARGET       Lib_roots
    TARGET_DEPS  Lib_linear
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/special_functions/CMakeLists.txt
+++ b/src/special_functions/CMakeLists.txt
@@ -19,11 +19,6 @@ file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -32,6 +27,7 @@ add_component_library(
    TARGET       Lib_special_functions
    TARGET_DEPS  "Lib_units;Lib_roots;GSL::gsl"
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/timestep/CMakeLists.txt
+++ b/src/timestep/CMakeLists.txt
@@ -19,11 +19,6 @@ file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -32,6 +27,7 @@ add_component_library(
    TARGET       Lib_timestep
    TARGET_DEPS  Lib_c4
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #

--- a/src/units/CMakeLists.txt
+++ b/src/units/CMakeLists.txt
@@ -17,11 +17,6 @@ file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -30,6 +25,7 @@ add_component_library(
    TARGET       Lib_units
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}"  )
 
 # ---------------------------------------------------------------------------- #

--- a/src/viz/CMakeLists.txt
+++ b/src/viz/CMakeLists.txt
@@ -18,11 +18,6 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-# Make the header files available in the IDE.
-if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode )
-   list( APPEND sources ${headers} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
@@ -31,6 +26,7 @@ add_component_library(
    TARGET       Lib_viz
    TARGET_DEPS  Lib_dsxx
    LIBRARY_NAME ${PROJECT_NAME}
+   HEADERS      "${headers}"
    SOURCES      "${sources}" )
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
### Background

+ Almost every `CMakeLists.txt` has a block of code that looks like this:

```
if( MSVC_IDE OR ${CMAKE_GENERATOR} MATCHES Xcode)
   list( APPEND sources ${headers} )
endif()
```

+ To simplify our `CMakeLists.txt` files, consolidate this logic into the cmake macro `add_component_library`.

### Description of changes

+ For each `CMakeLists.txt`:
  + Add a `HEADERS` parameter option to `add_component_library`.
  + Remove the conditional block of code shown above.
+ Refs [Redmine 1093](https://rtt.lanl.gov/redmine/issues/1093)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
* WIP requirements:
  * [x] Test under Visual Studio to ensure header files are associated with targets.
