### PR TITLE
Complete preliminary Draco_Mesh builder, using RTT mesh parser.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,6 @@ message( STATUS "Configuring Level 3 packages --" )
 add_dir_if_exists( cdi_ipcress )
 add_dir_if_exists( diagnostics )  # needs c4
 add_dir_if_exists( fit )          # needs linear
-add_dir_if_exists( mesh )         # needs c4, ds++, mesh_element
 add_dir_if_exists( meshReaders )  # needs c4
 add_dir_if_exists( min )          # needs linear
 add_dir_if_exists( norms )        # needs c4
@@ -92,9 +91,10 @@ if( NOT DEFINED ENV{APPVEYOR} AND NOT DEFINED ENV{TRAVIS} )
 endif()
 
 # Level 5
+message(" ")
+message( STATUS "Configuring Level 5 packages --" )
+add_dir_if_exists( mesh ) # needs c4, ds++, mesh_element
 if( NOT DEFINED ENV{APPVEYOR} AND NOT DEFINED ENV{TRAVIS} )
-  message(" ")
-  message( STATUS "Configuring Level 5 packages --" )
   add_dir_if_exists( quadrature )       # needs mesh_element, parser, special_functions
 endif()
 

--- a/src/RTT_Format_Reader/test/rttpolyhedron.2.mesh.in
+++ b/src/RTT_Format_Reader/test/rttpolyhedron.2.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    3D, 1 cell, 17 node mesh in an RTT file format.    ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -123,23 +123,23 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  2.0   0.0   0.0   1  
-  2  2.0   0.0   2.0   2  
-  3  2.0   2.0   2.0   3  
-  4  2.0   2.0   0.0   4  
-  5  0.0   0.0   0.0   5  
-  6  0.0   0.0   2.0   6  
-  7  0.0   2.0   2.0   7  
-  8  0.0   2.0   0.0   8  
-  9  1.0   2.0   0.0   9  
- 10  0.0   2.0   1.0  10  
- 11  1.0   2.0   2.0  11  
- 12  2.0   2.0   1.0  12  
- 13  1.0   2.0   1.0  13  
- 14  2.0   1.0   0.0  14  
- 15  2.0   1.0   2.0  15  
- 16  2.0   0.0   1.0  16  
- 17  2.0   1.0   1.0  17  
+  1  2.0   0.0   0.0   1
+  2  2.0   0.0   2.0   2
+  3  2.0   2.0   2.0   3
+  4  2.0   2.0   0.0   4
+  5  0.0   0.0   0.0   5
+  6  0.0   0.0   2.0   6
+  7  0.0   2.0   2.0   7
+  8  0.0   2.0   0.0   8
+  9  1.0   2.0   0.0   9
+ 10  0.0   2.0   1.0  10
+ 11  1.0   2.0   2.0  11
+ 12  2.0   2.0   1.0  12
+ 13  1.0   2.0   1.0  13
+ 14  2.0   1.0   0.0  14
+ 15  2.0   1.0   2.0  15
+ 16  2.0   0.0   1.0  16
+ 17  2.0   1.0   1.0  17
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword

--- a/src/RTT_Format_Reader/test/rttpolyhedron.2o.mesh.in
+++ b/src/RTT_Format_Reader/test/rttpolyhedron.2o.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    3D, 1 cell, 18 node mesh in an RTT file format.    ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -116,24 +116,24 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  2.0   0.0   0.0   1  
-  2  2.0   0.0   2.0   2  
-  3  2.0   2.0   2.0   3  
-  4  2.0   2.0   0.0   4  
-  5  0.0   0.0   0.0   5  
-  6  0.0   0.0   2.0   6  
-  7  0.0   2.0   2.0   7  
-  8  0.0   2.0   0.0   8  
-  9  1.0   2.0   0.0   9  
- 10  0.0   2.0   1.0  10  
- 11  1.0   2.0   2.0  11  
- 12  2.0   2.0   1.0  12  
- 13  1.0   2.0   1.0  13  
- 14  1.0   0.0   0.0  14  
- 15  2.0   0.0   1.0  15  
- 16  1.0   0.0   2.0  16  
- 17  0.0   0.0   1.0  17  
- 18  1.0   0.0   1.0  18  
+  1  2.0   0.0   0.0   1
+  2  2.0   0.0   2.0   2
+  3  2.0   2.0   2.0   3
+  4  2.0   2.0   0.0   4
+  5  0.0   0.0   0.0   5
+  6  0.0   0.0   2.0   6
+  7  0.0   2.0   2.0   7
+  8  0.0   2.0   0.0   8
+  9  1.0   2.0   0.0   9
+ 10  0.0   2.0   1.0  10
+ 11  1.0   2.0   2.0  11
+ 12  2.0   2.0   1.0  12
+ 13  1.0   2.0   1.0  13
+ 14  1.0   0.0   0.0  14
+ 15  2.0   0.0   1.0  15
+ 16  1.0   0.0   2.0  16
+ 17  0.0   0.0   1.0  17
+ 18  1.0   0.0   1.0  18
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword

--- a/src/RTT_Format_Reader/test/rttpolyhedron.3.mesh.in
+++ b/src/RTT_Format_Reader/test/rttpolyhedron.3.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    3D, 1 cell, 22 node mesh in an RTT file format.    ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -123,28 +123,28 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  2.0   0.0   0.0   1  
-  2  2.0   0.0   2.0   2  
-  3  2.0   2.0   2.0   3  
-  4  2.0   2.0   0.0   4  
-  5  0.0   0.0   0.0   5  
-  6  0.0   0.0   2.0   6  
-  7  0.0   2.0   2.0   7  
-  8  0.0   2.0   0.0   8  
-  9  1.0   2.0   0.0   9  
- 10  0.0   2.0   1.0  10  
- 11  1.0   2.0   2.0  11  
- 12  2.0   2.0   1.0  12  
- 13  1.0   2.0   1.0  13  
- 14  1.0   0.0   0.0  14  
- 15  2.0   0.0   1.0  15  
- 16  1.0   0.0   2.0  16  
- 17  0.0   0.0   1.0  17  
- 18  1.0   0.0   1.0  18  
- 19  2.0   1.0   2.0  19  
- 20  1.0   2.0   2.0  20  
- 21  0.0   1.0   2.0  21  
- 22  1.0   1.0   2.0  22  
+  1  2.0   0.0   0.0   1
+  2  2.0   0.0   2.0   2
+  3  2.0   2.0   2.0   3
+  4  2.0   2.0   0.0   4
+  5  0.0   0.0   0.0   5
+  6  0.0   0.0   2.0   6
+  7  0.0   2.0   2.0   7
+  8  0.0   2.0   0.0   8
+  9  1.0   2.0   0.0   9
+ 10  0.0   2.0   1.0  10
+ 11  1.0   2.0   2.0  11
+ 12  2.0   2.0   1.0  12
+ 13  1.0   2.0   1.0  13
+ 14  1.0   0.0   0.0  14
+ 15  2.0   0.0   1.0  15
+ 16  1.0   0.0   2.0  16
+ 17  0.0   0.0   1.0  17
+ 18  1.0   0.0   1.0  18
+ 19  2.0   1.0   2.0  19
+ 20  1.0   2.0   2.0  20
+ 21  0.0   1.0   2.0  21
+ 22  1.0   1.0   2.0  22
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword

--- a/src/RTT_Format_Reader/test/rttpolyhedron.4.mesh.in
+++ b/src/RTT_Format_Reader/test/rttpolyhedron.4.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    3D, 1 cell, 25 node mesh in an RTT file format.    ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -116,44 +116,44 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  2.0   0.0   0.0   1  
-  2  2.0   0.0   2.0   2  
-  3  2.0   2.0   2.0   3  
-  4  2.0   2.0   0.0   4  
-  5  0.0   0.0   0.0   5  
-  6  0.0   0.0   2.0   6  
-  7  0.0   2.0   2.0   7  
-  8  0.0   2.0   0.0   8  
-  9  1.0   2.0   0.0   9  
- 10  0.0   2.0   1.0  10  
- 11  1.0   2.0   2.0  11  
- 12  2.0   2.0   1.0  12  
- 13  1.0   2.0   1.0  13  
- 14  1.0   0.0   0.0  14  
- 15  2.0   0.0   1.0  15  
- 16  1.0   0.0   2.0  16  
- 17  0.0   0.0   1.0  17  
- 18  1.0   0.0   1.0  18  
- 19  2.0   1.0   2.0  19  
- 20  1.0   2.0   2.0  20  
- 21  0.0   1.0   2.0  21  
- 22  1.0   1.0   2.0  22  
- 23  2.0   1.0   0.0  23  
- 24  0.0   1.0   0.0  24  
- 25  1.0   1.0   0.0  25  
+  1  2.0   0.0   0.0   1
+  2  2.0   0.0   2.0   2
+  3  2.0   2.0   2.0   3
+  4  2.0   2.0   0.0   4
+  5  0.0   0.0   0.0   5
+  6  0.0   0.0   2.0   6
+  7  0.0   2.0   2.0   7
+  8  0.0   2.0   0.0   8
+  9  1.0   2.0   0.0   9
+ 10  0.0   2.0   1.0  10
+ 11  1.0   2.0   2.0  11
+ 12  2.0   2.0   1.0  12
+ 13  1.0   2.0   1.0  13
+ 14  1.0   0.0   0.0  14
+ 15  2.0   0.0   1.0  15
+ 16  1.0   0.0   2.0  16
+ 17  0.0   0.0   1.0  17
+ 18  1.0   0.0   1.0  18
+ 19  2.0   1.0   2.0  19
+ 20  1.0   2.0   2.0  20
+ 21  0.0   1.0   2.0  21
+ 22  1.0   1.0   2.0  22
+ 23  2.0   1.0   0.0  23
+ 24  0.0   1.0   0.0  24
+ 25  1.0   1.0   0.0  25
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword
-  1  5     1  4  3  2 23 12 19 15         1                   
-  2  5     8  5  6  7 24 17 21 10         1                   
-  3  6     4  8  7  3  9 10 11 12 13      1                   
-  4  6     5  1  2  6 14 15 16 17 18      1                   
-  5  6     2  3  7  6 19 20 21 16 22      1                   
-  6  6     1  5  8  4 14 24  9 23 25      1                   
+  1  5     1  4  3  2 23 12 19 15         1
+  2  5     8  5  6  7 24 17 21 10         1
+  3  6     4  8  7  3  9 10 11 12 13      1
+  4  6     5  1  2  6 14 15 16 17 18      1
+  5  6     2  3  7  6 19 20 21 16 22      1
+  6  6     1  5  8  4 14 24  9 23 25      1
 end_sides                      ! end_sides block keyword
 
 cells                          ! cells block keyword
-  1  7    1  2  3  4  5  6  7  8  9  10   11   12  13  14  15  16  17  18  19  20  21  22  23  24  25   1     
+  1  7    1  2  3  4  5  6  7  8  9  10   11   12  13  14  15  16  17  18  19  20  21  22  23  24  25   1
 end_cells                      ! end cell block keyword
 
 nodedat                        ! node data keyword

--- a/src/RTT_Format_Reader/test/rttpolyhedron.mesh.in
+++ b/src/RTT_Format_Reader/test/rttpolyhedron.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    3D, 1 cell, 13 node mesh in an RTT file format.    ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -116,27 +116,27 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  2.0   0.0   0.0   1  
-  2  2.0   0.0   2.0   2  
-  3  2.0   2.0   2.0   3  
-  4  2.0   2.0   0.0   4  
-  5  0.0   0.0   0.0   5  
-  6  0.0   0.0   2.0   6  
-  7  0.0   2.0   2.0   7  
-  8  0.0   2.0   0.0   8  
-  9  1.0   2.0   0.0   9  
- 10  0.0   2.0   1.0  10  
- 11  1.0   2.0   2.0  11  
- 12  2.0   2.0   1.0  12  
- 13  1.0   2.0   1.0  13  
+  1  2.0   0.0   0.0   1
+  2  2.0   0.0   2.0   2
+  3  2.0   2.0   2.0   3
+  4  2.0   2.0   0.0   4
+  5  0.0   0.0   0.0   5
+  6  0.0   0.0   2.0   6
+  7  0.0   2.0   2.0   7
+  8  0.0   2.0   0.0   8
+  9  1.0   2.0   0.0   9
+ 10  0.0   2.0   1.0  10
+ 11  1.0   2.0   2.0  11
+ 12  2.0   2.0   1.0  12
+ 13  1.0   2.0   1.0  13
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword
-  1  4   1  2  6  5                      1           
-  2  5   4  1  5  8  9                   1             
-  3  5   5  6  7  8  10                  1           
-  4  5   6  2  3  7  11                  1           
-  5  5   2  1  4  3  12                  1           
+  1  4   1  2  6  5                      1
+  2  5   4  1  5  8  9                   1
+  3  5   5  6  7  8  10                  1
+  4  5   6  2  3  7  11                  1
+  5  5   2  1  4  3  12                  1
   6  6   4  8  7  3  9  10  11  12  13   1
 end_sides                      ! end_sides block keyword
 

--- a/src/RTT_Format_Reader/test/rttquad.mesh.in
+++ b/src/RTT_Format_Reader/test/rttquad.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    2D, 3 cell, 13 node mesh in an RTT file format.    ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -107,30 +107,30 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  0.0   0.0   0.0   1  
-  2  2.0   0.0   0.0   2  
-  3  2.0   2.0   0.0   3  
-  4  0.0   2.0   0.0   4  
-  5  1.0   0.0   0.0   5  
-  6  2.0   1.0   0.0   6  
-  7  1.0   2.0   0.0   7  
-  8  0.0   1.0   0.0   8  
-  9  1.0   1.0   0.0   9  
- 10  4.0   0.0   0.0  10  
- 11  4.0   2.0   0.0  11  
+  1  0.0   0.0   0.0   1
+  2  2.0   0.0   0.0   2
+  3  2.0   2.0   0.0   3
+  4  0.0   2.0   0.0   4
+  5  1.0   0.0   0.0   5
+  6  2.0   1.0   0.0   6
+  7  1.0   2.0   0.0   7
+  8  0.0   1.0   0.0   8
+  9  1.0   1.0   0.0   9
+ 10  4.0   0.0   0.0  10
+ 11  4.0   2.0   0.0  11
  12  6.0   0.0   0.0  12
- 13  6.0   2.0   0.0  13  
+ 13  6.0   2.0   0.0  13
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword
   1  3   1 2 5   1                  ! side#, side type index, global node #, side flags
-  2  2   2  10   1               
-  3  2   10 12   1               
-  4  2   12 13   1               
-  5  2   13 11   1               
-  6  2   11  3   1               
-  7  3   3 4 7   1               
-  8  3   4 1 8   1               
+  2  2   2  10   1
+  3  2   10 12   1
+  4  2   12 13   1
+  5  2   13 11   1
+  6  2   11  3   1
+  7  3   3 4 7   1
+  8  3   4 1 8   1
 end_sides                      ! end_sides block keyword
 
 cells                          ! cells block keyword

--- a/src/RTT_Format_Reader/test/rttquad5.mesh.in
+++ b/src/RTT_Format_Reader/test/rttquad5.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    2D, 1 cell, 5 node mesh in an RTT file format.     ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -93,18 +93,18 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  0.0   0.0   0.0   1  
-  2  2.0   0.0   0.0   2  
-  3  2.0   2.0   0.0   3  
-  4  0.0   2.0   0.0   4  
-  5  0.0   1.0   0.0   5  
+  1  0.0   0.0   0.0   1
+  2  2.0   0.0   0.0   2
+  3  2.0   2.0   0.0   3
+  4  0.0   2.0   0.0   4
+  5  0.0   1.0   0.0   5
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword
   1  2   1 2     1                  ! side#, side type index, global node #, side flags
-  2  2   2 3     1               
-  3  2   3 4     1               
-  4  3   4 1 5   1               
+  2  2   2 3     1
+  3  2   3 4     1
+  4  3   4 1 5   1
 end_sides                      ! end_sides block keyword
 
 cells                          ! cells block keyword

--- a/src/RTT_Format_Reader/test/rttquad9.mesh.in
+++ b/src/RTT_Format_Reader/test/rttquad9.mesh.in
@@ -3,12 +3,12 @@ rtt_ascii                                              ! magic cookie
 header	                                               ! header keyword
 
   version   v1.0.0                                     ! version number
-  title     RTT_format mesh file definition, version 7.! mesh title 
+  title     RTT_format mesh file definition, version 7.! mesh title
   date      24 Jul 97                                  ! Date written
   cycle     1                                          ! Cycle number
   time      0.0                                        ! problem time
   ncomments 3                                          ! Number of comment lines
-    One tet mesh in an RTT mesh file format.           ! comment line#1
+    2D, 1 cell, 9 node mesh in an RTT file format.     ! comment line#1
     Date     : 24 Jul 97                               ! comment line#2
     Author(s): H. Trease, J.McGhee                     ! comment line#3
 
@@ -93,22 +93,22 @@ cell_defs                      ! cell_def block keyword
 end_cell_defs                  ! end cell_def block keyword
 
 nodes                          ! nodes block keyword
-  1  0.0   0.0   0.0   1  
-  2  2.0   0.0   0.0   2  
-  3  2.0   2.0   0.0   3  
-  4  0.0   2.0   0.0   4  
-  5  1.0   0.0   0.0   5  
-  6  2.0   1.0   0.0   6  
-  7  1.0   2.0   0.0   7  
-  8  0.0   1.0   0.0   8  
-  9  1.0   1.0   0.0   9  
+  1  0.0   0.0   0.0   1
+  2  2.0   0.0   0.0   2
+  3  2.0   2.0   0.0   3
+  4  0.0   2.0   0.0   4
+  5  1.0   0.0   0.0   5
+  6  2.0   1.0   0.0   6
+  7  1.0   2.0   0.0   7
+  8  0.0   1.0   0.0   8
+  9  1.0   1.0   0.0   9
 end_nodes                      ! end_nodes block keyword
 
 sides                          ! sides block keyword
   1  3   1 2 5   1                  ! side#, side type index, global node #, side flags
   2  3   2 3 6   1                  ! side#, side type index, global node #, side flags
-  3  3   3 4 7   1               
-  4  3   4 1 8   1               
+  3  3   3 4 7   1
+  4  3   4 1 8   1
 end_sides                      ! end_sides block keyword
 
 cells                          ! cells block keyword

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -23,7 +23,7 @@ file( GLOB headers *.hh )
 
 add_component_library(
    TARGET       Lib_mesh
-   TARGET_DEPS  "Lib_dsxx;Lib_mesh_element"
+   TARGET_DEPS  "Lib_dsxx;Lib_mesh_element;Lib_RTT_Format_Reader"
    LIBRARY_NAME ${PROJECT_NAME}
    SOURCES      "${sources}"
    HEADERS      "${headers}"

--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -32,7 +32,8 @@ namespace rtt_mesh {
  * Two important features for a fully realized Draco_Mesh are the following:
  * 1) Layout, which stores cell connectivity and hence the mesh topology.
  *    a) It has an internal layout containing local cell-to-cell linkage,
- *    b) and a boundary layout with side and off-process linkage.
+ *    b) and a boundary layout with side off-process linkage, and
+ *    c) a ghost layout containing cell-to-ghostd-cell linkage.
  * 2) Geometry, which implies a metric for distance between points.
  *
  * Possibly temporary features:
@@ -112,11 +113,17 @@ public:
   Geometry get_geometry() const { return geometry; }
   unsigned get_num_cells() const { return num_cells; }
   unsigned get_num_nodes() const { return num_nodes; }
+  const std::vector<unsigned> &get_side_set_flag() const {
+    return side_set_flag;
+  }
   const std::vector<unsigned> &get_ghost_cell_numbers() const {
     return ghost_cell_number;
   }
   const std::vector<unsigned> &get_ghost_cell_ranks() const {
     return ghost_cell_rank;
+  }
+  const std::vector<std::vector<double>> &get_node_coord_vec() const {
+    return node_coord_vec;
   }
   const Layout &get_cc_linkage() const { return cell_to_cell_linkage; }
   const Layout &get_cs_linkage() const { return cell_to_side_linkage; }

--- a/src/mesh/Draco_Mesh_Builder.hh
+++ b/src/mesh/Draco_Mesh_Builder.hh
@@ -1,0 +1,60 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/Draco_Mesh_Builder.hh
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Friday, Jun 29, 2018, 09:55 am
+ * \brief  Draco_Mesh_Builder class header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_mesh_Draco_Mesh_Builder_hh
+#define rtt_mesh_Draco_Mesh_Builder_hh
+
+#include <memory>
+
+namespace rtt_mesh_element {
+enum Geometry;
+}
+
+namespace rtt_mesh {
+
+// Forward declare mesh class
+class Draco_Mesh;
+
+//===========================================================================//
+/*!
+ * \class Draco_Mesh_Builder
+ *
+ * \brief Draco_Mesh unstructured mesh builder from reader.
+ *
+ * Reader is a template parameter ("FRT" = "Format Reater Type") to the builder
+ * class. Hence all readers that instantiate the template must have a common set
+ * of accessors.  In particular the reader must supply some functions in the
+ * RTT_Format_Reader class.
+ */
+//===========================================================================//
+
+template <typename FRT> class Draco_Mesh_Builder {
+private:
+  // >>> DATA
+
+  //! Pointer to reader
+  std::shared_ptr<FRT> reader;
+
+public:
+  //! Constructor
+  explicit Draco_Mesh_Builder(std::shared_ptr<FRT> reader_);
+
+  // >>> SERVICES
+
+  std::shared_ptr<Draco_Mesh> build_mesh(rtt_mesh_element::Geometry geometry);
+};
+
+} // end namespace rtt_mesh
+
+#endif // rtt_mesh_Draco_Mesh_Builder_hh
+
+//---------------------------------------------------------------------------//
+// end of mesh/Draco_Mesh_Builder.hh
+//---------------------------------------------------------------------------//

--- a/src/mesh/Draco_Mesh_Builder.hh
+++ b/src/mesh/Draco_Mesh_Builder.hh
@@ -11,11 +11,8 @@
 #ifndef rtt_mesh_Draco_Mesh_Builder_hh
 #define rtt_mesh_Draco_Mesh_Builder_hh
 
+#include "mesh_element/Geometry.hh"
 #include <memory>
-
-namespace rtt_mesh_element {
-enum Geometry;
-}
 
 namespace rtt_mesh {
 
@@ -44,11 +41,12 @@ private:
 
 public:
   //! Constructor
-  explicit Draco_Mesh_Builder(std::shared_ptr<FRT> reader_);
+  DLL_PUBLIC_mesh explicit Draco_Mesh_Builder(std::shared_ptr<FRT> reader_);
 
   // >>> SERVICES
 
-  std::shared_ptr<Draco_Mesh> build_mesh(rtt_mesh_element::Geometry geometry);
+  DLL_PUBLIC_mesh std::shared_ptr<Draco_Mesh>
+  build_mesh(rtt_mesh_element::Geometry geometry);
 };
 
 } // end namespace rtt_mesh

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -82,15 +82,12 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   // generate the cell-to-node linkage
   std::vector<unsigned> cell_to_node_linkage;
   cell_to_node_linkage.reserve(cn_linkage_size);
-  std::vector<unsigned>::const_iterator cn_first = cell_to_node_linkage.begin();
   for (size_t cell = 0; cell < num_cells; ++cell) {
 
     // insert the vector of node indices
     const std::vector<int> cell_nodes = reader->get_cells_nodes(cell);
-    cell_to_node_linkage.insert(cn_first, cell_nodes.begin(), cell_nodes.end());
-
-    // increment iterator
-    cn_first += cell_type[cell];
+    cell_to_node_linkage.insert(cell_to_node_linkage.end(), cell_nodes.begin(),
+                                cell_nodes.end());
   }
 
   // get the number of sides
@@ -124,15 +121,12 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   // generate the side-to-node linkage
   std::vector<unsigned> side_to_node_linkage;
   side_to_node_linkage.reserve(sn_linkage_size);
-  std::vector<unsigned>::const_iterator sn_first = side_to_node_linkage.begin();
   for (size_t side = 0; side < num_sides; ++side) {
 
     // insert the vector of node indices
     const std::vector<int> side_nodes = reader->get_sides_nodes(side);
-    side_to_node_linkage.insert(sn_first, side_nodes.begin(), side_nodes.end());
-
-    // increment iterator
-    sn_first += side_node_count[side];
+    side_to_node_linkage.insert(side_to_node_linkage.end(), side_nodes.begin(),
+                                side_nodes.end());
   }
 
   // get the number of nodes

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -1,0 +1,186 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/Draco_Mesh_Builder.t.hh
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Tuesday, Jul 03, 2018, 11:26 am
+ * \brief  Draco_Mesh_Builder class header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "Draco_Mesh.hh"
+#include "Draco_Mesh_Builder.hh"
+#include "ds++/Assert.hh"
+#include <algorithm>
+
+namespace rtt_mesh {
+
+//---------------------------------------------------------------------------//
+// CONSTRUCTOR
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Draco_Mesh_Builder constructor.
+ *
+ * \param[in] reader_ shared pointer to a mesh reader object
+ */
+template <typename FRT>
+Draco_Mesh_Builder<FRT>::Draco_Mesh_Builder(std::shared_ptr<FRT> reader_)
+    : reader(reader_) {
+  Require(reader_ != nullptr);
+  // \todo remove constraint of 2 dimensions
+  Insist(reader->get_dims_ndim() == 2, "Mesh must be 2D.");
+}
+
+//---------------------------------------------------------------------------//
+// PUBLIC INTERFACE
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Build a Draco_Mesh object
+ *
+ * \param[in] geometry enumeration of mesh geometry
+ *
+ * \return shared pointer to the Draco_Mesh object
+ */
+template <typename FRT>
+std::shared_ptr<Draco_Mesh>
+Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
+
+  // \todo: Should geometry be to rtt format parsing?
+  // \todo: Generate ghost node and cell data for domain-decomposed meshes.
+
+  Require(geometry != rtt_mesh_element::END_GEOMETRY);
+  // \todo: Eventually allow spherical geometry
+  Require(geometry != rtt_mesh_element::SPHERICAL);
+
+  // >>> GENERATE MESH CONSTRUCTOR ARGUMENTS
+
+  // get the number of dimensions
+  unsigned dimension = reader->get_dims_ndim();
+  // \todo: Eventually allow dim = 1, 3
+  Check(dimension == 2);
+
+  // get the number of cells
+  size_t num_cells = reader->get_dims_ncells();
+
+  // generate the cell type vector
+  size_t cn_linkage_size = 0;
+  std::vector<unsigned> cell_type(num_cells);
+  for (size_t cell = 0; cell < num_cells; ++cell) {
+
+    // first obtain a cell definition index
+    size_t cell_def = reader->get_cells_type(cell);
+
+    // for Draco_Mesh, cell_type is number of nodes
+    cell_type[cell] = reader->get_cell_defs_nnodes(cell_def);
+
+    // increment size of cell-to-node linkage array
+    cn_linkage_size += cell_type[cell];
+  }
+
+  // \todo: Can the cell defs past num_cells - 1 be checked as invalid?
+
+  // generate the cell-to-node linkage
+  std::vector<unsigned> cell_to_node_linkage;
+  cell_to_node_linkage.reserve(cn_linkage_size);
+  std::vector<unsigned>::const_iterator cn_first = cell_to_node_linkage.begin();
+  for (size_t cell = 0; cell < num_cells; ++cell) {
+
+    // insert the vector of node indices
+    const std::vector<int> cell_nodes = reader->get_cells_nodes(cell);
+    cell_to_node_linkage.insert(cn_first, cell_nodes.begin(), cell_nodes.end());
+
+    // increment iterator
+    cn_first += cell_type[cell];
+  }
+
+  // get the number of sides
+  size_t num_sides = reader->get_dims_nsides();
+
+  // generate the side node count vector
+  size_t sn_linkage_size = 0;
+  std::vector<unsigned> side_node_count(num_sides);
+  std::vector<unsigned> side_set_flag(num_sides);
+  for (size_t side = 0; side < num_sides; ++side) {
+
+    // first obtain a side definition index
+    size_t side_def = reader->get_sides_type(side);
+
+    // acquire the number of nodes associated with this side def
+    side_node_count[side] = reader->get_cell_defs_nnodes(side_def);
+
+    // this is not required in rtt meshes, but is so in Draco_Mesh
+    Check(dimension == 2 ? side_node_count[side] == 2 : true);
+
+    // get the 1st side flag associated with this side
+    // \todo: What happens when side has no flags?
+    side_set_flag[side] = reader->get_sides_flags(side, 0);
+
+    // increment size of cell-to-node linkage array
+    sn_linkage_size += side_node_count[side];
+  }
+
+  // \todo: Can the side defs past num_sides - 1 be checked as invalid?
+
+  // generate the side-to-node linkage
+  std::vector<unsigned> side_to_node_linkage;
+  side_to_node_linkage.reserve(sn_linkage_size);
+  std::vector<unsigned>::const_iterator sn_first = side_to_node_linkage.begin();
+  for (size_t side = 0; side < num_sides; ++side) {
+
+    // insert the vector of node indices
+    const std::vector<int> side_nodes = reader->get_sides_nodes(side);
+    side_to_node_linkage.insert(sn_first, side_nodes.begin(), side_nodes.end());
+
+    // increment iterator
+    sn_first += side_node_count[side];
+  }
+
+  // get the number of nodes
+  size_t num_nodes = reader->get_dims_nnodes();
+
+  Check(num_nodes >= num_cells);
+  Check(num_nodes <= cn_linkage_size);
+
+  // \todo: add global node numbers to rtt mesh reader?
+  // \todo: or, remove global_node_number from mesh constructor?
+  // assume domain is not decomposed, for now
+
+  // generate the global node number serialized vector of coordinates
+  std::vector<unsigned> global_node_number(num_nodes);
+  std::vector<double> coordinates(dimension * num_nodes);
+  for (size_t node = 0; node < num_nodes; ++node) {
+
+    // set the "global" node indices
+    global_node_number[node] = node;
+
+    // get coordinates for this node
+    const std::vector<double> node_coord = reader->get_nodes_coords(node);
+
+    // populate coordinate vector
+    for (unsigned d = 0; d < dimension; ++d)
+      coordinates[dimension * node + d] = node_coord[d];
+  }
+
+  Remember(auto cn_minmax = std::minmax_element(cell_to_node_linkage.begin(),
+                                                cell_to_node_linkage.end()));
+  Remember(auto sn_minmax = std::minmax_element(side_to_node_linkage.begin(),
+                                                side_to_node_linkage.end()));
+  Ensure(*cn_minmax.first >= 0);
+  Ensure(*cn_minmax.second < num_nodes);
+  Ensure(*sn_minmax.first >= 0);
+  Ensure(*sn_minmax.second < num_nodes);
+
+  // >>> CONSTRUCT THE MESH
+
+  std::shared_ptr<Draco_Mesh> mesh(new Draco_Mesh(
+      dimension, geometry, cell_type, cell_to_node_linkage, side_set_flag,
+      side_node_count, side_to_node_linkage, coordinates, global_node_number));
+
+  return mesh;
+}
+
+} // end namespace rtt_mesh
+
+//---------------------------------------------------------------------------//
+// end of mesh/Draco_Mesh_Builder.t.hh
+//---------------------------------------------------------------------------//

--- a/src/mesh/Draco_Mesh_Builder_pt.cc
+++ b/src/mesh/Draco_Mesh_Builder_pt.cc
@@ -1,0 +1,22 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/Draco_Mesh_Builder_pt.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Tuesday, Jul 03, 2018, 11:52 am
+ * \brief  Draco_Mesh_Builder class header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "Draco_Mesh_Builder.t.hh"
+#include "RTT_Format_Reader/RTT_Format_Reader.hh"
+
+namespace rtt_mesh {
+
+template class Draco_Mesh_Builder<rtt_RTT_Format_Reader::RTT_Format_Reader>;
+
+} // end namespace rtt_mesh
+
+//---------------------------------------------------------------------------//
+// end of mesh/Draco_Mesh_Builder_pt.cc
+//---------------------------------------------------------------------------//

--- a/src/mesh/test/CMakeLists.txt
+++ b/src/mesh/test/CMakeLists.txt
@@ -13,23 +13,26 @@ project( mesh_test CXX )
 # ---------------------------------------------------------------------------- #
 
 # create unit test lists
-set( one_pe_tests ${PROJECT_SOURCE_DIR}/tstDraco_Mesh.cc )
+set( one_pe_tests ${PROJECT_SOURCE_DIR}/tstDraco_Mesh.cc
+  ${PROJECT_SOURCE_DIR}/tstDraco_Mesh_Builder.cc )
 set( two_pe_tests ${PROJECT_SOURCE_DIR}/tstDraco_Mesh_DD.cc )
 
 # ---------------------------------------------------------------------------- #
 # Build Unit tests
 # ---------------------------------------------------------------------------- #
 
+set( libs_for_tests Lib_c4 Lib_mesh )
+
 add_parallel_tests(
     SOURCES "${one_pe_tests}"
     PE_LIST "1"
-    DEPS    "Lib_c4;Lib_mesh" )
+    DEPS    "${libs_for_tests}" )
 
 if( NOT ${DRACO_C4} STREQUAL "SCALAR" )
   add_parallel_tests(
     SOURCES "${two_pe_tests}"
     PE_LIST "2"
-    DEPS    "Lib_c4;Lib_mesh" )
+    DEPS    "${libs_for_tests}" )
 endif()
 
 #------------------------------------------------------------------------------#

--- a/src/mesh/test/Test_Mesh_Interface.hh
+++ b/src/mesh/test/Test_Mesh_Interface.hh
@@ -13,7 +13,6 @@
 
 #include "mesh/Draco_Mesh.hh"
 #include <algorithm>
-#include <bitset>
 
 namespace rtt_mesh_test {
 
@@ -133,14 +132,22 @@ Test_Mesh_Interface::Test_Mesh_Interface(
         num_nodes - 1 - num_xdir * (j + 2) - (j + 1);
   }
 
-  // set some coordinates and global node indices
-  coordinates.resize(dim * num_nodes);
-  for (unsigned i = 0; i < num_nodes; ++i) {
+  // set uniform coordinate increments
+  double dx = 1.0;
+  double dy = 1.0;
 
-    // TODO: generalize coordinate generation
-    std::bitset<8> b2(i);
-    coordinates[dim * i] = xdir_offset_ + static_cast<double>(b2[0]);
-    coordinates[1 + dim * i] = ydir_offset_ + static_cast<double>(b2[1]);
+  // generate some coordinates and global node indices
+  coordinates.resize(dim * num_nodes);
+  for (size_t j = 0; j < num_ydir + 1; ++j) {
+    for (size_t i = 0; i < num_xdir + 1; ++i) {
+
+      // get a serial cell index
+      size_t node = i + (num_xdir + 1) * j;
+
+      // TODO: generalize coordinate generation
+      coordinates[dim * node] = xdir_offset_ + i * dx;
+      coordinates[1 + dim * node] = ydir_offset_ + j * dy;
+    }
   }
 
   if (global_node_number.size() == 0) {

--- a/src/mesh/test/rttquad_2cell.mesh.in
+++ b/src/mesh/test/rttquad_2cell.mesh.in
@@ -1,0 +1,123 @@
+rtt_ascii
+
+header
+
+  version   v1.0.0
+  title     RTT_format mesh file definition, version 7.
+  date      2 Jul 18
+  cycle     1
+  time      0.0
+  ncomments 3
+    Two quad cell mesh in an RTT mesh file format
+    Date     : 2 Jul 18
+    Author(s): R. Wollaeger
+
+end_header
+
+dims
+
+  coor_units        cm
+  prob_time_units    s
+
+  ncell_defs         3
+  nnodes_max         4
+  nsides_max         4
+  nnodes_side_max    2
+
+  ndim               2
+  ndim_topo          2
+
+  nnodes             6
+  nnode_flag_types   0
+  nnode_flags        0
+  nnode_data         0
+
+  nsides             6
+  nside_types        1
+  side_types         2
+  nside_flag_types   1
+  nside_flags        4
+  nside_data         0
+
+  ncells             2
+  ncell_types        1
+  cell_types         3
+  ncell_flag_types   0
+  ncell_flags        0
+  ncell_data         0
+
+end_dims
+
+node_flags
+end_node_flags
+
+side_flags
+  1 boundary
+    1 bc1
+    2 bc2
+    3 bc3
+    4 bc4
+end_side_flags
+
+cell_flags
+end_cell_flags
+
+node_data_ids
+end_node_data_ids
+
+side_data_ids
+end_side_data_ids
+
+cell_data_ids
+end_cell_data_ids
+
+cell_defs
+  1 point                      ! cell index, cell name
+    1 0                        ! #nodes, #sides
+  2 bar2                       ! cell index, cell name
+    2 2                        ! #nodes, #sides
+    1 1                        ! side type index
+    1                          ! side #1 nodes
+    2                          ! side #2 nodes
+  3 quad4                      ! cell index, cell name
+    4 4                        ! #nodes, #sides
+    2 2 2 2                    ! side type index
+    1 2                        ! side #1 nodes
+    2 3                        ! side #2 nodes
+    3 4                        ! side #3 nodes
+    4 1                        ! side #4 nodes
+end_cell_defs
+
+nodes
+  1  0.0   0.0   0.0   1
+  2  1.0   0.0   0.0   2
+  3  2.0   0.0   0.0   3
+  4  0.0   1.0   0.0   4
+  5  1.0   1.0   0.0   5
+  6  2.0   1.0   0.0   6
+end_nodes
+
+sides
+  1  2   1   2   1
+  2  2   2   3   1
+  3  2   3   6   2
+  4  2   6   5   3
+  5  2   5   4   3
+  6  2   4   1   4
+end_sides
+
+cells
+  1  3   1 2 5 4
+  2  3   2 3 6 5
+end_cells
+
+nodedat
+end_nodedat
+
+sidedat
+end_sidedat
+
+celldat
+end_celldat
+
+end_rtt_mesh

--- a/src/mesh/test/tstDraco_Mesh.cc
+++ b/src/mesh/test/tstDraco_Mesh.cc
@@ -146,7 +146,7 @@ void cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
     std::vector<unsigned> test_sn_linkage =
         mesh_iface.flatten_sn_linkage(bd_layout);
 
-    // check that cn_linkage is a permutation of the original cell-node linkage
+    // check that sn_linkage is a permutation of the original side-node linkage
     std::vector<unsigned>::const_iterator sn_first =
         side_to_node_linkage.begin();
     std::vector<unsigned>::const_iterator test_sn_first =

--- a/src/mesh/test/tstDraco_Mesh_Builder.cc
+++ b/src/mesh/test/tstDraco_Mesh_Builder.cc
@@ -1,0 +1,161 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/test/tstDraco_Mesh_Builder.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Sunday, Jul 01, 2018, 18:21 pm
+ * \brief  Draco_Mesh class unit test.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "Test_Mesh_Interface.hh"
+#include "mesh/Draco_Mesh_Builder.hh"
+#include "RTT_Format_Reader/RTT_Format_Reader.hh"
+#include "c4/ParallelUnitTest.hh"
+#include "ds++/Release.hh"
+#include "ds++/Soft_Equivalence.hh"
+
+using rtt_mesh::Draco_Mesh;
+using rtt_mesh::Draco_Mesh_Builder;
+using rtt_RTT_Format_Reader::RTT_Format_Reader;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+// Parse a 2D Cartesian mesh and compare to reference
+void build_cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
+
+  // use Cartesian geometry
+  const Draco_Mesh::Geometry geometry = Draco_Mesh::Geometry::CARTESIAN;
+
+  // >>> CREATE REFERENCE MESH
+
+  // set the number of cells and nodes
+  const size_t num_xdir = 2;
+  const size_t num_ydir = 1;
+
+  // generate a constainer for data needed in mesh construction
+  rtt_mesh_test::Test_Mesh_Interface mesh_iface(num_xdir, num_ydir);
+
+  // short-cut to some arrays
+  const std::vector<unsigned> &cell_type = mesh_iface.cell_type;
+  const std::vector<unsigned> &cell_to_node_linkage =
+      mesh_iface.cell_to_node_linkage;
+  const std::vector<unsigned> &side_node_count = mesh_iface.side_node_count;
+  const std::vector<unsigned> &side_to_node_linkage =
+      mesh_iface.side_to_node_linkage;
+
+  // instantiate the mesh
+  std::shared_ptr<Draco_Mesh> ref_mesh(new Draco_Mesh(
+      mesh_iface.dim, geometry, cell_type, cell_to_node_linkage,
+      mesh_iface.side_set_flag, side_node_count, side_to_node_linkage,
+      mesh_iface.coordinates, mesh_iface.global_node_number));
+
+  // >>> PARSE AND BUILD MESH
+
+  const std::string inputpath = ut.getTestSourcePath();
+  const std::string filename = "rttquad_2cell.mesh.in";
+
+  // create an rtt mesh
+  std::shared_ptr<RTT_Format_Reader> rtt_mesh(
+      new RTT_Format_Reader(inputpath + filename));
+
+  // instantiate a mesh builder and build the mesh
+  Draco_Mesh_Builder<RTT_Format_Reader> mesh_builder(rtt_mesh);
+  std::shared_ptr<Draco_Mesh> mesh = mesh_builder.build_mesh(geometry);
+
+  // check that the scalar data is correct
+  if (mesh->get_dimension() != ref_mesh->get_dimension())
+    ITFAILS;
+  if (mesh->get_geometry() != ref_mesh->get_geometry())
+    ITFAILS;
+  if (mesh->get_num_cells() != ref_mesh->get_num_cells())
+    ITFAILS;
+  if (mesh->get_num_nodes() != ref_mesh->get_num_nodes())
+    ITFAILS;
+
+  // check side flag indices
+  if (mesh->get_side_set_flag() != ref_mesh->get_side_set_flag())
+    ITFAILS;
+
+  // check ghost cell data (should be empty defaults)
+  if (mesh->get_ghost_cell_numbers() != ref_mesh->get_ghost_cell_numbers())
+    ITFAILS;
+  if (mesh->get_ghost_cell_ranks() != ref_mesh->get_ghost_cell_ranks())
+    ITFAILS;
+
+  // check that the vector of coordinates match the reference mesh
+  if (!rtt_dsxx::soft_equiv(mesh->get_node_coord_vec(),
+                            ref_mesh->get_node_coord_vec()))
+    ITFAILS;
+
+  // check that cell-to-node linkage data is correct
+  {
+    std::vector<unsigned> ref_cn_linkage = mesh_iface.flatten_cn_linkage(
+        ref_mesh->get_cc_linkage(), ref_mesh->get_cs_linkage(),
+        ref_mesh->get_cg_linkage());
+    std::vector<unsigned> cn_linkage = mesh_iface.flatten_cn_linkage(
+        mesh->get_cc_linkage(), mesh->get_cs_linkage(), mesh->get_cg_linkage());
+
+    // check that cn_linkage is a permutation of the ref cell-node linkage
+    std::vector<unsigned>::const_iterator ref_cn_first = ref_cn_linkage.begin();
+    std::vector<unsigned>::const_iterator cn_first = cn_linkage.begin();
+
+    for (unsigned cell = 0; cell < mesh_iface.num_cells; ++cell) {
+
+      // nodes must only be permuted at the cell level
+      if (!std::is_permutation(cn_first, cn_first + cell_type[cell],
+                               ref_cn_first, ref_cn_first + cell_type[cell]))
+        ITFAILS;
+
+      // update the iterators
+      ref_cn_first += cell_type[cell];
+      cn_first += cell_type[cell];
+    }
+  }
+
+  // check that each cell has the correct sides
+  {
+    std::vector<unsigned> ref_sn_linkage =
+        mesh_iface.flatten_sn_linkage(ref_mesh->get_cs_linkage());
+    std::vector<unsigned> sn_linkage =
+        mesh_iface.flatten_sn_linkage(mesh->get_cs_linkage());
+
+    // check that sn_linkage is a permutation of the original side-node linkage
+    std::vector<unsigned>::const_iterator ref_sn_first = ref_sn_linkage.begin();
+    std::vector<unsigned>::const_iterator sn_first = sn_linkage.begin();
+    for (unsigned side = 0; side < mesh_iface.num_sides; ++side) {
+
+      // check that sn_linkage is a permutation of the original side-node linkage
+      if (!std::is_permutation(sn_first, sn_first + side_node_count[side],
+                               ref_sn_first,
+                               ref_sn_first + side_node_count[side]))
+        ITFAILS;
+
+      // update the iterators
+      ref_sn_first += side_node_count[side];
+      sn_first += side_node_count[side];
+    }
+  }
+
+  // successful test output
+  if (ut.numFails == 0)
+    PASSMSG("2D Cartesian Draco_Mesh_Builder tests ok.");
+  return;
+}
+
+//---------------------------------------------------------------------------//
+
+int main(int argc, char *argv[]) {
+  rtt_c4::ParallelUnitTest ut(argc, argv, rtt_dsxx::release);
+  try {
+    Insist(rtt_c4::nodes() == 1, "This test only uses 1 PE.");
+    build_cartesian_mesh_2d(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of mesh/test/tstDraco_Mesh_Builder.cc
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* In order to test Draco_Mesh on more complicated meshes, some parsing capability is needed.
* There is already mesh parsing functionality in Draco for RTT mesh formats.
* A mesh builder can act as an intermediary between parser and mesh constructor, ensuring all parsers provide the same sort of data to the constructor.

### Purpose of Pull Request

* Create Draco_Mesh_Builder, with reader/parser type as template parameter.
* Demonstrate parsing capability for Draco_Mesh with RTT mesh file format.
* Note the builder is currently assuming a non-decomposed mesh is being read (i.e. global_node_number = proc-local node indices).
* [See Redmine Issue #1182](https://rtt.lanl.gov/redmine/issues/1182)

### Description of changes

+ Add Draco_Mesh_Builder, templated on reader/parser type.
+ Add unit test with 2-cell RTT mesh input file.
+ Add side flag and node coordinate accessors to Draco_Mesh.
+ Fix coordinate generation in Test_Mesh_Interface.
+ Fix header comments in rtt mesh input files.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
