### PR TITLE
Add preliminary X3D Draco_Mesh parser.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 # Level 5
 message(" ")
 message( STATUS "Configuring Level 5 packages --" )
-add_dir_if_exists( mesh ) # needs c4, ds++, mesh_element
+add_dir_if_exists( mesh ) # needs c4, ds++, mesh_element, parser
 if( NOT DEFINED ENV{APPVEYOR} AND NOT DEFINED ENV{TRAVIS} )
   add_dir_if_exists( quadrature )       # needs mesh_element, parser, special_functions
 endif()

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -23,7 +23,7 @@ file( GLOB headers *.hh )
 
 add_component_library(
    TARGET       Lib_mesh
-   TARGET_DEPS  "Lib_dsxx;Lib_mesh_element;Lib_RTT_Format_Reader"
+   TARGET_DEPS  "Lib_dsxx;Lib_mesh_element;Lib_RTT_Format_Reader;Lib_parser"
    LIBRARY_NAME ${PROJECT_NAME}
    SOURCES      "${sources}"
    HEADERS      "${headers}"

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -28,7 +28,7 @@ Draco_Mesh_Builder<FRT>::Draco_Mesh_Builder(std::shared_ptr<FRT> reader_)
     : reader(reader_) {
   Require(reader_ != nullptr);
   // \todo remove constraint of 2 dimensions
-  Insist(reader->get_dims_ndim() == 2, "Mesh must be 2D.");
+  Insist(reader->get_numdim() == 2, "Mesh must be 2D.");
 }
 
 //---------------------------------------------------------------------------//
@@ -55,23 +55,20 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   // >>> GENERATE MESH CONSTRUCTOR ARGUMENTS
 
   // get the number of dimensions
-  unsigned dimension = reader->get_dims_ndim();
+  unsigned dimension = reader->get_numdim();
   // \todo: Eventually allow dim = 1, 3
   Check(dimension == 2);
 
   // get the number of cells
-  size_t num_cells = reader->get_dims_ncells();
+  size_t num_cells = reader->get_numcells();
 
   // generate the cell type vector
   size_t cn_linkage_size = 0;
   std::vector<unsigned> cell_type(num_cells);
   for (size_t cell = 0; cell < num_cells; ++cell) {
 
-    // first obtain a cell definition index
-    size_t cell_def = reader->get_cells_type(cell);
-
     // for Draco_Mesh, cell_type is number of nodes
-    cell_type[cell] = reader->get_cell_defs_nnodes(cell_def);
+    cell_type[cell] = reader->get_celltype(cell);
 
     // increment size of cell-to-node linkage array
     cn_linkage_size += cell_type[cell];
@@ -85,13 +82,13 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   for (size_t cell = 0; cell < num_cells; ++cell) {
 
     // insert the vector of node indices
-    const std::vector<int> cell_nodes = reader->get_cells_nodes(cell);
+    const std::vector<int> cell_nodes = reader->get_cellnodes(cell);
     cell_to_node_linkage.insert(cell_to_node_linkage.end(), cell_nodes.begin(),
                                 cell_nodes.end());
   }
 
   // get the number of sides
-  size_t num_sides = reader->get_dims_nsides();
+  size_t num_sides = reader->get_numsides();
 
   // generate the side node count vector
   size_t sn_linkage_size = 0;
@@ -99,18 +96,15 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   std::vector<unsigned> side_set_flag(num_sides);
   for (size_t side = 0; side < num_sides; ++side) {
 
-    // first obtain a side definition index
-    size_t side_def = reader->get_sides_type(side);
-
     // acquire the number of nodes associated with this side def
-    side_node_count[side] = reader->get_cell_defs_nnodes(side_def);
+    side_node_count[side] = reader->get_sidetype(side);
 
     // this is not required in rtt meshes, but is so in Draco_Mesh
     Check(dimension == 2 ? side_node_count[side] == 2 : true);
 
     // get the 1st side flag associated with this side
     // \todo: What happens when side has no flags?
-    side_set_flag[side] = reader->get_sides_flags(side, 0);
+    side_set_flag[side] = reader->get_sideflag(side);
 
     // increment size of cell-to-node linkage array
     sn_linkage_size += side_node_count[side];
@@ -124,13 +118,13 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   for (size_t side = 0; side < num_sides; ++side) {
 
     // insert the vector of node indices
-    const std::vector<int> side_nodes = reader->get_sides_nodes(side);
+    const std::vector<int> side_nodes = reader->get_sidenodes(side);
     side_to_node_linkage.insert(side_to_node_linkage.end(), side_nodes.begin(),
                                 side_nodes.end());
   }
 
   // get the number of nodes
-  size_t num_nodes = reader->get_dims_nnodes();
+  size_t num_nodes = reader->get_numnodes();
 
   Check(num_nodes >= num_cells);
   Check(num_nodes <= cn_linkage_size);
@@ -148,7 +142,7 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
     global_node_number[node] = node;
 
     // get coordinates for this node
-    const std::vector<double> node_coord = reader->get_nodes_coords(node);
+    const std::vector<double> node_coord = reader->get_nodecoord(node);
 
     // populate coordinate vector
     for (unsigned d = 0; d < dimension; ++d)

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -12,6 +12,7 @@
 #include "Draco_Mesh_Builder.hh"
 #include "ds++/Assert.hh"
 #include <algorithm>
+#include <iostream>
 
 namespace rtt_mesh {
 
@@ -155,8 +156,9 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
                                                 side_to_node_linkage.end()));
   Ensure(*cn_minmax.first >= 0);
   Ensure(*cn_minmax.second < num_nodes);
-  Ensure(*sn_minmax.first >= 0);
-  Ensure(*sn_minmax.second < num_nodes);
+  Ensure(side_to_node_linkage.size() > 0 ? *sn_minmax.first >= 0 : true);
+  Ensure(side_to_node_linkage.size() > 0 ? *sn_minmax.second < num_nodes
+                                         : true);
 
   // >>> CONSTRUCT THE MESH
 

--- a/src/mesh/Draco_Mesh_Builder_pt.cc
+++ b/src/mesh/Draco_Mesh_Builder_pt.cc
@@ -9,11 +9,13 @@
 //---------------------------------------------------------------------------//
 
 #include "Draco_Mesh_Builder.t.hh"
-#include "RTT_Format_Reader/RTT_Format_Reader.hh"
+#include "RTT_Draco_Mesh_Reader.hh"
+#include "X3D_Draco_Mesh_Reader.hh"
 
 namespace rtt_mesh {
 
-template class Draco_Mesh_Builder<rtt_RTT_Format_Reader::RTT_Format_Reader>;
+template class Draco_Mesh_Builder<RTT_Draco_Mesh_Reader>;
+template class Draco_Mesh_Builder<X3D_Draco_Mesh_Reader>;
 
 } // end namespace rtt_mesh
 

--- a/src/mesh/Draco_Mesh_Reader.hh
+++ b/src/mesh/Draco_Mesh_Reader.hh
@@ -11,6 +11,7 @@
 #ifndef rtt_mesh_Draco_Mesh_Reader_hh
 #define rtt_mesh_Draco_Mesh_Reader_hh
 
+#include <cstddef>
 #include <vector>
 
 namespace rtt_mesh {

--- a/src/mesh/Draco_Mesh_Reader.hh
+++ b/src/mesh/Draco_Mesh_Reader.hh
@@ -26,6 +26,9 @@ namespace rtt_mesh {
 
 class Draco_Mesh_Reader {
 public:
+  //! Virtual destructor
+  virtual ~Draco_Mesh_Reader() = 0;
+
   // >>> ACCESSORS
 
   virtual unsigned get_numdim() const = 0;

--- a/src/mesh/Draco_Mesh_Reader.hh
+++ b/src/mesh/Draco_Mesh_Reader.hh
@@ -27,7 +27,9 @@ namespace rtt_mesh {
 class Draco_Mesh_Reader {
 public:
   //! Virtual destructor
-  virtual ~Draco_Mesh_Reader() = 0;
+  virtual ~Draco_Mesh_Reader() {
+    // this can not evidently be pure
+  }
 
   // >>> ACCESSORS
 

--- a/src/mesh/Draco_Mesh_Reader.hh
+++ b/src/mesh/Draco_Mesh_Reader.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/Draco_Mesh_Reader.hh
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Friday, Jul 13, 2018, 13:48 pm
+ * \brief  RTT_Draco_Mesh_Reader header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_mesh_Draco_Mesh_Reader_hh
+#define rtt_mesh_Draco_Mesh_Reader_hh
+
+#include <vector>
+
+namespace rtt_mesh {
+
+//===========================================================================//
+/*!
+ * \class Draco_Mesh_Reader
+ *
+ * \brief Abstract base class for all readers supported by Draco_Mesh_Builder.
+ */
+//===========================================================================//
+
+class Draco_Mesh_Reader {
+public:
+  // >>> ACCESSORS
+
+  virtual unsigned get_numdim() const = 0;
+  virtual unsigned get_numcells() const = 0;
+  virtual unsigned get_numnodes() const = 0;
+  virtual std::vector<double> get_nodecoord(size_t node) const = 0;
+  virtual std::vector<int> get_cellnodes(size_t cell) const = 0;
+  virtual unsigned get_numsides() const = 0;
+  virtual unsigned get_sideflag(size_t side) const = 0;
+  virtual std::vector<int> get_sidenodes(size_t side) const = 0;
+  virtual unsigned get_celltype(size_t cell) const = 0;
+  virtual unsigned get_sidetype(size_t side) const = 0;
+};
+
+} // namespace rtt_mesh
+
+#endif // rtt_mesh_Draco_Mesh_Reader_hh
+
+//---------------------------------------------------------------------------//
+// end of mesh/Draco_Mesh_Reader.hh
+//---------------------------------------------------------------------------//

--- a/src/mesh/RTT_Draco_Mesh_Reader.cc
+++ b/src/mesh/RTT_Draco_Mesh_Reader.cc
@@ -20,11 +20,10 @@ namespace rtt_mesh {
  *
  * \param[in] filename_ name of file to be parsed
  */
-RTT_Draco_Mesh_Reader::RTT_Draco_Mesh_Reader(std::string filename_)
+RTT_Draco_Mesh_Reader::RTT_Draco_Mesh_Reader(const std::string filename_)
     : filename(filename_) {
   // check for valid file name
   Insist(filename_.size() > 0, "No file name supplied.");
-  // \todo: add more filename criteria?
 
   // \todo: remove read_mesh function and read in constructor(?)
   Require(rtt_reader == nullptr);
@@ -37,6 +36,12 @@ RTT_Draco_Mesh_Reader::RTT_Draco_Mesh_Reader(std::string filename_)
  * \brief Read the mesh by constructing an RTT_Format_Reader
  */
 void RTT_Draco_Mesh_Reader::read_mesh() {
+
+  // insist the file can be opened before trying read_mesh() wrapper
+  std::ifstream rttfile(filename.c_str());
+  Insist(rttfile.is_open(), "Failed to find or open specified RTT mesh file.");
+  rttfile.close();
+
   rtt_reader.reset(new rtt_RTT_Format_Reader::RTT_Format_Reader(filename));
 }
 

--- a/src/mesh/RTT_Draco_Mesh_Reader.cc
+++ b/src/mesh/RTT_Draco_Mesh_Reader.cc
@@ -1,0 +1,85 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/RTT_Draco_Mesh_Reader.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Friday, Jul 13, 2018, 08:38 am
+ * \brief  RTT_Draco_Mesh_Reader header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "RTT_Draco_Mesh_Reader.hh"
+
+namespace rtt_mesh {
+
+//---------------------------------------------------------------------------//
+// CONSTRUCTOR
+//---------------------------------------------------------------------------//
+/*!
+ * \brief RTT_Draco_Mesh_Reader constructor.
+ *
+ * \param[in] filename_ name of file to be parsed
+ */
+RTT_Draco_Mesh_Reader::RTT_Draco_Mesh_Reader(std::string filename_)
+    : filename(filename_) {
+  // check for valid file name
+  Insist(filename_.size() > 0, "No file name supplied.");
+  // \todo: add more filename criteria?
+
+  // \todo: remove read_mesh function and read in constructor(?)
+  Require(rtt_reader == nullptr);
+}
+
+//---------------------------------------------------------------------------//
+// PUBLIC FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Read the mesh by constructing an RTT_Format_Reader
+ */
+void RTT_Draco_Mesh_Reader::read_mesh() {
+  rtt_reader.reset(new rtt_RTT_Format_Reader::RTT_Format_Reader(filename));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Get the number of nodes for a cell.
+ *
+ * \param[in] cell index of cell (0-based)
+ *
+ * \return number of nodes for cell
+ */
+unsigned RTT_Draco_Mesh_Reader::get_celltype(size_t cell) const {
+
+  // first obtain a cell definition index
+  size_t cell_def = rtt_reader->get_cells_type(cell);
+
+  // for Draco_Mesh, cell_type is number of nodes
+  unsigned cell_type = rtt_reader->get_cell_defs_nnodes(cell_def);
+
+  return cell_type;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Get the vector of node indices for a side.
+ *
+ * \param[in] side index of side (0-based)
+ *
+ * \return number of nodes for side
+ */
+unsigned RTT_Draco_Mesh_Reader::get_sidetype(size_t side) const {
+
+  // first obtain a side definition index
+  size_t side_def = rtt_reader->get_sides_type(side);
+
+  // acquire the number of nodes associated with this side def
+  unsigned side_type = rtt_reader->get_cell_defs_nnodes(side_def);
+
+  return side_type;
+}
+
+} // end namespace rtt_mesh
+
+//---------------------------------------------------------------------------//
+// end of mesh/RTT_Draco_Mesh_Reader.cc
+//---------------------------------------------------------------------------//

--- a/src/mesh/RTT_Draco_Mesh_Reader.hh
+++ b/src/mesh/RTT_Draco_Mesh_Reader.hh
@@ -28,13 +28,13 @@ class RTT_Draco_Mesh_Reader : public Draco_Mesh_Reader {
 private:
   // >>> DATA
 
-  std::string filename;
+  const std::string filename;
 
   std::shared_ptr<rtt_RTT_Format_Reader::RTT_Format_Reader> rtt_reader;
 
 public:
   //! Constructor
-  explicit RTT_Draco_Mesh_Reader(std::string filename_);
+  DLL_PUBLIC_mesh explicit RTT_Draco_Mesh_Reader(const std::string filename_);
 
   // >>> SERVICES
 

--- a/src/mesh/RTT_Draco_Mesh_Reader.hh
+++ b/src/mesh/RTT_Draco_Mesh_Reader.hh
@@ -1,0 +1,72 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/RTT_Draco_Mesh_Reader.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Friday, Jul 13, 2018, 08:38 am
+ * \brief  RTT_Draco_Mesh_Reader header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_mesh_RTT_Draco_Mesh_Reader_hh
+#define rtt_mesh_RTT_Draco_Mesh_Reader_hh
+
+#include "RTT_Format_Reader/RTT_Format_Reader.hh"
+
+namespace rtt_mesh {
+
+//===========================================================================//
+/*!
+ * \class RTT_Draco_Mesh_Reader
+ *
+ * \brief Wrap RTT file format reader and provide data to Draco_Mesh_Builder.
+ */
+//===========================================================================//
+
+class RTT_Draco_Mesh_Reader {
+private:
+  // >>> DATA
+
+  std::string filename;
+
+  std::shared_ptr<rtt_RTT_Format_Reader::RTT_Format_Reader> rtt_reader;
+
+public:
+  //! Constructor
+  explicit RTT_Draco_Mesh_Reader(std::string filename_);
+
+  // >>> SERVICES
+
+  DLL_PUBLIC_mesh void read_mesh();
+
+  // >>> ACCESSORS
+
+  unsigned get_numdim() const { return rtt_reader->get_dims_ndim(); }
+  unsigned get_numcells() const { return rtt_reader->get_dims_ncells(); }
+  unsigned get_numnodes() const { return rtt_reader->get_dims_nnodes(); }
+  std::vector<double> get_nodecoord(size_t node) const {
+    return rtt_reader->get_nodes_coords(node);
+  }
+  std::vector<int> get_cellnodes(size_t cell) const {
+    return rtt_reader->get_cells_nodes(cell);
+  }
+  unsigned get_numsides() const { return rtt_reader->get_dims_nsides(); }
+  unsigned get_sideflag(size_t side) const {
+    return rtt_reader->get_sides_flags(side, 0);
+  }
+  std::vector<int> get_sidenodes(size_t side) const {
+    return rtt_reader->get_sides_nodes(side);
+  }
+
+  // accessors with deferred implementation
+  DLL_PUBLIC_mesh unsigned get_celltype(size_t cell) const;
+  DLL_PUBLIC_mesh unsigned get_sidetype(size_t side) const;
+};
+
+} // end namespace rtt_mesh
+
+#endif // rtt_mesh_RTT_Draco_Mesh_Reader_hh
+
+//---------------------------------------------------------------------------//
+// end of mesh/RTT_Draco_Mesh_Reader.hh
+//---------------------------------------------------------------------------//

--- a/src/mesh/RTT_Draco_Mesh_Reader.hh
+++ b/src/mesh/RTT_Draco_Mesh_Reader.hh
@@ -1,6 +1,6 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   mesh/RTT_Draco_Mesh_Reader.cc
+ * \file   mesh/RTT_Draco_Mesh_Reader.hh
  * \author Ryan Wollaeger <wollaeger@lanl.gov>
  * \date   Friday, Jul 13, 2018, 08:38 am
  * \brief  RTT_Draco_Mesh_Reader header file.
@@ -11,6 +11,7 @@
 #ifndef rtt_mesh_RTT_Draco_Mesh_Reader_hh
 #define rtt_mesh_RTT_Draco_Mesh_Reader_hh
 
+#include "Draco_Mesh_Reader.hh"
 #include "RTT_Format_Reader/RTT_Format_Reader.hh"
 
 namespace rtt_mesh {
@@ -23,7 +24,7 @@ namespace rtt_mesh {
  */
 //===========================================================================//
 
-class RTT_Draco_Mesh_Reader {
+class RTT_Draco_Mesh_Reader : public Draco_Mesh_Reader {
 private:
   // >>> DATA
 

--- a/src/mesh/X3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/X3D_Draco_Mesh_Reader.cc
@@ -1,0 +1,219 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/X3D_Draco_Mesh_Reader.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>, Kendra Keady
+ * \date   Thursday, Jul 12, 2018, 08:46 am
+ * \brief  X3D_Draco_Mesh_Reader class implementation file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "X3D_Draco_Mesh_Reader.hh"
+#include "ds++/DracoStrings.hh"
+#include <fstream>
+#include <iostream>
+
+namespace rtt_mesh {
+
+//---------------------------------------------------------------------------//
+// PUBLIC FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Build the cell-face index map to the corresponding coordinates.
+ */
+void X3D_Draco_Mesh_Reader::read_mesh() {
+
+  Require(parsed_pairs.size() == 0);
+
+  // STEP 1: open the file stream
+
+  std::ifstream x3dfile(filename.c_str());
+
+  // file must exist and be readable
+  Check(x3dfile.good());
+
+  // STEP 2: parse file token stream into an initial vector of string pairs
+
+  std::vector<std::pair<std::string, std::string>> raw_pairs;
+
+  while (!x3dfile.eof()) {
+    // get a line from the file
+    std::string data_line;
+    std::getline(x3dfile, data_line);
+
+    // trim outermost white space
+    data_line = rtt_dsxx::trim(data_line);
+
+    // ignore empty lines
+    if (data_line.size() == 0)
+      continue;
+
+    // find last char index of key
+    size_t key_offset = data_line.find(' ');
+
+    // first string without whitespace will be key
+    std::string key = data_line.substr(0, key_offset);
+
+    // check if anything is after key, to set as value
+    std::string value = "";
+    if (key_offset != std::string::npos)
+      value = data_line.substr(key_offset);
+
+    // add pairing even if value string is size 0 (gets headers and footers)
+    raw_pairs.push_back(std::pair<std::string, std::string>(key, value));
+  }
+
+  // STEP 3: close the file stream
+
+  x3dfile.close();
+
+  // STEP 4: split strings in value at whitespace
+
+  for (auto rpair : raw_pairs) {
+
+    // split the string value into a vector
+    std::vector<std::string> tmp_vec = rtt_dsxx::tokenize(rpair.second);
+
+    // add string-vector pair to intermediate map
+    parsed_pairs.push_back(Parsed_Element(rpair.first, tmp_vec));
+  }
+
+  // STEP 5: derive mesh data maps from parsed_pairs
+
+  // keep track of point parsed_pairs data
+  int dist = 0;
+  if (parsed_pairs[0].first != "header")
+    dist++;
+
+  // parse x3d header block and generate x3d_header_map
+  Remember(int dist_old = dist);
+  x3d_header_map = map_x3d_block<std::string, int>("header", dist);
+  Check(dist > 0);
+  Check(dist > dist_old);
+
+  // parse x3d node coordinate block and generate x3d_coord_map
+  Remember(dist_old = dist);
+  x3d_coord_map = map_x3d_block<int, double>("nodes", dist);
+  Check(dist > dist_old);
+
+  // parse x3d face-to-node index map
+  Remember(dist_old = dist);
+  x3d_facenode_map = map_x3d_block<int, int>("faces", dist);
+  Check(dist > dist_old);
+
+  // parse x3d cell-to-face index map
+  Remember(dist_old = dist);
+  x3d_cellface_map = map_x3d_block<int, int>("cells", dist);
+  Check(dist > dist_old);
+
+  Ensure(parsed_pairs.size() > 0);
+  Ensure(x3d_header_map.size() > 0);
+  Ensure(x3d_coord_map.size() > 0);
+  Ensure(x3d_facenode_map.size() > 0);
+  Ensure(x3d_cellface_map.size() > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Return number of nodes for a given cell.
+ *
+ * \param[in] cell index of cell
+ *
+ * \return number of nodes for cell
+ */
+unsigned X3D_Draco_Mesh_Reader::get_celltype(size_t cell) const {
+
+  // get the list of cell nodes
+  const std::vector<int> node_indexes = get_cellnodes(cell);
+
+  // merely the size of the vector of unique nodes
+  unsigned num_nodes_pc = node_indexes.size();
+
+  Ensure(num_nodes_pc > 0);
+  return num_nodes_pc;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Return the vector of node indices for a given cell.
+ *
+ * \param[in] cell index of cell
+ *
+ * \return vector of int node indices
+ */
+std::vector<int> X3D_Draco_Mesh_Reader::get_cellnodes(size_t cell) const {
+
+  Require(cell < static_cast<size_t>(x3d_header_map.at("elements")[0]));
+
+  // x3d file's node, face, and cell indexes start from 1
+  const std::vector<int> &cell_data = x3d_cellface_map.at(cell + 1);
+  const size_t num_faces = cell_data[0];
+
+  // calculate number of nodes for this cell
+  std::vector<int> node_indexes;
+
+  for (size_t i = 1; i <= num_faces; ++i) {
+
+    // get the face index, which will by key for face-to-node map
+    int face = cell_data[i];
+
+    // number of nodes is first value after face index in x3d file
+    const std::vector<int> &face_data = x3d_facenode_map.at(face);
+    const size_t num_nodes = face_data[0];
+
+    // push each node instance onto node vector (subtract 1 to get 0-based node)
+    for (size_t j = 1; j <= num_nodes; ++j)
+      node_indexes.push_back(face_data[j] - 1);
+  }
+
+  // reduce return vector to unique node entries
+  std::sort(node_indexes.begin(), node_indexes.end());
+  node_indexes.erase(std::unique(node_indexes.begin(), node_indexes.end()),
+                     node_indexes.end());
+
+  Ensure(node_indexes.size() > 0);
+  return node_indexes;
+}
+
+//---------------------------------------------------------------------------//
+// PRIVATE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Find iterator of a vector of pairs at a key value.
+ *
+ * \param[in] pairs const reference to the vector of pairs
+ * \param[in] key string key to search
+ * \param[in] start index from which to start search for key
+ *
+ * \return iterator to pair with key
+ */
+X3D_Draco_Mesh_Reader::Parsed_Elements::const_iterator
+X3D_Draco_Mesh_Reader::find_iter_of_key(const Parsed_Elements &pairs,
+                                        std::string key, size_t start) {
+  auto start_it = pairs.begin() + start;
+  auto it =
+      std::find_if(start_it, pairs.end(),
+                   [&key](const Parsed_Element &p) { return p.first == key; });
+  return it;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Simply return key as specialization to numerical conversion.
+ *
+ * \param[in] skey string key
+ *
+ * \return numerical key of type "KT"
+ */
+template <>
+std::string
+X3D_Draco_Mesh_Reader::convert_key<std::string>(const std::string &skey) {
+  std::string ret_key = skey;
+  return ret_key;
+}
+
+} // end namespace rtt_mesh
+
+//---------------------------------------------------------------------------//
+// end of mesh/X3D_Draco_Mesh_Reader.cc
+//---------------------------------------------------------------------------//

--- a/src/mesh/X3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/X3D_Draco_Mesh_Reader.cc
@@ -23,11 +23,10 @@ namespace rtt_mesh {
  *
  * \param[in] filename_ name of file to be parsed
  */
-X3D_Draco_Mesh_Reader::X3D_Draco_Mesh_Reader(std::string filename_)
+X3D_Draco_Mesh_Reader::X3D_Draco_Mesh_Reader(const std::string filename_)
     : filename(filename_) {
   // check for valid file name
   Insist(filename_.size() > 0, "No file name supplied.");
-  // \todo add more filename criteria?
 }
 
 //---------------------------------------------------------------------------//
@@ -45,7 +44,7 @@ void X3D_Draco_Mesh_Reader::read_mesh() {
   std::ifstream x3dfile(filename.c_str());
 
   // file must exist and be readable
-  Check(x3dfile.good());
+  Insist(x3dfile.is_open(), "Failed to find or open specified X3D mesh file.");
 
   // STEP 2: parse file token stream into an initial vector of string pairs
 

--- a/src/mesh/X3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/X3D_Draco_Mesh_Reader.cc
@@ -16,6 +16,21 @@
 namespace rtt_mesh {
 
 //---------------------------------------------------------------------------//
+// CONSTRUCTOR
+//---------------------------------------------------------------------------//
+/*!
+ * \brief X3D_Draco_Mesh_Reader constructor.
+ *
+ * \param[in] filename_ name of file to be parsed
+ */
+X3D_Draco_Mesh_Reader::X3D_Draco_Mesh_Reader(std::string filename_)
+    : filename(filename_) {
+  // check for valid file name
+  Insist(filename_.size() > 0, "No file name supplied.");
+  // \todo add more filename criteria?
+}
+
+//---------------------------------------------------------------------------//
 // PUBLIC FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -49,7 +49,7 @@ private:
   // >>> DATA
 
   //! File name
-  std::string filename;
+  const std::string filename;
 
   //! Vector of all parsed key-value data pairs (includes valueless delimiters)
   Parsed_Elements parsed_pairs;
@@ -68,7 +68,7 @@ private:
 
 public:
   //! Constructor
-  explicit X3D_Draco_Mesh_Reader(std::string filename_);
+  DLL_PUBLIC_mesh explicit X3D_Draco_Mesh_Reader(const std::string filename_);
 
   // >>> SERVICES
 
@@ -108,7 +108,7 @@ private:
                                                    size_t start = 0);
 
   template <typename KT, typename VT>
-  std::map<KT, std::vector<VT>> map_x3d_block(std::string block_name,
+  std::map<KT, std::vector<VT>> map_x3d_block(const std::string &block_name,
                                               int &dist);
 
   template <typename KT> KT convert_key(const std::string &skey);

--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -1,0 +1,129 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/X3D_Draco_Mesh_Reader.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>, Kendra Keady
+ * \date   Wednesday, Jul 11, 2018, 14:24 pm
+ * \brief  X3D_Draco_Mesh_Reader header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_mesh_X3D_Draco_Mesh_Reader_hh
+#define rtt_mesh_X3D_Draco_Mesh_Reader_hh
+
+#include "ds++/Assert.hh"
+#include "ds++/config.h"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace rtt_mesh {
+
+//===========================================================================//
+/*!
+ * \class X3D_Draco_Mesh_Reader
+ *
+ * \brief Read x3d file format and supply data to Draco_Mesh_Builder.
+ *
+ * This class parses mesh data from an x3d file format and manipulates it into a
+ * form that is compatible to the Draco_Mesh_Builder class.  The parsing of the
+ * file stream to the map follows work by Kendra Keady on a parsing framework.
+ *
+ * \todo: Boundary condition data is evidently parsed separately in X3D, so
+ * meshes generated from this reader will not have side flag data (which ids
+ * boundary conditions.
+ */
+//===========================================================================//
+
+class X3D_Draco_Mesh_Reader {
+public:
+  // >>> TYPEDEFS
+  typedef std::pair<std::string, std::vector<std::string>> Parsed_Element;
+  typedef std::vector<Parsed_Element> Parsed_Elements;
+
+private:
+  // >>> DATA
+
+  //! File name
+  std::string filename;
+
+  //! Vector of all parsed key-value data pairs (includes valueless delimiters)
+  Parsed_Elements parsed_pairs;
+
+  //! Header data map (header in x3d file)
+  std::map<std::string, std::vector<int>> x3d_header_map;
+
+  //! Node coordinates
+  std::map<int, std::vector<double>> x3d_coord_map;
+
+  //! Face-to-node map
+  std::map<int, std::vector<int>> x3d_facenode_map;
+
+  //! Cell-to-face map
+  std::map<int, std::vector<int>> x3d_cellface_map;
+
+public:
+  //! Constructor
+  explicit X3D_Draco_Mesh_Reader(std::string filename_);
+
+  // >>> SERVICES
+
+  DLL_PUBLIC_mesh void read_mesh();
+
+  // >>> ACCESSORS
+
+  // header data
+  unsigned get_process() const { return x3d_header_map.at("process")[0]; }
+  unsigned get_numdim() const { return x3d_header_map.at("numdim")[0]; }
+  unsigned get_numcells() const { return x3d_header_map.at("elements")[0]; }
+  unsigned get_numnodes() const { return x3d_header_map.at("nodes")[0]; }
+
+  // coord data
+  std::vector<double> get_nodecoord(size_t node) const {
+    return x3d_coord_map.at(node + 1);
+  }
+
+  // accessors with deferred implementations
+  unsigned get_celltype(size_t cell) const;
+  std::vector<int> get_cellnodes(size_t cell) const;
+
+  // data needed from x3d boundary file (?)
+  // \todo: parse x3d boundary file
+  unsigned get_numsides() const { return 0; }
+  unsigned get_sidetype(size_t /*side*/) const { return 0; }
+  unsigned get_sideflag(size_t /*side*/) const { return 0; }
+  std::vector<int> get_sidenodes(size_t /*side*/) const {
+    return std::vector<int>();
+  }
+
+private:
+  // >>> SUPPORT FUNCTIONS
+
+  Parsed_Elements::const_iterator find_iter_of_key(const Parsed_Elements &pairs,
+                                                   std::string key,
+                                                   size_t start = 0);
+
+  template <typename KT, typename VT>
+  std::map<KT, std::vector<VT>> map_x3d_block(std::string block_name,
+                                              int &dist);
+
+  template <typename KT> KT convert_key(const std::string &skey);
+};
+
+//---------------------------------------------------------------------------//
+// EXPLICIT SPECIALIZATIONS
+//---------------------------------------------------------------------------//
+template <>
+DLL_PUBLIC_mesh std::string
+X3D_Draco_Mesh_Reader::convert_key<std::string>(const std::string &skey);
+
+} // end namespace rtt_mesh
+
+// implementation header file
+#include "X3D_Draco_Mesh_Reader.i.hh"
+
+#endif // rtt_mesh_X3D_Draco_Mesh_Reader_hh
+
+//---------------------------------------------------------------------------//
+// end of mesh/X3D_Draco_Mesh_Reader.hh
+//---------------------------------------------------------------------------//

--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -32,6 +32,9 @@ namespace rtt_mesh {
  * \todo: Boundary condition data is evidently parsed separately in X3D, so
  * meshes generated from this reader will not have side flag data (which ids
  * boundary conditions.
+ *
+ * \todo: Consider using the Class_Parse_Table formalism developed by Kent Budge
+ * as an alternative.
  */
 //===========================================================================//
 
@@ -73,7 +76,7 @@ public:
   // >>> ACCESSORS
 
   // header data
-  unsigned get_process() const { return x3d_header_map.at("process")[0]; }
+  unsigned get_process() const { return x3d_header_map.at("process")[0] - 1; }
   unsigned get_numdim() const { return x3d_header_map.at("numdim")[0]; }
   unsigned get_numcells() const { return x3d_header_map.at("elements")[0]; }
   unsigned get_numnodes() const { return x3d_header_map.at("nodes")[0]; }

--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -30,6 +30,9 @@ namespace rtt_mesh {
  * form that is compatible to the Draco_Mesh_Builder class.  The parsing of the
  * file stream to the map follows work by Kendra Keady on a parsing framework.
  *
+ * For a description of the X3D mesh file layout, see:
+ * https://xcp-confluence.lanl.gov/display/SIMC/Ingen->Flag+Data+Transfer
+ *
  * \todo: Boundary condition data is evidently parsed separately in X3D, so
  * meshes generated from this reader will not have side flag data (which ids
  * boundary conditions.

--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -11,6 +11,7 @@
 #ifndef rtt_mesh_X3D_Draco_Mesh_Reader_hh
 #define rtt_mesh_X3D_Draco_Mesh_Reader_hh
 
+#include "Draco_Mesh_Reader.hh"
 #include "ds++/Assert.hh"
 #include "ds++/config.h"
 #include <map>
@@ -38,7 +39,7 @@ namespace rtt_mesh {
  */
 //===========================================================================//
 
-class X3D_Draco_Mesh_Reader {
+class X3D_Draco_Mesh_Reader : public Draco_Mesh_Reader {
 public:
   // >>> TYPEDEFS
   typedef std::pair<std::string, std::vector<std::string>> Parsed_Element;

--- a/src/mesh/X3D_Draco_Mesh_Reader.i.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.i.hh
@@ -13,21 +13,6 @@
 namespace rtt_mesh {
 
 //---------------------------------------------------------------------------//
-// CONSTRUCTOR
-//---------------------------------------------------------------------------//
-/*!
- * \brief X3D_Draco_Mesh_Reader constructor.
- *
- * \param[in] filename_ name of file to be parsed
- */
-X3D_Draco_Mesh_Reader::X3D_Draco_Mesh_Reader(std::string filename_)
-    : filename(filename_) {
-  // check for valid file name
-  Insist(filename_.size() > 0, "No file name supplied.");
-  // \todo add more filename criteria?
-}
-
-//---------------------------------------------------------------------------//
 // PRIVATE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/mesh/X3D_Draco_Mesh_Reader.i.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.i.hh
@@ -24,7 +24,7 @@ namespace rtt_mesh {
  */
 template <typename KT, typename VT>
 std::map<KT, std::vector<VT>>
-X3D_Draco_Mesh_Reader::map_x3d_block(std::string block_name, int &dist) {
+X3D_Draco_Mesh_Reader::map_x3d_block(const std::string &block_name, int &dist) {
 
   // parse x3d block and generate x3d_map
   auto label_first = find_iter_of_key(parsed_pairs, block_name, dist);

--- a/src/mesh/X3D_Draco_Mesh_Reader.i.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.i.hh
@@ -1,0 +1,113 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/X3D_Draco_Mesh_Reader.i.hh
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>, Kendra Keady
+ * \date   Thursday, Jul 12, 2018, 08:46 am
+ * \brief  X3D_Draco_Mesh_Reader class implementation header file.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "ds++/DracoStrings.hh"
+
+namespace rtt_mesh {
+
+//---------------------------------------------------------------------------//
+// CONSTRUCTOR
+//---------------------------------------------------------------------------//
+/*!
+ * \brief X3D_Draco_Mesh_Reader constructor.
+ *
+ * \param[in] filename_ name of file to be parsed
+ */
+X3D_Draco_Mesh_Reader::X3D_Draco_Mesh_Reader(std::string filename_)
+    : filename(filename_) {
+  // check for valid file name
+  Insist(filename_.size() > 0, "No file name supplied.");
+  // \todo add more filename criteria?
+}
+
+//---------------------------------------------------------------------------//
+// PRIVATE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Generate a map from a block in an x3d file
+ *
+ * \param[in] block_name name of parsed x3d block
+ *
+ * \return map of mesh data with key of type KT and value of type VT
+ */
+template <typename KT, typename VT>
+std::map<KT, std::vector<VT>>
+X3D_Draco_Mesh_Reader::map_x3d_block(std::string block_name, int &dist) {
+
+  // parse x3d block and generate x3d_map
+  auto label_first = find_iter_of_key(parsed_pairs, block_name, dist);
+  auto label_last = find_iter_of_key(parsed_pairs, "end_" + block_name, dist);
+
+  // add distance in map to exclude parsed file region
+  dist += std::distance(label_first, label_last);
+
+  Check(dist > 0);
+  Check(label_first < label_last);
+
+  // x3d map to return
+  std::map<KT, std::vector<VT>> ret_x3d_map;
+
+  for (auto it = label_first + 1; it < label_last; ++it) {
+
+    std::vector<VT> tmp_vec((*it).second.size());
+    size_t i = 0;
+
+    // convert value types from string to VT
+    for (auto j : (*it).second) {
+
+      // try to convert value type to VT, throw if impossible
+      try {
+        tmp_vec[i] = rtt_dsxx::parse_number_impl<VT>(j);
+      } catch (std::invalid_argument &err) {
+        Insist(false, err.what());
+      }
+
+      // increment counter
+      i++;
+    }
+
+    // try to convert to key type KT, throw assertion if impossible
+    KT tmp_key = convert_key<KT>((*it).first);
+
+    // insert the new entry
+    ret_x3d_map.insert(std::pair<KT, std::vector<VT>>(tmp_key, tmp_vec));
+  }
+
+  Ensure(ret_x3d_map.size() > 0);
+  return ret_x3d_map;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Convert key to template type.
+ *
+ * \param[in] skey string key
+ *
+ * \return numerical key of type "KT"
+ */
+template <typename KT>
+KT X3D_Draco_Mesh_Reader::convert_key(const std::string &skey) {
+
+  // try to convert to key type KT, throw assertion if impossible
+  KT ret_key;
+  try {
+    ret_key = rtt_dsxx::parse_number_impl<KT>(skey);
+  } catch (std::invalid_argument &err) {
+    Insist(false, err.what());
+  }
+
+  return ret_key;
+}
+
+} // namespace rtt_mesh
+
+//---------------------------------------------------------------------------//
+// end of mesh/X3D_Draco_Mesh_Reader.i.hh
+//---------------------------------------------------------------------------//

--- a/src/mesh/test/CMakeLists.txt
+++ b/src/mesh/test/CMakeLists.txt
@@ -14,7 +14,8 @@ project( mesh_test CXX )
 
 # create unit test lists
 set( one_pe_tests ${PROJECT_SOURCE_DIR}/tstDraco_Mesh.cc
-  ${PROJECT_SOURCE_DIR}/tstDraco_Mesh_Builder.cc )
+  ${PROJECT_SOURCE_DIR}/tstDraco_Mesh_Builder.cc
+  ${PROJECT_SOURCE_DIR}/tstX3D_Draco_Mesh_Reader.cc )
 set( two_pe_tests ${PROJECT_SOURCE_DIR}/tstDraco_Mesh_DD.cc )
 
 # ---------------------------------------------------------------------------- #

--- a/src/mesh/test/tstDraco_Mesh_Builder.cc
+++ b/src/mesh/test/tstDraco_Mesh_Builder.cc
@@ -10,14 +10,14 @@
 
 #include "Test_Mesh_Interface.hh"
 #include "mesh/Draco_Mesh_Builder.hh"
-#include "RTT_Format_Reader/RTT_Format_Reader.hh"
+#include "mesh/RTT_Draco_Mesh_Reader.hh"
 #include "c4/ParallelUnitTest.hh"
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
 
 using rtt_mesh::Draco_Mesh;
 using rtt_mesh::Draco_Mesh_Builder;
-using rtt_RTT_Format_Reader::RTT_Format_Reader;
+using rtt_mesh::RTT_Draco_Mesh_Reader;
 
 //---------------------------------------------------------------------------//
 // TESTS
@@ -55,14 +55,15 @@ void build_cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
   // >>> PARSE AND BUILD MESH
 
   const std::string inputpath = ut.getTestSourcePath();
-  const std::string filename = "rttquad_2cell.mesh.in";
+  const std::string filename = inputpath + "rttquad_2cell.mesh.in";
 
-  // create an rtt mesh
-  std::shared_ptr<RTT_Format_Reader> rtt_mesh(
-      new RTT_Format_Reader(inputpath + filename));
+  // create an rtt mesh reader and read the mesh
+  std::shared_ptr<RTT_Draco_Mesh_Reader> rtt_mesh(
+      new RTT_Draco_Mesh_Reader(filename));
+  rtt_mesh->read_mesh();
 
   // instantiate a mesh builder and build the mesh
-  Draco_Mesh_Builder<RTT_Format_Reader> mesh_builder(rtt_mesh);
+  Draco_Mesh_Builder<RTT_Draco_Mesh_Reader> mesh_builder(rtt_mesh);
   std::shared_ptr<Draco_Mesh> mesh = mesh_builder.build_mesh(geometry);
 
   // check that the scalar data is correct

--- a/src/mesh/test/tstDraco_Mesh_Builder.cc
+++ b/src/mesh/test/tstDraco_Mesh_Builder.cc
@@ -3,7 +3,7 @@
  * \file   mesh/test/tstDraco_Mesh_Builder.cc
  * \author Ryan Wollaeger <wollaeger@lanl.gov>
  * \date   Sunday, Jul 01, 2018, 18:21 pm
- * \brief  Draco_Mesh class unit test.
+ * \brief  Draco_Mesh_Builder class unit test.
  * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//

--- a/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
@@ -41,7 +41,7 @@ void read_x3d_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
 
   // >>> CHECK HEADER DATA
 
-  if (x3d_reader->get_process() != 1)
+  if (x3d_reader->get_process() != 0)
     ITFAILS;
 
   if (x3d_reader->get_numdim() != 2)

--- a/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
@@ -8,16 +8,20 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
+#include "mesh/Draco_Mesh.hh"
+#include "mesh/Draco_Mesh_Builder.hh"
 #include "mesh/X3D_Draco_Mesh_Reader.hh"
 #include "c4/ParallelUnitTest.hh"
 #include "ds++/DracoStrings.hh"
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <iterator>
+// #include <fstream>
+// #include <iomanip>
+// #include <iostream>
+// #include <iterator>
 
+using rtt_mesh::Draco_Mesh;
+using rtt_mesh::Draco_Mesh_Builder;
 using rtt_mesh::X3D_Draco_Mesh_Reader;
 
 //---------------------------------------------------------------------------//
@@ -79,6 +83,25 @@ void read_x3d_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
   if (x3d_reader->get_sidetype(0) != 0)
     ITFAILS;
   if (x3d_reader->get_sideflag(0) != 0)
+    ITFAILS;
+
+  // >>> BUILD A MESH
+
+  // use Cartesian geometry
+  const Draco_Mesh::Geometry geometry = Draco_Mesh::Geometry::CARTESIAN;
+
+  // instantiate a mesh builder and build the mesh
+  Draco_Mesh_Builder<X3D_Draco_Mesh_Reader> mesh_builder(x3d_reader);
+  std::shared_ptr<Draco_Mesh> mesh = mesh_builder.build_mesh(geometry);
+
+  // check that the scalar data is correct
+  if (mesh->get_dimension() != 2)
+    ITFAILS;
+  if (mesh->get_geometry() != geometry)
+    ITFAILS;
+  if (mesh->get_num_cells() != 1)
+    ITFAILS;
+  if (mesh->get_num_nodes() != 4)
     ITFAILS;
 
   // successful test output

--- a/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
@@ -15,10 +15,6 @@
 #include "ds++/DracoStrings.hh"
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
-// #include <fstream>
-// #include <iomanip>
-// #include <iostream>
-// #include <iterator>
 
 using rtt_mesh::Draco_Mesh;
 using rtt_mesh::Draco_Mesh_Builder;
@@ -103,6 +99,25 @@ void read_x3d_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
     ITFAILS;
   if (mesh->get_num_nodes() != 4)
     ITFAILS;
+
+  // check that layout is correct (empty for one cell, no side or ghost data)
+  // \todo: get Draco_Mesh_Builder to set side data if not provided by reader(?)
+  if ((mesh->get_cc_linkage()).size() > 0)
+    ITFAILS;
+  if ((mesh->get_cs_linkage()).size() > 0)
+    ITFAILS;
+  if ((mesh->get_cg_linkage()).size() > 0)
+    ITFAILS;
+
+  // check that we have the node coordinates
+  const std::vector<std::vector<double>> &mesh_coords =
+      mesh->get_node_coord_vec();
+  for (int node = 0; node < 4; ++node) {
+    if (!rtt_dsxx::soft_equiv(mesh_coords[node][0], test_coords[node][0]))
+      ITFAILS;
+    if (!rtt_dsxx::soft_equiv(mesh_coords[node][1], test_coords[node][1]))
+      ITFAILS;
+  }
 
   // successful test output
   if (ut.numFails == 0)

--- a/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
@@ -1,0 +1,103 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   mesh/test/tstX3D_Draco_Mesh_Reader.cc
+ * \author Ryan Wollaeger <wollaeger@lanl.gov>
+ * \date   Tuesday, Jul 10, 2018, 10:23 am
+ * \brief  X3D_Draco_Mesh_Reader class unit test.
+ * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "mesh/X3D_Draco_Mesh_Reader.hh"
+#include "c4/ParallelUnitTest.hh"
+#include "ds++/DracoStrings.hh"
+#include "ds++/Release.hh"
+#include "ds++/Soft_Equivalence.hh"
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+
+using rtt_mesh::X3D_Draco_Mesh_Reader;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+// Parse an X3D file format and compare to reference
+void read_x3d_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
+
+  // >>> PARSE MESH
+
+  const std::string inputpath = ut.getTestSourcePath();
+  const std::string filename = inputpath + "x3d.mesh.in";
+
+  // construct reader
+  std::shared_ptr<X3D_Draco_Mesh_Reader> x3d_reader(
+      new X3D_Draco_Mesh_Reader(filename));
+
+  // read mesh
+  x3d_reader->read_mesh();
+
+  // >>> CHECK HEADER DATA
+
+  if (x3d_reader->get_process() != 1)
+    ITFAILS;
+
+  if (x3d_reader->get_numdim() != 2)
+    ITFAILS;
+
+  if (x3d_reader->get_numcells() != 1)
+    ITFAILS;
+
+  if (x3d_reader->get_numnodes() != 4)
+    ITFAILS;
+
+  // >>> CHECK CELL-NODE DATA
+
+  if (x3d_reader->get_celltype(0) != 4)
+    ITFAILS;
+
+  std::vector<int> test_cellnodes = {0, 1, 2, 3};
+  if (x3d_reader->get_cellnodes(0) != test_cellnodes)
+    ITFAILS;
+
+  // >>> CHECK NODE-COORD DATA
+
+  std::vector<std::vector<double>> test_coords = {
+      {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {1.0, 1.0, 0.0}};
+  for (int node = 0; node < 4; ++node) {
+    if (x3d_reader->get_nodecoord(node) != test_coords[node])
+      ITFAILS;
+  }
+
+  // >>> CHECK SIDE DATA
+
+  // \todo: this should change when boundary file parsing is enabled
+  if (x3d_reader->get_numsides() != 0)
+    ITFAILS;
+  if (x3d_reader->get_sidetype(0) != 0)
+    ITFAILS;
+  if (x3d_reader->get_sideflag(0) != 0)
+    ITFAILS;
+
+  // successful test output
+  if (ut.numFails == 0)
+    PASSMSG("2D X3D_Draco_Mesh_Reader tests ok.");
+  return;
+}
+
+//---------------------------------------------------------------------------//
+
+int main(int argc, char *argv[]) {
+  rtt_c4::ParallelUnitTest ut(argc, argv, rtt_dsxx::release);
+  try {
+    Insist(rtt_c4::nodes() == 1, "This test only uses 1 PE.");
+    read_x3d_mesh_2d(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of mesh/test/tstX3D_Draco_Mesh_Reader.cc
+//---------------------------------------------------------------------------//

--- a/src/mesh/test/x3d.mesh.in
+++ b/src/mesh/test/x3d.mesh.in
@@ -1,0 +1,60 @@
+ascii
+header
+   process                         1
+   numdim                          2
+   materials                       1
+   nodes                           4
+   faces                           4
+   elements                        1
+   ghost_nodes                     0
+   slaved_nodes                    0
+   nodes_per_slave                 2
+   nodes_per_face                  2
+   faces_per_cell                  4
+   node_data_fields                0
+   cell_data_fields                2
+end_header
+
+matnames
+            1   0
+end_matnames
+
+mateos
+            1   -1
+end_mateos
+
+matopc
+            1   -1
+end_matopc
+
+nodes
+         1  0.000000000000000E+00  0.000000000000000E+00  0.000000000000000E+00
+         2  1.000000000000000E+00  0.000000000000000E+00  0.000000000000000E+00
+         3  0.000000000000000E+00  1.000000000000000E+00  0.000000000000000E+00
+         4  1.000000000000000E+00  1.000000000000000E+00  0.000000000000000E+00
+end_nodes
+
+faces
+         1         2         1         2         1         0         0         1         1         1         1         1
+         2         2         2         4         1         0         3         1         1         1         1         1
+         3         2         4         3         1         0         2         1         1         1         1         1
+         4         2         3         1         1         0         5         1         1         1         1         1
+end_faces
+
+cells
+         1         4         1         2         3         4
+end_cells
+
+slaved_nodes         0
+end_slaved_nodes
+ghost_nodes          0
+end_ghost_nodes
+
+cell_data
+matid
+         0
+end_matid
+partelm
+         1
+end_partelm
+end_cell_data


### PR DESCRIPTION
### Background

* X3D is an alternative file parsing format to RTT.
* It is useful to have a framework that easily permits new mesh parsers.
* It may be worthwhile to replace this or augment with Class_Parse_Table parsing to X3D mesh.

### Purpose of Pull Request

* Enable preliminary X3D parsing, excluding X3D boundary files (which supply side data), using a file-block-delimiter based formalism (parse into maps, following work by @keadyk ).
* [Addresses Redmine Issue #1182](https://rtt.lanl.gov/redmine/issues/1182)

### Description of changes

* Add abstract base class for `Draco_Mesh` readers (`Draco_Mesh_Reader`) with pure virtual functions, so that derived reader classes can always supply the `Draco_Mesh` builder class the correct accessors. 
* Add wrapper for `RTT_Format_Reader` (`RTT_Draco_Mesh_Reader`) that inherits from new abstract base class.
* Add `X3D_Draco_Mesh_Reader`, which uses `ds++/DracoStrings` (developed by @kgbudge) functions to generate X3D data maps.
* Add (currently hard-coded) unit test for X3D mesh reader and building of mesh from X3D file.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
