### PR TITLE
Safe a call to sqrt by wrapping its argument in fabs.

### DIFF
--- a/src/c4/Timer.cc
+++ b/src/c4/Timer.cc
@@ -74,8 +74,8 @@ Timer::Timer()
 
 //! Print out a timing report.
 void Timer::print(std::ostream &out, int p) const {
-  using std::setw;
   using std::ios;
+  using std::setw;
 
   out.setf(ios::fixed, ios::floatfield);
   out.precision(p);
@@ -131,8 +131,8 @@ void Timer::print(std::ostream &out, int p) const {
 //! Print out a timing report as a single line summary.
 void Timer::printline(std::ostream &out, unsigned const p,
                       unsigned const w) const {
-  using std::setw;
   using std::ios;
+  using std::setw;
 
   out.setf(ios::fixed, ios::floatfield);
   out.precision(p);
@@ -333,8 +333,8 @@ void Timer::pause(double const pauseSeconds) {
  */
 void Timer::printline_mean(std::ostream &out, unsigned const p,
                            unsigned const w, unsigned const v) const {
-  using std::setw;
   using std::ios;
+  using std::setw;
 
   unsigned const ranks = rtt_c4::nodes();
 
@@ -371,13 +371,13 @@ void Timer::printline_mean(std::ostream &out, unsigned const p,
     // Width of first column (intervals) should be set by client before calling
     // this function.
     out << setw(w) << mni << " +/- " << setw(v)
-        << sqrt((ni2 - 2 * mni * ni + ranks * mni * mni) / ranks) << setw(w)
+        << sqrt(fabs(ni2 - 2 * mni * ni + ranks * mni * mni) / ranks) << setw(w)
         << mu << " +/- " << setw(v)
-        << sqrt((u2 - 2 * mu * u + ranks * mu * mu) / ranks) << setw(w) << ms
-        << " +/- " << setw(v)
-        << sqrt((s2 - 2 * ms * s + ranks * ms * ms) / ranks) << setw(w) << mww
-        << " +/- " << setw(v)
-        << sqrt((ww2 - 2 * mww * ww + ranks * mww * mww) / ranks);
+        << sqrt(fabs(u2 - 2 * mu * u + ranks * mu * mu) / ranks) << setw(w)
+        << ms << " +/- " << setw(v)
+        << sqrt(fabs(s2 - 2 * ms * s + ranks * ms * ms) / ranks) << setw(w)
+        << mww << " +/- " << setw(v)
+        << sqrt(fabs(ww2 - 2 * mww * ww + ranks * mww * mww) / ranks);
 
     // Omit PAPI for now.
 


### PR DESCRIPTION
The variances whose sqrt are taken in the timer output code are formally positive indefinite, but roundof will sometimes make them very slightly negative and trigger a floating point exception. Wrapping in fabs is a perfectly adequate fix, since the result printed will be zero, which is the right printed value.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
