### PR TITLE
More extensions to support 64-bit builds under VS 2017.

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -65,6 +65,7 @@ function(_setup_cafs_config_and_build source_dir build_dir)
       gfortran
     PATHS
       c:/MinGW/bin
+      c:/msys64/mingw64/bin
     )
   if( NOT EXISTS ${CAFS_Fortran_COMPILER} )
     message(FATAL_ERROR

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -105,16 +105,12 @@ macro(dbsSetupCompilers)
   # assigned to individual targets.
 
   #  See https://cmake.org/cmake/help/git-stage/policy/CMP0069.html
-  include(CheckIPOSupported)
-  check_ipo_supported(RESULT USE_IPO)
-
-  # 2017-09-15 KT - eliminate configure warning in Win32 nightly regressions:
-  #                 "CMake doesn't support IPO for current compiler"
-  # 2017-11-13 KT - This also breaks linking MinGW gfortran libraries into
-  #                 MSVC applications, so just disable it for all Win32 builds.
   if( WIN32 )
     set( USE_IPO OFF CACHE BOOL
       "Enable Interprocedureal Optimization for Release builds." FORCE )
+  else()
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT USE_IPO)
   endif()
 
 endmacro()
@@ -172,16 +168,16 @@ macro(dbsSetupCxx)
   endif()
 
   # setup flags based on COMPILER_ID...
-  if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI" OR 
+  if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI" OR
       "${CMAKE_C_COMPILER_ID}"   STREQUAL "PGI" )
     include( unix-pgi )
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR 
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR
           "${CMAKE_C_COMPILER_ID}"   STREQUAL "Intel")
     include( unix-intel )
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray" OR 
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray" OR
           "${CMAKE_C_COMPILER_ID}"   STREQUAL "Cray")
     include( unix-crayCC )
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR 
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
           "${CMAKE_C_COMPILER_ID}"   STREQUAL "Clang")
     if( APPLE )
       include( apple-clang )
@@ -190,8 +186,8 @@ macro(dbsSetupCxx)
     endif()
   elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
           "${CMAKE_C_COMPILER_ID}"   STREQUAL "GNU")
-    include( unix-g++ )  
-  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR 
+    include( unix-g++ )
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR
           "${CMAKE_C_COMPILER_ID}"   STREQUAL "MSVC" )
     include( windows-cl )
   else()

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -61,7 +61,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # - /std:c++14 (should be added by cmake in compilerEnv.cmake)
   # - /showIncludes
   # - /FC
-  set( CMAKE_C_FLAGS "/W2 /Gy /fp:precise /DWIN32 /D_WINDOWS /MP${numproc} /wd4251" )
+  set( CMAKE_C_FLAGS "/W2 /Gy /fp:precise /arch:AVX2 /DWIN32 /D_WINDOWS /MP${numproc} /wd4251" )
   set( CMAKE_C_FLAGS_DEBUG "/${MD_or_MT_debug} /Od /Zi /DDEBUG /D_DEBUG" )
   set( CMAKE_C_FLAGS_RELEASE "/${MD_or_MT} /O2 /DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL "/${MD_or_MT} /O1 /DNDEBUG" )

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -147,7 +147,7 @@ win32$ set work_dir=c:/full/path/to/work_dir
   if( WIN32 )
     # add option for "NMake Makefiles JOM"?
     # set( CTEST_CMAKE_GENERATOR "NMake Makefiles" )
-    set( CTEST_CMAKE_GENERATOR "Visual Studio 15 2017" )
+    set( CTEST_CMAKE_GENERATOR "Visual Studio 15 2017 Win64" )
   else()
     set( CTEST_CMAKE_GENERATOR "Unix Makefiles" )
   endif()
@@ -532,8 +532,6 @@ Finding tools...
   if( ${drm_verbose} )
     message("
 CTEST_CMD           = ${CTEST_CMD}
-CTEST_CVS_COMMAND   = ${CTEST_CVS_COMMAND}
-CTEST_SVN_COMMAND   = ${CTEST_SVN_COMMAND}
 CTEST_GIT_COMMAND   = ${CTEST_GIT_COMMAND}
 CTEST_CMAKE_COMMAND = ${CTEST_CMAKE_COMMAND}
 MAKECOMMAND         = ${MAKECOMMAND}

--- a/regression/update_regression_dir.bat
+++ b/regression/update_regression_dir.bat
@@ -3,24 +3,29 @@ rem ---------------------------------------------------------------------------
 rem File  : regression/update_regrssion_dir.bat
 rem Date  : Tuesday, May 31, 2016, 14:48 pm
 rem Author: Kelly Thompson
-rem Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+rem Note  : Copyright (C) 2016-2018, Los Alamos National Security, LLC.
 rem         All rights are reserved.
 rem ---------------------------------------------------------------------------
 
-set LOGDIR=e:\regress\logs
-set GIT="c:\\Program Files\\Git\\bin\\git.exe"
-set PATH="c:\\Program Files\\Git\\bin";%PATH%
-echo cd e:\regress\draco
-cd /d e:\regress\draco
+set LOGDIR=c:\regress\logs
+set GIT="C:\Users\107638\AppData\Local\Programs\Git\bin\git.exe"
+set PATH="C:\Users\107638\AppData\Local\Programs\Git\bin";%PATH%
+
+echo Updating regression system...
+echo.
+echo LOGDIR = %LOGDIR%
+echo GIT    = %GIT%
+echo.
+
+echo cd c:\regress\draco
+cd /d c:\regress\draco
 echo %GIT% pull
 %GIT% pull
-echo cd e:\regress\jayenne
-cd /d e:\regress\jayenne
+echo cd c:\regress\jayenne
+cd /d c:\regress\jayenne
 echo %GIT% pull
 %GIT% pull
 
-rem set SVN_SSH="c:\\Program Files\\TortoiseSVN\\bin\\TortoisePlink.exe"
-rem set SVN="c:\\Program Files\\TortoiseSVN\\bin\\svn.exe"
-rem %SVN% update > %LOGDIR%\update_regression_dir.log
-
-rem 2&>1
+rem ---------------------------------------------------------------------------
+rem End regression/update_regression_dir.bat
+rem ---------------------------------------------------------------------------

--- a/regression/win32-regress.bat
+++ b/regression/win32-regress.bat
@@ -7,8 +7,7 @@ rem Note  : Copyright (C) 2016-2018, Los Alamos National Security, LLC.
 rem         All rights are reserved.
 rem ---------------------------------------------------------------------------
 
-rem This file copied from c:\program files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat.  
-rem It establishes a Visual Studio environment in a command prompt.  The 
+rem Establish a Visual Studio environment in a command prompt.  The 
 rem Windows shortcut runs the following command:
 rem
 rem %comspec% /[k|c] @call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86 %*
@@ -17,21 +16,19 @@ rem This fill is called from win32-regression-master.bat so that all outpout
 rem can be captured in a log file.
 
 :setupvs17commenv
-rem 32-bit builds ==> x86
-rem @call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86 %*
-@call "C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build\vcvarsall.bat" x86 %*
+@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" %*
 
 rem -------------------------------------------------------------------------------------------
 rem The main regression script starts here.
 rem -------------------------------------------------------------------------------------------
 
 :vendorsetup
-call e:\work\vendors\setupvendors.bat
+call c:\work\vendors64\setupvendors.bat
 
 :cdash
 rem set dashboard_type=Experimental
 set dashboard_type=Nightly
-set base_dir=e:\regress
+set base_dir=c:\regress
 set comp=cl
 set ctestparts=Configure,Build,Test,Submit
 
@@ -54,7 +51,7 @@ rem ----------------------------------------------------------------------------
 set subproj=draco
 set build_type=Debug
 set script_name=Draco_Win32.cmake
-set script_dir=e:\regress\draco\regression
+set script_dir=%base_dir%\draco\regression
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
 
 rem navigate to the workdir
@@ -71,6 +68,7 @@ echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%cte
 ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log 2>&1
 
 rem goto :done
+goto :dracorelease
 
 rem -------------------------------------------------------------------------------------------
 :jayennedebug
@@ -78,7 +76,7 @@ rem ----------------------------------------------------------------------------
 set subproj=jayenne
 set build_type=Debug
 set script_name=Jayenne_Win32.cmake
-set script_dir=e:\regress\jayenne\regression
+set script_dir=%base_dir%\jayenne\regression
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
 
 rem navigate to the workdir
@@ -104,7 +102,7 @@ REM rem ------------------------------------------------------------------------
 set subproj=draco
 set build_type=Release
 set script_name=Draco_Win32.cmake
-set script_dir=e:\regress\draco\regression
+set script_dir=%base_dir%\draco\regression
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
 
 rem navigate to the workdir
@@ -123,14 +121,14 @@ echo "ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%cte
 ctest -VV -S %script_dir%\%script_name%,%dashboard_type%,%build_type%,%ctestparts% > %base_dir%\logs\draco-%build_type%-cbts.log 2>&1
 
 rem release builds are failing so stop here.
-rem goto :done
+goto :done
 
 REM rem --------------------------------------------------------------------------
 :jayennerelease
 
 set subproj=jayenne
 set build_type=Release
-set script_dir=e:\regress\jayenne\regression
+set script_dir=%base_dir%\jayenne\regression
 set script_name=Jayenne_Win32.cmake
 set work_dir=%base_dir%\cdash\%subproj%\%dashboard_type%_%comp%\%build_type%
 

--- a/regression/win32-regression-master.bat
+++ b/regression/win32-regression-master.bat
@@ -15,16 +15,23 @@ rem midnight.
 rem Consider using date-based log file names.
 rem c:\myscript.%date:~-4%%date:~4,2%%date:~7,2%.%time::=%.log 2>&1
 
-set logdir=e:\regress\logs
+set logdir=c:\regress\logs
 
 rem Ensure Git/bin/sh.exe is not in the PATH.  It interferes with mingw operations.
-set PATH=%PATH:c:\Program Files\Git\bin;=%
+rem set PATH=%PATH:c:\Program Files\Git\bin;=%
+set PATH=%PATH:C:\Users\107638\AppData\Local\Programs\Git\bin\;=%
+
+rem Fix LANL proxy issues
+C:\Users\107638\AppData\Local\Programs\Git\bin\git.exe config --global http.proxy http://proxyout.lanl.gov:8080
+rem Don't set these because they prevent posting to rtt.lanl.gov/cdash.
+rem set HTTP_PROXY=http://proxyout.lanl.gov:8080
+rem set HTTPS_PROXY=http://proxyout.lanl.gov:8080
 
 rem Change '/c' to '/k' to keep the command window open after these commands 
 rem finish.
 
-%comspec% /c ""e:\regress\draco\regression\update_regression_dir.bat"" > %logdir%\update_regression_dir.log 2>&1
-%comspec% /c ""e:\regress\draco\regression\win32-regress.bat"" > %logdir%\regression-master.log 2>&1
+%comspec% /c ""c:\regress\draco\regression\update_regression_dir.bat"" > %logdir%\update_regression_dir.log 2>&1
+%comspec% /c ""c:\regress\draco\regression\win32-regress.bat"" > %logdir%\regression-master.log 2>&1
 
 rem ---------------------------------------------------------------------------
 rem end file regression/win32-regression-master.bat


### PR DESCRIPTION
### Background

* I'm migrating support for Visual Studio regressions (and builds in general) from my old desktop to my new desktop.  Since I'm recreating all of the regression setup for Visual Studio, I've chosen to also migrate to 64-bit builds at the same time.

### Purpose of Pull Request

* [Fixes Redmine Issue #1218](https://rtt.lanl.gov/redmine/issues/1218)

### Description of changes

+ Add support for msys64/mingw64 gfortran (64-bit gfortran) under Visual Studio. Look for gfortran at the standard install location (`c:/msys64/mingw64/bin`).
+ Disable IPO for Visual Studio.  In theory this should work but fails for hybrid VS+gfortran linking.
+ Tweak Visual Studio builds by assuming AVX2 is available.
+ Update regression scripts.
  - Default to 64-bit builds: `-G "Visual Studio 15 2017 Win64"`
  - Update run scripts to point to new locations for files, tools, etc.
  - Only run Draco regressions for now.  Jayenne will be added later.

### Remaining work related to this PR.

+ Re-instate Jayenne regressions for VS2017.
+ Record setup instructions in the Draco wiki.

Lower priority wish list:

+ Stand up lapack, metis, parmetis vendors for VS2017 and run the Draco tests for these tools.
+ Investigate option of allowing xthi and ythi to run under VS2017 (linux specific coding prevents compilation right now)
+ Investigate building CSK, libeospac, superlu-dist under VS2017.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
