### PR TITLE
Ensure that Processor_Group.t.hh is installed in the include/c4 directory.

### DIFF
--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -60,7 +60,8 @@ endif()
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 install( TARGETS Lib_c4 EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
-install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/c4 )
+install( FILES ${headers} ${template_implementations} DESTINATION
+  ${DBSCFGDIR}include/c4 )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests


### PR DESCRIPTION
### Background

Almost all Capsaicin regression tests failed this weekend. This was due to a build failure which in turn was due to an #include "c4/Processor_Group.i.hh" directive which did not find the file.

It turns out this file was moved to c4/Processor_Group.t.hh. In addition, the c4/CMakeLists.txt file does not install .t.hh files in the include/c4 directory, so merely changing the Capsaicin code to reference c4/Processor_Group.t.hh did not resolve the problem.

Capsaicin needs access to the definitions of template members of rtt_c4::Processor_Group so that it can instantiate them for Teuchos::ArrayView<double>, the preferred vector container in the Capsaicin library.

### Description of changes

c4/CMakeLists.txt was modified to install .t.hh files from c4 into include/c4.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
