### PR TITLE
Tweak indentation when printing valid keywords.

### DIFF
--- a/src/parser/Parse_Table.cc
+++ b/src/parser/Parse_Table.cc
@@ -158,8 +158,8 @@ void Parse_Table::sort_table_() noexcept(
       } else {
         // The keywords are genuinely ambiguous. Throw an exception
         // identifying the duplicate keyword.
-        using std::ostringstream;
         using std::endl;
+        using std::ostringstream;
         ostringstream err;
         err << "An ambiguous keyword was detected in a "
             << "Parse_Table:  " << i->moniker << endl
@@ -272,9 +272,9 @@ Token Parse_Table::parse(Token_Stream &tokens) const {
           // Give the user the possibilities.
           tokens.comment("Perhaps you meant one of:");
           for (auto const &i : vec) {
-            tokens.comment(i.moniker);
+            tokens.comment(string("  ") + i.moniker);
             if (i.description != nullptr) {
-              tokens.comment(string("  ") + i.description);
+              tokens.comment(string("    ") + i.description);
             }
           }
 
@@ -743,7 +743,7 @@ bool Parse_Table::check_class_invariants() const {
   return true;
 }
 
-} // rtt_parser
+} // namespace rtt_parser
 //---------------------------------------------------------------------------------------//
 // end of Parse_Table.cc
 //---------------------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

When a parser scans an invalid keyword, it generates a diagnostic message that includes "Perhaps you meant one of:\n" followed by a list of valid keywords. These can be a bit hard for the human reader to, um, parse.

### Purpose of Pull Request

Indent the list of valid keywords so it stands out a little better and is easier for human readers to parse.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
