### PR TITLE
Ensure that the lapack CMake target points to a blas installation.

### DIFF
--- a/config/print_target_properties.cmake
+++ b/config/print_target_properties.cmake
@@ -43,18 +43,18 @@ function(echo_target tgt)
   endif()
 
   message("======================== ${tgt} ========================")
-  
+
   # if ${tgt} is an IMPORTED target, it cannot be inspected directly.
   get_property(is_imported TARGET ${tgt} PROPERTY IMPORTED )
   if( is_imported )
     message( "IMPORTED = TRUE\n" )
-    return()
+    # return()
   endif()
 
-  # Get a list of known properties from cmake 
+  # Get a list of known properties from cmake
   # Ref: https://stackoverflow.com/questions/32183975/how-to-print-all-the-properties-of-a-target-in-cmake#34292622
   execute_process(
-    COMMAND cmake --help-property-list 
+    COMMAND cmake --help-property-list
     OUTPUT_VARIABLE CMAKE_PROPERTY_LIST)
   # Convert command output into a CMake list
   string(REGEX REPLACE ";" "\\\\;" CMAKE_PROPERTY_LIST "${CMAKE_PROPERTY_LIST}")
@@ -62,7 +62,7 @@ function(echo_target tgt)
 
   foreach(prop ${CMAKE_PROPERTY_LIST})
     # special cases first
-    
+
     # Some targets aren't allowed:
     # Ref: https://stackoverflow.com/questions/32197663/how-can-i-remove-the-the-location-property-may-not-be-read-from-target-error-i
     if(prop STREQUAL "LOCATION" OR prop MATCHES "^LOCATION_" OR prop MATCHES "_LOCATION$")
@@ -70,16 +70,16 @@ function(echo_target tgt)
     elseif( prop MATCHES "<LANG>" )
       continue()
     endif()
-    
-    if( ${prop} MATCHES "<CONFIG>")      
+
+    if( ${prop} MATCHES "<CONFIG>")
       foreach (c DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
         string(REPLACE "<CONFIG>" "${c}" p ${prop})
         # message("prop ${p}")
         echo_target_property("${tgt}" "${p}")
       endforeach()
     endif()
-    
-    # everything else    
+
+    # everything else
     # message("prop ${prop}")
     echo_target_property("${tgt}" "${prop}")
   endforeach()

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -47,7 +47,7 @@ macro( setupLAPACKLibrariesUnix )
         set( lapack_FOUND TRUE )
       endif()
     endforeach()
-    message( STATUS "Looking for lapack (netlib)....found ${LAPACK_LIB_DIR}")
+    message( STATUS "Looking for lapack (netlib)....found ${tmp}")
     set( lapack_FOUND ${lapack_FOUND} CACHE BOOL "Did we find LAPACK." FORCE )
 
     # The above might define blas, or it might not. Double check:
@@ -61,6 +61,13 @@ macro( setupLAPACKLibrariesUnix )
       else()
         message( FATAL_ERROR "Looking for lapack (netlib)....blas not found")
       endif()
+    else()
+      # ensure lapack --> blas?
+      get_target_property( ilil lapack IMPORTED_LINK_INTERFACE_LIBRARIES )
+      if( NOT "${ilil}" MATCHES "blas" )
+        set_target_properties( lapack PROPERTIES
+          IMPORTED_LINK_INTERFACE_LIBRARIES blas )
+      endif()
     endif()
 
   else()
@@ -68,6 +75,10 @@ macro( setupLAPACKLibrariesUnix )
   endif()
 
   mark_as_advanced( lapack_DIR lapack_FOUND )
+
+  # Debug targets:
+  # include(print_target_properties)
+  # print_targets_properties("lapack;blas")
 
   # Above we tried to find lapack-config.cmake at $LAPACK_LIB_DIR/cmake/lapack.
   # This is a draco supplied version of lapack.  If that search failed, then try


### PR DESCRIPTION
### Background

+ In rare cases, the `lapack` target populated by `config/vendor_libraries.cmake` will be a target that points to the lapack libraries but fails to include the transitive dependency on blas.

### Description of changes

+ If `lapack` and `blas` are both known by the Draco build system, ensure that the `lapack` target includes a property that points the associated blas library.
+ Also: minor cleanup in `print_target_properties.cmake`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
