### PR TITLE
Tweak some code for efficiency.

### DIFF
--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -776,7 +776,7 @@ void CDI::integrate_planck_rosseland(double const scaled_freq,
   Require(rtt_dsxx::soft_equiv(exp_scaled_freq, std::exp(-scaled_freq)));
 
   // Calculate the Planckian integral
-  planck = integrate_planck(scaled_freq);
+  planck = integrate_planck(scaled_freq, exp_scaled_freq);
 
   Require(planck >= 0.0);
   Require(planck <= 1.0);

--- a/src/quadrature/Octant_Quadrature.cc
+++ b/src/quadrature/Octant_Quadrature.cc
@@ -37,9 +37,6 @@ vector<Ordinate> Octant_Quadrature::create_ordinates_(
   // We build the 3-D first, then edit as appropriate.
 
   vector<double> mu, eta, wt;
-  mu.reserve(numOrdinates);
-  eta.reserve(numOrdinates);
-  wt.reserve(numOrdinates);
 
   create_octant_ordinates_(mu, eta, wt);
 


### PR DESCRIPTION
### Purpose of Pull Request

Some minor tweaks that nevertheless improve efficiency.

### Description of changes

Use make_shared in preference to initializing shared_ptr with a new expression. This reduces two allocation calls to one allocation call.

Eliminate an unnecessary extra call to exp when calculating Planck and Rosseland integrals for a set of groups.

### Status

* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [x] This PR should not include _fpe_trap_ changes.
