### PR TITLE
Minor tweaks to the configure process.

### DIFF
--- a/config/FindCOMPTON.cmake
+++ b/config/FindCOMPTON.cmake
@@ -87,10 +87,7 @@ find_path( COMPTON_INCLUDE_DIR
   PATH_SUFFIXES Release Debug
 )
 
-set( COMPTON_LIBRARY_NAME Lib_compton)
-if( OPENMP_FOUND )
-  set( COMPTON_LIBRARY_NAME Lib_compton_omp)
-endif()
+set( COMPTON_LIBRARY_NAME Lib_compton_omp;Lib_compton)
 find_library( COMPTON_LIBRARY
   NAMES ${COMPTON_LIBRARY_NAME}
   HINTS ${COMPTON_ROOT_DIR}/lib ${COMPTON_LIBDIR}
@@ -117,6 +114,8 @@ if( NOT COMPTON_VERSION )
     string( REGEX REPLACE ".*([0-9]+)" "\\1" COMPTON_MAJOR ${compton_h_major} )
     string( REGEX REPLACE ".*([0-9]+)" "\\1" COMPTON_MINOR ${compton_h_minor} )
     string( REGEX REPLACE ".*([0-9]+)" "\\1" COMPTON_SUBMINOR ${compton_h_subminor} )
+    set( COMPTON_VERSION "${COMPTON_MAJOR}.${COMPTON_MINOR}.${COMPTON_SUBMINOR}"
+      CACHE STRING "CSK version" FORCE )
   endif()
   # We might also try scraping the directory name for a regex match
   # "csk-X.X.X"

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -410,7 +410,8 @@ macro( setupMPILibrariesUnix )
          message( FATAL_ERROR "
 The Draco build system doesn't know how to configure the build for
   MPIEXEC     = ${MPIEXEC}
-  DBS_MPI_VER = ${DBS_MPI_VER}")
+  DBS_MPI_VER = ${DBS_MPI_VER}
+  CRAY_PE     = ${CRAY_PE}")
       endif()
 
       # Mark some of the variables created by the above logic as 'advanced' so

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -188,7 +188,7 @@ if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
       ;;
 
     # Pinto | Wolf
-    pi* | wf* )
+    pi* | wf* | lu* )
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_toss22
       ;;
 
@@ -202,7 +202,7 @@ if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_rfta
       ;;
     # trinitite (tt-fey) | trinity (tr-fe)
-    tt-fey* | tt-login* | tr-fe* | tr-login* | nid0* )
+    tt-fey* | tt-login* | tr-fe* | tr-login* | nid* )
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_tt
       ;;
     # rzuseq


### PR DESCRIPTION
### Description of changes

+ Modify `FindCOMPTON.cmake` so that two possible names for the CSK library are considered suitable.  Also, ensure that the `COMPTON_VERSION` variable is set.
+ If `setupMPI.cmake` fails, add the `CRAY_PE` value to the diagnostic message.
+ Re-enable bashrc setup for Luna.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
