### PR TITLE
Add an Appveyor (win32) build to the CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Draco
 ----------------
 
-[![Build Status](https://travis-ci.org/lanl/Draco.svg?branch=develop)](https://travis-ci.org/lanl/Draco)
+[![Linux Build Status](https://travis-ci.org/lanl/Draco.svg?branch=develop)](https://travis-ci.org/lanl/Draco)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/yp8r9jxl2gc9n1fs/branch/develop?svg=true)](https://ci.appveyor.com/project/lanl/Draco)
 [![codecov.io](https://codecov.io/github/lanl/Draco/coverage.svg?branch=develop)](https://codecov.io/github/lanl/Draco/branch/develop)
 [![Latest Version](https://img.shields.io/github/release/lanl/draco.svg?style=flat-square)](https://github.com/lanl/Draco/releases)
 [![PyPI](https://img.shields.io/pypi/l/Django.svg)](https://github.com/lanl/Draco/blob/develop/LICENSE.md)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,133 @@
+version: 1.0.{build}
+skip_tags: true
+max_jobs: 1
+image: Visual Studio 2017 Preview
+clone_depth: 3
+
+environment:
+  OMP_NUM_THREADS: 4
+  RANDOM123_INC_DIR: c:\projects\vendors\Random123-1.08\include
+  GSL_ROOT_DIR: c:\projects\vendors\gsl-1.16
+  VENDOR_DIR: c:\projects\vendors
+  PATH: c:\projects\vendors\bin;$(PATH)
+
+build_script:
+# we start at $(APPVEYOR_BUILD_FOLDER) = c:\projects\draco-2th1a
+# can't put vendors in the source directory.
+  - cd ..
+  - curl -L -o win32-vendors.zip https://github.com/KineticTheory/ci-demo/files/2131538/win32-vendors.zip
+  - 7z.exe -y x win32-vendors.zip
+  - mkdir build
+  - cd build
+# no MPI installed so force scalar builds.
+  - cmake -G "Visual Studio 15 2017" -DDRACO_C4=SCALAR %APPVEYOR_BUILD_FOLDER%
+  - cmake --build . --config Debug
+  - ctest -C Debug -j 2
+
+#build:
+#  verbosity: minimal
+
+# Applications
+# C:\Program Files\dotnet\dotnet.exe
+# C:\Program Files (x86)\dotnet\dotnet.exe
+# C:\Tools\NuGet\nuget.exe
+
+# Environment
+
+# 7zip="C:\Program Files\7-Zip\7z.exe"
+# ALLUSERSPROFILE=C:\ProgramData
+# APPDATA=C:\Users\appveyor\AppData\Roaming
+# APPVEYOR=True
+# APPVEYOR_ACCOUNT_NAME=KineticTheory
+# APPVEYOR_API_URL=http://localhost:49714/
+# APPVEYOR_BUILD_FOLDER=C:\projects\draco-2th1a
+# APPVEYOR_BUILD_ID=16839214
+# APPVEYOR_BUILD_NUMBER=3
+# APPVEYOR_BUILD_VERSION=1.0.3
+# APPVEYOR_BUILD_WORKER_IMAGE=Visual Studio 2017 Preview
+# APPVEYOR_JOB_ID=pkav9i05a0xr908m
+# APPVEYOR_JOB_NUMBER=1
+# APPVEYOR_PROJECT_ID=464008
+# APPVEYOR_PROJECT_NAME=Draco
+# APPVEYOR_PROJECT_SLUG=draco-2th1a
+# APPVEYOR_PULL_REQUEST_HEAD_COMMIT=220c5c1857495bffe29255cfad0732f5b1606581
+# APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH=appveyor
+# APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME=KineticTheory/Draco
+# APPVEYOR_PULL_REQUEST_NUMBER=422
+# APPVEYOR_PULL_REQUEST_TITLE=WIP: Add an Appveyor (win32) build to the CI.
+# APPVEYOR_REPO_BRANCH=develop
+# APPVEYOR_REPO_COMMIT=7abced22ab379b996a6afc10cc22bd4ca79dc98c
+# APPVEYOR_REPO_COMMIT_AUTHOR=Kelly (KT) Thompson
+# APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL=kgt@lanl.gov
+# APPVEYOR_REPO_COMMIT_MESSAGE=Add an Appveyor (win32) build to the CI.
+# APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED=+ For now, only build and test ds++ and cdi.\n+ Add a badge for the VS2017-build to the README.md.
+# APPVEYOR_REPO_COMMIT_TIMESTAMP=2018-06-26T00:23:38.0000000Z
+# APPVEYOR_REPO_NAME=lanl/Draco
+# APPVEYOR_REPO_PROVIDER=gitHub
+# APPVEYOR_REPO_SCM=git
+# APPVEYOR_REPO_TAG=false
+# APPVEYOR_URL=https://ci.appveyor.com
+# APR_ICONV_PATH=C:\Program Files (x86)\Subversion\iconv
+# AVVM_DOWNLOAD_URL=https://appveyordownloads.blob.core.windows.net/avvm
+# ChocolateyInstall=C:\ProgramData\chocolatey
+# ChocolateyLastPathUpdate=Thu Jan 11 21:02:54 2018
+# CI=True
+# CI_LINUX=False
+# CI_WINDOWS=True
+# CommonProgramFiles=C:\Program Files\Common Files
+# CommonProgramFiles(x86)=C:\Program Files (x86)\Common Files
+# CommonProgramW6432=C:\Program Files\Common Files
+# COMPUTERNAME=MASTER-WIN2016
+# ComSpec=C:\windows\system32\cmd.exe
+# DXSDK_DIR=C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\
+# EnableNuGetPackageRestore=true
+# ERLANG_HOME=C:\Program Files\erl9.2
+# FSHARPINSTALLDIR=C:\Program Files (x86)\Microsoft SDKs\F#\10.1\Framework\v4.0\
+# GIT_LFS_PATH=C:\Program Files\Git LFS
+# GooGetRoot=C:\ProgramData\GooGet
+# GOROOT=C:\go
+# GSL_ROOT_DIR=c:\projects\Draco\vendors\gsl-1.16
+# HOMEDRIVE=C:
+# HOMEPATH=\Users\appveyor
+# JAVA_HOME=C:\Progra~1\Java\jdk1.8.0
+# lastexitcode=0
+# LOCALAPPDATA=C:\Users\appveyor\AppData\Local
+# LOGONSERVER=\\MASTER-WIN2016
+# M2_HOME=C:\Program Files (x86)\Apache\Maven
+# MAVEN_HOME=C:\Program Files (x86)\Apache\Maven
+# MSYS2_PATH_TYPE=inherit
+# NUMBER_OF_PROCESSORS=2
+# OMP_NUM_THREADS=4
+# OPENSSL_CONF=C:\OpenSSL-Win32\bin\openssl.cfg
+# OS=Windows_NT
+# Path=c:\projects\Draco\vendors\bin;C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\GooGet;C:\Program Files (x86)\Google\Cloud SDK\google-cloud-sdk\bin;C:\Program Files\Compute Engine\sysprep;C:\Program Files\Google\Compute Engine\sysprep\;C:\Program Files\Google\Compute Engine\metadata_scripts\;C:\Program Files\7-Zip;C:\Program Files\Microsoft\Web Platform Installer\;C:\Tools\NuGet;C:\Tools\GitVersion;C:\Tools\PsTools;C:\Program Files\Git LFS;C:\Program Files\Mercurial\;C:\Program Files (x86)\Subversion\bin;C:\Tools\WebDriver;C:\Tools\Coverity\bin;C:\Tools\MSpec;C:\Tools\NUnit\bin;C:\Tools\NUnit3;C:\Tools\xUnit;C:\go\bin;C:\Tools\curl\bin;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\110\Tools\Binn\;C:\Program Files (x86)\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\Microsoft SQL Server\120\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\120\Tools\Binn\ManagementStudio\;C:\Program Files (x86)\Microsoft SQL Server\120\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\130\DTS\Binn\;C:\Program Files\Microsoft SQL Server\130\DTS\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\;C:\Program Files (x86)\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Ruby193\bin;C:\Program Files\nodejs;C:\Program Files (x86)\iojs;C:\Program Files\iojs;C:\Users\appveyor\AppData\Roaming\npm;C:\Python27;C:\Python27\Scripts;C:\Program Files\Java\jdk1.8.0\bin;C:\Program Files (x86)\Apache\Maven\bin;C:\Program Files (x86)\CMake\bin;C:\Users\appveyor\.dnx\bin;C:\Program Files\Microsoft DNX\Dnvm\;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\130;C:\Program Files\Amazon\AWSCLI\;C:\Program Files\dotnet\;C:\Tools\vcpkg;C:\Users\appveyor\AppData\Local\Microsoft\WindowsApps;C:\Users\appveyor\AppData\Local\Yarn\bin;C:\Users\appveyor\AppData\Roaming\npm;C:\Program Files (x86)\dotnet\;C:\Users\appveyor\AppData\Local\Microsoft\WindowsApps;C:\Users\appveyor\AppData\Roaming\npm;C:\Users\appveyor\AppData\Local\Yarn\bin;C:\Program Files\Docker;C:\Program Files (x86)\Microsoft SQL Server\140\Tools\Binn\;C:\Program Files\Microsoft SQL Server\140\Tools\Binn\;C:\Program Files\Microsoft SQL Server\140\DTS\Binn\;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\Extensions\TestPlatform;C:\Program Files\erl9.2\bin;C:\Program Files (x86)\Microsoft SQL Server\110\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\140\DTS\Binn\;C:\Program Files\LLVM\bin;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\nodejs;C:\Program Files (x86)\Yarn\bin\;C:\Program Files\Microsoft Service Fabric\bin\Fabric\Fabric.Code;C:\Program Files\Microsoft SDKs\Service Fabric\Tools\ServiceFabricLocalClusterManager;C:\Tools\Octopus;C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\MSBuild\15.0\Bin;C:\Program Files\PowerShell\6.0.2;C:\Program Files (x86)\nodejs\;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\ProgramData\chocolatey\bin;C:\Users\appveyor\AppData\Local\Microsoft\WindowsApps;C:\Users\appveyor\AppData\Local\Yarn\bin;C:\Users\appveyor\.dotnet\tools;C:\Users\appveyor\AppData\Roaming\npm;C:\Program Files\AppVeyor\BuildAgent\
+# PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY;.CPL
+# PROCESSOR_ARCHITECTURE=AMD64
+# PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 63 Stepping 0, GenuineIntel
+# PROCESSOR_LEVEL=6
+# PROCESSOR_REVISION=3f00
+# ProgramData=C:\ProgramData
+# ProgramFiles=C:\Program Files
+# ProgramFiles(x86)=C:\Program Files (x86)
+# ProgramW6432=C:\Program Files
+# PROMPT=$P$G
+# PSModulePath=C:\Users\appveyor\Documents\WindowsPowerShell\Modules;C:\Program Files (x86)\WindowsPowerShell\Modules;C:\windows\system32\WindowsPowerShell\v1.0\Modules;C:\Program Files (x86)\Google\Cloud SDK\google-cloud-sdk\platform\PowerShell;C:\Users\appveyor\Documents\WindowsPowerShell\Modules;C:\Program Files (x86)\Microsoft SQL Server\120\Tools\PowerShell\Modules;C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules;C:\Program Files (x86)\AWS Tools\PowerShell;C:\Program Files\AppVeyor\BuildAgent\Modules;C:\Program Files (x86)\Microsoft SQL Server\140\Tools\PowerShell\Modules;C:\Program Files\WindowsPowerShell\Modules;C:\Program Files (x86)\Microsoft SDKs\Azure\PowerShell\ResourceManager\AzureResourceManager;C:\Program Files (x86)\Microsoft SDKs\Azure\PowerShell\ServiceManagement;C:\Program Files (x86)\Microsoft SDKs\Azure\PowerShell\Storage
+# PUBLIC=C:\Users\Public
+# RANDOM123_INC_DIR=c:\projects\Draco\vendors\Random123-1.08\include
+# SESSIONNAME=Console
+# SystemDrive=C:
+# SystemRoot=C:\windows
+# TEMP=C:\Users\appveyor\AppData\Local\Temp\1
+# TMP=C:\Users\appveyor\AppData\Local\Temp\1
+# USERDOMAIN=MASTER-WIN2016
+# USERDOMAIN_ROAMINGPROFILE=MASTER-WIN2016
+# USERNAME=appveyor
+# USERPROFILE=C:\Users\appveyor
+# VENDOR_DIR=c:\projects\Draco\vendors
+# VS110COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\Tools\
+# VS120COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\
+# VS140COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\
+# VSSDK140Install=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\
+# windir=C:\windows
+# WIX=C:\Program Files (x86)\WiX Toolset v3.11\
+# xunit20=C:\Tools\xUnit20

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -114,16 +114,29 @@ endif()
 # Extra runtime libraries...
 #
 
-find_library( Lib_win_winsock NAMES wsock32;winsock32;ws2_32 )
-if( EXISTS "${Lib_win_winsock}" AND CMAKE_CL_64 )
-  string(REPLACE "um/x86" "um/x64" Lib_win64_winsock "${Lib_win_winsock}" )
-  if( EXISTS "${Lib_win64_winsock}" )
-    set( Lib_win_winsock "${Lib_win64_winsock}")
+# Locate a Windows sockets library (required!)
+foreach( lib ws2_32;wsock32;winsock32;mswsock32 )
+  if( NOT Lib_win_winsock )
+    find_library( winsock_lib_${lib} ${lib} )
+    find_library( winsock_lib_${lib}
+      NAMES ${lib}
+      HINTS "C:/Windows/System32"
+            "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x86" )
+    set( Lib_win_winsock "${winsock_lib_${lib}}" CACHE FILEPATH
+      "Windows sockets library.")
   endif()
-endif()
+endforeach()
 
-if( ${Lib_win_winsock} MATCHES "NOTFOUND" )
-  message( FATAL_ERROR "Could not find library winsock32 or ws2_32!" )
+# Extra logic for 64-bit builds under Visual Studio
+# if( EXISTS "${Lib_win_winsock}" AND CMAKE_CL_64 )
+#   string(REPLACE "um/x86" "um/x64" Lib_win64_winsock "${Lib_win_winsock}" )
+#   if( EXISTS "${Lib_win64_winsock}" )
+#     set( Lib_win_winsock "${Lib_win64_winsock}")
+#   endif()
+# endif()
+
+if( NOT Lib_win_winsock )
+  message( FATAL_ERROR "Could not find library wsock32, mswsock32 or ws2_32!" )
 endif()
 
 #------------------------------------------------------------------------------#

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ message(" ")
 message( STATUS "Configuring Level 1 packages --" )
 add_dir_if_exists( ds++ )
 
+if( NOT DEFINED ENV{APPVEYOR} )
+
 # Level 2
 message(" ")
 message( STATUS "Configuring Level 2 packages --" )
@@ -63,8 +65,6 @@ add_dir_if_exists( norms )        # needs c4
 add_dir_if_exists( parser )       # needs units, c4
 add_dir_if_exists( roots )        # needs linear
 add_dir_if_exists( timestep )     # needs c4, ds++
-
-if( NOT DEFINED ENV{APPVEYOR} )
 
 if( HAVE_Fortran )
   add_dir_if_exists( FortranChecks )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,9 @@ add_dir_if_exists( norms )        # needs c4
 add_dir_if_exists( parser )       # needs units, c4
 add_dir_if_exists( roots )        # needs linear
 add_dir_if_exists( timestep )     # needs c4, ds++
+
+if( NOT DEFINED ENV{APPVEYOR} )
+
 if( HAVE_Fortran )
   add_dir_if_exists( FortranChecks )
 endif()
@@ -79,6 +82,8 @@ add_dir_if_exists( RTT_Format_Reader)  # needs meshReaders
 message(" ")
 message( STATUS "Configuring Level 5 packages --" )
 add_dir_if_exists( quadrature )       # needs mesh_element, parser, special_functions
+
+endif( NOT DEFINED ENV{APPVEYOR} )
 
 # Summary
 


### PR DESCRIPTION
### Background

* We run nightly regressions for Visual Studio 2017, but most developer's don't have access to VS2017 for testing purposes.
* [Appveyor](https://www.appveyor.com/) provides a capability similar to [Travis](https://travis-ci.org), but targets Visual Studio builds.
* We will start with a basic build (ds++ only). If successful, we will add other Draco packages to this CI testing framework.

### Description of changes

+ For now, only build and test ds++. Limit included directories by querying for `ENV{APPVEYOR}` from `src\CMakeLists.txt`. 
  + There were some link issues in c4 related to `DLL_PUBLIC_c4`.  Once those are fixed, we can activate the build for all but 3 packages.  
  + The remaining packages are trying to use a 64-bit Fortran compiler with a 32-bit CXX compiler.  It will take some digging to fix these.
+ Provide a basic appveyor script that instructs the CI concerning environment and build commands.
+ Tweak the `config\windows-cl.cmake` to make the search for the windows socket library more robust.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
