### PR TITLE
Add a check_all function to the UnitTest class tree.

### DIFF
--- a/src/c4/ParallelUnitTest.hh
+++ b/src/c4/ParallelUnitTest.hh
@@ -91,6 +91,9 @@ public:
 
   //! Provide a report of the number of unit test passes and fails.
   DLL_PUBLIC_c4 void status(void);
+
+  DLL_PUBLIC_c4 virtual bool check_all(bool good, std::string const &checkmsg,
+                                       bool fatal = false);
 };
 
 } // end namespace rtt_c4

--- a/src/c4/test/tstParallelUnitTest.cc
+++ b/src/c4/test/tstParallelUnitTest.cc
@@ -28,6 +28,26 @@ using namespace rtt_c4;
  * Demonstrate that the normal access functions work as indended.
  */
 void tstMemberFunctions(ParallelUnitTest &ut, stringstream &output) {
+  // test check_all function for failing case. We put this first so we can
+  // flush output afterwards.
+  {
+    string const msg("Testing the check_all member function for failing case.");
+    ut.check_all(rtt_c4::node() == 0, msg);
+
+    string const data(output.str());
+    size_t const found = data.find(msg);
+    if (ut.numPasses == 0 && found != string::npos) {
+      cout << "Test: passed\n\t check_all member function works for failing "
+              "case ."
+           << endl;
+      ut.reset();
+      output.clear();
+    } else {
+      cout << "Test: failed\n\t passes member function failed for failing case."
+           << endl;
+    }
+  }
+
   // test pass functions
   {
     string const msg("Testing the passes member function.");
@@ -39,6 +59,20 @@ void tstMemberFunctions(ParallelUnitTest &ut, stringstream &output) {
       cout << "Test: passed\n\t passes member function works." << endl;
     else
       cout << "Test: failed\n\t passes member function failed." << endl;
+  }
+
+  // test check_all function
+  {
+    string const msg("Testing the check_all member function for passing case.");
+    ut.check_all(true, msg);
+
+    string const data(output.str());
+    size_t const found = data.find(msg);
+    if (ut.numPasses == 1 && found != string::npos)
+      cout << "Test: passed\n\t check_all member function works for pass."
+           << endl;
+    else
+      cout << "Test: failed\n\t check_all member function failed." << endl;
   }
 
   // Test the PASSMSG macro

--- a/src/ds++/UnitTest.hh
+++ b/src/ds++/UnitTest.hh
@@ -108,6 +108,10 @@ public:
   DLL_PUBLIC_dsxx bool passes(std::string const &passmsg);
   DLL_PUBLIC_dsxx bool check(bool, std::string const &checkmsg,
                              bool fatal = false);
+  DLL_PUBLIC_dsxx virtual bool check_all(bool good, std::string const &checkmsg,
+                                         bool fatal = false) {
+    return check(good, checkmsg, fatal);
+  }
   /*!
    * \brief Provide a summary of the test status
    *

--- a/src/ds++/test/tstScalarUnitTest.cc
+++ b/src/ds++/test/tstScalarUnitTest.cc
@@ -47,6 +47,7 @@ char *convert_string_to_char_ptr(std::string const &s) {
 void tstOne(UnitTest &unitTest) {
   unitTest.passes("Looks like the passes member function is working.");
   unitTest.check(true, "Also for check version.");
+  unitTest.check_all(true, "Also for check_all version.");
   PASSMSG("Looks like the PASSMSG macro is working as a member function.");
   UT_CHECK(unitTest, true);
   return;
@@ -56,6 +57,7 @@ void tstOne(UnitTest &unitTest) {
 void tstTwo(UnitTest &unitTest) {
   unitTest.failure("Looks like the failure member function is working.");
   unitTest.check(false, "Also for check version.");
+  unitTest.check_all(false, "Also for check_all version.");
   FAILMSG("Looks like the FAILMSG macro is working.");
   ITFAILS;
   FAILURE;
@@ -75,13 +77,13 @@ void tstTwoCheck(UnitTest &unitTest, ostringstream &msg) {
   map<string, unsigned> word_list(rtt_dsxx::get_word_count(msg, verbose));
 
   // Check the list of occurrences against the expected values
-  if (word_list[string("Test")] == 8)
-    unitTest.passes("Found 7 occurrences of \"Test\"");
+  if (word_list[string("Test")] == 9)
+    unitTest.passes("Found 9 occurrences of \"Test\"");
   else
     unitTest.failure("Did not find expected number of occurrences of \"Test\"");
 
-  if (word_list[string("failed")] != 6)
-    unitTest.failure("Did not find 5 occurrences of failure.");
+  if (word_list[string("failed")] != 7)
+    unitTest.failure("Did not find 7 occurrences of failure.");
   if (word_list[string("FAILMSG")] != 1)
     unitTest.failure("Found 1 occurrence of \"FAILMSG\"");
   if (word_list[string("failure")] != 1)


### PR DESCRIPTION


### Background

When a condition is checked on all processors, one gets multiple success/failure messages for that test. The test is also not handled very gracefully if only *some* processors fail, particularly in the fatal failure case.

### Purpose of Pull Request

Provide less vebose output for parallel tests and make sure failure on only some processor is handled gracefully.

### Description of changes

Added a check_all function to the UnitTest class tree. This is used for a test that must pass on all processors and is checked synchronously. Only one pass/fail message will be generated rather than one per processor. The failing processors will be listed if the test fails. This makes for cleaner recovery if a test fails on only some processors, particularly for the fatal failure case.

This is simply a redirect to check() for ScalarUnitTest.

Note: I can't think of a clean way to test the fatal failure case automatically. (I've checked it manually.) This means there will be a line of uncovered code introduced by this merge.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
