### PR TITLE
Fix broken Jayenne-win32 builds (CMakeAddFortranSubdirectory failures)

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -156,12 +156,12 @@ macro(dbsSetupCxx)
   set( CMAKE_C_EXTENSIONS   OFF )
 
   # Setup compiler flags
-  get_filename_component( my_cxx_compiler ${my_cxx_compiler} NAME )
+  get_filename_component( my_cxx_compiler "${my_cxx_compiler}" NAME )
 
   # If the CMake_<LANG>_COMPILER is a MPI wrapper...
-  if( ${my_cxx_compiler} MATCHES "mpicxx" )
+  if( "${my_cxx_compiler}" MATCHES "mpicxx" )
     # MPI wrapper
-    execute_process( COMMAND ${my_cxx_compiler} --version
+    execute_process( COMMAND "${my_cxx_compiler}" --version
       OUTPUT_VARIABLE mpicxx_version_output
       OUTPUT_STRIP_TRAILING_WHITESPACE )
     # make output safe for regex matching
@@ -172,46 +172,52 @@ macro(dbsSetupCxx)
   endif()
 
   # setup flags based on COMPILER_ID...
-  if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "PGI" )
+  if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI" OR 
+      "${CMAKE_C_COMPILER_ID}"   STREQUAL "PGI" )
     include( unix-pgi )
-  elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" )
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR 
+          "${CMAKE_C_COMPILER_ID}"   STREQUAL "Intel")
     include( unix-intel )
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray" )
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray" OR 
+          "${CMAKE_C_COMPILER_ID}"   STREQUAL "Cray")
     include( unix-crayCC )
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR 
+          "${CMAKE_C_COMPILER_ID}"   STREQUAL "Clang")
     if( APPLE )
       include( apple-clang )
     else()
       include( unix-clang )
     endif()
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
+          "${CMAKE_C_COMPILER_ID}"   STREQUAL "GNU")
     include( unix-g++ )  
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
+          "${CMAKE_C_COMPILER_ID}"   STREQUAL "MSVC" )
     include( windows-cl )
   else()
     # missing CMAKE_CXX_COMPILER_ID? - try to match the the compiler path+name
     # to a string.
-    if( ${my_cxx_compiler} MATCHES "pgCC" OR
-        ${my_cxx_compiler} MATCHES "pgc[+][+]" )
+    if( "${my_cxx_compiler}" MATCHES "pgCC" OR
+        "${my_cxx_compiler}" MATCHES "pgc[+][+]" )
       include( unix-pgi )
-    elseif( ${my_cxx_compiler} MATCHES "CC" )
+    elseif( "${my_cxx_compiler}" MATCHES "CC" )
       message( FATAL_ERROR
 "I think the C++ compiler is a Cray compiler wrapper, but I don't know what "
 "compiler is wrapped.  CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
-    elseif( ${my_cxx_compiler} MATCHES "cl" )
+    elseif( "${my_cxx_compiler}" MATCHES "cl" )
       include( windows-cl )
-    elseif( ${my_cxx_compiler} MATCHES "icpc" )
+    elseif( "${my_cxx_compiler}" MATCHES "icpc" )
       include( unix-intel )
-    elseif( ${my_cxx_compiler} MATCHES "xl" )
+    elseif( "${my_cxx_compiler}" MATCHES "xl" )
       include( unix-xl )
-    elseif( ${my_cxx_compiler} MATCHES "clang" OR
-        ${my_cxx_compiler} MATCHES "llvm" )
+    elseif( "${my_cxx_compiler}" MATCHES "clang" OR
+        "${my_cxx_compiler}" MATCHES "llvm" )
       if( APPLE )
         include( apple-clang )
       else()
         include( unix-clang )
       endif()
-    elseif( ${my_cxx_compiler} MATCHES "[cg][+x]+" )
+    elseif( "${my_cxx_compiler}" MATCHES "[cg][+x]+" )
       include( unix-g++ )
     else()
       message(FATAL_ERROR "Build system does not support CXX=${my_cxx_compiler}")

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -180,7 +180,7 @@ set( CMAKE_C_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG}"          CACHE
 set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}"        CACHE 
      STRING "compiler flags" FORCE )
 set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_MINSIZEREL}"     CACHE 
-     STRING "compiler flags" FORCE )c
+     STRING "compiler flags" FORCE )
 set( CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" CACHE 
      STRING "compiler flags" FORCE )
 

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -31,11 +31,13 @@ option( GCC_ENABLE_GLIBCXX_DEBUG
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 check_c_compiler_flag(   "-march=native" HAS_MARCH_NATIVE )
-check_cxx_compiler_flag( "-Wnoexcept"    HAS_WNOEXCEPT )
-check_cxx_compiler_flag( "-Wsuggest-attribute=const" HAS_WSUGGEST_ATTRIBUTE )
-check_cxx_compiler_flag( "-Wunused-local-typedefs"   HAS_WUNUSED_LOCAL_TYPEDEFS )
-#check_cxx_compiler_flag( "-Wunused-macros"           HAS_WUNUSED_MACROS )
-check_cxx_compiler_flag( "-Wzero-as-null-pointer-constant" HAS_WZER0_AS_NULL_POINTER_CONSTANT )
+if( DEFINED CMAKE_CXX_COMPILER_ID )
+  check_cxx_compiler_flag( "-Wnoexcept"    HAS_WNOEXCEPT )
+  check_cxx_compiler_flag( "-Wsuggest-attribute=const" HAS_WSUGGEST_ATTRIBUTE )
+  check_cxx_compiler_flag( "-Wunused-local-typedefs"   HAS_WUNUSED_LOCAL_TYPEDEFS )
+  #check_cxx_compiler_flag( "-Wunused-macros"           HAS_WUNUSED_MACROS )
+  check_cxx_compiler_flag( "-Wzero-as-null-pointer-constant" HAS_WZER0_AS_NULL_POINTER_CONSTANT )
+endif()
 
 # is this bullseye?
 execute_process(
@@ -171,17 +173,27 @@ endif()
 ##---------------------------------------------------------------------------##
 # Ensure cache values always match current selection
 ##---------------------------------------------------------------------------##
-set( CMAKE_C_FLAGS                "${CMAKE_C_FLAGS}"                CACHE STRING "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG}"          CACHE STRING "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}"        CACHE STRING "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_MINSIZEREL}"     CACHE STRING "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" CACHE STRING "compiler flags" FORCE )
+set( CMAKE_C_FLAGS                "${CMAKE_C_FLAGS}"                CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_C_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG}"          CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}"        CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_MINSIZEREL}"     CACHE 
+     STRING "compiler flags" FORCE )c
+set( CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" CACHE 
+     STRING "compiler flags" FORCE )
 
-set( CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS}"                CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG}"          CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE}"        CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL}"     CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE STRING "compiler flags" FORCE )
+set( CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS}"                CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG}"          CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE}"        CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL}"     CACHE 
+     STRING "compiler flags" FORCE )
+set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE 
+     STRING "compiler flags" FORCE )
 
 #
 # Toggle compiler flags for optional features


### PR DESCRIPTION
### Background

+ These changes are needed to allow the CMakeAddFortranSubdirectory feature to work correctly after #408 and #409.

### Description of changes

+ In `compilerEnv.cmake`, add quotes around some CMake variables to account for spaces in paths and empty strings.
+ When identifying the compiler ID, check both CXX and C compilers.
+ In `unix-g++.cmake`, only perform `check_cxx_compiler_flag` operations when a C++ compiler is defined. This is almost always true -- except for some test directories that only require Fortran and C.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
