### PR TITLE
Tweaks to eliminate build warnings for 64-bit builds under VS2017.

### DIFF
--- a/config/ApplicationUnitTest.cmake
+++ b/config/ApplicationUnitTest.cmake
@@ -249,9 +249,9 @@ macro( aut_register_test )
   endif(VERBOSE_DEBUG)
 
   # Look for python, which is used to drive application unit tests
-  find_program(PYTHON_COMMAND python)
-  if( NOT EXISTS ${PYTHON_COMMAND})
-    message( FATAL_ERROR "Python not found in PATH")
+  if( NOT PYTHONINTERP_FOUND )
+     # python should have been found when vendor_libraries.cmake was run.
+    message( FATAL_ERROR "Draco requires python. Python not found in PATH.")
   endif()
 
   # Check to see if driver file is python or CMake
@@ -289,7 +289,7 @@ macro( aut_register_test )
   if (${PYTHON_TEST})
     add_test(
       NAME ${ctestname_base}${argname}
-      COMMAND ${PYTHON_COMMAND}
+      COMMAND "${PYTHON_EXECUTABLE}"
       ${aut_DRIVER}
       ${SHARED_ARGUMENTS}
       )

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -584,7 +584,7 @@ function( copy_dll_link_libraries_to_build_dir target )
 
   # Debug dependencies for a particular target (uncomment the next line and
   # provide the targetname): "Ut_${compname}_${testname}_exe"
-  if( "Exe_draco_info_gui_foo" STREQUAL ${target} )
+  if( "Ut_rng_ut_gsl_exe_foo" STREQUAL ${target} )
      set(lverbose ON)
   endif()
   if( lverbose )
@@ -699,11 +699,14 @@ function( copy_dll_link_libraries_to_build_dir target )
         endif()
         continue()
       endif()
-      # TYPE = {STATIC_LIBRARY, MODULE_LIBRARY, SHARED_LIBRARY, 
+      # TYPE = {STATIC_LIBRARY, MODULE_LIBRARY, SHARED_LIBRARY,
       #         INTERFACE_LIBRARY, EXECUTABLE}
       # We cannot query INTERFACE_LIBRARY targets.
       get_target_property(lib_type ${lib} TYPE )
       if( ${lib_type} STREQUAL "INTERFACE_LIBRARY" )
+        if( lverbose )
+          message("  I think ${lib} is an INTERFACE_LIBRARY. Skipping to next dependency.")
+        endif()
         continue()
       endif()
       get_target_property(is_imported ${lib} IMPORTED )
@@ -725,19 +728,25 @@ function( copy_dll_link_libraries_to_build_dir target )
         get_target_property(target_gnutoms ${lib} GNUtoMS)
       elseif( EXISTS ${lib} )
         # If $lib is a full path to a library, add it to the list
+        if (lverbose )
+          message("  ${lib} is the full path to a library; adding to the list.")
+        endif()
         set( target_loc ${lib} )
         set( target_gnutoms NOTFOUND )
       else()
+        if (lverbose )
+          message("  ${lib} is a target that points to $<TARGET:${lib}>.")
+        endif()
         set( target_loc $<TARGET_FILE:${lib}> )
         get_target_property( target_gnutoms ${lib} GNUtoMS )
       endif()
 
       add_custom_command( TARGET ${target} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${target_loc}
-	${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR} )
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR} )
 
       if( lverbose )
-	message("  CMAKE_COMMAND -E copy_if_different ${target_loc} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
+        message("  CMAKE_COMMAND -E copy_if_different ${target_loc} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
       endif()
 
     endif()

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -514,19 +514,19 @@ macro( setupMPILibrariesWindows )
             COMMAND wmic cpu get NumberOfCores
             OUTPUT_VARIABLE MPI_CORES_PER_CPU
             OUTPUT_STRIP_TRAILING_WHITESPACE )
-        execute_process(
+         execute_process(
             COMMAND wmic computersystem get NumberOfLogicalProcessors
             OUTPUT_VARIABLE MPIEXEC_MAX_NUMPROCS
             OUTPUT_STRIP_TRAILING_WHITESPACE )
          execute_process(
             COMMAND wmic computersystem get NumberOfProcessors
             OUTPUT_VARIABLE MPI_CPUS_PER_NODE
-            OUTPUT_STRIP_TRAILING_WHITESPACE )
-         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPI_CORES_PER_CPU
+            OUTPUT_STRIP_TRAILING_WHITESPACE ) 
+         string( REGEX REPLACE ".*[\n]([0-9]+$)" "\\1" MPI_CORES_PER_CPU
            ${MPI_CORES_PER_CPU})
-         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPIEXEC_MAX_NUMPROCS
+         string( REGEX REPLACE ".*[\n]([0-9]+$)" "\\1" MPIEXEC_MAX_NUMPROCS
            ${MPIEXEC_MAX_NUMPROCS})
-         string( REGEX REPLACE ".*([0-9]+)" "\\1" MPI_CPUS_PER_NODE
+         string( REGEX REPLACE ".*[\n]([0-9]+$)" "\\1" MPI_CPUS_PER_NODE
            ${MPI_CPUS_PER_NODE})
 
          set( MPI_CPUS_PER_NODE ${MPI_CPUS_PER_NODE} CACHE STRING

--- a/src/c4/test/tstProcessor_Group.cc
+++ b/src/c4/test/tstProcessor_Group.cc
@@ -43,7 +43,7 @@ void tstProcessor_Group(rtt_dsxx::UnitTest &ut) {
   vector<double> myvec;
   size_t const vlen(5);
   for (size_t i = 0; i < vlen; ++i)
-    myvec.push_back(pid * 1000 + i);
+    myvec.push_back(pid * 1000.0 + i);
   vector<double> globalvec;
   comm.assemble_vector(myvec, globalvec);
 
@@ -54,7 +54,7 @@ void tstProcessor_Group(rtt_dsxx::UnitTest &ut) {
   vector<double> goldglobalvec;
   for (size_t j = 0; j < group_pids; ++j)
     for (size_t i = 0; i < vlen; ++i)
-      goldglobalvec.push_back((base + 2 * j) * 1000 + i);
+      goldglobalvec.push_back((base + 2.0 * j) * 1000 + i);
 
   if (!rtt_dsxx::soft_equiv(goldglobalvec.begin(), goldglobalvec.end(),
                             globalvec.begin(), globalvec.end()))

--- a/src/c4/test/tstTime.cc
+++ b/src/c4/test/tstTime.cc
@@ -100,7 +100,7 @@ void wall_clock_test(rtt_dsxx::UnitTest &ut) {
   std::vector<double> foo(len);
   double sum(0);
   for (size_t i = 0; i < len; ++i) {
-    double const d(i + 1);
+    double const d(i + 1.0);
     foo[i] = std::sqrt(std::log(d * 3.14) * std::fabs(std::cos(d / 3.14)));
     sum += foo[i];
   }
@@ -173,7 +173,7 @@ void wall_clock_test(rtt_dsxx::UnitTest &ut) {
 
   t.start();
   for (size_t i = 0; i < len; ++i)
-    foo[i] = i * 4;
+    foo[i] = i * 4.0;
   t.stop();
 
   t.print(cout, 6);

--- a/src/ds++/Release.hh
+++ b/src/ds++/Release.hh
@@ -20,8 +20,8 @@
 namespace rtt_dsxx {
 
 // Typedefs
-typedef std::multimap<size_t, std::string, std::greater<int>> mmdevs;
-typedef std::pair<size_t, std::string> fomdev;
+typedef std::multimap<int, std::string, std::greater<int>> mmdevs;
+typedef std::pair<int, std::string> fomdev;
 
 //! Query package for the release number.
 DLL_PUBLIC_dsxx const std::string release();

--- a/src/rng/test/ut_gsl.c
+++ b/src/rng/test/ut_gsl.c
@@ -42,6 +42,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 
+#ifdef _MSC_FULL_VER
+// 'type cast': pointer truncation from 'char[54]' to 'long'
+#pragma warning(disable : 4311)
+#endif
+
 /* Exercise the GSL_CBRNG macro */
 
 GSL_CBRNG(cbrng, threefry4x64); /* creates gsl_rng_cbrng */


### PR DESCRIPTION
### Background

* On my new system, I'm standing up regressions for 64-bit compiles under Visual Studio.  There are  a few new warnings that I'm dealing with.
* I'm also being more careful about setting up TPLs for VS2017.
  * https://gitlab.kitware.com/cmake/cmake/merge_requests/2236
  * https://github.com/ampl/gsl/pull/31

### Description of changes

+ `ApplicationUnitTest.cmake`: Replace local variables `PYTHON_COMMAND` with CMake global variable `PYTHON_EXECUTABLE` and make use of PYTHONINTERP_FOUND.
+ `component_macros.cmake`: Add more optional debugging output for cmake function `copy_dll_link_libraries_to_build_dir`.  This is used to help debug issues related to missing dll libraries on Win32 platforms.
+ `setupMPI.cmake`: On Windows do a better job of querying and setting `MPI_CORES_PER_CPU`, `MPIEXEC_MAX_NUMPROCS`, and `MPI_CPUS_PER_NODE`.
+ Update a few hh/cc files to eliminate warnings about automatic data demotion or promotion or just add pragmas to silence warnings (`ut_gsl.c`).


### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
