### PR TITLE
Provide a unit test for ythi.

### DIFF
--- a/src/c4/bin/xthi.cc
+++ b/src/c4/bin/xthi.cc
@@ -8,12 +8,6 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-// #define _GNU_SOURCE
-// #include <cstdio>
-// #include <cstring>
-// #include <sched.h>
-// #include <unistd.h>
-
 #include "c4_omp.h"
 #include "c4/C4_Functions.hh"
 #include "ds++/SystemCall.hh"

--- a/src/c4/bin/ythi.cc
+++ b/src/c4/bin/ythi.cc
@@ -1,18 +1,24 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   c4/bin/xthi.cc
- * \author Mike Berry <mrberry@lanl.gov>, Kelly Thompson <kgt@lanl.gov>
- * \date   Wednesday, Aug 09, 2017, 11:45 am
+ * \author Mike Berry <mrberry@lanl.gov>, Kelly Thompson <kgt@lanl.gov>,
+ *         Tim Kelley <tkelley@lanl.gov.
+ * \date   Tuesday, Jun 05, 2018, 17:12 pm
  * \brief  Print MPI rank, thread number and core affinity bindings.
  * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
- *         All rights reserved. */
-//---------------------------------------------------------------------------//
-
-/* Rewritten by Tim Kelley to run C++11 std::threads
- * You may override NUM_WORKERS on the compile command line.
- * example:  $ ./ythi 4   # run with 4 worker threads)
- * default is 1 worker thread (over and above the host thread)
+ *         All rights reserved.
+ *
+ * Rewritten by Tim Kelley to run C++11 std::threads You may override
+ * \c NUM_WORKERS on the compile command line.  For example to run with 4 worker
+ * threads:
+ *
+ * \code
+ * $ ./ythi 4
+ * \endcode
+ *
+ * The default is 1 worker thread (over and above the host thread)
  */
+//---------------------------------------------------------------------------//
 
 #include "c4/C4_Functions.hh"
 #include "ds++/SystemCall.hh"

--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -102,8 +102,11 @@ if( NOT WIN32 AND NOT APPLE )
   add_app_unit_test(
     DRIVER    ${CMAKE_CURRENT_SOURCE_DIR}/tstXthi.py
     APP       $<TARGET_FILE_DIR:Exe_xthi>/$<TARGET_FILE_NAME:Exe_xthi>
-    PE_LIST   "1;2"
-    )
+    PE_LIST   "1;2" )
+  add_app_unit_test(
+    DRIVER    ${CMAKE_CURRENT_SOURCE_DIR}/tstYthi.py
+    APP       $<TARGET_FILE_DIR:Exe_ythi>/$<TARGET_FILE_NAME:Exe_ythi>
+    PE_LIST   "1;2" )
 endif()
 
 #------------------------------------------------------------------------------#

--- a/src/c4/test/tstXthi.py
+++ b/src/c4/test/tstXthi.py
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   Saturday, Sep 09, 2017, 14:17 pm
 # brief  This is a Python script that is used to test c4/bin/xthi
-# note   Copyright (C) 2017, Los Alamos National Security, LLC.
+# note   Copyright (C) 2017-2018, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 import sys
@@ -26,6 +26,10 @@ try:
   sys.path.append(draco_config_dir)
   from application_unit_test import UnitTest
   #----------------------------------------------------------------------------#
+
+  ##---------------------------------------------------------------------------##
+  ## Test Xthi
+  ##---------------------------------------------------------------------------##
 
   # Setup test using sys.argv and run:
   tstXthi = UnitTest()


### PR DESCRIPTION
### Background

* Earlier today, @timmah provided a C++11 threads version of `xthi`.

### Purpose of Pull Request

* Add a python-based unit test for `ythi` that is nearly identical to the unit thest for `xith`.
* Clean up some of the comments for xthi and ythi.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
