### PR TITLE
Improve error diagnostics for Parse_Table.

### DIFF
--- a/src/parser/Console_Token_Stream.cc
+++ b/src/parser/Console_Token_Stream.cc
@@ -113,6 +113,18 @@ void Console_Token_Stream::report(string const &message) {
 
 //-------------------------------------------------------------------------------------//
 /*!
+ * This function sends a message by writing it to the error console stream.
+ * This version prints no location information.
+ */
+
+void Console_Token_Stream::comment(string const &message) {
+  std::cerr << message << std::endl;
+
+  Ensure(check_class_invariants());
+}
+
+//-------------------------------------------------------------------------------------//
+/*!
  * \author Kent G. Budge
  * \date Wed Jan 22 15:35:42 MST 2003
  * \brief Rewind the token stream.

--- a/src/parser/Console_Token_Stream.hh
+++ b/src/parser/Console_Token_Stream.hh
@@ -58,6 +58,8 @@ public:
 
   virtual void report(const string &message);
 
+  virtual void comment(std::string const &message);
+
 protected:
   // IMPLEMENTATION
 

--- a/src/parser/File_Token_Stream.cc
+++ b/src/parser/File_Token_Stream.cc
@@ -209,6 +209,18 @@ void File_Token_Stream::report(string const &message) {
 
 //-------------------------------------------------------------------------------------//
 /*!
+ * This function sends a message by writing it to the error console stream.
+ * This version prints no location information.
+ */
+
+void File_Token_Stream::comment(string const &message) {
+  cerr << message << endl;
+
+  Ensure(check_class_invariants());
+}
+
+//-------------------------------------------------------------------------------------//
+/*!
  * This function rewinds the file stream associated with the file token
  * stream and flushes its internal buffers, so that scanning resumes at
  * the beginning of the file stream. The error count is also reset.

--- a/src/parser/File_Token_Stream.hh
+++ b/src/parser/File_Token_Stream.hh
@@ -55,6 +55,8 @@ public:
 
   virtual void report(string const &message);
 
+  virtual void comment(std::string const &message);
+
 protected:
   // IMPLEMENTATION
 

--- a/src/parser/Parallel_File_Token_Stream.cc
+++ b/src/parser/Parallel_File_Token_Stream.cc
@@ -324,6 +324,25 @@ void Parallel_File_Token_Stream::report(string const &message) {
 
 //-------------------------------------------------------------------------//
 /*!
+ * This function sends a message by writing it to the error console stream.
+ * Only processor 0 writes the message, to avoid many (possibly thousands) of
+ * duplicate messages.
+ *
+ * This version prints no location information.
+ */
+
+void Parallel_File_Token_Stream::comment(string const &message) {
+  Require(check_class_invariants());
+
+  if (rtt_c4::node() == 0) {
+    cerr << message << endl;
+  }
+
+  Ensure(check_class_invariants());
+}
+
+//-------------------------------------------------------------------------//
+/*!
  *
  * This function rewinds the file stream associated with the file token
  * stream and flushes its internal buffers, so that scanning resumes at

--- a/src/parser/Parallel_File_Token_Stream.hh
+++ b/src/parser/Parallel_File_Token_Stream.hh
@@ -62,6 +62,9 @@ public:
   //! Report a condition.
   virtual void report(string const &message);
 
+  //! Report a comment.
+  virtual void comment(std::string const &message);
+
   // ACCESSORS
 
   //! Check the class invariants.

--- a/src/parser/Parse_Table.cc
+++ b/src/parser/Parse_Table.cc
@@ -268,6 +268,16 @@ Token Parse_Table::parse(Token_Stream &tokens) const {
 
           tokens.report_semantic_error(token, ": unrecognized keyword: " +
                                                   token.text());
+
+          // Give the user the possibilities.
+          tokens.comment("Perhaps you meant one of:");
+          for (auto const &i : vec) {
+            tokens.comment(i.moniker);
+            if (i.description != nullptr) {
+              tokens.comment(string("  ") + i.description);
+            }
+          }
+
           is_recovering = true;
         }
         // else we are in recovery mode, and additional diagnostics

--- a/src/parser/Parse_Table.hh
+++ b/src/parser/Parse_Table.hh
@@ -89,6 +89,25 @@ struct Keyword {
      * moniker in the same Parse_Table.
      */
   char const *module;
+
+  /*! Explanation of keyword.
+   *
+   * This optional member is a brief description of the keyword. If the
+   * parser sees a keyword in the Token_Stream that it does not recognize,
+   * it will list the recognized keywords and, if a keyword has a non-null
+   * description, it will print that description.
+   */
+  char const *description;
+
+  Keyword()
+      : moniker(nullptr), func(nullptr), index(0), module(nullptr),
+        description(nullptr) {}
+
+  Keyword(char const *moniker, void (*func)(Token_Stream &, int),
+          int const index, char const *module,
+          char const *description = nullptr)
+      : moniker(moniker), func(func), index(index), module(module),
+        description(description) {}
 };
 
 //-------------------------------------------------------------------------//

--- a/src/parser/String_Token_Stream.cc
+++ b/src/parser/String_Token_Stream.cc
@@ -160,6 +160,19 @@ void String_Token_Stream::report(string const &message) {
 }
 
 //-------------------------------------------------------------------------------------//
+/*!
+ * This function sends a message by writing it to an internal string..
+ *
+ * This version prints no location information.
+ */
+
+void String_Token_Stream::comment(string const &message) {
+  messages_ += message + '\n';
+
+  Ensure(check_class_invariants());
+}
+
+//-------------------------------------------------------------------------------------//
 void String_Token_Stream::rewind() {
   pos_ = 0;
 

--- a/src/parser/String_Token_Stream.hh
+++ b/src/parser/String_Token_Stream.hh
@@ -54,6 +54,9 @@ public:
   //! Report a condition.
   virtual void report(string const &message);
 
+  //! Report a comment.
+  virtual void comment(std::string const &message);
+
   // ACCESSORS
 
   //! Return the text to be tokenized.

--- a/src/parser/Token_Stream.hh
+++ b/src/parser/Token_Stream.hh
@@ -164,6 +164,21 @@ public:
   virtual void report(std::string const &message) = 0;
 
   //-----------------------------------------------------------------------//
+  /*!
+     * \brief Send a comment, without location information, to the user.
+     *
+     * This function sends a message to the user in a stream-specific manner.
+     * This differs from the report() functions chiefly in that the message
+     * is not preceded by any location information. This is useful for
+     * extended comments, e.g., listing available keywords when the stream
+     * contains an unrecognized keyword.
+     *
+     * \param message
+     * Message to be passed to the user.
+     */
+  virtual void comment(std::string const &message) = 0;
+
+  //-----------------------------------------------------------------------//
   /*! Check a syntax condition.
      *
      * By putting the check branch here, we improve coverage statistics for

--- a/src/parser/test/tstConsole_Token_Stream.cc
+++ b/src/parser/test/tstConsole_Token_Stream.cc
@@ -37,6 +37,7 @@ void tstConsole_Token_Stream(rtt_dsxx::UnitTest &ut) {
 
   {
     Console_Token_Stream tokens;
+    tokens.comment("begin Console_Token_Stream tests");
     if (tokens.whitespace() != Text_Token_Stream::default_whitespace)
       FAILMSG("whitespace characters are NOT correct defaults");
     else

--- a/src/parser/test/tstFile_Token_Stream.cc
+++ b/src/parser/test/tstFile_Token_Stream.cc
@@ -31,6 +31,7 @@ void tstFile_Token_Stream(rtt_dsxx::UnitTest &ut) {
 
   {
     File_Token_Stream tokens(inputFile);
+    tokens.comment("begin tests of File_Token_Stream");
     if (tokens.whitespace() != Text_Token_Stream::default_whitespace)
       FAILMSG("whitespace characters are NOT correct defaults");
     else

--- a/src/parser/test/tstParallel_File_Token_Stream.cc
+++ b/src/parser/test/tstParallel_File_Token_Stream.cc
@@ -32,6 +32,7 @@ void tstParallel_File_Token_Stream(rtt_dsxx::UnitTest &ut) {
 
   {
     Parallel_File_Token_Stream tokens(inputFile);
+    tokens.comment("begin test of Parallel_File_Token_Stream");
     if (tokens.whitespace() != Text_Token_Stream::default_whitespace)
       FAILMSG("Whitespace not set correctly");
     else

--- a/src/parser/test/tstParse_Table.cc
+++ b/src/parser/test/tstParse_Table.cc
@@ -60,7 +60,7 @@ const Keyword raw_table[] = {
     {"BLACK", Parse_Color, 0, "main"},
     {"BLUE GREEN", Parse_Color, 2, "main"},
     {"BLUISH GREEN", Parse_Color, 2, "main"},
-    {"lower blue", Parse_Color, 2, "main"},
+    {"lower blue", Parse_Color, 2, "main", "keyword to test case sensitivity"},
     {"COLOR", Parse_Any_Color, 0, "main"},
 };
 const size_t raw_table_size = sizeof(raw_table) / sizeof(Keyword);
@@ -73,6 +73,10 @@ const size_t raw_table_2_size = sizeof(raw_table_2) / sizeof(Keyword);
 class Error_Token_Stream : public Token_Stream {
 public:
   void rewind() {}
+
+  void comment(string const & /*err*/) {
+    cout << "comment reported to Error_Token_Stream" << endl;
+  }
 
 protected:
   void report(Token const &, string const & /*err*/) {
@@ -91,6 +95,10 @@ public:
   Colon_Token_Stream() : count_(0) {}
 
   void rewind() {}
+
+  void comment(string const & /*err*/) {
+    cout << "comment reported to Colon_Token_Stream" << endl;
+  }
 
 protected:
   void report(Token const &, string const & /*err*/) {
@@ -334,6 +342,7 @@ void tstParse_Table(UnitTest &ut) {
   }
   {
     Colon_Token_Stream tokens;
+    tokens.comment("dummy test");
     if (table.parse(tokens).type() != END) {
       FAILMSG("END detection FAILED");
     }
@@ -344,6 +353,7 @@ void tstParse_Table(UnitTest &ut) {
   // Error handling
   {
     Error_Token_Stream tokens;
+    tokens.comment("dummy comment");
     if (table.parse(tokens).type() != rtt_parser::ERROR) {
       FAILMSG("error detection FAILED");
     }

--- a/src/parser/test/tstString_Token_Stream.cc
+++ b/src/parser/test/tstString_Token_Stream.cc
@@ -41,6 +41,7 @@ void tstString_Token_Stream(UnitTest &ut) {
 
   {
     String_Token_Stream tokens(contents);
+    tokens.comment("begin test of String_Token_Stream");
     if (tokens.whitespace() != Text_Token_Stream::default_whitespace)
       FAILMSG("whitespace characters are NOT correct defaults");
     else


### PR DESCRIPTION
### Background

No one ever reads the users' manual, which is rarely updated in a timely way anyway. The result is that even experienced users are unaware of which keywords are present in a parse table.

### Purpose of Pull Request

Add diagnostic capability to Parse_Table that lets a user know what keywords are available when the parser sees something it doesn't recognize.

### Description of changes

Add code such that a Parse_Table will list the known keywords for the client whenever it encounters an unknown keyword. The keyword may optionally be followed by a description. This is more likely to be useful than the users' manual that no one ever reads.

In support of this capability, add a description member to the Keyword struct. Add a default constructor for Keyword and a constructor compatible with the usual brace initializers we have been using. The latter adds the description with the description defaulting to nullptr. This allows all our existing braced initializations of Keywords to continue working as before without generating a warning, thanks to new C++11 syntax that allows braced initializers to be treated as constructor calls.

Also in support of this capability, add a comment member to the various Token_Stream children. This is similar to the report function, but does not precede everything with a token location, which is useful for extended comments from the parser.

Exercise all these functions in the test suite.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
