### PR TITLE
Minor tweaks to enable new package 'mesh' to build under VS2017.

### DIFF
--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -58,7 +58,7 @@ configure_file( config.h.in ${PROJECT_BINARY_DIR}/ds++/config.h )
 
 # Generate the dll_declspec.h file that defines DLL_PUBLIC_<pkg> CPP macros.
 include(generate_dll_declspec)
-generate_dll_declspec( "ds++" "c4;cdi;cdi_test;cdi_analytic;cdi_eospac;cdi_ipcress;cdi_ipcress_test;device;diagnostics;dsxx;fit;FC_Derived_Type;linear;meshReaders;mesh_element;min;norms;ode;parser;quadrature;quadrature_test;rng;roots;RTT_Format_Reader;special_functions;timestep;timestep_test;units;viz" )
+generate_dll_declspec( "ds++" "c4;cdi;cdi_test;cdi_analytic;cdi_eospac;cdi_ipcress;cdi_ipcress_test;device;diagnostics;dsxx;fit;FC_Derived_Type;linear;mesh;meshReaders;mesh_element;min;norms;ode;parser;quadrature;quadrature_test;rng;roots;RTT_Format_Reader;special_functions;timestep;timestep_test;units;viz" )
 
 # ---------------------------------------------------------------------------- #
 # Source files

--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -11,6 +11,7 @@
 #ifndef rtt_mesh_Draco_Mesh_hh
 #define rtt_mesh_Draco_Mesh_hh
 
+#include "ds++/config.h"
 #include "mesh_element/Geometry.hh"
 #include <map>
 #include <vector>
@@ -84,14 +85,14 @@ private:
 
 public:
   //! Constructor.
-  Draco_Mesh(unsigned dimension_, Geometry geometry_,
-             const std::vector<unsigned> &cell_type_,
-             const std::vector<unsigned> &cell_to_node_linkage_,
-             const std::vector<unsigned> &side_set_flag_,
-             const std::vector<unsigned> &side_node_count_,
-             const std::vector<unsigned> &side_to_node_linkage_,
-             const std::vector<double> &coordinates_,
-             const std::vector<unsigned> &global_node_number_);
+  DLL_PUBLIC_mesh Draco_Mesh(unsigned dimension_, Geometry geometry_,
+                             const std::vector<unsigned> &cell_type_,
+                             const std::vector<unsigned> &cell_to_node_linkage_,
+                             const std::vector<unsigned> &side_set_flag_,
+                             const std::vector<unsigned> &side_node_count_,
+                             const std::vector<unsigned> &side_to_node_linkage_,
+                             const std::vector<double> &coordinates_,
+                             const std::vector<unsigned> &global_node_number_);
 
   // >>> ACCESSORS
 


### PR DESCRIPTION
### Background

* New package `mesh` requires a couple of extra instructions to allow it to compile under Visual Studio 2017. 

### Description of changes

* Modify scripts that generate CPP macro for `DLL_PUBLIC_imc`.
* Use the new decoration for the `Draco_Mesh` constructor.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
