### PR TITLE
Fixes for gitlab style runner

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,7 @@ coverage:
          macro: no
 
   ignore:
-    - "src/*/test"
+    - "src/.*/test/.*"
     - "src/FortranChecks/f90sub/Draco_Test.F90"
 
 comment:

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -472,6 +472,7 @@ macro( dbsSetupProfilerTools )
       set( MEMORYCHECK_SUPPRESSIONS_FILE "${msf}" CACHE FILEPATH
       "valgrind warning suppression file." FORCE )
     endif()
+    mark_as_advanced( msf )
   endif()
 
 endmacro()

--- a/config/dracoVersion.cmake
+++ b/config/dracoVersion.cmake
@@ -83,6 +83,7 @@ macro( set_ccs2_software_version PROJNAME )
     CACHE STRING "${PROJNAME} version information" FORCE)
   set( ${PROJNAME}_VERSION_FULL  "${${PROJNAME}_VERSION}.${${PROJNAME}_VERSION_PATCH}"
     CACHE STRING "${PROJNAME} version information" FORCE)
+  mark_as_advanced( ${PROJNAME}_VERSION )
 
   message( "\n======================================================\n"
     "This is ${PROJNAME} version ${${PROJNAME}_VERSION_FULL}.\n"

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -40,6 +40,7 @@ macro( setupRandom123 )
 
  message( STATUS "Looking for Random123...")
   find_package( Random123 REQUIRED QUIET )
+  mark_as_advanced( RANDOM123_FOUND )
   if( RANDOM123_FOUND )
     message( STATUS "Looking for Random123.found ${RANDOM123_INCLUDE_DIR}")
   else()
@@ -377,7 +378,7 @@ macro( setupQt )
 
   if( QT_FOUND )
     mark_as_advanced( Qt5Core_DIR Qt5Gui_DIR Qt5Gui_EGL_LIBRARY
-      Qt5Widgets_DIR )
+      Qt5Widgets_DIR QTDIR)
   endif()
 
   set_package_properties( Qt PROPERTIES

--- a/regression/check_style.sh
+++ b/regression/check_style.sh
@@ -37,21 +37,36 @@ if [[ ${CLANG_FORMAT_VER} ]]; then
 else
   cfver=""
 fi
+# Assume applications have version postfix.
 gcf=`which git-clang-format${cfver}`
 cf=`which clang-format${cfver}`
+# if not found, try to find applications w/o version postfix.
+if ! [[ -f ${gcf} ]]; then
+  gcf=`which git-clang-format`
+fi
+if ! [[ -f ${cf} ]]; then
+  gcf=`which clang-format`
+fi
+# if still not found, abort.
 if [[ ! ${gcf} ]]; then
    echo "ERROR: git-clang-format${cfver} was not found in your PATH."
    echo "pwd="
    pwd
    echo "which git-clang-format${cfver}"
    echo $gcf
+   exit 1
+else
+  echo "Using $gcf --binary $cf"
+fi
+if [[ ! ${cf} ]]; then
+   echo "ERROR: clang-format${cfver} was not found in your PATH."
+   echo "pwd="
+   pwd
    echo "which clang-format${cfver}"
    echo $cf
    echo "which git"
    which git
    exit 1
-else
-  echo "Using $gcf --binary $cf"
 fi
 
 ver=`${cf} --version`


### PR DESCRIPTION
### Background

* On glitlab for Capsaicin and Jayenne, the style CI check has been broken for a while.  One of the issues is that the application names for `git-clang-format` and `clang-format` might have a version suffix and Draco's `style_check.sh` script wasn't flexible enough to find and use the alternate names.

### Purpose of Pull Request

* Update the regression scripts in Draco that are used by Capsaicin and Jayenne's gitlab 'style' checker.
* [Fixes Redmine Issue #1154](https://rtt.lanl.gov/redmine/issue/1154)

### Description of changes

* When trying to find clang-format and git-clang-format allow optional `-X.X` version number. 
* Allow clang-format to use the suffix, and git-clang-format to be bare.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
