### PR TITLE
Fix bug in compilerEnv.cmake wrt MSVC builds.

### DIFF
--- a/README.draco
+++ b/README.draco
@@ -40,6 +40,10 @@ Common options:
   -DCMAKE_BUILD_TYPE=Release|Debug|RelWithDebInfo
   -DBUILD_TESTING=OFF
 
+Starting the build with cmake:
+  
+  cmake --build . [--target <target>] [--config Debug|Release]
+  
 Common targets:
 
  - all
@@ -72,63 +76,67 @@ See environment/elisp/README.elisp
 Active Draco Component Synopsis
 =============================
 
+* Consider viewing the doxygen generated autodoc web pages found at 
+  https://rtt.lanl.gov/autodoc/draco.  These pages are updated nightly 
+  based on the current 'develop' branch of the code.
+
 RTT_Format_Reader:{mesh container and services}
 
 c4: {Communications library that wraps MPI}
 
 cdi: {Get access to material data}
-The Common Data Interface specifies an common abstraction for objects and
-libraries that return material data (opacities, atomic cross sections,
-equation-of-state data, etc.)
+  The Common Data Interface specifies an common abstraction for objects and
+  libraries that return material data (opacities, atomic cross sections,
+  equation-of-state data, etc.)
 
 cdi_analytic: {Analytic models for physical data}
 
 cdi_eospac: {Equation-of-State data}
-This class wraps the EOSPAC6 libraries (local copy at
-    /ccs/codes/radtran/vendors/eospac).  The interface inherits from CDI/EOS.hh
-    and can be used as a stand alone component or as a plug-in to CDI.  To make
-    the component available you must set in your environment or in the
-    CMakeCache.txt the variable EOSPAC_LIB_DIR to the path to libeospac.a
+  This class wraps the EOSPAC6 libraries (local copy at
+  /ccs/codes/radtran/vendors/eospac).  The interface inherits from CDI/EOS.hh
+  and can be used as a stand alone component or as a plug-in to CDI.  To make
+  the component available you must set in your environment or in the
+  CMakeCache.txt the variable EOSPAC_LIB_DIR to the path to libeospac.a
 
 cdi_ipcress: {Gray and multigroup opacities}
-    The classes in this component will read and parse opacity values from an
-    IPCRESS file produced by TOPS.  The component presents this data through
-    various accessors.  The interface inherits from CDI/Opacity.hh and can be
-    used as a stand alone component or as a plug-in to CDI.
+  The classes in this component will read and parse opacity values from an
+  IPCRESS file produced by TOPS.  The component presents this data through
+  various accessors.  The interface inherits from CDI/Opacity.hh and can be
+  used as a stand alone component or as a plug-in to CDI.
 
 device: {Wrapper for heterogeneous device communication}
-    The classes in this component provide access to DaCS and CUDA calls for use
-    on heterogeneous architecture platforms (Roadrunner or GPU machines).
+  The classes in this component provide access to DaCS and CUDA calls for use
+  on heterogeneous architecture platforms (Roadrunner or GPU machines).
 
 diagnostics:
-CPP macros that are activated at compile time that can provide additional
-diagnostic verbosity during calculations.
+  CPP macros that are activated at compile time that can provide additional
+  diagnostic verbosity during calculations.
 
 ds++: {Basic services}
-    Array containers, assertion and Design-by-Contract, Ffle system information,
-    path manipulation, unit test system, etc.
+  Array containers, assertion and Design-by-Contract, Ffle system information,
+  path manipulation, unit test system, etc.
 
 fit: {Least squares fit}
 
 fpe_trap: {Catch IEEE floating point exceptions}
 
 FortranCheck: {Test Fortran compatibility and interoperability}
-The examples in this component will demonstrate if the Fortran compiler is
-working; if Fortran/C interlanguage linking/running is working and sample
-ISO_C_BINDING calls.
+  The examples in this component will demonstrate if the Fortran compiler is
+  working; if Fortran/C interlanguage linking/running is working and sample
+  ISO_C_BINDING calls.
 
 lapack_wrap:
-BLAS and LAPACK functionality for C++.
+  BLAS and LAPACK functionality for C++.
 
 linear: {linear equations}
-Routines to solve small systems of linear equations.
+  Routines to solve small systems of linear equations.
 
 meshReaders:
-Read RTT format mesh files.
+  Read RTT format mesh files.
 
 mesh_element:
-Provide a description of unstructured mesh. Used by meshReaders and
-RTT_Format_Reader.
+  Provide a description of unstructured mesh. Used by meshReaders and
+  RTT_Format_Reader.
 
 min: Optimizaiton routines. Find the minimum of a function.
 
@@ -141,14 +149,15 @@ parser: Lexical file parser.
 plot2d: Generate GNU plot 2-dimensional plots.
 
 quadrature: {Get access to quadrature data}
-Provides a creator class to generate quadrature objects.  Quadrature objects
-encapsulate discrete ordinates angular differencing methods and data. Also
-provide service functions that are commonly used.
+  Provides a creator class to generate quadrature objects.  Quadrature objects
+  encapsulate discrete ordinates angular differencing methods and data. Also
+  provide service functions that are commonly used.
 
 rng: {A random number generator component}
-The primary set of functions provided by this component were derived from
-Random123 (https://www.deshawresearch.com/downloads/download_random123.cgi)
-    random number library.  A few additional random number generators are also provided.
+  The primary set of functions provided by this component were derived from
+  Random123 (https://www.deshawresearch.com/downloads/download_random123.cgi)
+  random number library.  A few additional random number generators are also 
+  provided.
 
 roots: Root solvers
 
@@ -161,8 +170,8 @@ timestep: An object-oriented class that encapsulates a time step controller.
 traits: A traits class used by viz.
 
 units:
-    Provides units standardization for Draco. Contains Units class for
-    representing arbitrary systems and converting quantities to SI units.
+  Provides units standardization for Draco. Contains Units class for
+  representing arbitrary systems and converting quantities to SI units.
 
 viz:
-Generates Ensight files for data vizualization.
+  Generates Ensight files for data vizualization.

--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -266,6 +266,10 @@ function(cmake_add_fortran_subdirectory subdir)
         )
     endif()
     if( WIN32 )
+      if( ARGS_VERBOSE )
+        message("    set_target_properties(${tgt} PROPERTIES
+        IMPORTED_IMPLIB \"${library_dir}/lib${lib}${CMAKE_STATIC_LIBRARY_SUFFIX}\" )" )
+      endif()
       set_target_properties(${tgt} PROPERTIES
         IMPORTED_IMPLIB "${library_dir}/lib${lib}${CMAKE_STATIC_LIBRARY_SUFFIX}" )
     endif()

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -185,12 +185,14 @@ macro(dbsSetupCxx)
       include( unix-clang )
     endif()
   elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-    include( unix-g++ )
+    include( unix-g++ )  
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
+    include( windows-cl )
   else()
     # missing CMAKE_CXX_COMPILER_ID? - try to match the the compiler path+name
     # to a string.
     if( ${my_cxx_compiler} MATCHES "pgCC" OR
-        ${my_cxx_compiler} MATCHES "pgc++" )
+        ${my_cxx_compiler} MATCHES "pgc[+][+]" )
       include( unix-pgi )
     elseif( ${my_cxx_compiler} MATCHES "CC" )
       message( FATAL_ERROR


### PR DESCRIPTION
### Background

* Recent changes to the build system were not checked against Windows/Visual Studio configurations.  Small tweak are required to keep the Visual Studio builds working.

### Description of changes

+ Add a conditional that checks if `CMAKE_CXX_COMPILER_ID == MSVC`.  Change conditional for pgc++ by putting the '+' in brackets.
+ Add additional debug output from `CMakeAddFortranSubdirectory.cmake` when `VERBOSE` is set.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
