### PR TITLE
Update environments and regression scripts.

### DIFF
--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -47,9 +47,12 @@ case $target in
       module use --append $HOME/privatemodules
     fi
     dm_core="ack dia doxygen git graphviz htop mscgen numdiff python random123 \
-tk ndi totalview"
+tk totalview"
     dm_gcc="gcc cmake eospac/6.3.1_r20161202150449 gsl metis netlib-lapack qt"
-    dm_openmpi="openmpi csk parmetis superlu-dist trilinos"
+    dm_openmpi="openmpi parmetis superlu-dist trilinos"
+    if [[ `groups | grep -c ccsrad` != 0 ]]; then
+      dm_openmpi="$dm_openmpi csk ndi"
+    fi
     export dracomodules="$dm_core $dm_gcc $dm_openmpi"
     ;;
   ccsnet3*)

--- a/environment/bashrc/.bashrc_toss22
+++ b/environment/bashrc/.bashrc_toss22
@@ -52,8 +52,12 @@ else
   module use --append ${VENDOR_DIR}-ec/modulefiles
 
   export dracomodules="clang-format/3.9.0 intel/17.0.4 openmpi/2.1.2 mkl \
-trilinos superlu-dist/5.1.3 metis parmetis ndi random123 \
-eospac/6.3.0 subversion cmake/3.9.0 numdiff git totalview emacs grace csk"
+trilinos superlu-dist/5.1.3 metis parmetis random123 eospac/6.3.0 subversion \
+cmake/3.9.0 numdiff git totalview emacs grace"
+
+if [[ `groups | grep -c ccsrad` != 0 ]]; then
+  draco_modules="$draco_modules csk ndi"
+fi
 
 fi
 

--- a/environment/bashrc/.bashrc_toss3
+++ b/environment/bashrc/.bashrc_toss3
@@ -51,7 +51,7 @@ else
   module load friendly-testing
   module use --append ${VENDOR_DIR}-ec/modulefiles
 
-  export dracomodules="ack htop clang-format/3.9.0 \
+  export dracomodules="ack htop clang-format \
 intel/17.0.4 openmpi/2.1.2 mkl \
 subversion cmake/3.9.0 numdiff git totalview trilinos/12.10.1 \
 superlu-dist/5.1.3 metis parmetis random123 eospac/6.3.0"

--- a/environment/bashrc/.bashrc_toss3
+++ b/environment/bashrc/.bashrc_toss3
@@ -54,7 +54,11 @@ else
   export dracomodules="ack htop clang-format/3.9.0 \
 intel/17.0.4 openmpi/2.1.2 mkl \
 subversion cmake/3.9.0 numdiff git totalview trilinos/12.10.1 \
-superlu-dist/5.1.3 metis parmetis ndi random123 eospac/6.3.0 csk"
+superlu-dist/5.1.3 metis parmetis random123 eospac/6.3.0"
+
+  if [[ `groups | grep -c ccsrad` != 0 ]]; then
+    draco_modules="$draco_modules csk ndi"
+  fi
 
 fi
 

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -70,8 +70,12 @@ if [[ ${SLURM_JOB_PARTITION} == "knl" ]]; then
 fi
 
 export dracomodules="cmake/3.9.0 git subversion \
-clang-format eospac/6.3.0 gsl/2.3 metis ndi numdiff random123 \
-parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1 csk"
+clang-format eospac/6.3.0 gsl/2.3 metis numdiff random123 \
+parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1"
+
+if [[ `groups | grep -c ccsrad` != 0 ]]; then
+  draco_modules="$draco_modules csk ndi"
+fi
 
 function dracoenv ()
 {

--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -473,6 +473,7 @@ auto-mode-alist."
       (abbrev-mode 1)
       (setq f90-font-lock-keywords f90-font-lock-keywords-3)
       (setq f90-beginning-ampersand nil)
+      (setq f90-associate-indent 0)
       (require 'fill-column-indicator)
       (fci-mode))
      ;; let .F denone Fortran and not freeze files

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -81,6 +81,7 @@ echo "                  ${subproj}-${build_type}${epdash}${extra_params}${prdash
 echo "==========================================================================="
 
 run "ulimit -a"
+run "top -n 1 -bc"
 
 # Modules
 # ----------------------------------------

--- a/regression/ccscs3-crontab
+++ b/regression/ccscs3-crontab
@@ -3,17 +3,11 @@
 # Update the regression scripts.
 01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh
 
-# Send a copy of our repositories to the Red.
-00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh
-
-# Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
+# Keep a local bare copy of the repo available on the ccs-net.
 */20 * * * * /scratch/regress/draco/regression/sync_repository.sh
 
-# Run the metrics report on the first Monday of each month.
-00 05 1-7 * * /home/kellyt/bin/first_monday_of_month_report.sh &> /home/kellyt/logs/first_monday_of_month_report.log
-
 #------------------------------------------------------------------------------#
-# Regressions:
+# Regressions
 # -a build autodoc
 # -r use regress account
 # -b build_type: Release|Debug
@@ -32,11 +26,19 @@
 # gcc-8.1.0, openmpi-3.1.0
 #------------------------------------------------------------------------------#
 
-05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p \"draco jayenne capsaicin\"
+01 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p \"draco\"
 
-00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e coverage
+15 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"jayenne capsaicin\" -e vtest
 
-30 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e valgrind
+00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne\" -e scalar
+
+30 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne\" -e static
+
+#------------------------------------------------------------------------------#
+# Clang-6.0.0, openmpi-3.1.0
+#------------------------------------------------------------------------------#
+
+00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin\" -e clang
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -186,9 +186,9 @@ for ep in $extra_params; do
       run "module purge &> /dev/null"
       run "module list"
       run "module load user_contrib friendly-testing"
-      run "module load intel/18.0.1 openmpi/2.1.2 mkl"
+      run "module load intel/18.0.2 openmpi/2.1.2 mkl"
       run "module load superlu-dist metis parmetis"
-      run "module load trilinos/12.10.1 superlu-dist metis parmetis"
+      run "module load trilinos/12.10.1"
       run "module load cmake/3.9.0 ndi numdiff git"
       run "module load mkl random123 eospac/6.3.0 csk"
       ;;
@@ -227,7 +227,7 @@ comp=$comp-$featurebranch
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
-  keychain=keychain-2.7.1
+  keychain=keychain-2.8.5
   $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
   if test -f $HOME/.keychain/$machine-sh; then
     run "source $HOME/.keychain/$machine-sh"

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -32,6 +32,38 @@
 ## Helpful functions
 ##---------------------------------------------------------------------------##
 
+function dracohelp()
+{
+echo -e "Bash functions defined by Draco:\n\n"
+echo -e "Also try 'slurmhelp'\n"
+echo "allow_file_to_age - pause a program until a file is 'old'"
+echo "cleanemacs    - remove ~ and .elc files."
+echo "die           - exit with a message"
+echo "dracoenv/rmdracoenv - load/unload the draco environment"
+echo "establish_permissions - Change group to othello, dacodes or draco and change permissions to g+rwX,o-rwX"
+echo "flavor        - build a string that looks like fire-openmpi-2.0.2-intel-17.0.1"
+echo "fn_exists     - return true if named bash function is defined"
+echo "install_verions - helper for doing releases (see release_toss2.sh)"
+echo "lookupppn     - return PE's per node."
+echo "machineName   - return a string to represent the current machine."
+echo "npes_build    - return PE's to be used for compiling."
+echo "npes_test     - return PE's to be used for testing."
+echo "osName        - return a string to represent the current machine's OS."
+echo "proxy         - toggle the status of the LANL proxy variables."
+echo "publish_release - helper for doing releases (see release_toss2.sh)"
+echo "qrm           - quick rm for directories located in lustre scratch spaces."
+echo "rdde          - more agressive reset of the draco environment."
+echo "run           - echo a command and then run it."
+echo "selectscratchdir - find a scratch drive"
+echo "whichall      - Find all matchs."
+echo "xfstatus      - print status 'transfered' files."
+echo -e "\nUse 'type <function>' to print the full content of any function.\n"
+}
+
+#------------------------------------------------------------------------------#
+#
+#------------------------------------------------------------------------------#
+
 # Print an error message and exit.
 # e.g.: cd $dir || die "can't change dir to $dir".
 function die () { echo " "; echo "FATAL ERROR: $1"; exit 1;}

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -35,7 +35,7 @@
 # Special: NR, PerfBench and FullDiagnostics regressions.
 #------------------------------------------------------------------------------#
 
-# intel-18.0.1 + openmpi-2.1.2
+# intel-18.0.2 + openmpi-2.1.2
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin\" -e newtools
 
 # gcc-6.4.0 + openmpi-2.1.2

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -120,14 +120,14 @@ done
 if [[ -d $logdir ]]; then
   echo -e "\nCleaning up old log files."
   run "cd $logdir"
-  run "find . -mtime +14 -type f"
-  run "find . -mtime +14 -type f -delete"
+  run "find . -mtime +5 -type f"
+  run "find . -mtime +5 -type f -delete"
 fi
 if [[ -d $REGDIR/cdash ]]; then
   echo -e "\nCleaning up old builds."
   run "cd $REGDIR/cdash"
-  run "find . -maxdepth 3 -mtime +14 -name 'Experimental*-pr*' -type d"
-  run "find . -maxdepth 3 -mtime +14 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
+  run "find . -maxdepth 3 -mtime +5 -name 'Experimental*-pr*' -type d"
+  run "find . -maxdepth 3 -mtime +5 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
 fi
 if [[ -d /usr/projects/ccsrad/regress/cdash ]]; then
   echo -e "\nCleaning up old builds."

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -132,8 +132,8 @@ fi
 if [[ -d /usr/projects/ccsrad/regress/cdash ]]; then
   echo -e "\nCleaning up old builds."
   run "cd /usr/projects/ccsrad/regress/cdash"
-  run "find . -maxdepth 3 -mtime +2 -name 'Experimental*-pr*' -type d"
-  run "find . -maxdepth 3 -mtime +2 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
+  run "find . -maxdepth 3 -mtime +3 -name 'Experimental*-pr*' -type d"
+  run "find . -maxdepth 3 -mtime +3 -name 'Experimental*-pr*' -type d -exec rm -rf {} \;"
 fi
 
 echo -e "\n--------------------------------------------------------------------------------"


### PR DESCRIPTION
### Background

* It seems that we are always tweaking the developer environment and the regression scripts.  Here is another set of small changes...

### Notes

* [Related to #1178](https://rtt.lanl.gov/redmine/issue/1178)

### Description of changes

+ When loading modules via Draco's .bashrc files, only load ndi and csk modules if the those installation directories are accessible.
+ On ccs-net machines, the regression script will now use `top` to print the current machine load and list active jobs before the regressions start.
+ For ccs-net machines, the vtest, scalar, static and clang regressions have been moved from ccscs2 to ccscs3.
+ Begin loading clang-format/6.0 when available.
+ On ccs-net machines, the regressions system was updated to make it less likely that multiple regressions are running simultaneously. Also move some PR testing and nightly regression testing from ccscs2 to ccscs3 (vtest, scalar, static, and clang builds) to reduce machine load and improve turn-around times.
+ To reduce the number of files in the regression log directory and the regression cdash/$p/Experimental-* directories, only keep results for 5 days instead of 14 days.  This should reduce our on-disk footprint.
+ Modify the emacs setup so that f90-mode doesn't indent code between `associate` and `end associate` commands.  This style change reflects coding practice found in Cassio.
+ Update snow's `newtools` regression build to use `intel/18.0.2`.
+ Add a new bash function `dracohelp` to the draco developer environment.  This command will print a list of functions provided by the draco dev environment.  We could possibly extend this to print information about configuring/building our codes.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
