### PR TITLE
Fix OpenMPI detection when using clang++/clang/gfortran combination.

### DIFF
--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -234,7 +234,7 @@ macro( dbsConfigInfo )
          OUTPUT_QUIET
          )
       string( REGEX REPLACE ".*for ([0-9x]+)" "\\1"
-         tmp "${DBS_CXX_COMPILER_VER}" )
+         tmp "${CMAKE_CXX_COMPILER_VER}" )
       if( ${tmp} MATCHES "80x86" )
          set( DBS_ISA_MODE "32-bit" )
       elseif( ${tmp} MATCHES "x64" )

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -80,7 +80,6 @@ macro(dbsSetupCompilers)
     # message(STATUS "Building static libraries.")
     set( MD_or_MT "MD" )
     set( DRACO_SHARED_LIBS 0 )
-    set( DRACO_LIBEXT ".a" )
   elseif( ${DRACO_LIBRARY_TYPE} MATCHES "SHARED" )
     # message(STATUS "Building shared libraries.")
     set( MD_or_MT "MD" )
@@ -88,7 +87,6 @@ macro(dbsSetupCompilers)
     # declspec(dllimport) or declspec(dllexport) for MSVC.
     set( DRACO_SHARED_LIBS 1 )
     mark_as_advanced(DRACO_SHARED_LIBS)
-    set( DRACO_LIBEXT ".so" )
   else()
     message( FATAL_ERROR "DRACO_LIBRARY_TYPE must be set to either STATIC or SHARED.")
   endif()
@@ -118,7 +116,6 @@ macro(dbsSetupCompilers)
   # 2017-11-13 KT - This also breaks linking MinGW gfortran libraries into
   #                 MSVC applications, so just disable it for all Win32 builds.
   if( WIN32 )
-  # if( ${CMAKE_GENERATOR} MATCHES "NMake Makefiles" )
     set( USE_IPO OFF CACHE BOOL
       "Enable Interprocedureal Optimization for Release builds." FORCE )
   endif()
@@ -134,21 +131,15 @@ macro(dbsSetupCxx)
 
   # Deal with compiler wrappers
   if( ${CMAKE_CXX_COMPILER} MATCHES "tau_cxx.sh" )
-    # When using the TAU profiling tool, the actual compiler vendor
-    # is hidden under the tau_cxx.sh script.  Use the following
-    # command to determine the actual compiler flavor before setting
-    # compiler flags (end of this macro).
+    # When using the TAU profiling tool, the actual compiler vendor is hidden
+    # under the tau_cxx.sh script.  Use the following command to determine the
+    # actual compiler flavor before setting compiler flags (end of this macro).
     execute_process(
       COMMAND ${CMAKE_CXX_COMPILER} -tau:showcompiler
       OUTPUT_VARIABLE my_cxx_compiler )
   else()
     set( my_cxx_compiler ${CMAKE_CXX_COMPILER} )
   endif()
-
-  string( REGEX REPLACE "[^0-9]*([0-9]+).([0-9]+).([0-9]+).*" "\\1"
-    DBS_CXX_COMPILER_VER_MAJOR "${CMAKE_CXX_COMPILER_VERSION}" )
-  string( REGEX REPLACE "[^0-9]*([0-9]+).([0-9]+).([0-9]+).*" "\\2"
-    DBS_CXX_COMPILER_VER_MINOR "${CMAKE_CXX_COMPILER_VERSION}" )
 
   # C11 support:
   set( CMAKE_C_STANDARD 11 )

--- a/config/dracoTesting.cmake
+++ b/config/dracoTesting.cmake
@@ -18,7 +18,7 @@ if( UNIX )
        endif()
     endforeach()
     list( LENGTH proc_ids DRACO_NUM_CORES )
-    set( MPIEXEC_MAX_NUMPROCS ${DRACO_NUM_CORES} CACHE STRING 
+    set( MPIEXEC_MAX_NUMPROCS ${DRACO_NUM_CORES} CACHE STRING
        "Number of cores on the local machine." )
   endif()
 endif()
@@ -42,5 +42,5 @@ if( BUILD_TESTING )
     add_custom_target( check
       COMMAND "${CMAKE_COMMAND}" --build "${Draco_BINARY_DIR}" -- ${pbuildtestflags}
       COMMAND ${CMAKE_CTEST_COMMAND} ${pbuildtestflags} $(ARGS) )
-  endif() 
-endif() 
+  endif()
+endif()

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -151,22 +151,8 @@ macro( setupOpenMPI )
 
   set( MPI_FLAVOR "openmpi" CACHE STRING "Flavor of MPI." ) # OpenMPI
 
-  # Find the version of OpenMPI
-
-  if( "${DBS_MPI_VER}" MATCHES "[0-9]+[.][0-9]+[.][0-9]+" )
-    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\1"
-      DBS_MPI_VER_MAJOR ${DBS_MPI_VER} )
-    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\2"
-      DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
-  elseif( "${DBS_MPI_VER}" MATCHES "[0-9]+[.][0-9]+" )
-    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+).*" "\\1"
-      DBS_MPI_VER_MAJOR ${DBS_MPI_VER} )
-    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+).*" "\\2"
-      DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
-  endif()
-
-  # sanity check, these OpenMPI flags (below) require version >= 1.4
-  if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.8 )
+  # sanity check, these OpenMPI flags (below) require version >= 1.8
+  if( ${MPI_C_VERSION} VERSION_LESS 1.8 )
     message( FATAL_ERROR "OpenMPI version < 1.8 found." )
   endif()
 
@@ -363,22 +349,6 @@ macro( setupMPILibrariesUnix )
       # Set DRACO_C4 and other variables
       setupDracoMPIVars()
 
-      # Find the mpirun version (skip this on Cray because this command seems to
-      # occasionally hang).
-      if( NOT CRAY_PE )
-        execute_process( COMMAND ${MPIEXEC} --version
-          OUTPUT_VARIABLE DBS_MPI_VER_OUT
-          ERROR_VARIABLE DBS_MPI_VER_ERR)
-        set( DBS_MPI_VER "${DBS_MPI_VER_OUT}${DBS_MPI_VER_ERR}")
-      endif()
-
-      set_package_properties( MPI PROPERTIES
-        URL "http://www.open-mpi.org/"
-        DESCRIPTION "A High Performance Message Passing Library"
-        TYPE RECOMMENDED
-        PURPOSE "If not available, all Draco components will be built as scalar applications."
-        )
-
       # ---------------------------------------------------------------------- #
       # Check flavor and add optional flags
       #
@@ -428,6 +398,13 @@ The Draco build system doesn't know how to configure the build for
       # Set DRACO_C4 and other variables
       setupDracoMPIVars()
     endif()
+
+    set_package_properties( MPI PROPERTIES
+      URL "http://www.open-mpi.org/"
+      DESCRIPTION "A High Performance Message Passing Library"
+      TYPE RECOMMENDED
+      PURPOSE "If not available, all Draco components will be built as scalar applications."
+      )
 
    mark_as_advanced( MPI_FLAVOR MPIEXEC_OMP_POSTFLAGS MPI_LIBRARIES )
 
@@ -597,7 +574,7 @@ macro( setupMPILibrariesWindows )
      endforeach()
 
      # Reset the include directories for MPI::MPI_Fortran to pull in the
-     # extra $arch locations (if any)     
+     # extra $arch locations (if any)
      set_target_properties(MPI::MPI_Fortran
        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${mpiincdir}")
 

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -7,25 +7,13 @@
 #        All rights reserved.
 #
 # Try to find MPI in the default locations (look for mpic++ in PATH)
-# This module will set the following variables:
 #
-# MPI_<lang>_FOUND           TRUE if FindMPI found MPI flags for <lang>
-# MPI_<lang>_COMPILER        MPI Compiler wrapper for <lang>
-# MPI_<lang>_COMPILE_FLAGS   Compilation flags for MPI programs
-# MPI_<lang>_INCLUDE_PATH    Include path(s) for MPI header
-# MPI_<lang>_LINK_FLAGS      Linking flags for MPI programs
-# MPI_<lang>_LIBRARIES       All libraries to link MPI programs against
+# See cmake --help-module FindMPI for details on variables set and published
+# targets. Additionally, this module will set the following variables:
 #
-# MPIEXEC                    Executable for running MPI programs
-# MPIEXEC_NUMPROC_FLAG       Flag to pass to MPIEXEC before giving it the
-#                            number of processors to run on
-# MPIEXEC_PREFLAGS           Flags to pass to MPIEXEC directly before the
-#                            executable to run.
-# MPIEXEC_POSTFLAGS          Flags to pass to MPIEXEC after all other flags.
-#
-# DRACO_C4                   MPI|SCALAR
-# C4_SCALAR                  BOOL
-# C4_MPI                     BOOL
+# DRACO_C4   MPI|SCALAR
+# C4_SCALAR  BOOL
+# C4_MPI     BOOL
 #
 #------------------------------------------------------------------------------#
 include( FeatureSummary )
@@ -346,6 +334,48 @@ macro( setupMPILibrariesUnix )
       # Call the standard CMake FindMPI macro.
       find_package( MPI QUIET )
 
+      # if the FindMPI.cmake module didn't set the version, then try to do so
+      # here.
+      if( NOT MPI_VERSION )
+
+        # If the language specific MPI version is found, use it.
+        if( MPI_C_VERSION )
+          set( MPI_VERSION ${MPI_C_VERSION} )
+
+        # Otherwise, try 'mpirun --version' and parse the output.
+        else()
+
+          if( NOT CRAY_PE )
+            execute_process( COMMAND ${MPIEXEC} --version
+              OUTPUT_VARIABLE DBS_MPI_VER_OUT
+              ERROR_VARIABLE DBS_MPI_VER_ERR)
+            set( DBS_MPI_VER "${DBS_MPI_VER_OUT}${DBS_MPI_VER_ERR}")
+          endif()
+
+          if( "${DBS_MPI_VER}" MATCHES "[0-9]+[.][0-9]+[.][0-9]+" )
+            string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\1"
+              DBS_MPI_VER_MAJOR ${DBS_MPI_VER} )
+            string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\2"
+              DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
+            string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\3"
+              DBS_MPI_VER_PATCH ${DBS_MPI_VER} )
+            set( MPI_VERSION
+              "${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR}.${DBS_MPI_VER_PATCH}" )
+          elseif( "${DBS_MPI_VER}" MATCHES "[0-9]+[.][0-9]+" )
+            string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+).*" "\\1"
+              DBS_MPI_VER_MAJOR ${DBS_MPI_VER} )
+            string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+).*" "\\2"
+              DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
+            set( MPI_VERSION "${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR}" )
+          endif()
+          foreach( lang C CXX Fortran )
+            set( MPI_${lang}_VERSION ${MPI_VERSION} )
+          endforeach()
+
+        endif()
+      endif()
+
+
       # Set DRACO_C4 and other variables
       setupDracoMPIVars()
 
@@ -428,8 +458,10 @@ macro( setupMPILibrariesWindows )
       # what arch this is and save this path to MPI_Fortran_INCLUDE_PATH
       list( GET MPI_CXX_LIBRARIES 0 first_cxx_mpi_library )
       if( first_cxx_mpi_library AND NOT MPI_Fortran_INCLUDE_PATH )
-        get_filename_component( MPI_Fortran_INCLUDE_PATH "${first_cxx_mpi_library}" DIRECTORY )
-        string( REGEX REPLACE "[Ll]ib" "Include" MPI_Fortran_INCLUDE_PATH ${MPI_Fortran_INCLUDE_PATH} )
+        get_filename_component( MPI_Fortran_INCLUDE_PATH
+          "${first_cxx_mpi_library}" DIRECTORY )
+        string( REGEX REPLACE "[Ll]ib" "Include" MPI_Fortran_INCLUDE_PATH
+          ${MPI_Fortran_INCLUDE_PATH} )
         set( MPI_Fortran_INCLUDE_PATH
              "${MPI_CXX_INCLUDE_PATH};${MPI_Fortran_INCLUDE_PATH}"
              CACHE STRING "Location for MPI include files for Fortran.")
@@ -450,9 +482,12 @@ macro( setupMPILibrariesWindows )
         ERROR_STRIP_TRAILING_WHITESPACE
         )
       if( "${DBS_MPI_VER_OUT}" MATCHES "Microsoft MPI Startup Program" )
-          string( REGEX REPLACE ".*Version ([0-9.]+).*" "\\1" DBS_MPI_VER "${DBS_MPI_VER_OUT}${DBS_MPI_VER_ERR}")
-          string( REGEX REPLACE ".*([0-9])[.]([0-9])[.]([0-9]+).*" "\\1" DBS_MPI_VER_MAJOR ${DBS_MPI_VER} )
-          string( REGEX REPLACE ".*([0-9])[.]([0-9])[.]([0-9]+).*" "\\2" DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
+          string( REGEX REPLACE ".*Version ([0-9.]+).*" "\\1" DBS_MPI_VER
+            "${DBS_MPI_VER_OUT}${DBS_MPI_VER_ERR}")
+          string( REGEX REPLACE ".*([0-9])[.]([0-9])[.]([0-9]+).*" "\\1"
+            DBS_MPI_VER_MAJOR ${DBS_MPI_VER} )
+          string( REGEX REPLACE ".*([0-9])[.]([0-9])[.]([0-9]+).*" "\\2"
+            DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
           set( DBS_MPI_VER "${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR}")
       else()
          set(DBS_MPI_VER "5.0")
@@ -466,7 +501,8 @@ macro( setupMPILibrariesWindows )
         )
 
       # Check flavor and add optional flags
-      if("${MPIEXEC}" MATCHES "Microsoft HPC" OR "${MPIEXEC}" MATCHES "Microsoft MPI")
+      if("${MPIEXEC}" MATCHES "Microsoft HPC" OR
+          "${MPIEXEC}" MATCHES "Microsoft MPI")
          set( MPI_FLAVOR "MicrosoftHPC" CACHE STRING "Flavor of MPI." )
 
          # Use wmic to learn about the current machine
@@ -482,9 +518,12 @@ macro( setupMPILibrariesWindows )
             COMMAND wmic computersystem get NumberOfProcessors
             OUTPUT_VARIABLE MPI_CPUS_PER_NODE
             OUTPUT_STRIP_TRAILING_WHITESPACE )
-         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPI_CORES_PER_CPU ${MPI_CORES_PER_CPU})
-         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPIEXEC_MAX_NUMPROCS ${MPIEXEC_MAX_NUMPROCS})
-         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPI_CPUS_PER_NODE ${MPI_CPUS_PER_NODE})
+         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPI_CORES_PER_CPU
+           ${MPI_CORES_PER_CPU})
+         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPIEXEC_MAX_NUMPROCS
+           ${MPIEXEC_MAX_NUMPROCS})
+         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPI_CPUS_PER_NODE
+           ${MPI_CPUS_PER_NODE})
 
          set( MPI_CPUS_PER_NODE ${MPI_CPUS_PER_NODE} CACHE STRING
             "Number of multi-core CPUs per node" FORCE )

--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -30,30 +30,27 @@ query_openmp_availability()
 #
 
 if( NOT CXX_FLAGS_INITIALIZED )
-   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+  set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
-   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -Wno-long-long -pedantic" )
-   if (NOT ${CMAKE_GENERATOR} MATCHES Xcode AND HAS_MARCH_NATIVE)
-      set( CMAKE_C_FLAGS             "${CMAKE_C_FLAGS} -march=native" )
-   endif()
-   set( CMAKE_C_FLAGS_DEBUG          "-g -fno-inline -O0 -Wextra -DDEBUG")
-   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
-   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
-   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -Wextra -funroll-loops" )
+  set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -Wno-long-long -pedantic" )
+  if (NOT ${CMAKE_GENERATOR} MATCHES Xcode AND HAS_MARCH_NATIVE)
+    set( CMAKE_C_FLAGS             "${CMAKE_C_FLAGS} -march=native" )
+  endif()
+  set( CMAKE_C_FLAGS_DEBUG          "-g -fno-inline -O0 -Wextra -DDEBUG")
+  set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
+  set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
+  set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -Wextra -funroll-loops" )
 
-# Suppress warnings about typeid() called with function as an argument. In this
-# case, the function might not be called if the type can be deduced.
-   set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS} -stdlib=libc++ -Wno-potentially-evaluated-expression" )
-   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8 )
-     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
-   endif()
-   set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
-   set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
-   set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
-   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
-
-   # Use C99 standard.
-   set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  # Suppress warnings about typeid() called with function as an argument. In this
+  # case, the function might not be called if the type can be deduced.
+  set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS} -stdlib=libc++ -Wno-potentially-evaluated-expression" )
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8 )
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
+  endif()
+  set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
+  set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
+  set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
+  set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
 
 endif()
 
@@ -72,10 +69,15 @@ set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE}"        CACHE ST
 set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL}"     CACHE STRING "compiler flags" FORCE )
 set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE STRING "compiler flags" FORCE )
 
-# Toggle for C++11 support
+# Toggle for OpenMP support
 if( OpenMP_C_FLAGS )
-  toggle_compiler_flag( OPENMP_FOUND "${OpenMP_C_FLAGS}" "C;CXX;EXE_LINKER" "" )
+  toggle_compiler_flag( OPENMP_FOUND "${OpenMP_C_FLAGS}" "C" "" )
 endif()
+if( OpenMP_CXX_FLAGS )
+  toggle_compiler_flag( OPENMP_FOUND "${OpenMP_CXX_FLAGS}" "CXX" "" )
+endif()
+# adding openmp option to EXE_LINKER will break MPI detection for gfortran when
+# running with clang++/clang/gfortran.
 
 #------------------------------------------------------------------------------#
 # End config/unix-clang.cmake

--- a/config/unix-pgi.cmake
+++ b/config/unix-pgi.cmake
@@ -53,11 +53,6 @@ if( NOT CXX_FLAGS_INITIALIZED )
   #              option appears to break our exception handling model resulting
   #              in SEGV.
   # This may be related to PGI bug 1858 (http://www.pgroup.com/support/release_tprs.htm).
-#  if( "${DBS_CXX_COMPILER_VER_MAJOR}.${DBS_CXX_COMPILER_VER_MINOR}" GREATER 10 )
-#    if( NOT "${CMAKE_CXX_FLAGS}" MATCHES "--nozc_eh" )
-#      set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --nozc_eh" )
-#    endif()
-#  endif()
 
   set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG}")
   set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE} -Munroll=c:10 -Mautoinline=levels:10 -Mvect=sse -Mflushz -Mlre")


### PR DESCRIPTION
### Background

* While trying to stand up builds with _clang@6.0.0 + gfortran@4.8.5_, CMake's MPI detection was failing for _gfortran_.  This turned out to be a result of a clang-only option to enable OpenMP that was added to the link line for programs that use _gfortran_ for the final link.

### Purpose of Pull Request

* [Fixes Redmine Issue #1147](https://rtt.lanl.gov/redmine/issue/1147) for clang@6.0.0

### Description of changes

+ In `unix_clang.cmake`, do not add the `OpenMP_C_FLAGS` value to the `CMAKE_EXE_LINKER` flags.
+ Eliminate some unused or deprecated variables from the build system:
  - `DBS_CXX_COMPILER_VER*`
  - `DRACO_LIBEXT`
  - `DBS_MPI_VER` (only removed from the OpenMPI section of `setupMPI.cmake`). Use `MPI_C_VERSION` instead as it is provided by `FindMPI.cmake`.

### Status

* WIP
  * [x] Requires #392 to be merged first
* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass - travis is broken right now.  See [ticket 1154](https://rtt.lanl.gov/redmine/issues/1154)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
