### PR TITLE
More tweaks for Win32...

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -323,6 +323,7 @@ macro( add_component_library )
     OUTPUT_NAME ${acl_LIBRARY_NAME_PREFIX}${acl_LIBRARY_NAME}
     FOLDER      ${folder_name}
     INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
     )
 
   #

--- a/src/VendorChecks/test/tstParmetis.cc
+++ b/src/VendorChecks/test/tstParmetis.cc
@@ -59,7 +59,7 @@ void test_parmetis(rtt_c4::ParallelUnitTest &ut) {
   // An array of size ncon that is used to specify the imbalance tolerance for
   // each vertex weight, with 1 being perfect balance and nparts being perfect
   // imbalance. A value of 1.05 for each of the ncon weights is recommended.
-  real_t ubvec(1.05);
+  real_t ubvec(static_cast<real_t>(1.05));
   // This is an array of integers that is used to pass additional parameters
   // for the routine.
   std::vector<idx_t> options(4, 0);


### PR DESCRIPTION
### Background

* I'm trying to make the builds system friendlier and more robust for Visual Studio.

### Purpose of Pull Request

* [Related to Redmine Issue #1218](https://rtt.lanl.gov/redmine/issues/1218)

### Description of changes

+ Eliminate a build warning in `tstParmetis.cc` by using a cast.
+ Begin using the target property `WINDOWS_EXPORT_ALL_SYMBOLS` for all libraries.  This should eliminate some thrashing related to `DLL_PUBLIC` CPP macros.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
