### PR TITLE
Improve FindEOSPAC.cmake

### DIFF
--- a/config/FindEOSPAC.cmake
+++ b/config/FindEOSPAC.cmake
@@ -96,7 +96,7 @@ endif()
 
 find_library(EOSPAC_LIBRARY
   NAMES ${EOSPAC_LIBRARY_NAME}
-  PATHS ${COMPTON_ROOT_DIR}/lib
+  PATHS ${EOSPAC_ROOT_DIR}/lib
   PATH_SUFFIXES Release Debug
   )
 
@@ -110,7 +110,7 @@ set( EOSPAC_INCLUDE_DIRS ${EOSPAC_INCLUDE_DIR} )
 set( EOSPAC_LIBRARIES ${EOSPAC_LIBRARY} )
 
 # Try to find the version.
-# if( NOT EOSPAC_VERSION )
+if( NOT EOSPAC_VERSION )
 #   if( EXISTS "${EOSPAC_INCLUDE_DIRS}/eospac.h" )
 #     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_major
 #         REGEX "define EOSPAC_VER_MAJOR" )
@@ -122,17 +122,19 @@ set( EOSPAC_LIBRARIES ${EOSPAC_LIBRARY} )
 #     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_MINOR ${eospac_h_minor} )
 #     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_SUBMINOR ${eospac_h_subminor} )
 #   endif()
-#   # We might also try scraping the directory name for a regex match
-#   # "eospac-X.X.X"
-#   if( NOT EOSPAC_MAJOR )
-#     string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\1"
-#       EOSPAC_MAJOR ${EOSPAC_INCLUDE_DIR} )
-#     string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\2"
-#       EOSPAC_MINOR ${EOSPAC_INCLUDE_DIR} )
-#     string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\3"
-#       EOSPAC_SUBMINOR ${EOSPAC_INCLUDE_DIR} )
-#   endif()
-# endif()
+  # We might also try scraping the directory name for a regex match
+  # "eospac-X.X.X"
+  if( NOT EOSPAC_MAJOR )
+    string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\1"
+      EOSPAC_MAJOR ${EOSPAC_INCLUDE_DIR} )
+    string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\2"
+      EOSPAC_MINOR ${EOSPAC_INCLUDE_DIR} )
+    string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\3"
+      EOSPAC_SUBMINOR ${EOSPAC_INCLUDE_DIR} )
+    set( EOSPAC_VERSION "${EOSPAC_MAJOR}.${EOSPAC_MINOR}.${EOSPAC_SUBMINOR}")
+  endif()
+  # Another option is `strings libeospac6.a | grep eos_version_name`
+endif()
 
 #=============================================================================
 # handle the QUIETLY and REQUIRED arguments and set EOSPAC_FOUND to TRUE if

--- a/config/FindEOSPAC.cmake
+++ b/config/FindEOSPAC.cmake
@@ -5,81 +5,201 @@
 # note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
-# - Find EOSPAC
-# Find the native EOSPAC includes and library
-#
-#  EOSPAC_INCLUDE_DIRS   - where to find eos_Interface.h, etc.
-#  EOSPAC_LIBRARIES      - List of libraries when using EOSPAC.
-#  EOSPAC_FOUND          - True if EOSPAC found.
 
-if (APPLE)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.dylib")
+#.rst:
+# FindEOSPAC
+# ---------
+#
+# Find the LANL EOSPAC library and header files.
+#
+# A collection of C routines that can be used to access the Sesame data
+# library. https://laws.lanl.gov/projects/data/eos.html
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# If EOSPAC is found, this module defines the following :prop_tgt:`IMPORTED`
+# targets::
+#
+#  EOSPAC::eospac        - The EOSPAC library.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project::
+#
+#  EOSPAC_FOUND          - True if EOSPAC found on the local system
+#  EOSPAC_INCLUDE_DIRS   - Location of EOSPAC header files.
+#  EOSPAC_LIBRARIES      - The EOSPAC libraries.
+#  EOSPAC_VERSION        - The version of the discovered EOSPAC install.
+#
+# Hints
+# ^^^^^
+#
+# Set ``EOSPAC_ROOT_DIR`` to a directory that contains a EOSPAC installation.
+#
+# This script expects to find libraries at ``$EOSPAC_ROOT_DIR/lib`` and the
+# EOSPAC headers at ``$EOSPAC_ROOT_DIR/include``.  The library directory may
+# optionally provide Release and Debug folders.
+#
+# Cache Variables
+# ^^^^^^^^^^^^^^^
+#
+# This module may set the following variables depending on platform and type of
+# EOSPAC installation discovered.  These variables may optionally be set to
+# help this module find the correct files::
+#
+#  EOSPAC_LIBRARY        - Location of the EOSPAC library.
+#  EOSPAC_LIBRARY_DEBUG  - Location of the debug EOSPAC library (if any).
+#
+#------------------------------------------------------------------------------#
+
+# Include these modules to handle the QUIETLY and REQUIRED arguments.
+include(FindPackageHandleStandardArgs)
+
+#=============================================================================
+# If the user has provided ``EOSPAC_ROOT_DIR``, use it!  Choose items found
+# at this location over system locations.
+if( EXISTS "$ENV{EOSPAC_ROOT_DIR}" )
+  file( TO_CMAKE_PATH "$ENV{EOSPAC_ROOT_DIR}" EOSPAC_ROOT_DIR )
+  set( EOSPAC_ROOT_DIR "${EOSPAC_ROOT_DIR}" CACHE PATH
+    "Prefix for EOSPAC installation." )
 endif()
 
-find_path( EOSPAC_INCLUDE_DIR 
-    NAMES
-       eos_Interface.h
-    PATHS
-       ${EOSPAC_INC_DIR}
-       $ENV{EOSPAC_INC_DIR}
-       $ENV{VENDOR_DIR}/include
-       ${VENDOR_DIR}/include
-    NO_DEFAULT_PATH
-)
+#=============================================================================
+# Set EOSPAC_INCLUDE_DIRS and EOSPAC_LIBRARIES. Try to find the libraries at
+# $EOSPAC_ROOT_DIR (if provided) or in standard system locations.  These
+# find_library and find_path calls will prefer custom locations over standard
+# locations (HINTS).  If the requested file is not found at the HINTS location,
+# standard system locations will be still be searched (/usr/lib64 (Redhat),
+# lib/i386-linux-gnu (Debian)).
+
+find_path( EOSPAC_INCLUDE_DIR
+  NAMES eos_Interface.h
+  HINTS ${EOSPAC_ROOT_DIR}/include
+  PATH_SUFFIXES Release Debug
+  )
+
+# if (APPLE)
+#     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.dylib")
+# endif()
 
 if( WIN32 )
-   if( EOSPAC_STATIC )
-      set( EOSPAC_LIBRARY_NAME eospac.lib)
-   else()
-      set( EOSPAC_LIBRARY_NAME libeospac_dll.lib)
-   endif()
+  if( EOSPAC_STATIC )
+    set( EOSPAC_LIBRARY_NAME eospac.lib)
+  else()
+    set( EOSPAC_LIBRARY_NAME libeospac_dll.lib)
+  endif()
 else()
-   set( EOSPAC_LIBRARY_NAME eospac6)
+  set( EOSPAC_LIBRARY_NAME eospac6)
 endif()
 
 find_library(EOSPAC_LIBRARY
-    NAMES ${EOSPAC_LIBRARY_NAME}
-    PATHS
-        ${EOSPAC_LIB_DIR}
-        $ENV{EOSPAC_LIB_DIR}
-        $ENV{VENDOR_DIR}/lib
-        ${VENDOR_DIR}/lib
-    NO_DEFAULT_PATH
+  NAMES ${EOSPAC_LIBRARY_NAME}
+  PATHS ${COMPTON_ROOT_DIR}/lib
+  PATH_SUFFIXES Release Debug
+  )
+
+# Do we also have debug versions?
+find_library( EOSPAC_LIBRARY_DEBUG
+  NAMES ${EOSPAC_LIBRARY_NAME}
+  HINTS ${EOSPAC_ROOT_DIR}/lib ${EOSPAC_LIBDIR}
+  PATH_SUFFIXES Debug
 )
+set( EOSPAC_INCLUDE_DIRS ${EOSPAC_INCLUDE_DIR} )
+set( EOSPAC_LIBRARIES ${EOSPAC_LIBRARY} )
 
-# If above fails, look in default locations
-if( NOT EOSPAC_LIBRARY )
-   find_path( EOSPAC_INCLUDE_DIR    NAMES eos_Interface.h )
-   find_library(EOSPAC_LIBRARY      NAMES ${EOSPAC_LIBRARY_NAME} )
+# Try to find the version.
+# if( NOT EOSPAC_VERSION )
+#   if( EXISTS "${EOSPAC_INCLUDE_DIRS}/eospac.h" )
+#     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_major
+#         REGEX "define EOSPAC_VER_MAJOR" )
+#     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_minor
+#         REGEX "define EOSPAC_VER_MINOR" )
+#     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_subminor
+#         REGEX "define EOSPAC_VER_SUBMINOR" )
+#     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_MAJOR ${eospac_h_major} )
+#     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_MINOR ${eospac_h_minor} )
+#     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_SUBMINOR ${eospac_h_subminor} )
+#   endif()
+#   # We might also try scraping the directory name for a regex match
+#   # "eospac-X.X.X"
+#   if( NOT EOSPAC_MAJOR )
+#     string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\1"
+#       EOSPAC_MAJOR ${EOSPAC_INCLUDE_DIR} )
+#     string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\2"
+#       EOSPAC_MINOR ${EOSPAC_INCLUDE_DIR} )
+#     string( REGEX REPLACE ".*eospac-([0-9]+).([0-9]+).([0-9]+).*" "\\3"
+#       EOSPAC_SUBMINOR ${EOSPAC_INCLUDE_DIR} )
+#   endif()
+# endif()
+
+#=============================================================================
+# handle the QUIETLY and REQUIRED arguments and set EOSPAC_FOUND to TRUE if
+# all listed variables are TRUE.
+find_package_handle_standard_args( EOSPAC
+  FOUND_VAR
+    EOSPAC_FOUND
+  REQUIRED_VARS
+    EOSPAC_INCLUDE_DIR
+    EOSPAC_LIBRARY
+  VERSION_VAR
+    EOSPAC_VERSION
+    )
+
+mark_as_advanced( EOSPAC_ROOT_DIR EOSPAC_VERSION EOSPAC_LIBRARY
+  EOSPAC_INCLUDE_DIR EOSPAC_LIBRARY_DEBUG EOSPAC_USE_PKGCONFIG EOSPAC_CONFIG )
+
+#=============================================================================
+# Register imported libraries:
+# 1. If we can find a Windows .dll file (or if we can find both Debug and
+#    Release libraries), we will set appropriate target properties for these.
+# 2. However, for most systems, we will only register the import location and
+#    include directory.
+
+# Look for dlls, or Release and Debug libraries.
+if(WIN32)
+  string( REPLACE ".lib" ".dll" EOSPAC_LIBRARY_DLL
+    "${EOSPAC_LIBRARY}" )
+  string( REPLACE ".lib" ".dll" EOSPAC_LIBRARY_DEBUG_DLL
+    "${EOSPAC_LIBRARY_DEBUG}" )
 endif()
-mark_as_advanced( EOSPAC_LIBRARY EOSPAC_INCLUDE_DIR )
 
-# handle the QUIETLY and REQUIRED arguments and set EOSPAC_FOUND to TRUE if 
-# all listed variables are TRUE
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(EOSPAC DEFAULT_MSG EOSPAC_INCLUDE_DIR EOSPAC_LIBRARY)
+if( EOSPAC_FOUND AND NOT TARGET EOSPAC::eospac )
+  if( EXISTS "${EOSPAC_LIBRARY_DLL}" )
 
-if (EOSPAC_FOUND)
-   set(EOSPAC_FOUND ${EOSPAC_FOUND} CACHE BOOL "Did we find the EOSPAC libraries?")
-   set(EOSPAC_INCLUDE_DIRS ${EOSPAC_INCLUDE_DIR})
-   set(EOSPAC_LIBRARIES    ${EOSPAC_LIBRARY} CACHE
-      FILEPATH "EOSPAC libraries for linking."  )
-   
-   string( REPLACE "_dll.lib" ".dll" EOSPAC_DLL ${EOSPAC_LIBRARY} )
-   mark_as_advanced( EOSPAC_DLL )
-   if( EXISTS ${EOSPAC_DLL} )
-      set(EOSPAC_DLL_LIBRARIES "${EOSPAC_DLL}" CACHE STRING 
-         "list of eospac dll files.")
-   mark_as_advanced( EOSPAC_DLL_LIBRARIES EOSPAC_LIBRARIES )
-   else()
-      set( EOSPAC_DLL "NOTFOUND")
-   endif()
+    # Windows systems with dll libraries.
+    add_library( EOSPAC::eospac SHARED IMPORTED )
+
+    # Windows with dlls, but only Release libraries.
+    set_target_properties( EOSPAC::eospac PROPERTIES
+      IMPORTED_LOCATION_RELEASE         "${EOSPAC_LIBRARY_DLL}"
+      IMPORTED_IMPLIB                   "${EOSPAC_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${EOSPAC_INCLUDE_DIRS}"
+      IMPORTED_CONFIGURATIONS           Release
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+
+    # If we have both Debug and Release libraries
+    if( EXISTS "${EOSPAC_LIBRARY_DEBUG_DLL}" )
+      set_property( TARGET EOSPAC::eospac APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS Debug )
+      set_target_properties( EOSPAC::eospac PROPERTIES
+        IMPORTED_LOCATION_DEBUG           "${EOSPAC_LIBRARY_DEBUG_DLL}"
+        IMPORTED_IMPLIB_DEBUG             "${EOSPAC_LIBRARY_DEBUG}" )
+    endif()
+
+  else()
+
+    # For all other environments (ones without dll libraries), create the
+    # imported library targets.
+    add_library( EOSPAC::eospac    UNKNOWN IMPORTED )
+    set_target_properties( EOSPAC::eospac PROPERTIES
+      IMPORTED_LOCATION                 "${EOSPAC_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${EOSPAC_INCLUDE_DIRS}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+  endif()
 endif()
 
-if( VERBOSE )
-message("
-EOSPAC_FOUND =        ${EOSPAC_FOUND}
-EOSPAC_INCLUDE_DIRS = ${EOSPAC_INCLUDE_DIR}
-EOSPAC_LIBRARIES    = ${EOSPAC_LIBRARY}
-")
-endif()
+#------------------------------------------------------------------------------#
+# End FindEOSPAC.cmake
+#------------------------------------------------------------------------------#

--- a/config/print_target_properties.cmake
+++ b/config/print_target_properties.cmake
@@ -43,18 +43,18 @@ function(echo_target tgt)
   endif()
 
   message("======================== ${tgt} ========================")
-  
+
   # if ${tgt} is an IMPORTED target, it cannot be inspected directly.
   get_property(is_imported TARGET ${tgt} PROPERTY IMPORTED )
   if( is_imported )
     message( "IMPORTED = TRUE\n" )
-    return()
+    # return()
   endif()
 
-  # Get a list of known properties from cmake 
+  # Get a list of known properties from cmake
   # Ref: https://stackoverflow.com/questions/32183975/how-to-print-all-the-properties-of-a-target-in-cmake#34292622
   execute_process(
-    COMMAND cmake --help-property-list 
+    COMMAND cmake --help-property-list
     OUTPUT_VARIABLE CMAKE_PROPERTY_LIST)
   # Convert command output into a CMake list
   string(REGEX REPLACE ";" "\\\\;" CMAKE_PROPERTY_LIST "${CMAKE_PROPERTY_LIST}")
@@ -62,7 +62,7 @@ function(echo_target tgt)
 
   foreach(prop ${CMAKE_PROPERTY_LIST})
     # special cases first
-    
+
     # Some targets aren't allowed:
     # Ref: https://stackoverflow.com/questions/32197663/how-can-i-remove-the-the-location-property-may-not-be-read-from-target-error-i
     if(prop STREQUAL "LOCATION" OR prop MATCHES "^LOCATION_" OR prop MATCHES "_LOCATION$")
@@ -70,16 +70,16 @@ function(echo_target tgt)
     elseif( prop MATCHES "<LANG>" )
       continue()
     endif()
-    
-    if( ${prop} MATCHES "<CONFIG>")      
+
+    if( ${prop} MATCHES "<CONFIG>")
       foreach (c DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
         string(REPLACE "<CONFIG>" "${c}" p ${prop})
         # message("prop ${p}")
         echo_target_property("${tgt}" "${p}")
       endforeach()
     endif()
-    
-    # everything else    
+
+    # everything else
     # message("prop ${prop}")
     echo_target_property("${tgt}" "${prop}")
   endforeach()

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -446,6 +446,32 @@ macro( setupSuperLU_DIST )
 endmacro()
 
 #------------------------------------------------------------------------------
+# Setup Eospac (https://laws.lanl.gov/projects/data/eos.html)
+#------------------------------------------------------------------------------
+macro( setupEOSPAC )
+
+  if( NOT TARGET EOSPAC::eospac )
+    message( STATUS "Looking for EOSPAC..." )
+
+    find_package( EOSPAC QUIET )
+
+    if( EOSPAC_FOUND )
+      message( STATUS "Looking for EOSPAC.....found ${EOSPAC_LIBRARY}" )
+    else()
+      message( STATUS "Looking for EOSPAC.....not found" )
+    endif()
+
+    #===========================================================================
+    # Include some information that can be printed by the build system.
+    set_package_properties( EOSPAC PROPERTIES
+      DESCRIPTION "Access SESAME thermodynamic and transport data."
+      TYPE OPTIONAL
+      PURPOSE "Required for bulding the cdi_eospac component." )
+  endif()
+
+endmacro()
+
+#------------------------------------------------------------------------------
 # Setup COMPTON (https://gitlab.lanl.gov/keadyk/CSK_generator)
 #------------------------------------------------------------------------------
 macro( setupCOMPTON )
@@ -481,6 +507,7 @@ macro( SetupVendorLibrariesUnix )
   setupParMETIS()
   setupSuperLU_DIST()
   setupCOMPTON()
+  setupEospac()
 
   # Random123 ----------------------------------------------------------------
   message( STATUS "Looking for Random123...")

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -47,7 +47,7 @@ macro( setupLAPACKLibrariesUnix )
         set( lapack_FOUND TRUE )
       endif()
     endforeach()
-    message( STATUS "Looking for lapack (netlib)....found ${LAPACK_LIB_DIR}")
+    message( STATUS "Looking for lapack (netlib)....found ${tmp}")
     set( lapack_FOUND ${lapack_FOUND} CACHE BOOL "Did we find LAPACK." FORCE )
 
     # The above might define blas, or it might not. Double check:
@@ -61,6 +61,13 @@ macro( setupLAPACKLibrariesUnix )
       else()
         message( FATAL_ERROR "Looking for lapack (netlib)....blas not found")
       endif()
+    else()
+      # ensure lapack --> blas?
+      get_target_property( ilil lapack IMPORTED_LINK_INTERFACE_LIBRARIES )
+      if( NOT "${ilil}" MATCHES "blas" )
+        set_target_properties( lapack PROPERTIES
+          IMPORTED_LINK_INTERFACE_LIBRARIES blas )
+      endif()
     endif()
 
   else()
@@ -68,6 +75,10 @@ macro( setupLAPACKLibrariesUnix )
   endif()
 
   mark_as_advanced( lapack_DIR lapack_FOUND )
+
+  # Debug targets:
+  # include(print_target_properties)
+  # print_targets_properties("lapack;blas")
 
   # Above we tried to find lapack-config.cmake at $LAPACK_LIB_DIR/cmake/lapack.
   # This is a draco supplied version of lapack.  If that search failed, then try

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -7,17 +7,8 @@
 cmake_minimum_required(VERSION 3.9.0)
 project( cdi_eospac CXX )
 
-##---------------------------------------------------------------------------##
-# Requires EOSPAC
-##---------------------------------------------------------------------------##
-find_package( EOSPAC QUIET )
-set_package_properties( EOSPAC PROPERTIES
-   DESCRIPTION "Access SESAME thermodynamic and transport data."
-   TYPE OPTIONAL
-   PURPOSE "Required for bulding the cdi_eospac component."
-   )
-
 if( EOSPAC_FOUND )
+
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
@@ -32,12 +23,10 @@ list( REMOVE_ITEM sources ${PROJECT_SOURCE_DIR}/QueryEospac.cc )
 
 add_component_library(
    TARGET       Lib_cdi_eospac
-   TARGET_DEPS  Lib_cdi
+   TARGET_DEPS  "Lib_cdi;EOSPAC::eospac"
    LIBRARY_NAME cdi_eospac
    SOURCES      "${sources}"
-   HEADERS      "${headers}"
-   VENDOR_LIST "EOSPAC"
-   VENDOR_LIBS "${EOSPAC_LIBRARY}" )
+   HEADERS      "${headers}" )
 target_include_directories( Lib_cdi_eospac PUBLIC ${EOSPAC_INCLUDE_DIR} )
 
 add_component_executable(


### PR DESCRIPTION
### Background

* eospac is now published by spack, so we need to upgrade the `FindEOSPAC.cmake` module to find eospac installed in a _normal_ way.  Previously, we relied on hand rolled environment variables to help the build system find `libeospac.a`.

### Description of changes

+ Teach `FindEOSPAC.cmake` to find eospac that is provided via spack and without environment variables like `EOSPAC_LIB_DIR`.
+ Update the `FindEOSPAC.cmake` script to use modern CMake recommendations, including a populated link target `EOSPAC::eospac`.
+ Move eospac discovery from `cdi_eospac/CMakeLists.txt` to `config/vendor_libraries.cmake`.
+ In `cdi_eospac/CMakeLists.txt` use the new `EOSPAC::eospac` build target as a link dependency instead of cmake variables like `${EOSPAC_LIBRARY}`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
