### PR TITLE
Cleanup some code to eliminate build/run warnings.

### DIFF
--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -1411,7 +1411,16 @@
    fun:orte_init
    ...
 }
-
+{
+   openmpi/301/e0001
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:pmix_server_commit
+   ...
+   fun:opal_libevent2022_event_base_loop
+   ...
+}
 
 #------------------------------------------------------------------------------#
 # Python 2.7

--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -294,11 +294,10 @@
 }
 # after moving to eospac/6.3.1...
 {
-
+  eospac/6.3.1/e001
    Memcheck:Cond
    fun:eos_SearchIndices_XF
-   fun:eos_InverseRationalInterpolateXF
-   fun:_eos_InterpolateRecordType1
+   ...
    fun:eos_InterpolateRecordType1
    fun:eos_InterpolateEosInterpolation
    fun:eos_Interpolate

--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -292,6 +292,18 @@
    fun:eos_CreateTablesEosDataMap
    ...
 }
+# after moving to eospac/6.3.1...
+{
+
+   Memcheck:Cond
+   fun:eos_SearchIndices_XF
+   fun:eos_InverseRationalInterpolateXF
+   fun:_eos_InterpolateRecordType1
+   fun:eos_InterpolateRecordType1
+   fun:eos_InterpolateEosInterpolation
+   fun:eos_Interpolate
+   ...
+}
 
 ## ---------------------------------------------------------------------- ##
 ## Numdiff
@@ -319,7 +331,7 @@
 # ==18912==    by 0x40ABB6: init_mpa_support (in /ccs/codes/radtran/vendors/numdiff-5.2.1/bin/numdiff)
 # ==18912==    by 0x40BC6F: main (in /ccs/codes/radtran/vendors/numdiff-5.2.1/bin/numdiff)
 {
-   <insert_a_suppression_name_here>
+   numdiff/e002
    Memcheck:Cond
    ...
    fun:__gmpf_set_str
@@ -328,43 +340,42 @@
    fun:main
 }
 {
-   <insert_a_suppression_name_here>
+   numdiff/e003
    Memcheck:Value8
    fun:__gmpn_mul_basecase
    ...
 }
 {
-   <insert_a_suppression_name_here>
+   numdiff/e004
    Memcheck:Cond
    fun:__gmpn_mul_basecase
    ...
 }
 {
-   <insert_a_suppression_name_here>
+   numdiff/e005
    Memcheck:Cond
    ...
    fun:init_mpa_support
    ...
 }
 {
-   <insert_a_suppression_name_here>
+   numdiff/e006
    Memcheck:Value8
    fun:__gmpn_sqr_basecase
    ...
 }
 {
-   <insert_a_suppression_name_here>
+   numdiff/e007
    Memcheck:Value8
    fun:__gmpn_sqr_n
 }
 {
-   <insert_a_suppression_name_here>
+   numdiff/e008
    Memcheck:Cond
    ...
    fun:__gmpn_divrem
    ...
 }
-
 {
    numdiff/lost/04
    Memcheck:Leak

--- a/src/RTT_Format_Reader/RTT_Format_Reader.cc
+++ b/src/RTT_Format_Reader/RTT_Format_Reader.cc
@@ -5,10 +5,7 @@
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Implementation file for RTT_Format_Reader library.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "RTT_Format_Reader.hh"
@@ -57,7 +54,7 @@ void RTT_Format_Reader::readMesh(const string &RTT_File) {
     spSideData->readSideData(meshfile);
     spCellData->readCellData(meshfile);
     readEndKeyword(meshfile);
-  } catch (rtt_dsxx::assertion as) {
+  } catch (rtt_dsxx::assertion &as) {
     std::cout << "Assertion thrown: " << as.what() << std::endl;
     Insist(false, as.what());
   }

--- a/src/cdi_eospac/Eospac.cc
+++ b/src/cdi_eospac/Eospac.cc
@@ -324,7 +324,8 @@ double Eospac::getIonTemperature(     // keV
     double /*Tguess*/) const          // keV
 {
   EOS_INTEGER const returnType = EOS_T_DUic;
-  // EOS_INTEGER const returnType = EOS_T_DUiz; // I think I need the DUic version!
+  // EOS_INTEGER const returnType = EOS_T_DUiz; - I think I need the DUic
+  // version!
   double Te_K = getF(dbl_v1(density), dbl_v1(SpecificIonInternalEnergy),
                      returnType, ETDD_VALUE)[0];
   return Te_K / keV2K(1.0); // Convert from K back to keV.


### PR DESCRIPTION
### Description of changes

+ Minor cleanup to silence warnings that appeared when switching regressions to gcc-8.1.0.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass (broken)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
