### PR TITLE
Fix bug in operator precedence in Expression parser.

### DIFF
--- a/src/parser/Expression.cc
+++ b/src/parser/Expression.cc
@@ -1120,7 +1120,7 @@ static pE parse_or(unsigned const number_of_variables,
   while (tokens.lookahead().text() == "||") {
     tokens.shift();
     Result.reset(new Or_Expression(
-        Result, parse_relational(number_of_variables, variable_map, tokens)));
+        Result, parse_and(number_of_variables, variable_map, tokens)));
   }
   return Result;
 }

--- a/src/parser/test/tstExpression.cc
+++ b/src/parser/test/tstExpression.cc
@@ -131,7 +131,7 @@ void tstExpression(UnitTest &ut) {
 #pragma warning(pop)
 #endif
 
-  tokens = string("20*(r>=1.1*m && z<=1.5*m || r>=2.0*m)");
+  tokens = string("20*(r>=1.1*m && z<=1.5*m || r>=2.0*m && r<=7.0*m)");
 
   expression = Expression::parse(4, variable_map, tokens);
 
@@ -141,7 +141,8 @@ void tstExpression(UnitTest &ut) {
     FAILMSG("expression NOT successfully parsed");
 
   if (soft_equiv((*expression)(xs),
-                 20.0 * ((r >= 1.1) && ((z <= 1.5) || (r >= 2.0))))) {
+                 20.0 *
+                     ((r >= 1.1) && ((z <= 1.5) || (r >= 2.0 && r <= 7.0))))) {
     PASSMSG("expression successfully evaluated");
   } else {
     FAILMSG("expression NOT successfully evaluated");
@@ -151,7 +152,7 @@ void tstExpression(UnitTest &ut) {
     ostringstream expression_text_copy;
     expression->write(vars, expression_text_copy);
 
-    char const *expression_text_raw = "20*(r>=1.1*m&&z<=1.5*m||r>=2*m)";
+    char const *expression_text_raw = "20*(r>=1.1*m&&z<=1.5*m||r>=2*m&&r<=7*m)";
     // changes slightly due to stripping of extraneous whitespace, parentheses,
     // and positive prefix
     if (expression_text_copy.str() == expression_text_raw) {


### PR DESCRIPTION
Add this use case to the test suite.

### Background

The Draco parser package includes a parser for an Expression, which is a very convenient way to express some quantity that varies across a problem domain. The form of an Expression looks very much like FORTRAN/C/C++ expression syntax, with a smaller set of operators but the same precedence rules.

### Purpose of Pull Request

A problem using the expression z>0.9*cm && z<1.1*cm || r>0.9*cm && r<1.1*cm failed. The error was
reported to be in the syntax of this expression. I found that the precedence rules had a bug such that
the final && r<1.1*cm was not properly parsed, because the parser for an or-expression mistakenly looked for a subsequent relation-expression rather than and-expression and stopped parsing at the second &&.

### Description of changes

Fixed the precedence by having an or-expression look for subsequent and-expressions rather than relation-expressions.

I added this as a use case in the test suite by extending one of the text expressions to have the problematic form, and verified that the bug was fixed.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
