### PR TITLE
Patch logic used to identify the Fortran compiler flavor.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -362,29 +362,34 @@ macro(dbsSetupFortran)
       endif()
     endif()
 
-    if( ${my_fc_compiler} MATCHES "pgf9[05]" OR
-        ${my_fc_compiler} MATCHES "pgfortran" )
+    # setup flags
+    if( "${CMAKE_Fortran_COMPILER_ID}" MATCHES "PGI" )
       include( unix-pgf90 )
-    elseif( ${my_fc_compiler} MATCHES "ftn" )
-    if( "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" )
+    elseif( "${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel" )
       include( unix-ifort )
     elseif( "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Cray" )
       include( unix-crayftn )
     elseif( "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" )
       include( unix-gfortran )
     else()
-      message( FATAL_ERROR "I think the C++ comiler is a Cray compiler wrapper,"
-        "but I don't know what compiler is wrapped."
-        "CMAKE_Fortran_COMPILER_ID = ${CMAKE_Fortran_COMPILER_ID}")
-    endif()
-    elseif( ${my_fc_compiler} MATCHES "ifort" )
-      include( unix-ifort )
-    elseif( ${my_fc_compiler} MATCHES "xl" )
-      include( unix-xlf )
-    elseif( ${my_fc_compiler} MATCHES "gfortran" )
-      include( unix-gfortran )
-    else()
-      message( FATAL_ERROR "Build system does not support FC=${my_fc_compiler}" )
+      # missing CMAKE_Fortran_COMPILER_ID? - try to match the the compiler
+      # path+name to a string.
+      if( ${my_fc_compiler} MATCHES "pgf9[05]" OR
+          ${my_fc_compiler} MATCHES "pgfortran" )
+        include( unix-pgf90 )
+      elseif( ${my_fc_compiler} MATCHES "ftn" )
+        message( FATAL_ERROR
+"I think the C++ comiler is a Cray compiler wrapper, but I don't know what "
+"compiler is wrapped.CMAKE_Fortran_COMPILER_ID = ${CMAKE_Fortran_COMPILER_ID}")
+      elseif( ${my_fc_compiler} MATCHES "ifort" )
+        include( unix-ifort )
+      elseif( ${my_fc_compiler} MATCHES "xl" )
+        include( unix-xlf )
+      elseif( ${my_fc_compiler} MATCHES "gfortran" )
+        include( unix-gfortran )
+      else()
+        message(FATAL_ERROR "Build system does not support FC=${my_fc_compiler}")
+      endif()
     endif()
 
     if( _LANGUAGES_ MATCHES "^C$" OR _LANGUAGES_ MATCHES CXX )


### PR DESCRIPTION
### Background

+ The old logic breaks for gcc-8.1.0 on ccs-net because the spack hash in the path to gfortran includes the string "xl" (as in IBM XL Fortran).

### Description of changes

+ New logic uses [CMake provided Compiler ID strings](https://cmake.org/cmake/help/v3.10/variable/CMAKE_LANG_COMPILER_ID.html?highlight=compiler_id#variable:CMAKE_%3CLANG%3E_COMPILER_ID). 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
