### PR TITLE
Load modules 1-by-1 in bash_functions2 version of dracoenv.

### DIFF
--- a/environment/bashrc/bash_functions2.sh
+++ b/environment/bashrc/bash_functions2.sh
@@ -16,7 +16,9 @@ if test $fn_exists = 0; then
   # only define if they do not already exist...
   function dracoenv ()
   {
-    module load $dracomodules
+    for m in $dracomodules; do
+	module load $m
+    done
   }
   function rmdracoenv ()
   {


### PR DESCRIPTION
### Background

* When a module isn't found on linux64 system, the module load command in the `dracoenv` function in bash_functions2 might not be able to load any modules.

### Purpose of Pull Request

* Load all possible modules.

### Description of changes

* Change module load of list to a loop loading modules 1-by-1.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
