### PR TITLE
Minor tweaks to the draco developer environment.

### DIFF
--- a/autodoc/README.autodoc
+++ b/autodoc/README.autodoc
@@ -1,0 +1,52 @@
+Autodoc
+================================================================================
+
+Developer documentation is generated using doxygen
+(https://www.stack.nl/~dimitri/doxygen). If available, this build can use
+graphviz (dot), dia and mscgen to generate graphics like dependency diagrams,
+UML and sequence diagrams.
+
+Documentation is generated nightly and published to the LANL Yellow Network at
+https://rtt.lanl.gov/autodoc.
+
+The Draco source code templates (draco/environment/templates) provide
+recommended doxygen commands for use by Draco developers.
+
+Additional information:
+
+- mscgen diagrams: http://www.mcternan.me.uk/mscgen
+- dia            : https://www.stack.nl/~dimitri/doxygen/manual/config.html
+- equations      : https://www.stack.nl/~dimitri/doxygen/manual/formulas.html
+- call graphs    : https://www.stack.nl/~dimitri/doxygen/manual/diagrams.html
+
+================================================================================
+Sample: mscgen diagram
+
+/*!
+ * \par Versions
+ *
+ * msc {
+ *
+ * ML, SN, TT;
+ *
+ * | | |;
+ *
+ * ML rbox ML [label="Moonlight/Pinto"],
+ * SN rbox SN [label="Snow/Badger"],
+ * TT rbox TT [label="Trinitite"];
+ *
+ * ML abox TT [label="Draco-6_24_0", textbgcolor="#00ff00"];
+ * ML abox TT [label="Draco-6_23_0", textbgcolor="#00ff00"];
+ * ML abox TT [label="Draco-6_22_0", textbgcolor="#00ff00"];
+ *
+ * }
+ */
+
+================================================================================
+Sample: equation
+
+/*!
+ * \par Test equation generation
+ *
+ * This is an inline equation: \f$ x = a + c \f$ Is it?
+ */

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -43,7 +43,7 @@ case ${-} in
    shopt -s cdspell # autocorrect spelling errors on cd command line.
 
    # Prevent creation of core files (ulimit -a to see all limits).
-   ulimit -c 0
+   # ulimit -c 0
 
    ##------------------------------------------------------------------------##
    ## Common aliases

--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -35,6 +35,7 @@ case ${-} in
      echo "checkjob [job-id]  - Print information about the specified job-id."
      echo "sreason [job-id]   - Print why job-id is not starting."
      echo "myjobpriorities    - List of all jobs and their priorities."
+     echo "myuseage           - Report total hours used."
      echo -e "\nAll jobs:\n"
      echo "sq        - Show all jobs for all users (running, pending, blocked)."
      echo "sqrun     - Show running jobs for all users"
@@ -79,6 +80,7 @@ case ${-} in
      sprio -h -n -o "$formatstring" $* | sort -r -k 3,3
    }
    alias myjobpriorities='jobpriorities -u $USER'
+   alias myusage='sreport -t Hours cluster AccountUtilizationByUser user=$LOGNAME start=1/1/10 end=`date +"%m/%d/%Y"`'
    function sqqos() {
      local myqos="dev"
      if [ $1 ]; then myqos=$1; fi

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -101,7 +101,7 @@ else
 fi
 
 # Load default set of modules
-dm_core="eospac git ndi python graphviz doxygen ccache numdiff"
+dm_core="eospac git ndi python graphviz doxygen mscgen ccache numdiff"
 dm_gcc="gcc/7.2.0 cmake netlib-lapack gsl metis random123 csk qt"
 dm_openmpi="openmpi parmetis superlu-dist trilinos"
 export dracomodules="$dm_core $dm_gcc $dm_openmpi"


### PR DESCRIPTION
### Description of changes

+ No longer disable the generation of core files. Let the developer set this in his or her own `.bashrc` file.
+ Add a new bash helper function `myusage` to report slurm account use. This feature was provided by Ryan.
+ Enable the use of **mscgen** with **doxygen** when the autodoc pages are generated nightly on ccscs2.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
