### PR TITLE
Add slurm function to print total cpu-hr usage.

### DIFF
--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -49,7 +49,8 @@ case ${-} in
      echo "knownaccounts  - Table of known accounts."
      echo "jobpriorities  - List of all jobs and their priorities."
      echo "backfill       - Maximum job size to allow immediate start?"
-}
+     echo "usercpuhrs [moniker] [start date (mm/dd/yy)] [end date (mm/dd/yy)] - Print total cpu-hr usage by account."
+   }
 
    alias hluser="egrep --color -E '.*${USER}.*|$'"
    boldface=$(tput bold)
@@ -129,7 +130,18 @@ case ${-} in
    function sreason () {
      squeue -o "%.7i %.10u %.10T %r" -t PD,S,CG,CD,CF,CA,F,TO,PR,NF -j $1
    }
-
+   function usercpuhrs () {	 
+     if [[ $1 =~ [a-z].* ]]; then
+       user=$1
+       fday=$2
+       lday=$3
+     elif [[ $1 =~ [0-9].* ]]; then
+       fday=$1
+       lday=$2
+     fi
+     [ -z "$user" ] && user=${USER}
+     sreport -t Hours cluster AccountUtilizationByUser user=$user start=$fday end=$lday
+   }
    ;; # end case 'interactive'
 
 ##---------------------------------------------------------------------------##


### PR DESCRIPTION
### Purpose of Pull Request

* CPU-hr usage by account by user may be useful for generating reports or prioritizing resources.

### Description of changes

* Add slurm function `usercpuhrs`, in .bashrc_slurm, to print total cpu-hr usage, which takes optional inputs: user, start date, and end date.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
