### PR TITLE
Disable Travis config/build/test builds.

### DIFF
--- a/.travis-install-dependencies.sh
+++ b/.travis-install-dependencies.sh
@@ -21,7 +21,8 @@ topdir=`pwd` # /home/travis/build/lanl/Draco
 RANDOM123_VER=1.09
 CMAKE_VERSION=3.9.0-Linux-x86_64
 NUMDIFF_VER=5.8.1
-CLANG_FORMAT_VER=3.9
+CLANG_FORMAT_VER=6.0
+DISTRO=trusty
 OPENMPI_VER=1.10.5
 
 # Return integer > 0 if 'develop' branch is found.
@@ -52,59 +53,64 @@ if [[ ${STYLE} ]]; then
   fi
 
   # clang-format and git-clang-format
+  # https://blog.kowalczyk.info/article/k/how-to-install-latest-clang-6.0-on-ubuntu-16.04-xenial-wsl.html
   echo " "
   echo "Clang-format"
-  run "sudo add-apt-repository 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-${CLANG_FORMAT_VER} main'"
-  run "wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -"
-  run "sudo apt-get update -qq"
-  run "sudo apt-get install -qq -y clang-format-${CLANG_FORMAT_VER}"
+  run "wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -"
+  run "sudo add-apt-repository 'deb http://apt.llvm.org/${DISTRO}/ llvm-toolchain-${DISTRO}-${CLANG_FORMAT_VER} main'"
+  run "sudo apt-get update"
+  run "sudo apt-get install -y clang-format-${CLANG_FORMAT_VER}"
   run "cd ${VENDOR_DIR}/bin"
-  run "ln -s /usr/bin/clang-format-${CLANG_FORMAT_VER} clang-format"
-  run "ln -s /usr/bin/git-clang-format-${CLANG_FORMAT_VER} git-clang-format"
+  if [[ -x /usr/bin/clang-format-${CLANG_FORMAT_VER} ]]; then
+    run "sudo ln -s /usr/bin/clang-format-${CLANG_FORMAT_VER} clang-format"
+    run "sudo ln -s /usr/bin/git-clang-format-${CLANG_FORMAT_VER} git-clang-format"
+  else
+    die "Didn't find /usr/bin/clang-format-${CLANG_FORMAT_VER}"
+  fi
   run "cd $topdir"
 
-else
+# else
 
-  # Random123
-  echo " "
-  echo "Random123"
-  cd $HOME
-  run "wget http://www.deshawresearch.com/downloads/download_random123.cgi/Random123-${RANDOM123_VER}.tar.gz"
-  run "tar -xvf Random123-${RANDOM123_VER}.tar.gz &> build-r123.log"
-  echo "Please set RANDOM123_INC_DIR=$HOME/Random123-${RANDOM123_VER}/include"
-  run "ls $HOME/Random123-${RANDOM123_VER}/include"
+  # # Random123
+  # echo " "
+  # echo "Random123"
+  # cd $HOME
+  # run "wget http://www.deshawresearch.com/downloads/download_random123.cgi/Random123-${RANDOM123_VER}.tar.gz"
+  # run "tar -xvf Random123-${RANDOM123_VER}.tar.gz &> build-r123.log"
+  # echo "Please set RANDOM123_INC_DIR=$HOME/Random123-${RANDOM123_VER}/include"
+  # run "ls $HOME/Random123-${RANDOM123_VER}/include"
 
-  # CMake
-  echo " "
-  echo "CMake"
-  run "cd $HOME"
-  run "wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz"
-  run "tar -xzf cmake-${CMAKE_VERSION}.tar.gz &> build-cmake.log"
-  run "cd $topdir"
+  # # CMake
+  # echo " "
+  # echo "CMake"
+  # run "cd $HOME"
+  # run "wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz"
+  # run "tar -xzf cmake-${CMAKE_VERSION}.tar.gz &> build-cmake.log"
+  # run "cd $topdir"
 
-  # Numdiff
-  echo " "
-  echo "Numdiff"
-  run "wget http://mirror.lihnidos.org/GNU/savannah/numdiff/numdiff-${NUMDIFF_VER}.tar.gz"
-  run "tar -xvf numdiff-${NUMDIFF_VER}.tar.gz >& build-numdiff.log"
-  run "cd numdiff-${NUMDIFF_VER}"
-  run "./configure --prefix=/usr && make >> build-numdiff.log 2>&1"
-  run "sudo make install"
-  run "cd $topdir"
+  # # Numdiff
+  # echo " "
+  # echo "Numdiff"
+  # run "wget http://mirror.lihnidos.org/GNU/savannah/numdiff/numdiff-${NUMDIFF_VER}.tar.gz"
+  # run "tar -xvf numdiff-${NUMDIFF_VER}.tar.gz >& build-numdiff.log"
+  # run "cd numdiff-${NUMDIFF_VER}"
+  # run "./configure --prefix=/usr && make >> build-numdiff.log 2>&1"
+  # run "sudo make install"
+  # run "cd $topdir"
 
-  # OpenMPI
-  echo " "
-  echo "OpenMPI"
-  run "wget --no-check-certificate https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-${OPENMPI_VER}.tar.gz"
-  run "tar -zxf openmpi-${OPENMPI_VER}.tar.gz > build-openmpi.log"
-  run "cd openmpi-${OPENMPI_VER}"
-  run "./configure --enable-mpi-thread-multiple --quiet >> build-openmpi.log 2>&1"
-  # run "travis_wait 20 make"
-  run "make >> build-openmpi.log 2>&1"
-  run "sudo make install"
-  run "sudo sh -c 'echo \"/usr/local/lib\n/usr/local/lib/openmpi\" > /etc/ld.so.conf.d/openmpi.conf'"
-  run "sudo ldconfig"
-  run "cd $topdir"
+  # # OpenMPI
+  # echo " "
+  # echo "OpenMPI"
+  # run "wget --no-check-certificate https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-${OPENMPI_VER}.tar.gz"
+  # run "tar -zxf openmpi-${OPENMPI_VER}.tar.gz > build-openmpi.log"
+  # run "cd openmpi-${OPENMPI_VER}"
+  # run "./configure --enable-mpi-thread-multiple --quiet >> build-openmpi.log 2>&1"
+  # # run "travis_wait 20 make"
+  # run "make >> build-openmpi.log 2>&1"
+  # run "sudo make install"
+  # run "sudo sh -c 'echo \"/usr/local/lib\n/usr/local/lib/openmpi\" > /etc/ld.so.conf.d/openmpi.conf'"
+  # run "sudo ldconfig"
+  # run "cd $topdir"
 
 fi
 

--- a/.travis-run-tests.sh
+++ b/.travis-run-tests.sh
@@ -29,49 +29,49 @@ export FC=`which gfortran-${GCCVER}`
 
 if [[ ${STYLE} ]]; then
   regression/check_style.sh -t
-else
-  mkdir -p build
-  cd build
-  # configure
-  # -Wl,--no-as-needed is a workaround for bugs.debian.org/457284 .
-  echo " "
-  echo "${CMAKE} -DCMAKE_EXE_LINKER_FLAGS=\"-Wl,--no-as-needed\" .."
-  ${CMAKE} -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" ..
-  error_code=$?
-  # if configure was successful, the start the build, otherwise abort.
-  if [[ $error_code -eq 0 ]]; then
-    echo " "
-    echo "make -j 2 VERBOSE=1"
-    make -j 2 VERBOSE=1
-    error_code=$?
-  else
-    echo "configure failed, errorcode=$error_code"
-    exit $error_code
-  fi
-  # if the build was successful, then run the tests, otherwise abort.
-  if [[ $error_code -eq 0 ]]; then
-    echo " "
-    echo "${CTEST} -VV -E \(c4_tstOMP_2\)"
-    ${CTEST} -VV -E \(c4_tstOMP_2\)
-    error_code=$?
-  else
-    echo "build failed, errorcode=$error_code"
-    exit $error_code
-  fi
-  # if some of the tests failed, rerun them with full verbosity to provide more
-  # information in the output log.
-  # if ! [[ $error_code -eq 0 ]]; then
-  #   echo "some tests failed, errorcode=$error_code, trying again with more verbosity."
-  #   echo " "
-  #   echo "${CTEST} --rerun-failed -VV -E \(c4_tstOMP_2\)"
-  #   ${CTEST} --rerun-failed -VV -E \(c4_tstOMP_2\)
-  #   exit $error_code
-  #   echo "error_code=$error_code"
-  # fi
-  echo " "
-  echo "make install DESTDIR=${HOME}"
-  make install DESTDIR="${HOME}"
-  cd -
+# else
+#   mkdir -p build
+#   cd build
+#   # configure
+#   # -Wl,--no-as-needed is a workaround for bugs.debian.org/457284 .
+#   echo " "
+#   echo "${CMAKE} -DCMAKE_EXE_LINKER_FLAGS=\"-Wl,--no-as-needed\" .."
+#   ${CMAKE} -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" ..
+#   error_code=$?
+#   # if configure was successful, the start the build, otherwise abort.
+#   if [[ $error_code -eq 0 ]]; then
+#     echo " "
+#     echo "make -j 2 VERBOSE=1"
+#     make -j 2 VERBOSE=1
+#     error_code=$?
+#   else
+#     echo "configure failed, errorcode=$error_code"
+#     exit $error_code
+#   fi
+#   # if the build was successful, then run the tests, otherwise abort.
+#   if [[ $error_code -eq 0 ]]; then
+#     echo " "
+#     echo "${CTEST} -VV -E \(c4_tstOMP_2\)"
+#     ${CTEST} -VV -E \(c4_tstOMP_2\)
+#     error_code=$?
+#   else
+#     echo "build failed, errorcode=$error_code"
+#     exit $error_code
+#   fi
+#   # if some of the tests failed, rerun them with full verbosity to provide more
+#   # information in the output log.
+#   # if ! [[ $error_code -eq 0 ]]; then
+#   #   echo "some tests failed, errorcode=$error_code, trying again with more verbosity."
+#   #   echo " "
+#   #   echo "${CTEST} --rerun-failed -VV -E \(c4_tstOMP_2\)"
+#   #   ${CTEST} --rerun-failed -VV -E \(c4_tstOMP_2\)
+#   #   exit $error_code
+#   #   echo "error_code=$error_code"
+#   # fi
+#   echo " "
+#   echo "make install DESTDIR=${HOME}"
+#   make install DESTDIR="${HOME}"
+#   cd -
 fi
 
 # Finish up and report

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,22 @@ dist: trusty
 
 env:
   global:
-    - BLAS_blas_LIBRARY=/usr/lib/libblas.a
+#    - BLAS_blas_LIBRARY=/usr/lib/libblas.a
     - CC=gcc-6
     - CCACHE_CPP2=yes
     - CMAKE=$HOME/cmake-3.9.0-Linux-x86_64/bin/cmake
     - CTEST=$HOME/cmake-3.9.0-Linux-x86_64/bin/ctest
     - CXX=g++-6
     - FC=gfortran-6
-    - LAPACK_LIB_DIR=/usr/lib
-    - OMP_NUM_THREADS=4
-    - RANDOM123_INC_DIR=$HOME/Random123-1.09/include
-    - VENDOR_DIR=${HOME}
+#    - LAPACK_LIB_DIR=/usr/lib
+#    - OMP_NUM_THREADS=4
+#    - RANDOM123_INC_DIR=$HOME/Random123-1.09/include
+#    - VENDOR_DIR=${HOME}
     - topdir=/home/travis/build/losalamos/Draco
     - COVERAGE=ON
   matrix:
     - STYLE=ON
-    - WERROR=ON
+#    - WERROR=ON
 
 addons:
   apt:
@@ -32,17 +32,16 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - ccache
-      - libgsl0-dev
+#      - libgsl0-dev
       - gcc-6
       - g++-6
       - gfortran-6
-      - liblapack-dev
+#      - liblapack-dev
 
 before_install:
   - mkdir -p ${VENDOR_DIR}/bin & export PATH=${VENDOR_DIR}/bin:$PATH
   - pip install --upgrade --user pip
-#  - pip install --upgrade setuptools
-  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
+#  - pip install --upgrade setuptools   - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
   - travis_wait 30 ./.travis-install-dependencies.sh

--- a/autodoc/ci-testing.dcc
+++ b/autodoc/ci-testing.dcc
@@ -1,0 +1,32 @@
+/*!
+
+\page ci_testing Setup CI Testing on GitHub.
+
+Draco is hosted on GitHub at https://github.com/lanl/Draco.
+
+\par Travis testing
+
+New pull requests should be on development branches and the request is to merge
+each branch back to the 'develop' branch.  When a pull request is generated, we
+want Travis (https://travis-ci.org) to run a basic build test.
+
+You must have an account with travis-ci.org and register the Draco project with
+travis-ci.org so that a web hook is installed.  The web hook runs the code
+provided by ~/.travis.yml.
+
+It is desireable for the travis script to run (1) a code style check (this uses
+clang-format), (2) a build check using cmake and g++ and (3) a code coverage
+report (see next paragraph).
+
+\par Code Coverage
+
+Track code coverage
+
+\par AppVeyor
+
+Run basic build test with the Visual Studio compiler.
+
+*/
+//---------------------------------------------------------------------------//
+// end of ci-testing.dcc
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

+ The Travis configure/build/test runner has been failing for some time.   Disable it until we can bring it back online.

### Description of changes

+ Comment out all of the Travis runner scripting that runs to regular configure/build/test sequence.
+ The style checker will remain active, but we will begin using clang-format-6.0.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
