### PR TITLE
Allow multiple values for extra_params in the regression system.

### DIFF
--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -52,6 +52,10 @@ umask 0002
 # Set a variable to avoid errors of the form "Assertion failure at psm_ep.c:835:
 # ep->epid !=0". This was suggested by Howard Pritchard via email on 2018 Jan 18.
 export OMPI_MCA_PML=ob1
+# export OMPI_MCA_pml_base_verbose=100
+# email from Howard Pritchard, 2018-03-22
+# export PSM2_TRACEMASK=0x1c3
+# Ref PSM2 user guide (https://www.intel.com/content/dam/support/us/en/documents/network/omni-adptr/sb/Intel_PSM2_PG_H76473_v1_0.pdf )
 
 export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
@@ -93,7 +97,7 @@ source $rscriptdir/cts1-options.sh
 # ----------------------------------------
 echo "==========================================================================="
 echo "${machine_name_long} regression: ${ctestparts} from ${machine}."
-echo "                      ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
+echo "                      ${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}"
 echo "==========================================================================="
 if [[ ${SLURM_JOB_PARTITION} ]]; then
   echo " "
@@ -132,74 +136,91 @@ if [[ "${comp}" == "icpc" ]]; then
   comp="intel"
 fi
 
+# sanity checks
+compiler_set=no
+
 # Extra parameters
-case $extra_params in
-"")
-    # no-op
-    ;;
-fulldiagnostics)
-    # no-op
-    ;;
-gcc610)
-    run "module purge &> /dev/null"
-    run "module list"
-    run "module load user_contrib friendly-testing"
-    run "module load gcc/6.1.0 openmpi/1.10.5"
-    run "module load trilinos/12.8.1 superlu-dist metis parmetis"
-    run "module load cmake/3.9.0 ndi numdiff git"
-    run "module load random123 eospac/6.2.4 lapack/3.6.1"
-    comp="${LCOMPILER}"
-    echo "comp = $comp"
-    ;;
-gcc640)
-    run "module purge &> /dev/null"
-    run "module list"
-    run "module load user_contrib friendly-testing"
-    run "module load gcc/6.4.0 openmpi/2.1.2 mkl"
-    run "module load trilinos/12.10.1 superlu-dist metis parmetis"
-    run "module load cmake/3.9.0 ndi numdiff git"
-    run "module load random123 eospac/6.2.4"
-    comp="${LCOMPILER}"
-    echo "comp = $comp"
-    ;;
-newtools)
-    run "module purge &> /dev/null"
-    run "module list"
-    run "module load user_contrib friendly-testing"
-    run "module load intel/18.0.1 openmpi/2.1.2 mkl"
-    run "module load superlu-dist metis parmetis"
-    run "module load trilinos/12.10.1 superlu-dist metis parmetis"
-    run "module load cmake/3.9.0 ndi numdiff git"
-    run "module load mkl random123 eospac/6.2.4 csk"
-    ;;
-nr)
-    # no-op
-    ;;
-perfbench)
-    # no-op
-    ;;
-vtest)
-    # no-op
-    ;;
-@($pem_match) )
+for ep in $extra_params; do
+  case $ep in
+    "")
+      # no-op
+      ;;
+    fulldiagnostics)
+      # no-op
+      ;;
+    gcc610)
+      if [[ $compiler_set == yes ]]; then
+        die "You cannot select multiple compilers with the '-e' argument."
+      fi
+      compiler_set=yes
+      run "module purge &> /dev/null"
+      run "module list"
+      run "module load user_contrib friendly-testing"
+      run "module load gcc/6.1.0 openmpi/1.10.5"
+      run "module load trilinos/12.8.1 superlu-dist metis parmetis"
+      run "module load cmake/3.9.0 ndi numdiff git"
+      run "module load random123 eospac/6.2.4 lapack/3.6.1"
+      comp="${LCOMPILER}"
+      echo "comp = $comp"
+      ;;
+    gcc640)
+      if [[ $compiler_set == yes ]]; then
+        die "You cannot select multiple compilers with the '-e' argument."
+      fi
+      compiler_set=yes
+      run "module purge &> /dev/null"
+      run "module list"
+      run "module load user_contrib friendly-testing"
+      run "module load gcc/6.4.0 openmpi/2.1.2 mkl"
+      run "module load trilinos/12.10.1 superlu-dist metis parmetis"
+      run "module load cmake/3.9.0 ndi numdiff git"
+      run "module load random123 eospac/6.2.4"
+      comp="${LCOMPILER}"
+      echo "comp = $comp"
+      ;;
+    newtools)
+      if [[ $compiler_set == yes ]]; then
+        die "You cannot select multiple compilers with the '-e' argument."
+      fi
+      compiler_set=yes
+      run "module purge &> /dev/null"
+      run "module list"
+      run "module load user_contrib friendly-testing"
+      run "module load intel/18.0.1 openmpi/2.1.2 mkl"
+      run "module load superlu-dist metis parmetis"
+      run "module load trilinos/12.10.1 superlu-dist metis parmetis"
+      run "module load cmake/3.9.0 ndi numdiff git"
+      run "module load mkl random123 eospac/6.2.4 csk"
+      ;;
+    nr)
+      # no-op
+      ;;
+    perfbench)
+      # no-op
+      ;;
+    vtest)
+      # no-op
+      ;;
+    @($pem_match) )
     # found in tt-options.sh but no rule found here
     echo "FATAL ERROR"
-    echo "Extra parameter = ${extra_param} requested and known by ${machine_name_short}-options.sh,"
+    echo "Extra parameter = ${ep} requested and known by ${machine_name_short}-options.sh,"
     echo "but ${0##*/} doesn't know about this option."
     exit 1
     ;;
-*)
-    echo "FATAL ERROR"
-    echo "Extra parameter = ${extra_param} requested but is unknown to"
-    echo "the regression system (edit ${0##*/})."
-    exit 1
-    ;;
-esac
+    *)
+      echo "FATAL ERROR"
+      echo "Extra parameter = ${ep} requested but is unknown to"
+      echo "the regression system (edit ${0##*/})."
+      exit 1
+      ;;
+  esac
+done
 run "module list"
 
 # Use a unique regression folder for each github branch
-if [[ $extra_params ]]; then
-  comp=$comp-$extra_params
+if [[ $extra_params_sort_safe ]]; then
+  comp=$comp-$extra_params_sort_safe
 fi
 comp=$comp-$featurebranch
 
@@ -250,6 +271,7 @@ echo "${0##*/}: comp           = $comp"
 echo "${0##*/}: machine        = $machine"
 echo "${0##*/}: subproj        = $subproj"
 echo "${0##*/}: regdir         = $regdir"
+echo "${0##*/}: extra_params_sort_safe = $extra_params_sort_safe"
 
 #----------------------------------------------------------------------#
 # CTest

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -80,6 +80,10 @@ endmacro()
 # ------------------------------------------------------------
 macro( set_defaults )
 
+  message("\n----------------------------------------
+Setting defaults
+----------------------------------------\n")
+
   # Prerequisits:
   #
   # This setup assumes that the project work_dir will contain 3 subdirectories:
@@ -251,6 +255,10 @@ endmacro( set_defaults )
 # ------------------------------------------------------------
 macro( parse_args )
 
+  message("\n----------------------------------------
+Parsing arguments
+----------------------------------------\n")
+
   # Default is "Experimental." Special builds are "Nightly" or "Continuous"
   if( ${CTEST_SCRIPT_ARG} MATCHES Nightly )
     set( CTEST_MODEL "Nightly" )
@@ -353,28 +361,31 @@ macro( parse_args )
 
   # append the compiler_short_name with the extra_params string (if any) and set
   # some variables based on extra_param's value.
-  if( NOT "$ENV{extra_params}x" STREQUAL "x" )
-    set( compiler_short_name "${compiler_short_name}-$ENV{extra_params}" )
-    if( $ENV{extra_params} MATCHES "cuda" )
+  if( DEFINED ENV{extra_params_sort_safe} )
+
+    set( compiler_short_name
+      "${compiler_short_name}-$ENV{extra_params_sort_safe}" )
+
+    if( $ENV{extra_params_sort_safe} MATCHES "cuda" )
       set(USE_CUDA ON)
     endif()
-    if( $ENV{extra_params} MATCHES "fulldiagnostics" )
+    if( $ENV{extra_params_sort_safe} MATCHES "fulldiagnostics" )
       set( FULLDIAGNOSTICS "DRACO_DIAGNOSTICS:STRING=7")
       # Note 'DRACO_TIMING:STRING=2' will break milagro tests (python cannot
       # parse output).
     endif()
-    if( $ENV{extra_params} MATCHES "nr" )
+    if( $ENV{extra_params_sort_safe} MATCHES "nr" )
       set( RNG_NR "ENABLE_RNG_NR:BOOL=ON" )
     endif()
-    if( $ENV{extra_params} MATCHES "scalar" )
+    if( $ENV{extra_params_sort_safe} MATCHES "scalar" )
       set( DRACO_C4 "DRACO_C4:STRING=SCALAR" )
-    elseif( $ENV{extra_params} MATCHES "static" )
+    elseif( $ENV{extra_params_sort_safe} MATCHES "static" )
       set( DRACO_LIBRARY_TYPE "DRACO_LIBRARY_TYPE:STRING=STATIC" )
     endif()
-    if( $ENV{extra_params} MATCHES "vtest" )
+    if( $ENV{extra_params_sort_safe} MATCHES "vtest" )
       list( APPEND CUSTOM_VARS "RUN_VERIFICATION_TESTS:BOOL=ON" )
     endif()
-    if( $ENV{extra_params} MATCHES "perfbench" )
+    if( $ENV{extra_params_sort_safe} MATCHES "perfbench" )
       list( APPEND CUSTOM_VARS "ENABLE_PERFBENCH:BOOL=ON" )
     endif()
   endif()
@@ -450,6 +461,10 @@ endmacro( parse_args )
 # Names of developer tools
 # ------------------------------------------------------------
 macro( find_tools )
+
+  message("\n----------------------------------------
+Finding tools...
+----------------------------------------\n")
 
   find_program( CTEST_CMD
     NAMES ctest
@@ -794,12 +809,13 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   # *-nr-*              *-*
   # *-vtest-*           *-*
   # *-perfbench-*       *-*
+  # *-knl-perfbench-*   *-knl-*
 
   if( "${dep_pkg}" MATCHES "draco" )
     # not any ${extraparam} since many map to draco builds that have the same
     # ${extraparam}.  For example: *-newtools-*.
     foreach( extraparam nr perfbench vtest )
-      string( REPLACE "-${extraparam}-" "-" ${dep_pkg}_work_dir
+      string( REGEX REPLACE "[-_]${extraparam}[-_]" "-" ${dep_pkg}_work_dir
         ${${dep_pkg}_work_dir} )
     endforeach()
 

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -28,6 +28,9 @@
 
 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne capsaicin\" -e vtest
 
+# performance over time
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p \"jayenne capsaicin\"
+
 # --------------------
 # KNL
 # --------------------
@@ -36,6 +39,9 @@
 
 # not sure we support two extra parameters (kt)
 #01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e \"knl vtest\"
+
+# performance over time
+#01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e \"knl perfbench\" -p \"jayenne capsaicin\"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -27,10 +27,6 @@ nargs=${#args[@]}
 scriptname=${0##*/}
 host=`uname -n`
 
-# import some bash functions
-export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $rscriptdir/scripts/common.sh
-
 export SHOWQ=`which squeue`
 export MSUB=`which sbatch`
 
@@ -40,8 +36,32 @@ for (( i=0; i < $nargs ; ++i )); do
    dep_jobids="${dep_jobids} ${args[$i]} "
 done
 
+# load some common bash functions
+export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ -f $rscriptdir/scripts/common.sh ]]; then
+  source $rscriptdir/scripts/common.sh
+else
+  echo " "
+  echo "FATAL ERROR: Unable to locate Draco's bash functions: "
+  echo "   looking for .../regression/scripts/common.sh"
+  echo "   searched rscriptdir = $rscriptdir"
+  exit 1
+fi
+
 # sanity checks
 job_launch_sanity_checks
+
+# available_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\)|.*/\1/' | sed -e 's/|.*//'`
+available_account=`sacctmgr -np list assoc user=$LOGNAME format=Account | sed -e 's/|//' | sed -e 's/,/ /g' | xargs -n 1 | sort -u | xargs`
+available_partition=`sacctmgr -np list assoc user=$LOGNAME format=Partition | sed -e 's/|//' | sed -e 's/,/ /g' | xargs -n 1 | sort -u | xargs`
+available_qos=`sacctmgr -np list assoc user=$LOGNAME format=Qos | sed -e 's/|//' | sed -e 's/,/ /g' | xargs -n 1 | sort -u | xargs`
+# not sure how to detect access to
+# pm="--reservation=PreventMaint"
+case $available_qos in
+#  *access*) access_queue="-A access --qos=access" ;;
+  *dev*)    access_queue="--qos=dev ${pm}" ;;
+# *interactive*
+esac
 
 # Banner
 print_job_launch_banner
@@ -55,6 +75,13 @@ for jobid in ${dep_jobids}; do
        sleep 5m
     done
 done
+
+if ! [[ -d $logdir ]]; then
+  mkdir -p $logdir
+  chgrp draco $logdir
+  chmod g+rwX $logdir
+  chmod g+s $logdir
+fi
 
   # srun options: (also see config/setupMPI.cmake)
   # -------------------------------------------------
@@ -75,17 +102,20 @@ done
 
 # Note that we build on the haswell back-end (even when building code for knl):
 build_partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0"
-case $extra_params in
-knl) partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0 -p knl" ;;
-*)   partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0" ;;
+case $extra_params_sort_safe in
+*knl*) partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0 -p knl" ;;
 esac
+
+# When on DST use
+#build_partition_options+=" ${pm}"
+#partition_options+=" ${pm}"
 
 # Configure on front end
 # Only the front-end can see the github and gitlab repositories.
 echo "Configure on the front end..."
 export REGRESSION_PHASE=c
 echo " "
-cmd="${rscriptdir}/tt-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log"
+cmd="${rscriptdir}/tt-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-${REGRESSION_PHASE}.log"
 echo "${cmd}"
 eval "${cmd}"
 
@@ -96,7 +126,7 @@ echo " "
 export REGRESSION_PHASE=b
 echo "Build from the back end..."
 echo " "
-logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
+logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
 cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} ${build_partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
@@ -107,6 +137,7 @@ echo "jobid = ${jobid}"
 sleep 1m
 while test "`${SHOWQ} | grep $jobid`" != ""; do
    ${SHOWQ} | grep $jobid
+   echo "   ${subproj}: waiting for jobid = $jobid to finish (sleeping 5 minutes)."
    sleep 5m
 done
 
@@ -118,7 +149,7 @@ echo " "
 export REGRESSION_PHASE=t
 echo "Test from the back end..."
 echo " "
-logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
+logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
 cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} ${partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
@@ -140,7 +171,7 @@ echo " "
 echo "Submit:"
 export REGRESSION_PHASE=s
 echo "- jobs done, now submitting ${build_type} results from tt-fey."
-cmd="${rscriptdir}/tt-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log"
+cmd="${rscriptdir}/tt-regress.msub >& ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-${REGRESSION_PHASE}.log"
 echo "${cmd}"
 eval "${cmd}"
 

--- a/regression/tt-options.sh
+++ b/regression/tt-options.sh
@@ -15,7 +15,7 @@
 export machine_class="tt"
 export machine_name_short="tt"
 export machine_name_long="Trinitite"
-platform_extra_params="fulldiagnostics knl  nr perfbench vtest"
+platform_extra_params="fulldiagnostics knl nr perfbench vtest"
 pem_match=`echo $platform_extra_params | sed -e 's/[ ]/|/g'`
 
 ##---------------------------------------------------------------------------##

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -92,7 +92,7 @@ source $rscriptdir/tt-options.sh
 # ----------------------------------------
 echo "==========================================================================="
 echo "${machine_name_long} regression: ${ctestparts} from ${machine}."
-echo "                      ${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}"
+echo "                      ${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}"
 echo "==========================================================================="
 if [[ ${SLURM_JOB_PARTITION} ]]; then
   echo " "
@@ -144,36 +144,38 @@ export OMP_NUM_THREADS=16
 comp=CC
 
 # Extra parameters
-case $extra_params in
-"")
-    # no-op
-    ;;
-knl)
-    run "module swap craype-haswell craype-mic-knl"
-    export OMP_NUM_THREADS=17
-    ;;
-vtest)
-    # no-op
-    ;;
-@($pem_match) )
+for ep in $extra_params; do
+  case $ep in
+    "")
+      # no-op
+      ;;
+    knl)
+      run "module swap craype-haswell craype-mic-knl"
+      export OMP_NUM_THREADS=17
+      ;;
+    vtest | perfbench)
+      # no-op
+      ;;
+    @($pem_match) )
     # found in tt-options.sh but no rule found here
     echo "FATAL ERROR"
-    echo "Extra parameter = ${extra_param} requested and known by ${machine_name_short}-options.sh,"
+    echo "Extra parameter = ${ep} requested and known by ${machine_name_short}-options.sh,"
     echo "but ${0##*/} doesn't know about this option."
     exit 1
     ;;
-*)
-    echo "FATAL ERROR"
-    echo "Extra parameter = ${extra_param} requested but is unknown to"
-    echo "the regression system (edit ${0##*/})."
-    exit 1
-    ;;
-esac
+    *)
+      echo "FATAL ERROR"
+      echo "Extra parameter = ${ep} requested but is unknown to"
+      echo "the regression system (edit ${0##*/})."
+      exit 1
+      ;;
+  esac
+done
 run "module list"
 
 # Use a unique regression folder for each github branch
-if [[ $extra_params ]]; then
-  comp=$comp-$extra_params
+if [[ ${extra_params_sort_safe} ]]; then
+  comp=$comp-$extra_params_sort_safe
 fi
 comp=$comp-$featurebranch
 
@@ -224,6 +226,7 @@ echo "${0##*/}: comp           = $comp"
 echo "${0##*/}: machine        = $machine"
 echo "${0##*/}: subproj        = $subproj"
 echo "${0##*/}: regdir         = $regdir"
+echo "${0##*/}: extra_params_sort_safe = $extra_params_sort_safe"
 
 #----------------------------------------------------------------------#
 # CTest
@@ -253,42 +256,47 @@ echo "${0##*/}: scratch_dir    = ${scratch_dir}"
 echo " "
 setup_dirs=`echo $ctestparts | grep Configure`
 if [[ ${setup_dirs} ]]; then
-   if ! test -d ${work_dir}/source; then
+   if ! [[ -d ${work_dir}/source ]]; then
       run "mkdir -p ${work_dir}/source"
    fi
    # See notes above where scratch_dir is set concerning why these are soft
    # links.
-   if test "${regress_mode}" = "on"; then
-     if ! test -d ${scratch_dir}/build; then
+   if [[ "${regress_mode}" == "on" ]]; then
+     if ! [[ -d ${scratch_dir}/build ]]; then
        run "mkdir -p ${scratch_dir}/build"
      fi
      # remove symlinks
-     rm ${work_dir}/build ${work_dir}/target
-     if ! test -d ${work_dir}/build; then
+     if [[ -L ${work_dir}/build ]]; then
+       rm ${work_dir}/build
+     fi
+     if [[ -L ${work_dir}/target ]]; then
+       rm ${work_dir}/target
+     fi
+     if ! [[ -d ${work_dir}/build ]]; then
        run "ln -s ${scratch_dir}/build ${work_dir}/build"
      fi
-     if ! test -d ${scratch_dir}/target; then
+     if ! [[ -d ${scratch_dir}/target ]]; then
        run "mkdir -p ${scratch_dir}/target"
      fi
-     if ! test -d ${work_dir}/target; then
+     if ! [[ -d ${work_dir}/target ]]; then
        run "ln -s ${scratch_dir}/target ${work_dir}/target"
      fi
    else
      # $work_dir is $scratchdir/$USER/cdash/$machine/$build_name
-     if ! test -d ${work_dir}/build; then
+     if ! [[ -d ${work_dir}/build ]]; then
        run "mkdir -p ${work_dir}/build"
      fi
-     if ! test -d ${work_dir}/target; then
+     if ! [[ -d ${work_dir}/target ]]; then
        run "mkdir -p ${work_dir}/target"
      fi
    fi
 
    # clean the installation directory to remove any files that might no longer
    # be generated.
-   if test -d ${work_dir}/target/lib; then
+   if [[ -d ${work_dir}/target/lib ]]; then
        run "rm -rf ${work_dir}/target/*"
    fi
-   if test -f ${work_dir}/build/CMakeCache.txt; then
+   if [[ -f ${work_dir}/build/CMakeCache.txt ]]; then
        run "rm -rf ${work_dir}/build/*"
    fi
 fi

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -53,6 +53,10 @@ case ${target} in
     VENDOR_DIR=/scratch/vendors
     keychain=keychain-2.8.2
     ;;
+  sn-* | ba-* | tt-* )
+    REGDIR=/usr/projects/jayenne/regress
+    VENDOR_DIR=/usr/projects/draco/vendors
+    ;;
   *)
     REGDIR=/scratch/regress
     ;;


### PR DESCRIPTION
### Background

* Until recently, the regression system has only allowed (and only needed) single values for "extra_params" (`-e` option).
* Capsaicin now requires `-e "knl perfbench"`, so an upgrade to the existing scripts was required.

### Purpose of Pull Request

* Allow Capsaicin to run `perfbench` regressions on the knl nodes of trinitite.
* [Fixes Redmine Issue #1142](https://rtt.lanl.gov/redmine/issue/1142)

### Description of changes

+ Modify the `-e` option to allow multiple words.  For example:  `regression-master.sh -e "knl perfbench"`
+ Update logic in regressions scripts to expect multiple values for `$extra_params`. Create new variable `$extra_params_sort_safe` that contains a single string whose value is a sorted list of `$extra_params` where spaces are replaced by underscores.  This variable will be used for regression directory names. For example: `knl_perfbench`.
+ Add sanity checks to avoid conflicting `$extra_params` values.  For example: `-e "gcc610 gcc640"` is not allowed.
+ Use the value of `$ENV{extra_params_sort_safe}` when creating the `CTEST_BUILD_NAME`. This is the name shown on CDash.
+ Synchronize some content of `*-regress.msub scripts` for _cts1_ and _tt_.
+ Some de-duplication of code needs to be done - but that is for a separate PR.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
