### PR TITLE
Fix bug in Timer::printline_mean

### DIFF
--- a/src/c4/Timer.cc
+++ b/src/c4/Timer.cc
@@ -373,9 +373,9 @@ void Timer::printline_mean(std::ostream &out, unsigned const p,
     out << setw(w) << mni << " +/- " << setw(v)
         << sqrt((ni2 - 2 * mni * ni + ranks * mni * mni) / ranks) << setw(w)
         << mu << " +/- " << setw(v)
-        << sqrt((u2 - 2 * mu * u + ranks * mu * mu) / ranks) << setw(w) << mu
+        << sqrt((u2 - 2 * mu * u + ranks * mu * mu) / ranks) << setw(w) << ms
         << " +/- " << setw(v)
-        << sqrt((s2 - 2 * ms * s + ranks * ms * ms) / ranks) << setw(w) << mu
+        << sqrt((s2 - 2 * ms * s + ranks * ms * ms) / ranks) << setw(w) << mww
         << " +/- " << setw(v)
         << sqrt((ww2 - 2 * mww * ww + ranks * mww * mww) / ranks);
 


### PR DESCRIPTION
Fairly brain-dead typo bug: User time was being reported as system and wall time as well.

### Background

Kris Garrett noticed that the exact same time was being reported for user, system, and wall, though the reported variance varied.

Inspection showed the Timer::print_mean function was printing the mean user time in each case rather than the user time, system time, and wall time. Ironically, the variances were being done correctly and so were, ah, varying.

### Purpose of Pull Request

Fix the bug

### Description of changes

Change "mu" to "ms" and "mww" in the appropriate points.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass (broken)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
