### PR TITLE
Add new CI testing (checkpr.sh)

### DIFF
--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -250,8 +250,14 @@ case $target in
   # CCS-NET: Release, vtest, coverage
   ccscs2*)
     startCI ${project} Release na $pr
-    startCI ${project} Release vtest $pr
-    startCI ${project} Debug coverage $pr ;;
+    if ! [[ ${project} == "draco" ]]; then
+      startCI ${project} Release vtest $pr
+    fi
+    startCI ${project} Debug coverage $pr
+    if ! [[ ${project} == "capsaicin" ]]; then
+      startCI ${project} Debug clang $pr
+    fi
+    ;;
 
   # CCS-NET: Valgrind (Debug)
   ccscs6*) startCI ${project} Debug valgrind $pr ;;
@@ -259,14 +265,18 @@ case $target in
   # Snow: Debug
   sn-fe*)
     startCI ${project} Release na $pr
-    startCI ${project} Release vtest $pr
+    if ! [[ ${project} == "draco" ]]; then
+      startCI ${project} Release vtest $pr
+    fi
     startCI ${project} Debug fulldiagnostics $pr
     ;;
 
   # Trinitite: Release
   tt-fe*)
     startCI ${project} Release na $pr
-    startCI ${project} Release vtest $pr
+    if ! [[ ${project} == "draco" ]]; then
+      startCI ${project} Release vtest $pr;
+    fi
     startCI ${project} Release knl $pr
     ;;
 

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -363,8 +363,10 @@ Parsing arguments
   # some variables based on extra_param's value.
   if( DEFINED ENV{extra_params_sort_safe} )
 
-    set( compiler_short_name
-      "${compiler_short_name}-$ENV{extra_params_sort_safe}" )
+    if( NOT "$ENV{extra_params_sort_safe}empty" STREQUAL "empty" )
+      set( compiler_short_name
+        "${compiler_short_name}-$ENV{extra_params_sort_safe}" )
+    endif()
 
     if( $ENV{extra_params_sort_safe} MATCHES "cuda" )
       set(USE_CUDA ON)

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -37,11 +37,10 @@
 
 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e knl
 
-# not sure we support two extra parameters (kt)
-#01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e \"knl vtest\"
+01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne capsaicin\" -e \"knl vtest\"
 
 # performance over time
-#01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e \"knl perfbench\" -p \"jayenne capsaicin\"
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e \"knl perfbench\" -p \"capsaicin\"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -101,9 +101,10 @@ fi
 # sinfo -o "%45n %30b %65f" | cut -b 47-120 | sort | uniq -c
 
 # Note that we build on the haswell back-end (even when building code for knl):
-build_partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0"
+build_partition_options="-N 1 -t 1:00:00"
+test_partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0"
 case $extra_params_sort_safe in
-*knl*) partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0 -p knl" ;;
+  *knl*) test_partition_options="-N 1 -t 8:00:00 --gres=craynetwork:0 -p knl" ;;
 esac
 
 # When on DST use
@@ -150,7 +151,7 @@ export REGRESSION_PHASE=t
 echo "Test from the back end..."
 echo " "
 logfile=${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-${REGRESSION_PHASE}.log
-cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} ${partition_options} ${rscriptdir}/tt-regress.msub"
+cmd="$MSUB -o ${logfile} -J ${subproj:0:5}-${featurebranch} ${test_partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 # delete blank lines


### PR DESCRIPTION
### Background

+ When running the 'vtest' (long running verification problems) tests for Capsaicin and Jayenne, there is not reason to build a special 'vtest' version of Draco. Use the regular 'Release' build of Draco.
+ Capsaicin has requested a 'knl-perfbench'  nightly regression on trinitite.
+ Jayenne has requested a 'knl-vtest  nightly regression on trinitite.
+ Jayenne has requested that a clang CI be completed on ccscs2 for all new PRs. The current clang-based toolchain is unable to build Capsaicin, so do not add a clang based CI for them.
+ After pull request #386, regression runs that did not set any value for the '-e' option to `regression-master.sh` has poorly formed build names.  Modify `draco_regression_macros.cmake` to create better build names.

### Description of changes

+ `checkpr.sh` modified to skip 'vtest' testing for Draco.
+ `checkpr.sh` modified to start a 'clang' CI for Draco and Jayenne (ccscs2 only).
+ Added two new nightly regressions on trinity via `tt-crontab`:
  * knl-perfbench
  * knl-vtest
+ In `tt-job-launch.sh`, correct malformed sbatch arguments for trinity (this was a bug introduced in pull request #386).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
