### PR TITLE
Promote python requirement to 'always required'

### DIFF
--- a/autodoc/CMakeLists.txt
+++ b/autodoc/CMakeLists.txt
@@ -12,8 +12,8 @@
 # lose a few features, but wouldn't need to maintain this file.
 # Ref. https://cmake.org/cmake/help/v3.10/module/FindDoxygen.html
 
-# Doxygen
-find_package( Doxygen OPTIONAL_COMPONENTS dot mscgen dia )
+# config/vendor_libraries.cmake is responsible for detecting if doxygen is
+# available.
 
 if( DOXYGEN_FOUND )
 

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -500,7 +500,7 @@ macro( SetupVendorLibrariesUnix )
   # PYTHON ----------------------------------------------------------------
 
   message( STATUS "Looking for Python...." )
-  find_package(PythonInterp QUIET)
+  find_package(PythonInterp QUIET REQUIRED)
   #  PYTHONINTERP_FOUND - Was the Python executable found
   #  PYTHON_EXECUTABLE  - path to the Python interpreter
   set_package_properties( PythonInterp PROPERTIES
@@ -516,6 +516,16 @@ macro( SetupVendorLibrariesUnix )
 
   # Qt -----------------------------------------------------------------------
   setupQt()
+
+  # Doxygen ------------------------------------------------------------------
+
+  message( STATUS "Looking for Doxygen..." )
+  find_package( Doxygen OPTIONAL_COMPONENTS dot mscgen dia )
+  set_package_properties( Doxygen PROPERTIES
+    DESCRIPTION "Doxygen autodoc generator"
+    TYPE OPTIONAL
+    PURPOSE "Required for building develop HTML documentation."
+    )
 
 endmacro()
 


### PR DESCRIPTION
### Background

+ Python has become a significantly more important requirement for Draco (see `ApplicationUnitTest.py`, and the ipcress data viewer, etc.). This PR tells CMake that
  python is now an essential requirement.  Draco will no longer configure if python is missing.
+ Also move the detection of doxygen from autodoc/CMakeLists.txt to `vendor_libraries.cmake`.

### Purpose of Pull Request

* [Fixes Redmine Issue #1130](https://rtt.lanl.gov/redmine/issue/1130)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
