### PR TITLE
WIP: Reorder cbrng

### DIFF
--- a/src/rng/Counter_RNG2.hh
+++ b/src/rng/Counter_RNG2.hh
@@ -98,34 +98,34 @@ constexpr uint32_t max_gens() { return 4; }
  * NR system. It should go away when NR is retired.
  */
 uint32_t get_seed_impl(ctr_type::value_type const *const rng_data) {
-  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
-    "Implementation relies on known integer size!");
+  static_assert(std::is_same<ctr_type::value_type, uint64_t>::value,
+                "Implementation relies on known integer size!");
   uint64_t const val64 = rng_data[2] & SEED_MASK;
   return static_cast<uint32_t>(val64);
 }
 
 uint32_t get_step_counter_impl(ctr_type::value_type const *const rng_data) {
-  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
-    "Implementation relies on known integer size!");
+  static_assert(std::is_same<ctr_type::value_type, uint64_t>::value,
+                "Implementation relies on known integer size!");
   uint64_t const val64 = rng_data[0] & STEP_MASK;
   return static_cast<uint32_t>(val64);
 }
 
 uint64_t get_time_step_impl(ctr_type::value_type const *const rng_data) {
-  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
-    "Implementation relies on known integer size!");
+  static_assert(std::is_same<ctr_type::value_type, uint64_t>::value,
+                "Implementation relies on known integer size!");
   return rng_data[3];
 }
 
 uint64_t get_stream_number_impl(ctr_type::value_type const *const rng_data) {
-  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
-    "Implementation relies on known integer size!");
+  static_assert(std::is_same<ctr_type::value_type, uint64_t>::value,
+                "Implementation relies on known integer size!");
   return rng_data[1];
 }
 
 uint32_t get_spawn_id_impl(ctr_type::value_type const *const rng_data) {
-  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
-    "Implementation relies on known integer size!");
+  static_assert(std::is_same<ctr_type::value_type, uint64_t>::value,
+                "Implementation relies on known integer size!");
   uint64_t const val64 = rng_data[0] & SPAWN_MASK;
   return static_cast<uint32_t>(val64 >> 32);
 }
@@ -135,23 +135,23 @@ uint32_t get_spawn_id_impl(ctr_type::value_type const *const rng_data) {
  */
 uint32_t get_spawn_gen_impl(ctr_type::value_type const *const rng_data) {
   uint32_t const sid = get_spawn_id_impl(rng_data);
-  if(0 == sid){
+  if (0 == sid) {
     return 0;
   }
-  if(0xFF >= sid){
+  if (0xFF >= sid) {
     return 1;
   }
-  if(0xFFFF >= sid){
+  if (0xFFFF >= sid) {
     return 2;
   }
-  if(0xFFFFFF >= sid){
+  if (0xFFFFFF >= sid) {
     return 3;
   }
   return 4;
 }
 
 /**\brier Can a generator spawn? */
-bool can_spawn_impl(ctr_type::value_type const *const rng_data){
+bool can_spawn_impl(ctr_type::value_type const *const rng_data) {
   uint32_t const spawn_gen = get_spawn_gen_impl(rng_data);
   uint32_t const max_gen = max_gens();
   return spawn_gen < max_gen;
@@ -174,7 +174,8 @@ namespace // anonymous
  * version of the RNG seed, stream number, and spawn indicator and then returns
  * the lower 64 bits of the result.
  */
-static inline uint64_t get_unique_num_impl(const ctr_type::value_type *const data) {
+static inline uint64_t
+get_unique_num_impl(const ctr_type::value_type *const data) {
   CBRNG hash;
   uint64_t const sp64 = static_cast<uint64_t>(get_spawn_id_impl(data));
   const ctr_type ctr = {{data[1], sp64}};
@@ -185,13 +186,12 @@ static inline uint64_t get_unique_num_impl(const ctr_type::value_type *const dat
 
 //---------------------------------------------------------------------------//
 /*! \brief Increment the counter, rolling over after 32b exhausted. */
-inline uint64_t increment_CBRNG2_step_counter( uint64_t in){
+inline uint64_t increment_CBRNG2_step_counter(uint64_t in) {
   uint64_t spawn64 = in & (~STEP_MASK);
   uint64_t const ctr = in & STEP_MASK;
   uint64_t const new_ctr = ctr + 1;
   return spawn64 | (new_ctr & STEP_MASK);
 }
-
 
 //---------------------------------------------------------------------------//
 /*! \brief Generate a random double.
@@ -240,7 +240,7 @@ class Counter_RNG2_Ref {
 public:
   //! Constructor.  db and de specify the extents of an RNG state block.
   Counter_RNG2_Ref(ctr_type::value_type *const db,
-                  ctr_type::value_type *const de)
+                   ctr_type::value_type *const de)
       : data(db, de) {
     Require(std::distance(db, de) * sizeof(ctr_type::value_type) ==
             sizeof(ctr_type) + sizeof(key_type));
@@ -267,9 +267,7 @@ public:
   uint64_t get_num() const { return get_stream_number_impl(data.access()); }
 
   //! Can the referred RNG spawn?
-  bool can_spawn() const {
-    return can_spawn_impl(data.access());
-  }
+  bool can_spawn() const { return can_spawn_impl(data.access()); }
 
 private:
   mutable rtt_dsxx::Data_Table<ctr_type::value_type> data;
@@ -335,7 +333,7 @@ public:
    */
   Counter_RNG2() {
     Require(sizeof(data) == sizeof(ctr_type) + sizeof(key_type));
-    for(size_t i = 0; i < CBRNG_DATA_SIZE; ++i){
+    for (size_t i = 0; i < CBRNG_DATA_SIZE; ++i) {
       data[i] = 0;
     }
   }
@@ -343,7 +341,7 @@ public:
   //! Construct a Counter_RNG2 using a seed and stream number.
   Counter_RNG2(const uint32_t seed, const uint64_t streamnum,
                uint64_t const timestep) {
-    for(size_t i = 0; i < CBRNG_DATA_SIZE; ++i){
+    for (size_t i = 0; i < CBRNG_DATA_SIZE; ++i) {
       data[i] = 0;
     }
     initialize(seed, streamnum, timestep);
@@ -360,7 +358,7 @@ public:
 
   //! Return a random double in the interval (0, 1).
   double ran() const {
-    if(get_step_counter() == max_steps){
+    if (get_step_counter() == max_steps) {
       passed_max_ = true;
     }
     return ran_impl(data);
@@ -368,7 +366,7 @@ public:
 
   //! Spawn a new, independent generator from this one.
   void spawn(Counter_RNG2 &new_gen, uint32_t const child_idx) const {
-    new_gen._spawn(data,child_idx);
+    new_gen._spawn(data, child_idx);
   }
 
   //! Return a unique identifier for this generator.
@@ -400,9 +398,7 @@ public:
   size_t size_bytes() const { return sizeof(data); }
 
   //! Has this counter passed the maximum number of steps?
-  bool passed_max() const {
-    return passed_max_;
-  }
+  bool passed_max() const { return passed_max_; }
 
   /* Field guide to layout of bits and elements in 'data' array
    *          | data[1]| data[0] |
@@ -419,7 +415,7 @@ public:
   */
 
   //! set the seed
-  void set_seed(uint32_t const s){
+  void set_seed(uint32_t const s) {
     uint64_t tmp = data[2];
     tmp = tmp & ~SEED_MASK;
     data[2] = tmp | static_cast<uint64_t>(s);
@@ -433,13 +429,13 @@ public:
   }
 
   //! set stream number
-  void set_stream_number(uint64_t const n){
+  void set_stream_number(uint64_t const n) {
     data[1] = n;
     return;
   }
 
   //! set spawn id
-  void set_spawn_id(uint32_t const i){
+  void set_spawn_id(uint32_t const i) {
     uint64_t tmp = data[0];
     // clear out any existing data, preserving the counter data
     tmp = tmp & ~SPAWN_MASK;
@@ -447,7 +443,7 @@ public:
   }
 
   //! set the step counter
-  void set_step_counter(uint32_t const c){
+  void set_step_counter(uint32_t const c) {
     uint64_t tmp = data[0];
     tmp = tmp & ~STEP_MASK;
     data[0] = tmp | static_cast<uint64_t>(c);
@@ -469,9 +465,7 @@ public:
   //! get the spawn id
   uint32_t get_spawn_id() const { return get_spawn_id_impl(data); }
 
-  bool can_spawn() const {
-    return can_spawn_impl(data);
-  }
+  bool can_spawn() const { return can_spawn_impl(data); }
 
   /**\brief Can this generator support spawning children? */
   // static bool can_spawn(ctr_type::value_type const *const rng_data) {
@@ -484,7 +478,6 @@ public:
   static constexpr uint32_t max_children_per_gen() { return 255; }
 
 private:
-
   mutable ctr_type::value_type data[CBRNG_DATA_SIZE];
 
   mutable bool passed_max_ = false;
@@ -514,7 +507,7 @@ private:
 //! Spawn a new, independent generator from this reference.
 inline void Counter_RNG2_Ref::spawn(Counter_RNG2 &new_gen,
                                     uint32_t child_idx) const {
-  new_gen._spawn(data.access(),child_idx);
+  new_gen._spawn(data.access(), child_idx);
 }
 
 //---------------------------------------------------------------------------//
@@ -530,8 +523,8 @@ inline void Counter_RNG2::initialize(const uint32_t seed,
                                      const uint64_t streamnum,
                                      const uint64_t timestep) {
   // If data[] is not an array of uint64_t, then this is likely broken!
-  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
-    "Expected the ctr_type::value_type to be 64b unsigned int");
+  static_assert(std::is_same<ctr_type::value_type, uint64_t>::value,
+                "Expected the ctr_type::value_type to be 64b unsigned int");
 
   set_step_counter(0);
 
@@ -576,7 +569,7 @@ inline void Counter_RNG2::_spawn(ctr_type::value_type const *const parent_data,
   uint32_t const parent_gen = get_spawn_gen_impl(parent_data);
   /* parent gen will not be greater than 3. Therefore, idx will be shifted
    * left at most 24b. */
-  for(uint32_t i = 0; i < parent_gen; ++i){
+  for (uint32_t i = 0; i < parent_gen; ++i) {
     idx = idx << 8;
   }
   uint32_t const this_sid = parent_sid | idx;

--- a/src/rng/Counter_RNG2.hh
+++ b/src/rng/Counter_RNG2.hh
@@ -562,7 +562,7 @@ inline void Counter_RNG2::initialize(const uint32_t seed,
  */
 inline void Counter_RNG2::_spawn(ctr_type::value_type const *const parent_data,
                                  uint32_t idx) {
-  Require(Counter_RNG2::can_spawn(parent_data));
+  Require(can_spawn_impl(parent_data));
   Require(idx > 0);
   Require(idx <= Counter_RNG2::max_children_per_gen());
   // Initialize this generator with the seed and stream number from the parent.

--- a/src/rng/Counter_RNG2.hh
+++ b/src/rng/Counter_RNG2.hh
@@ -174,7 +174,7 @@ namespace // anonymous
  * version of the RNG seed, stream number, and spawn indicator and then returns
  * the lower 64 bits of the result.
  */
-static inline uint64_t _get_unique_num(const ctr_type::value_type *const data) {
+static inline uint64_t get_unique_num_impl(const ctr_type::value_type *const data) {
   CBRNG hash;
   uint64_t const sp64 = static_cast<uint64_t>(get_spawn_id_impl(data));
   const ctr_type ctr = {{data[1], sp64}};
@@ -199,7 +199,7 @@ inline uint64_t increment_CBRNG2_step_counter( uint64_t in){
  * Given a pointer to RNG state data, this function returns a random double in
  * the open interval (0, 1)---i.e., excluding the endpoints.
  */
-static inline double _ran(ctr_type::value_type *const data) {
+static inline double ran_impl(ctr_type::value_type *const data) {
   CBRNG rng;
 
   // Assemble a counter from the first two elements in data.
@@ -247,7 +247,7 @@ public:
   }
 
   //! Return a random double in the open interval (0, 1).
-  double ran() const { return _ran(data.access()); }
+  double ran() const { return ran_impl(data.access()); }
 
   //! Spawn a new, independent generator from this reference.
   inline void spawn(Counter_RNG2 &new_gen, uint32_t const child_idx) const;
@@ -258,7 +258,7 @@ public:
   }
 
   //! Return a unique identifier for this generator.
-  uint64_t get_unique_num() const { return _get_unique_num(data.access()); }
+  uint64_t get_unique_num() const { return get_unique_num_impl(data.access()); }
 
   //! Is this Counter_RNG2_Ref a reference to rng?
   inline bool is_alias_for(Counter_RNG2 const &rng) const;
@@ -363,7 +363,7 @@ public:
     if(get_step_counter() == max_steps){
       passed_max_ = true;
     }
-    return _ran(data);
+    return ran_impl(data);
   }
 
   //! Spawn a new, independent generator from this one.
@@ -372,7 +372,7 @@ public:
   }
 
   //! Return a unique identifier for this generator.
-  uint64_t get_unique_num() const { return _get_unique_num(data); }
+  uint64_t get_unique_num() const { return get_unique_num_impl(data); }
 
   //! Return an iterator to the beginning of the state block.
   const_iterator begin() const { return data; }

--- a/src/rng/Counter_RNG2.hh
+++ b/src/rng/Counter_RNG2.hh
@@ -1,0 +1,594 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   rng/Counter_RNG2.hh
+ * \brief  (Re)Declaration of class Counter_RNG2.
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved */
+//---------------------------------------------------------------------------//
+
+#ifndef Counter_RNG2_hh
+#define Counter_RNG2_hh
+
+#include "rng/config.h"
+
+#ifdef _MSC_FULL_VER
+// Engines have multiple copy constructors, quite legal C++, disable MSVC
+// complaint.
+#pragma warning(disable : 4521)
+#endif
+
+#if defined(__ICC)
+// Suppress Intel's "unrecognized preprocessor directive" warning, triggered by
+// use of #warning in Random123/features/sse.h.
+#pragma warning disable 11
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+
+/*
+#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+// Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
+// "unused local typedef" warning, from a pre-C++11 implementation of a static
+// assertion in compilerfeatures.h.
+*/
+#pragma GCC diagnostic push
+#if (RNG_GNUC_VERSION >= 70000)
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+#endif
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexpansion-to-defined"
+#endif
+
+#include "Random123/threefry.h"
+#include "uniform.hpp"
+
+#ifdef __clang__
+// Restore clang diagnostics to previous state.
+#pragma clang diagnostic pop
+#endif
+
+/* #if (RNG_GNUC_VERSION >= 40600) */
+#if defined(__GNUC__) && !defined(__clang__)
+/* && (RNG_GNUC_VERSION >= 70000) */
+// Restore GCC diagnostics to previous state.
+#pragma GCC diagnostic pop
+#endif
+
+#include "ds++/Data_Table.hh"
+#include <algorithm>
+#include <limits>
+#include <type_traits>
+
+namespace rtt_rng {
+
+// Forward declaration.
+class Counter_RNG2;
+
+// Select a particular counter-based random number generator from Random123.
+typedef r123::Threefry2x64 CBRNG;
+
+// Counter and key types.
+typedef CBRNG::ctr_type ctr_type;
+typedef CBRNG::key_type key_type;
+
+#define CBRNG_DATA_SIZE 4
+
+// These implementation details get moved out here because of the
+// circularity of Counter_RNG2_Ref and Counter_RNG2. Once the former is
+// eliminated, these masks and getters will move back into Counter_RNG2.
+static const uint64_t SEED_MASK = 0x00000000FFFFFFFF;
+
+static const uint64_t STEP_MASK = 0x00000000FFFFFFFF;
+
+static const uint64_t SPAWN_MASK = ~STEP_MASK;
+
+constexpr uint32_t max_gens() { return 4; }
+
+/* These getter functions control the indexing of the RNG's data array.
+ * Stateless functions permit calling them on an RNG's data, instead of the
+ * RNG object itself. Why was that a good idea? Because it allowed one
+ * to spawn from an RNG_Ref or from an RNG. This is a component of the
+ * NR system. It should go away when NR is retired.
+ */
+uint32_t get_seed_impl(ctr_type::value_type const *const rng_data) {
+  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
+    "Implementation relies on known integer size!");
+  uint64_t const val64 = rng_data[2] & SEED_MASK;
+  return static_cast<uint32_t>(val64);
+}
+
+uint32_t get_step_counter_impl(ctr_type::value_type const *const rng_data) {
+  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
+    "Implementation relies on known integer size!");
+  uint64_t const val64 = rng_data[0] & STEP_MASK;
+  return static_cast<uint32_t>(val64);
+}
+
+uint64_t get_time_step_impl(ctr_type::value_type const *const rng_data) {
+  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
+    "Implementation relies on known integer size!");
+  return rng_data[3];
+}
+
+uint64_t get_stream_number_impl(ctr_type::value_type const *const rng_data) {
+  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
+    "Implementation relies on known integer size!");
+  return rng_data[1];
+}
+
+uint32_t get_spawn_id_impl(ctr_type::value_type const *const rng_data) {
+  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
+    "Implementation relies on known integer size!");
+  uint64_t const val64 = rng_data[0] & SPAWN_MASK;
+  return static_cast<uint32_t>(val64 >> 32);
+}
+
+/**\brief get the RNG's spawn generation. 0 means this generator is
+ * 'original' (no parents), 1 -> 1 parent gen, 2 -> 2 parent gens etc.
+ */
+uint32_t get_spawn_gen_impl(ctr_type::value_type const *const rng_data) {
+  uint32_t const sid = get_spawn_id_impl(rng_data);
+  if(0 == sid){
+    return 0;
+  }
+  if(0xFF >= sid){
+    return 1;
+  }
+  if(0xFFFF >= sid){
+    return 2;
+  }
+  if(0xFFFFFF >= sid){
+    return 3;
+  }
+  return 4;
+}
+
+/**\brier Can a generator spawn? */
+bool can_spawn_impl(ctr_type::value_type const *const rng_data){
+  uint32_t const spawn_gen = get_spawn_gen_impl(rng_data);
+  uint32_t const max_gen = max_gens();
+  return spawn_gen < max_gen;
+}
+
+namespace // anonymous
+{
+
+//---------------------------------------------------------------------------//
+/*! \brief Generate a nearly-unique identifier.
+ *
+ * Given a pointer to RNG state data, this function generates a 64-bit
+ * identifier unique to this generator but not to the specific position of its
+ * RNG stream.  In other words, the identifier associated with a given generator
+ * will not change as random numbers are generated from it.  However, this
+ * insensitivity to the specific stream position also means that repeated
+ * spawning will eventually produce two generators with the same identifier.
+ *
+ * This function simply applies the chosen counter-based RNG to a shuffled
+ * version of the RNG seed, stream number, and spawn indicator and then returns
+ * the lower 64 bits of the result.
+ */
+static inline uint64_t _get_unique_num(const ctr_type::value_type *const data) {
+  CBRNG hash;
+  uint64_t const sp64 = static_cast<uint64_t>(get_spawn_id_impl(data));
+  const ctr_type ctr = {{data[1], sp64}};
+  const key_type key = {{data[3], data[2]}};
+  const ctr_type result = hash(ctr, key);
+  return result[0];
+}
+
+//---------------------------------------------------------------------------//
+/*! \brief Increment the counter, rolling over after 32b exhausted. */
+inline uint64_t increment_CBRNG2_step_counter( uint64_t in){
+  uint64_t spawn64 = in & (~STEP_MASK);
+  uint64_t const ctr = in & STEP_MASK;
+  uint64_t const new_ctr = ctr + 1;
+  return spawn64 | (new_ctr & STEP_MASK);
+}
+
+
+//---------------------------------------------------------------------------//
+/*! \brief Generate a random double.
+ *
+ * Given a pointer to RNG state data, this function returns a random double in
+ * the open interval (0, 1)---i.e., excluding the endpoints.
+ */
+static inline double _ran(ctr_type::value_type *const data) {
+  CBRNG rng;
+
+  // Assemble a counter from the first two elements in data.
+  ctr_type ctr = {{data[0], data[1]}};
+
+  // Assemble a key from the last two elements in data.
+  const key_type key = {{data[2], data[3]}};
+
+  // Invoke the counter-based rng.
+  const ctr_type result = rng(ctr, key);
+
+  // Increment the counter.
+  uint64_t new_ctr = increment_CBRNG2_step_counter(data[0]);
+  data[0] = new_ctr;
+
+  // Convert the first 64 bits of the RNG output into a double-precision value
+  // in the open interval (0, 1) and return it.
+  return r123::u01fixedpt<double, ctr_type::value_type>(result[0]);
+}
+
+} // namespace
+
+//===========================================================================//
+/*!
+ * \class Counter_RNG2_Ref
+ * \brief A reference to a Counter_RNG2.
+ * \deprecated{The Counter_RNG2_Ref will be removed when NR is removed.}
+ *
+ * Counter_RNG2_Ref provides an interface to a counter-based random number
+ * generator from the Random123 library from D. E. Shaw Research
+ * (http://www.deshawresearch.com/resources_random123.html).  Unlike
+ * Counter_RNG2, Counter_RNG2_Ref doesn't own its own RNG state (i.e., key and
+ * counter); instead, it operates using a data block specified during
+ * construction.
+ */
+//===========================================================================//
+class Counter_RNG2_Ref {
+public:
+  //! Constructor.  db and de specify the extents of an RNG state block.
+  Counter_RNG2_Ref(ctr_type::value_type *const db,
+                  ctr_type::value_type *const de)
+      : data(db, de) {
+    Require(std::distance(db, de) * sizeof(ctr_type::value_type) ==
+            sizeof(ctr_type) + sizeof(key_type));
+  }
+
+  //! Return a random double in the open interval (0, 1).
+  double ran() const { return _ran(data.access()); }
+
+  //! Spawn a new, independent generator from this reference.
+  inline void spawn(Counter_RNG2 &new_gen, uint32_t const child_idx) const;
+
+  //! get the stream number
+  uint64_t get_stream_number() const {
+    return get_stream_number_impl(data.access());
+  }
+
+  //! Return a unique identifier for this generator.
+  uint64_t get_unique_num() const { return _get_unique_num(data.access()); }
+
+  //! Is this Counter_RNG2_Ref a reference to rng?
+  inline bool is_alias_for(Counter_RNG2 const &rng) const;
+
+  //! Return the stream number
+  uint64_t get_num() const { return get_stream_number_impl(data.access()); }
+
+  //! Can the referred RNG spawn?
+  bool can_spawn() const {
+    return can_spawn_impl(data.access());
+  }
+
+private:
+  mutable rtt_dsxx::Data_Table<ctr_type::value_type> data;
+};
+
+//===========================================================================//
+/*!
+ * \class Counter_RNG2
+ * \brief A counter-based random-number generator.
+ *
+ * Counter_RNG2 provides an interface to a counter-based random number generator
+ * from the Random123 library from D. E. Shaw Research
+ * (http://www.deshawresearch.com/resources_random123.html).
+ *
+ * Counter_RNG2 changes how data are interpretted from the original Counter_RNG.
+ * In this version, the RNG state is interpretted as five quantities: the time
+ * step, the unique stream number, the spawn id, the user-provided seed, and
+ * the actual step counter.
+ *
+ * The 128 bits of the counter are divied between a 64b
+ * stream id, a 32b counter, and a 32b spawn id. The key consists of time step
+ * (64b) and the random number seed (32b). The last 32b, er, reserved for future
+ * use. The key is expected to be the same for all particles, meaning that a
+ * thrifty programmer could save 16B/particle storage.
+ *
+ *  Counter |________|____|____|
+ *            strm #   spwn ctr
+ *
+ *  Key |________|____|____|
+ *       time stp| res|seed|
+ *
+ * Spawning is limited to four generations maximum, with each generation
+ * admitting 256 children.
+ *
+ * Another change is the behavior on rollover. Previously, the counter had
+ * 96b of counter space for RNs. Now, the counter only has 32b.
+ *
+ * Counter_RNG2_Ref is a friend of Counter_RNG2 because spawning a new generator
+ * modifies both the parent and the child generator in ways that should not be
+ * exposed through the public interface of Counter_RNG2.
+ *
+ * Similarly, Rnd_Control is a friend of Counter_RNG2 because initializing a
+ * generator requires access to private data that should not be exposed through
+ * the public interface.  Rnd_Control takes no responsibility for instantiating
+ * Counter_RNG2s itself, and since copying Counter_RNG2s is disabled (via a
+ * private copy constructor), an Rnd_Control must be able to initialize a
+ * generator that was instantiated outside of its control.
+ */
+//===========================================================================//
+class Counter_RNG2 {
+  friend class Counter_RNG2_Ref;
+  friend class Rnd_Control;
+
+public:
+  typedef ctr_type::const_iterator const_iterator;
+
+  static constexpr uint32_t max_steps = std::numeric_limits<uint32_t>::max();
+
+  /*! \brief Default constructor.
+   *
+   * This default constructor is invoked when a client wants to create a
+   * Counter_RNG2 but delegate its initialization to an Rnd_Control object.
+   */
+  Counter_RNG2() {
+    Require(sizeof(data) == sizeof(ctr_type) + sizeof(key_type));
+    for(size_t i = 0; i < CBRNG_DATA_SIZE; ++i){
+      data[i] = 0;
+    }
+  }
+
+  //! Construct a Counter_RNG2 using a seed and stream number.
+  Counter_RNG2(const uint32_t seed, const uint64_t streamnum,
+               uint64_t const timestep) {
+    for(size_t i = 0; i < CBRNG_DATA_SIZE; ++i){
+      data[i] = 0;
+    }
+    initialize(seed, streamnum, timestep);
+  }
+
+  //! Create a new Counter_RNG2 from data.
+  Counter_RNG2(const ctr_type::value_type *const begin,
+               const ctr_type::value_type *const end) {
+    Require(std::distance(begin, end) * sizeof(ctr_type::value_type) ==
+            sizeof(ctr_type) + sizeof(key_type));
+
+    std::copy(begin, end, data);
+  }
+
+  //! Return a random double in the interval (0, 1).
+  double ran() const {
+    if(get_step_counter() == max_steps){
+      passed_max_ = true;
+    }
+    return _ran(data);
+  }
+
+  //! Spawn a new, independent generator from this one.
+  void spawn(Counter_RNG2 &new_gen, uint32_t const child_idx) const {
+    new_gen._spawn(data,child_idx);
+  }
+
+  //! Return a unique identifier for this generator.
+  uint64_t get_unique_num() const { return _get_unique_num(data); }
+
+  //! Return an iterator to the beginning of the state block.
+  const_iterator begin() const { return data; }
+
+  //! Return an iterator to the end of the state block.
+  const_iterator end() const { return data + size(); }
+
+  //! Test for equality.
+  bool operator==(Counter_RNG2 const &rhs) const {
+    return std::equal(begin(), end(), rhs.begin());
+  }
+
+  //! Test for inequality.
+  bool operator!=(Counter_RNG2 const &rhs) const {
+    return !std::equal(begin(), end(), rhs.begin());
+  }
+
+  //! Return a Counter_RNG2_Ref corresponding to this Counter_RNG2.
+  Counter_RNG2_Ref ref() const { return Counter_RNG2_Ref(data, data + size()); }
+
+  //! Return the size of this Counter_RNG2.
+  size_t size() const { return size_bytes() / sizeof(ctr_type::value_type); }
+
+  //! Return the size of this Counter_RNG2 in bytes.
+  size_t size_bytes() const { return sizeof(data); }
+
+  //! Has this counter passed the maximum number of steps?
+  bool passed_max() const {
+    return passed_max_;
+  }
+
+  /* Field guide to layout of bits and elements in 'data' array
+   *          | data[1]| data[0] |
+   *
+   *  Counter |________|____|____|
+   *            strm #   spwn ctr
+   *
+   *      | data[3]| data[2] |
+   *
+   *  Key |________|____|____|
+   *       time stp| res|seed|
+   *                 erv
+   *                 ed
+  */
+
+  //! set the seed
+  void set_seed(uint32_t const s){
+    uint64_t tmp = data[2];
+    tmp = tmp & ~SEED_MASK;
+    data[2] = tmp | static_cast<uint64_t>(s);
+    return;
+  }
+
+  //! set time step
+  void set_time_step(uint64_t const s) {
+    data[3] = s;
+    return;
+  }
+
+  //! set stream number
+  void set_stream_number(uint64_t const n){
+    data[1] = n;
+    return;
+  }
+
+  //! set spawn id
+  void set_spawn_id(uint32_t const i){
+    uint64_t tmp = data[0];
+    // clear out any existing data, preserving the counter data
+    tmp = tmp & ~SPAWN_MASK;
+    data[0] = tmp | (static_cast<uint64_t>(i) << 32);
+  }
+
+  //! set the step counter
+  void set_step_counter(uint32_t const c){
+    uint64_t tmp = data[0];
+    tmp = tmp & ~STEP_MASK;
+    data[0] = tmp | static_cast<uint64_t>(c);
+    return;
+  }
+
+  //! get the seed
+  uint32_t get_seed() const { return get_seed_impl(data); }
+
+  //! get step counter
+  uint32_t get_step_counter() const { return get_step_counter_impl(data); }
+
+  //! get time step
+  uint64_t get_time_step() const { return get_time_step_impl(data); }
+
+  //! get stream number
+  uint64_t get_stream_number() const { return get_stream_number_impl(data); }
+
+  //! get the spawn id
+  uint32_t get_spawn_id() const { return get_spawn_id_impl(data); }
+
+  bool can_spawn() const {
+    return can_spawn_impl(data);
+  }
+
+  /**\brief Can this generator support spawning children? */
+  // static bool can_spawn(ctr_type::value_type const *const rng_data) {
+  //   // uint32_t const spawn_gen = get_spawn_gen_impl(rng_data);
+  //   // uint32_t const max_gen = max_gens();
+  //   // return spawn_gen < max_gen;
+  //   return can_spawn_impl(rng_data);
+  // }
+
+  static constexpr uint32_t max_children_per_gen() { return 255; }
+
+private:
+
+  mutable ctr_type::value_type data[CBRNG_DATA_SIZE];
+
+  mutable bool passed_max_ = false;
+
+  //! Private copy constructor.
+  Counter_RNG2(const Counter_RNG2 &);
+
+  //! Private assignment operator.
+  Counter_RNG2 &operator=(const Counter_RNG2 &);
+
+  // private interface functions
+
+  //! Initialize internal state from a seed and stream number.
+  inline void initialize(const uint32_t seed, const uint64_t streamnum,
+                         const uint64_t timestep);
+
+  //! Spawn a new, independent generator from the provided state block.
+  inline void _spawn(ctr_type::value_type const *const parent_data,
+                     uint32_t const child_idx);
+
+}; // class Counter_RNG2
+
+//---------------------------------------------------------------------------//
+// Implementation
+//---------------------------------------------------------------------------//
+
+//! Spawn a new, independent generator from this reference.
+inline void Counter_RNG2_Ref::spawn(Counter_RNG2 &new_gen,
+                                    uint32_t child_idx) const {
+  new_gen._spawn(data.access(),child_idx);
+}
+
+//---------------------------------------------------------------------------//
+//! Is this Counter_RNG2_Ref a reference to rng?
+inline bool Counter_RNG2_Ref::is_alias_for(Counter_RNG2 const &rng) const {
+  return rng.begin() == data.access();
+}
+
+//---------------------------------------------------------------------------//
+//! \brief Initialize internal state from a seed, stream number, and time step.
+//! \remark This should not be used in spawning!
+inline void Counter_RNG2::initialize(const uint32_t seed,
+                                     const uint64_t streamnum,
+                                     const uint64_t timestep) {
+  // If data[] is not an array of uint64_t, then this is likely broken!
+  static_assert(std::is_same<ctr_type::value_type,uint64_t>::value,
+    "Expected the ctr_type::value_type to be 64b unsigned int");
+
+  set_step_counter(0);
+
+  set_stream_number(streamnum);
+
+  set_seed(seed);
+
+  set_time_step(timestep);
+}
+
+//---------------------------------------------------------------------------//
+/*! \brief Initialize this RNG's state by spawning from the provided parent
+ * state block.
+ *
+ * \param parent_data: the data from the parent RNG.
+ * \param idx: new child index, in the range [1,max_children_per_gen].
+ *
+ * \remark Check can_spawn() before spawning to ensure this generator is not
+ * final generation.
+ *
+ * \remark Caller must provide an index of the child RNG.
+ *
+ * The child's spawn id, part of its RNG counter, is formed by ORing the
+ * parent's id with a modifed version of the provided index. The provided
+ * index is shifted left to move it one generation (8b) past the parent's gen.
+ * The result is that the child will not conflict with any of the parent's
+ * siblings.
+ */
+inline void Counter_RNG2::_spawn(ctr_type::value_type const *const parent_data,
+                                 uint32_t idx) {
+  Require(Counter_RNG2::can_spawn(parent_data));
+  Require(idx > 0);
+  Require(idx <= Counter_RNG2::max_children_per_gen());
+  // Initialize this generator with the seed and stream number from the parent.
+  uint32_t const seed = get_seed_impl(parent_data);
+  uint64_t const streamnum = get_stream_number_impl(parent_data);
+  uint64_t const time_step = get_time_step_impl(parent_data);
+
+  this->initialize(seed, streamnum, time_step);
+
+  uint32_t const parent_sid = get_spawn_id_impl(parent_data);
+  uint32_t const parent_gen = get_spawn_gen_impl(parent_data);
+  /* parent gen will not be greater than 3. Therefore, idx will be shifted
+   * left at most 24b. */
+  for(uint32_t i = 0; i < parent_gen; ++i){
+    idx = idx << 8;
+  }
+  uint32_t const this_sid = parent_sid | idx;
+  Check(this_sid > parent_sid);
+  set_spawn_id(this_sid);
+  return;
+} // Counter_RNG2::_spawn(
+
+} // end namespace rtt_rng
+
+#endif
+
+//---------------------------------------------------------------------------//
+// end Counter_RNG2.hh
+//---------------------------------------------------------------------------//

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set( test_sources
    ${PROJECT_SOURCE_DIR}/tstRnd_Control_Inline.cc
    ${PROJECT_SOURCE_DIR}/tstSubrandom_Sequence.cc
    ${PROJECT_SOURCE_DIR}/tstCounter_RNG.cc
+   ${PROJECT_SOURCE_DIR}/tstCounter_RNG2.cc
 )
 
 # Random123 unit tests (these tests have special PASS/FAIL REGEX conditions)

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set( test_sources
    ${PROJECT_SOURCE_DIR}/tstSubrandom_Sequence.cc
    ${PROJECT_SOURCE_DIR}/tstCounter_RNG.cc
    ${PROJECT_SOURCE_DIR}/tstCounter_RNG2.cc
+   ${PROJECT_SOURCE_DIR}/compare_RNG1_RNG2.cc
 )
 
 # Random123 unit tests (these tests have special PASS/FAIL REGEX conditions)
@@ -46,7 +47,7 @@ set( random123_known_answer_tests
 
 add_scalar_tests(
    SOURCES "${test_sources}"
-   DEPS    "Lib_rng" )
+   DEPS    "Lib_c4;Lib_rng" )
 
 add_scalar_tests(
    SOURCES    "${random123_unit_tests}"

--- a/src/rng/test/compare_RNG1_RNG2.cc
+++ b/src/rng/test/compare_RNG1_RNG2.cc
@@ -1,0 +1,103 @@
+// compare_RNG1_RNG2.cc
+// T. M. Kelley
+// Aug 15, 2018
+// (c) Copyright 2018 LANSLLC, all rights reserved
+
+#include "c4/Timer.hh"
+#include "rng/Counter_RNG.hh"
+#include "rng/Counter_RNG2.hh"
+#include <vector>
+
+#define NUM_ELEMS 1000000
+
+double out_1[NUM_ELEMS];
+double out_2[NUM_ELEMS];
+
+uint64_t const time_step = 18436;
+uint64_t const seed = 0xFEED;
+uint64_t const stream_num = 30001;
+
+using namespace rtt_rng;
+
+void run_rng_1(){
+  uint64_t data[4];
+  data[0] = 0;
+  data[1] = stream_num;
+  data[2] = seed;
+  data[3] = time_step;
+  Counter_RNG rng(data, data+4);
+  rtt_c4::Timer timer;
+  timer.start();
+  for(size_t i = 0; i < NUM_ELEMS; ++i){
+    out_1[i] = rng.ran();
+  }
+  timer.stop();
+  std::cout << "RNG 1: Generating " << NUM_ELEMS << " randoms took "
+    << timer.wall_clock() << " seconds.\n";
+  return;
+}
+
+void run_rng_2(){
+  Counter_RNG2 rng(seed, stream_num, time_step);
+  rtt_c4::Timer timer;
+  timer.start();
+  for(size_t i = 0; i < NUM_ELEMS; ++i){
+    out_2[i] = rng.ran();
+  }
+  timer.stop();
+  std::cout << "RNG 2: Generating " << NUM_ELEMS << " randoms took "
+    << timer.wall_clock() << " seconds.\n";
+  return;
+}
+
+void compare_rngs(){
+  bool ok = true;
+  size_t num_fails = 0;
+  constexpr size_t max_fails = 10;
+  size_t fails[max_fails];
+  // zero fails array
+  for(size_t i = 0; i < max_fails; ++i){
+    fails[i] = 0;
+  }
+  for(size_t i = 0; i < NUM_ELEMS; ++i){
+    bool this_ok = (out_1 == out_2);
+    if(!this_ok){
+      if(num_fails < max_fails){
+        fails[num_fails] = i;
+      }
+      num_fails++;
+    }
+    this_ok = ok && this_ok;
+  }
+  if(!ok){
+    std::cout << "Arrays were not the same, at least " << num_fails
+      << " failed to matchl eading indices: \n";
+    for(size_t i = 0; i < NUM_ELEMS; ++i){
+      std::cout << fails[i] << "; ";
+      std::cout << "\n";
+    }
+
+  }
+  else{
+    std::cout << "Arrays agreed\n";
+  }
+  return;
+}
+
+void init_arrays(){
+  for(size_t i = 0; i < NUM_ELEMS; ++i){
+    out_1[i] = 0.0;
+    out_2[i] = 0.0;
+  }
+  return;
+}
+
+int main(){
+  init_arrays();
+  run_rng_1();
+  run_rng_2();
+  compare_rngs();
+  return 0;
+}
+
+// End of file

--- a/src/rng/test/compare_RNG1_RNG2.cc
+++ b/src/rng/test/compare_RNG1_RNG2.cc
@@ -4,6 +4,8 @@
 // (c) Copyright 2018 LANSLLC, all rights reserved
 
 #include "c4/Timer.hh"
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
 #include "rng/Counter_RNG.hh"
 #include "rng/Counter_RNG2.hh"
 #include <vector>
@@ -50,7 +52,7 @@ void run_rng_2(){
   return;
 }
 
-void compare_rngs(){
+void compare_rngs(rtt_dsxx::UnitTest &ut){
   bool ok = true;
   size_t num_fails = 0;
   constexpr size_t max_fails = 10;
@@ -81,6 +83,10 @@ void compare_rngs(){
   else{
     std::cout << "Arrays agreed\n";
   }
+  if (ut.numFails == 0){
+    PASSMSG("compare old & new RNGs passed");
+  }
+
   return;
 }
 
@@ -92,11 +98,15 @@ void init_arrays(){
   return;
 }
 
-int main(){
-  init_arrays();
-  run_rng_1();
-  run_rng_2();
-  compare_rngs();
+int main(int argc, char **argv){
+  rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
+  try{
+    init_arrays();
+    run_rng_1();
+    run_rng_2();
+    compare_rngs(ut);
+  }
+  UT_EPILOG(ut);
   return 0;
 }
 

--- a/src/rng/test/compare_RNG1_RNG2.cc
+++ b/src/rng/test/compare_RNG1_RNG2.cc
@@ -21,86 +21,85 @@ uint64_t const stream_num = 30001;
 
 using namespace rtt_rng;
 
-void run_rng_1(){
+void run_rng_1() {
   uint64_t data[4];
   data[0] = 0;
   data[1] = stream_num;
   data[2] = seed;
   data[3] = time_step;
-  Counter_RNG rng(data, data+4);
+  Counter_RNG rng(data, data + 4);
   rtt_c4::Timer timer;
   timer.start();
-  for(size_t i = 0; i < NUM_ELEMS; ++i){
+  for (size_t i = 0; i < NUM_ELEMS; ++i) {
     out_1[i] = rng.ran();
   }
   timer.stop();
   std::cout << "RNG 1: Generating " << NUM_ELEMS << " randoms took "
-    << timer.wall_clock() << " seconds.\n";
+            << timer.wall_clock() << " seconds.\n";
   return;
 }
 
-void run_rng_2(){
+void run_rng_2() {
   Counter_RNG2 rng(seed, stream_num, time_step);
   rtt_c4::Timer timer;
   timer.start();
-  for(size_t i = 0; i < NUM_ELEMS; ++i){
+  for (size_t i = 0; i < NUM_ELEMS; ++i) {
     out_2[i] = rng.ran();
   }
   timer.stop();
   std::cout << "RNG 2: Generating " << NUM_ELEMS << " randoms took "
-    << timer.wall_clock() << " seconds.\n";
+            << timer.wall_clock() << " seconds.\n";
   return;
 }
 
-void compare_rngs(rtt_dsxx::UnitTest &ut){
+void compare_rngs(rtt_dsxx::UnitTest &ut) {
   bool ok = true;
   size_t num_fails = 0;
   constexpr size_t max_fails = 10;
   size_t fails[max_fails];
   // zero fails array
-  for(size_t i = 0; i < max_fails; ++i){
+  for (size_t i = 0; i < max_fails; ++i) {
     fails[i] = 0;
   }
-  for(size_t i = 0; i < NUM_ELEMS; ++i){
+  for (size_t i = 0; i < NUM_ELEMS; ++i) {
     bool this_ok = (out_1 == out_2);
-    if(!this_ok){
-      if(num_fails < max_fails){
+    if (!this_ok) {
+      if (num_fails < max_fails) {
         fails[num_fails] = i;
       }
       num_fails++;
     }
     this_ok = ok && this_ok;
   }
-  if(!ok){
+  if (!ok) {
     std::cout << "Arrays were not the same, at least " << num_fails
-      << " failed to matchl eading indices: \n";
-    for(size_t i = 0; i < NUM_ELEMS; ++i){
+              << " failed to matchl eading indices: \n";
+    for (size_t i = 0; i < NUM_ELEMS; ++i) {
       std::cout << fails[i] << "; ";
       std::cout << "\n";
     }
 
-  }
-  else{
+  } else {
     std::cout << "Arrays agreed\n";
   }
-  if (ut.numFails == 0){
+  if (ut.numFails == 0) {
     PASSMSG("compare old & new RNGs passed");
   }
 
   return;
 }
 
-void init_arrays(){
-  for(size_t i = 0; i < NUM_ELEMS; ++i){
+void init_arrays() {
+  for (size_t i = 0; i < NUM_ELEMS; ++i) {
     out_1[i] = 0.0;
     out_2[i] = 0.0;
   }
   return;
 }
 
-int main(int argc, char **argv){
+int main(int argc, char **argv) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
-  try{
+  try {
     init_arrays();
     run_rng_1();
     run_rng_2();

--- a/src/rng/test/tstCounter_RNG2.cc
+++ b/src/rng/test/tstCounter_RNG2.cc
@@ -1,0 +1,818 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   rng/test/tstCounter_RNG2.cc
+ * \author Peter Ahrens
+ * \date   Fri Aug 3 16:53:23 2012
+ * \brief  Counter_RNG2 tests.
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "rng/Counter_RNG2.hh"
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include "ds++/Soft_Equivalence.hh"
+#include <set>
+
+using namespace std;
+using namespace rtt_dsxx;
+using namespace rtt_rng;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+/* I've included some test of getters and setters since they're not trivial. */
+void test_set_get_seed(UnitTest &ut){
+  uint32_t seed = 1;
+  uint64_t const streamnum = 2;
+  uint64_t const time_step = 349;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  rng.ran();
+  rng.ran();
+  rng.ran();
+
+  rng.set_seed(42);
+  FAIL_IF_NOT(42 == rng.get_seed());
+  FAIL_IF_NOT(3 == rng.get_step_counter());
+  FAIL_IF_NOT(time_step == rng.get_time_step());
+  FAIL_IF_NOT(streamnum == rng.get_stream_number());
+  FAIL_IF_NOT(0 == rng.get_spawn_id());
+
+  if (ut.numFails == 0)
+    PASSMSG("test_set_get_seed passed");
+} // test_set_get_seed
+
+void test_set_get_step_counter(UnitTest &ut){
+  uint32_t const seed = 1;
+  uint64_t const streamnum = 2;
+  uint64_t const time_step = 349;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  rng.ran();
+  rng.ran();
+  rng.ran();
+
+  rng.set_step_counter(42);
+  FAIL_IF_NOT(seed == rng.get_seed());
+  FAIL_IF_NOT(42 == rng.get_step_counter());
+  FAIL_IF_NOT(time_step == rng.get_time_step());
+  FAIL_IF_NOT(streamnum == rng.get_stream_number());
+  FAIL_IF_NOT(0 == rng.get_spawn_id());
+
+  if (ut.numFails == 0)
+    PASSMSG("test_set_get_step_counter passed");
+} // test_set_get_step_counter
+
+void test_set_get_time_step(UnitTest &ut){
+  uint32_t const seed = 1;
+  uint64_t const streamnum = 2;
+  uint64_t time_step = 349;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  rng.ran();
+  rng.ran();
+  rng.ran();
+
+  rng.set_time_step(1000000);
+  FAIL_IF_NOT(seed == rng.get_seed());
+  FAIL_IF_NOT(3 == rng.get_step_counter());
+  FAIL_IF_NOT(1000000 == rng.get_time_step());
+  FAIL_IF_NOT(streamnum == rng.get_stream_number());
+  FAIL_IF_NOT(0 == rng.get_spawn_id());
+
+  if (ut.numFails == 0)
+    PASSMSG("test_set_get_time_step passed");
+} // test_set_get_time_step
+
+void test_set_get_stream_number(UnitTest &ut){
+  uint32_t const seed = 1;
+  uint64_t streamnum = 2;
+  uint64_t const time_step = 349;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  rng.ran();
+  rng.ran();
+  rng.ran();
+
+  rng.set_stream_number(1000000);
+  FAIL_IF_NOT(seed == rng.get_seed());
+  FAIL_IF_NOT(3 == rng.get_step_counter());
+  FAIL_IF_NOT(time_step == rng.get_time_step());
+  FAIL_IF_NOT(1000000 == rng.get_stream_number());
+  FAIL_IF_NOT(0 == rng.get_spawn_id());
+
+  if (ut.numFails == 0)
+    PASSMSG("test_set_get_stream_number passed");
+} // test_set_get_stream_number
+
+void test_set_get_spawn_id(UnitTest &ut){
+  uint32_t const seed = 1;
+  uint64_t const streamnum = 2;
+  uint64_t const time_step = 349;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  rng.ran();
+  rng.ran();
+  rng.ran();
+
+  rng.set_spawn_id(1000000);
+  FAIL_IF_NOT(seed == rng.get_seed());
+  FAIL_IF_NOT(3 == rng.get_step_counter());
+  FAIL_IF_NOT(time_step == rng.get_time_step());
+  FAIL_IF_NOT(streamnum == rng.get_stream_number());
+  FAIL_IF_NOT(1000000 == rng.get_spawn_id());
+
+  if (ut.numFails == 0)
+    PASSMSG("test_set_get_spawn_id passed");
+} // test_set_get_spawn_id
+
+void test_increment_CBRNG2_step_counter(UnitTest &ut){
+  uint64_t const ctr1 = 0xFFFFFFFF00000000;
+  uint64_t const inc1 = increment_CBRNG2_step_counter(ctr1);
+  FAIL_IF_NOT(inc1 == ctr1 + 1);
+  uint64_t const ctr2 = 0xFFFFFFFFFFFFFFFF;
+  uint64_t const inc2 = increment_CBRNG2_step_counter(ctr2);
+  FAIL_IF_NOT(inc2 == ctr1);
+  if (ut.numFails == 0)
+    PASSMSG("test_increment_CBRNG2_step_counter passed");
+}
+
+void test_equality(UnitTest &ut) {
+  // Create a Counter_RNG2 by specifying a seed and stream number.
+  uint32_t seed = 1;
+  uint64_t streamnum = 2;
+  uint64_t time_step = 349;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  if (rng.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng.size() != CBRNG_DATA_SIZE)
+    ITFAILS;
+  if (rng.size_bytes() != CBRNG_DATA_SIZE * sizeof(uint64_t))
+    ITFAILS;
+  if (rng != rng)
+    ITFAILS;
+
+  // Create another Counter_RNG2 with a different seed.
+  seed = 2;
+  Counter_RNG2 rng2(seed, streamnum, time_step);
+
+  // rng2's stream number should match rng's, but the two generators should not
+  // be identical.
+  if (rng2.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng2.get_stream_number() != rng.get_stream_number())
+    ITFAILS;
+  if (rng2.get_unique_num() == rng.get_unique_num())
+    ITFAILS;
+  if (rng2 == rng)
+    ITFAILS;
+  if (rng2 != rng2)
+    ITFAILS;
+
+  // Create another Counter_RNG2 with a different stream number.
+  seed = 1;
+  streamnum = 3;
+  Counter_RNG2 rng3(seed, streamnum, time_step);
+
+  // rng3 should be different from the previous two generators.
+  if (rng3.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng3.get_unique_num() == rng.get_unique_num())
+    ITFAILS;
+  if (rng3.get_unique_num() == rng2.get_unique_num())
+    ITFAILS;
+  if (rng3 == rng)
+    ITFAILS;
+  if (rng3 == rng2)
+    ITFAILS;
+  if (rng3 != rng3)
+    ITFAILS;
+
+  // Create another Counter_RNG2 with the original seed and stream number.
+  streamnum = 2;
+  Counter_RNG2 rng4(seed, streamnum, time_step);
+
+  // rng4 should be equal to rng but different from rng2 and rng3.
+  if (rng4.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng4.get_unique_num() != rng.get_unique_num())
+    ITFAILS;
+  if (rng4.get_unique_num() == rng2.get_unique_num())
+    ITFAILS;
+  if (rng4.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (rng4 != rng)
+    ITFAILS;
+  if (rng4 == rng2)
+    ITFAILS;
+  if (rng4 == rng3)
+    ITFAILS;
+  if (rng4 != rng4)
+    ITFAILS;
+
+  // Create a Counter_RNG2 from a data array.
+  vector<uint64_t> data(CBRNG_DATA_SIZE);
+  data[0] = 1234;
+  data[1] = 5678;
+  data[2] = 9012;
+  data[3] = 3456;
+  Counter_RNG2 rng5(&data[0], &data[0] + CBRNG_DATA_SIZE);
+
+  streamnum = data[1];
+  if (rng5.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng5.get_unique_num() == rng.get_unique_num())
+    ITFAILS;
+  if (rng5.get_unique_num() == rng2.get_unique_num())
+    ITFAILS;
+  if (rng5.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (rng5.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (rng5 == rng)
+    ITFAILS;
+  if (rng5 == rng2)
+    ITFAILS;
+  if (rng5 == rng3)
+    ITFAILS;
+  if (rng5 == rng4)
+    ITFAILS;
+  if (rng5 != rng5)
+    ITFAILS;
+
+  // TK: I cut a test that was based on manually manipulating the RNG
+  // state. Pls don't manually manipulate the RNG state as an array of ints.
+
+// Try to create a Counter_RNG2 from a data array that's too short.
+// 1. Only test exceptions if DbC is enabled.
+// 2. However, do not run these tests if no-throw DbC is enabled (DBC & 8)
+#ifdef REQUIRE_ON
+#if !(DBC & 8)
+  bool caught = false;
+  try {
+    Counter_RNG2 rng7(&data[0], &data[0] + CBRNG_DATA_SIZE - 1);
+  } catch (rtt_dsxx::assertion &err) {
+    cout << "Good, caught assertion: " << err.what() << endl;
+    caught = true;
+  }
+  if (!caught)
+    ITFAILS;
+#endif
+#endif
+
+  if (ut.numFails == 0)
+    PASSMSG("test_equality passed");
+}
+
+//---------------------------------------------------------------------------//
+void test_stream(UnitTest &ut) {
+  // Create two identical Counter_RNG2s.
+  uint32_t seed = 0x12121212;
+  uint64_t streamnum = 1234;
+  uint64_t time_step = 456789;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+  Counter_RNG2 rng2(seed, streamnum, time_step);
+
+  if (rng != rng2)
+    ITFAILS;
+
+  // Generate a random double (and advance the stream) from rng.
+  double x = rng.ran();
+
+  // rng and rng2 should no longer match, but their stream numbers and unique
+  // identifiers should be the same.
+  if (rng == rng2)
+    ITFAILS;
+  if (rng.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (rng.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+
+  // Generate a random double (and advance the stream) from rng2.
+  double y = rng2.ran();
+
+  // Now rng and rng2 should match again, and the two generated doubles should
+  // be identical.
+  if (rng != rng2)
+    ITFAILS;
+  if (!soft_equiv(x, y))
+    ITFAILS;
+
+  // Generate another random double from rng.
+  double z = rng.ran();
+
+  // Now they should differ again.
+  if (rng == rng2)
+    ITFAILS;
+  if (rng.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (rng.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (soft_equiv(x, z))
+    ITFAILS;
+
+  // Create a Counter_RNG2 from a data array.
+  vector<uint64_t> data(CBRNG_DATA_SIZE);
+  data[0] = 0;
+  data[1] = streamnum;
+  data[2] = seed;
+  data[3] = time_step;
+  Counter_RNG2 rng3(&data[0], &data[0] + CBRNG_DATA_SIZE);
+
+  // Initially, rng3 should exactly match neither rng nor rng2, but all three
+  // should have the same stream number and "unique" identifier.
+  if (!std::equal(rng3.begin(), rng3.end(), data.begin()))
+    ITFAILS;
+  if (rng3 == rng)
+    ITFAILS;
+  if (rng3 == rng2)
+    ITFAILS;
+  if (rng3.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng3.get_unique_num() != rng.get_unique_num())
+    ITFAILS;
+  if (rng3.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+
+  // Generate a random double from rng3; it should match rng2 but not data
+  // afterward.
+  double w = rng3.ran();
+  if (rng3 == rng)
+    ITFAILS;
+  if (rng3 != rng2)
+    ITFAILS;
+  if (std::equal(rng3.begin(), rng3.end(), data.begin()))
+    ITFAILS;
+  if (rng3.get_stream_number() != streamnum)
+    ITFAILS;
+  if (rng3.get_unique_num() != rng.get_unique_num())
+    ITFAILS;
+  if (rng3.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (!soft_equiv(w, y))
+    ITFAILS;
+
+  if (ut.numFails == 0)
+    PASSMSG("test_stream passed");
+}
+
+//---------------------------------------------------------------------------//
+void test_alias(UnitTest &ut) {
+  // Create four Counter_RNG2s; rng and rng2 are identical, and rng, rng2, and
+  // rng3 have the same stream number.
+  uint64_t const streamnum = 0x20202020;
+  uint64_t const time_step = 799;
+  Counter_RNG2 rng(0x1111, streamnum, time_step);
+  Counter_RNG2 rng2(0x1111, streamnum, time_step);
+  Counter_RNG2 rng3(0x2222, streamnum, time_step);
+  Counter_RNG2 rng4(0x3333, streamnum+1, time_step);
+
+  if (rng.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (rng.get_stream_number() != rng3.get_stream_number())
+    ITFAILS;
+  if (rng.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (rng2.get_stream_number() != rng3.get_stream_number())
+    ITFAILS;
+  if (rng2.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (rng3.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (rng.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (rng.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (rng.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (rng2.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (rng2.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (rng3.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (rng != rng2)
+    ITFAILS;
+  if (rng == rng3)
+    ITFAILS;
+  if (rng == rng4)
+    ITFAILS;
+  if (rng2 == rng3)
+    ITFAILS;
+  if (rng2 == rng4)
+    ITFAILS;
+  if (rng3 == rng4)
+    ITFAILS;
+
+  // Create a Counter_RNG2_Ref from rng.
+  Counter_RNG2_Ref ref(rng.ref());
+
+  if (ref.get_stream_number() != rng.get_stream_number())
+    ITFAILS;
+  if (ref.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (ref.get_stream_number() != rng3.get_stream_number())
+    ITFAILS;
+  if (ref.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (ref.get_unique_num() != rng.get_unique_num())
+    ITFAILS;
+  if (ref.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (ref.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (ref.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (!ref.is_alias_for(rng))
+    ITFAILS;
+  if (ref.is_alias_for(rng2))
+    ITFAILS;
+  if (ref.is_alias_for(rng3))
+    ITFAILS;
+  if (ref.is_alias_for(rng4))
+    ITFAILS;
+
+  // Generate a random double (and advance the stream) from rng via ref.
+  double x = ref.ran();
+
+  if (ref.get_stream_number() != rng.get_stream_number())
+    ITFAILS;
+  if (ref.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (ref.get_stream_number() != rng3.get_stream_number())
+    ITFAILS;
+  if (ref.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (ref.get_unique_num() != rng.get_unique_num())
+    ITFAILS;
+  if (ref.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (ref.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (ref.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (!ref.is_alias_for(rng))
+    ITFAILS;
+  if (ref.is_alias_for(rng2))
+    ITFAILS;
+  if (ref.is_alias_for(rng3))
+    ITFAILS;
+  if (ref.is_alias_for(rng4))
+    ITFAILS;
+
+  // Invoking ref.ran should have altered rng; it should still have the same
+  // stream number as rng2 and rng3, but it should be identical to none of them.
+  if (rng.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (rng.get_stream_number() != rng3.get_stream_number())
+    ITFAILS;
+  if (rng.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (rng.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (rng.get_unique_num() == rng3.get_unique_num())
+    ITFAILS;
+  if (rng.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (rng == rng2)
+    ITFAILS;
+  if (rng == rng3)
+    ITFAILS;
+  if (rng == rng4)
+    ITFAILS;
+
+  // Create a bare data array that should match rng.
+  vector<uint64_t> data(CBRNG_DATA_SIZE);
+  data[0] = 1;
+  data[1] = streamnum;
+  data[2] = static_cast<uint64_t>(0x1111);
+  data[3] = time_step;
+
+  if (!std::equal(rng.begin(), rng.end(), data.begin()))
+    ITFAILS;
+
+  // Create a Counter_RNG2_Ref from a bare data array.
+  data[0] = 0;
+  data[1] = streamnum;
+  data[2] = static_cast<uint64_t>(0x2222);
+  data[3] = time_step;
+  Counter_RNG2_Ref ref2(&data[0], &data[0] + CBRNG_DATA_SIZE);
+
+  // ref2 should have the same stream number as rng, rng2, and rng3 but
+  // shouldn't be an alias for any of them.
+  if (ref2.get_stream_number() != rng.get_stream_number())
+    ITFAILS;
+  if (ref2.get_stream_number() != rng2.get_stream_number())
+    ITFAILS;
+  if (ref2.get_stream_number() != rng3.get_stream_number())
+    ITFAILS;
+  if (ref2.get_stream_number() == rng4.get_stream_number())
+    ITFAILS;
+  if (ref2.get_unique_num() == rng.get_unique_num())
+    ITFAILS;
+  if (ref2.get_unique_num() == rng2.get_unique_num())
+    ITFAILS;
+  if (ref2.get_unique_num() != rng3.get_unique_num())
+    ITFAILS;
+  if (ref2.get_unique_num() == rng4.get_unique_num())
+    ITFAILS;
+  if (ref2.is_alias_for(rng))
+    ITFAILS;
+  if (ref2.is_alias_for(rng2))
+    ITFAILS;
+  if (ref2.is_alias_for(rng3))
+    ITFAILS;
+  if (ref2.is_alias_for(rng4))
+    ITFAILS;
+
+  // Generate a random double from ref.
+  double y = ref2.ran();
+
+  // The underlying data array should have changed.
+  if (data[0] != 1)
+    ITFAILS;
+  if (data[2] != static_cast<uint64_t>(0x2222))
+    ITFAILS;
+  if (data[1] != 0x20202020)
+    ITFAILS;
+  if (data[3] != time_step)
+    ITFAILS;
+  if (soft_equiv(y, x))
+    ITFAILS;
+
+  // Generate a random double from rng3; it should match the one from ref2.
+  double z = rng3.ran();
+
+  if (!soft_equiv(z, y))
+    ITFAILS;
+  if (soft_equiv(z, x))
+    ITFAILS;
+
+// Try to create a Counter_RNG2_Ref with a data array that's too short.
+// 1. Only test exceptions if DbC is enabled.
+// 2. However, do not run these tests if no-throw DbC is enabled (DBC & 8)
+#ifdef REQUIRE_ON
+#if !(DBC & 8)
+  bool caught = false;
+  try {
+    Counter_RNG2_Ref ref3(&data[0], &data[0] + CBRNG_DATA_SIZE - 1);
+  } catch (rtt_dsxx::assertion &err) {
+    cout << "Good, caught assertion: " << err.what() << endl;
+    caught = true;
+  }
+  if (!caught)
+    ITFAILS;
+#endif
+#endif
+
+  if (ut.numFails == 0)
+    PASSMSG("test_alias passed");
+}
+
+//---------------------------------------------------------------------------//
+void test_rollover(UnitTest &ut) {
+  // Create a Counter_RNG2 with a large counter value.
+  // data[0] = fffffffd;
+  // data[1] = 1;
+  // data[2] = 0xabcd;
+  // data[3] = 0xef00;
+  Counter_RNG2 rng;
+  uint32_t const lotta_steps(0xFFFFFFFD);
+  uint32_t const seed(0xCEED);
+  uint64_t const time_step(99723);
+  uint64_t const stream_number(0xC0FFEE);
+
+  rng.set_step_counter(lotta_steps);
+  rng.set_seed(seed);
+  rng.set_time_step(time_step);
+  rng.set_stream_number(stream_number);
+  // convenient lambda for testing
+  auto rest_unchanged = [=](Counter_RNG2 const &rng){
+    return seed == rng.get_seed() &&
+           time_step == rng.get_time_step() &&
+           stream_number == rng.get_stream_number();
+  };
+
+  // Increment data[0], generate a random double, and compare.
+  double x = rng.ran();
+  FAIL_IF_NOT(lotta_steps + 1 == rng.get_step_counter());
+  FAIL_IF_NOT(rest_unchanged(rng));
+
+  // ... and again.
+  double y = rng.ran();
+  if (soft_equiv(y, x))
+    ITFAILS;
+  FAIL_IF_NOT(lotta_steps + 2 == rng.get_step_counter());
+  FAIL_IF_NOT(rest_unchanged(rng));
+
+  // Generate another random double and verify that the counter has incremented
+  // correctly.
+  FAIL_IF(rng.passed_max());
+  double z = rng.ran();
+  if (soft_equiv(z, x))
+    ITFAILS;
+  if (soft_equiv(z, y))
+    ITFAILS;
+  FAIL_IF_NOT(0 == rng.get_step_counter());
+  FAIL_IF_NOT(rng.passed_max());
+  FAIL_IF_NOT(rest_unchanged(rng));
+
+  // Repeat the test with a Counter_RNG2_Ref.
+  vector<uint64_t> data(CBRNG_DATA_SIZE);
+  data[0] = lotta_steps + 1;
+  data[1] = stream_number;
+  data[2] = seed;
+  data[3] = time_step;
+  Counter_RNG2_Ref ref(&data[0], &data[0] + CBRNG_DATA_SIZE);
+
+  double y2 = ref.ran();
+  if (!soft_equiv(y2, y))
+    ITFAILS;
+  if (data[0] != lotta_steps + 2)
+    ITFAILS;
+  if (data[1] != stream_number)
+    ITFAILS;
+  if (data[2] != seed)
+    ITFAILS;
+  if (data[3] != time_step)
+    ITFAILS;
+
+  double z2 = ref.ran();
+  if (!soft_equiv(z2, z))
+    ITFAILS;
+  if (data[0] != 0)
+    ITFAILS;
+  if (data[1] != stream_number)
+    ITFAILS;
+  if (data[2] != seed)
+    ITFAILS;
+  if (data[3] != time_step)
+    ITFAILS;
+
+  if (ut.numFails == 0)
+    PASSMSG("test_rollover passed");
+} // test_rollover(UnitTest &ut)
+
+//---------------------------------------------------------------------------//
+void test_spawn(UnitTest &ut) {
+  // Create a generator.
+  uint32_t const seed = 0xabcdef;
+  uint64_t const streamnum = 0;
+  uint64_t const time_step = 10001;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+
+  // Compare two rngs, making sure what should be different is and what
+  // shouldn't be different isn't.
+  auto close_but_not_too_close = [&](Counter_RNG2 const &child,
+                                     Counter_RNG2 const &parent) {
+    FAIL_IF(child == parent);
+    FAIL_IF(child.get_stream_number() != parent.get_stream_number());
+    FAIL_IF(child.get_time_step() != parent.get_time_step());
+    FAIL_IF(child.get_seed() != parent.get_seed());
+    FAIL_IF(child.get_spawn_id() == parent.get_spawn_id());
+    FAIL_IF(child.get_spawn_id() == 0);
+    return;
+  };
+
+  // Can spawn?
+  FAIL_IF_NOT(rng.can_spawn());
+
+  // Spawn a new generator.
+  Counter_RNG2 rng_child1;
+  rng.spawn(rng_child1, 1ull);
+
+  // child should have same stream number, time step, and seed. It should
+  // should have different spawn id. Its step counter should be zero.
+  close_but_not_too_close(rng_child1, rng);
+
+  // Create a reference to rng, and spawn from the reference.
+  Counter_RNG2_Ref rng_ref(rng.ref());
+  if (!rng_ref.is_alias_for(rng))
+    ITFAILS;
+
+  FAIL_IF_NOT(rng_ref.can_spawn());
+  Counter_RNG2 rng_child2;
+  rng_ref.spawn(rng_child2,2ull);
+
+  // rng_child2 should have the same stream number as rng and rng_child1 but
+  // should not be identical to either previous generator.
+  close_but_not_too_close(rng_child2, rng);
+  FAIL_IF(rng_child2 == rng_child1);
+
+  // Spawn a generator from rng_child1.
+  FAIL_IF_NOT(rng_child1.can_spawn());
+  Counter_RNG2 rng_grandchild1;
+  rng_child1.spawn(rng_grandchild1,3);
+  close_but_not_too_close(rng_grandchild1, rng_child1);
+  close_but_not_too_close(rng_grandchild1, rng);
+
+  // Spawn a generator from rng_child2.
+  FAIL_IF_NOT(rng_child2.can_spawn());
+  Counter_RNG2 rng_grandchild2;
+  rng_child2.spawn(rng_grandchild2,4);
+  close_but_not_too_close(rng_grandchild2, rng_child2);
+
+  // ensure that RNG::can_spawn returns false after the right number of gens
+  uint32_t const mx_gens = max_gens();
+  std::vector<Counter_RNG2> rngs(mx_gens+1);
+  for(size_t i = 0; i <= mx_gens; ++i){
+    Counter_RNG2 &g = rngs[i];
+    Counter_RNG2 &parent = i == 0 ? rng : rngs[i-1];
+    parent.spawn(g,i);
+    if(i < mx_gens){
+      FAIL_IF_NOT(g.can_spawn());
+    }
+    else{
+      FAIL_IF(g.can_spawn());
+      /* should never get here--if it does, interrogate a bit */
+      if(g.can_spawn()){
+        printf("%s:%i i = %lu, mx_gens = %u\n",__FUNCTION__,__LINE__,i,mx_gens);
+      }
+    }
+  }
+
+  if (ut.numFails == 0)
+    PASSMSG("test_spawn passed");
+}
+
+//---------------------------------------------------------------------------//
+void test_unique(UnitTest &ut) {
+  // Create three identical generators.
+  uint32_t const seed = 332211;
+  uint64_t const streamnum = 2468;
+  uint64_t const time_step = 147963;
+  Counter_RNG2 rng(seed, streamnum, time_step);
+  Counter_RNG2 rng2(seed, streamnum, time_step);
+  Counter_RNG2 rng3(seed, streamnum, time_step);
+
+  Counter_RNG2_Ref rng_ref(rng.ref());
+  Counter_RNG2_Ref rng2_ref(rng2.ref());
+  Counter_RNG2_Ref rng3_ref(rng3.ref());
+
+  if (rng != rng2)
+    ITFAILS;
+  if (rng != rng3)
+    ITFAILS;
+  if (rng.get_unique_num() != rng2.get_unique_num())
+    ITFAILS;
+  if (rng.get_unique_num() != rng3.get_unique_num())
+    ITFAILS;
+
+  if (!rng_ref.is_alias_for(rng))
+    ITFAILS;
+  if (!rng2_ref.is_alias_for(rng2))
+    ITFAILS;
+  if (!rng3_ref.is_alias_for(rng3))
+    ITFAILS;
+
+  // Generate some random numbers from rng2.  The stream number and unique
+  // number of rng2 should remain the same during this process.
+  set<uint64_t> ids;
+  ids.insert(rng.get_unique_num());
+
+  for (int i = 0; i < 1000000; ++i) {
+    rng2.ran();
+
+    if (rng2.get_stream_number() != rng.get_stream_number())
+      ITFAILS;
+    if (rng2_ref.get_unique_num() != rng2.get_unique_num())
+      ITFAILS;
+    if (ids.find(rng2.get_unique_num()) == ids.end())
+      ITFAILS;
+  }
+
+  if (ut.numFails == 0)
+    PASSMSG("test_unique passed");
+}
+
+//---------------------------------------------------------------------------//
+
+int main(int argc, char *argv[]) {
+  ScalarUnitTest ut(argc, argv, release);
+  try {
+    test_set_get_seed(ut);
+    test_set_get_step_counter(ut);
+    test_set_get_time_step(ut);
+    test_set_get_stream_number(ut);
+    test_set_get_spawn_id(ut);
+    test_increment_CBRNG2_step_counter(ut);
+    test_equality(ut);
+    test_stream(ut);
+    test_alias(ut);
+    test_rollover(ut);
+    test_spawn(ut);
+    test_unique(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of tstCounter_RNG2.cc
+//---------------------------------------------------------------------------//

--- a/src/rng/test/tstCounter_RNG2.cc
+++ b/src/rng/test/tstCounter_RNG2.cc
@@ -722,11 +722,12 @@ void test_spawn(UnitTest &ut) {
   // ensure that RNG::can_spawn returns false after the right number of gens
   uint32_t const mx_gens = max_gens();
   std::vector<Counter_RNG2> rngs(mx_gens+1);
-  for(size_t i = 0; i <= mx_gens; ++i){
+  for(size_t i = 0; i < mx_gens; ++i){
     Counter_RNG2 &g = rngs[i];
     Counter_RNG2 &parent = i == 0 ? rng : rngs[i-1];
-    parent.spawn(g,i);
-    if(i < mx_gens){
+
+    parent.spawn(g,i+1);
+    if(i < mx_gens-1){
       FAIL_IF_NOT(g.can_spawn());
     }
     else{
@@ -737,7 +738,7 @@ void test_spawn(UnitTest &ut) {
       }
     }
   }
-
+printf("%s:%i \n",__FUNCTION__,__LINE__);
   if (ut.numFails == 0)
     PASSMSG("test_spawn passed");
 }

--- a/src/rng/test/tstCounter_RNG2.cc
+++ b/src/rng/test/tstCounter_RNG2.cc
@@ -8,10 +8,10 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include "rng/Counter_RNG2.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
+#include "rng/Counter_RNG2.hh"
 #include <set>
 
 using namespace std;
@@ -23,7 +23,7 @@ using namespace rtt_rng;
 //---------------------------------------------------------------------------//
 
 /* I've included some test of getters and setters since they're not trivial. */
-void test_set_get_seed(UnitTest &ut){
+void test_set_get_seed(UnitTest &ut) {
   uint32_t seed = 1;
   uint64_t const streamnum = 2;
   uint64_t const time_step = 349;
@@ -44,7 +44,7 @@ void test_set_get_seed(UnitTest &ut){
     PASSMSG("test_set_get_seed passed");
 } // test_set_get_seed
 
-void test_set_get_step_counter(UnitTest &ut){
+void test_set_get_step_counter(UnitTest &ut) {
   uint32_t const seed = 1;
   uint64_t const streamnum = 2;
   uint64_t const time_step = 349;
@@ -65,7 +65,7 @@ void test_set_get_step_counter(UnitTest &ut){
     PASSMSG("test_set_get_step_counter passed");
 } // test_set_get_step_counter
 
-void test_set_get_time_step(UnitTest &ut){
+void test_set_get_time_step(UnitTest &ut) {
   uint32_t const seed = 1;
   uint64_t const streamnum = 2;
   uint64_t time_step = 349;
@@ -86,7 +86,7 @@ void test_set_get_time_step(UnitTest &ut){
     PASSMSG("test_set_get_time_step passed");
 } // test_set_get_time_step
 
-void test_set_get_stream_number(UnitTest &ut){
+void test_set_get_stream_number(UnitTest &ut) {
   uint32_t const seed = 1;
   uint64_t streamnum = 2;
   uint64_t const time_step = 349;
@@ -107,7 +107,7 @@ void test_set_get_stream_number(UnitTest &ut){
     PASSMSG("test_set_get_stream_number passed");
 } // test_set_get_stream_number
 
-void test_set_get_spawn_id(UnitTest &ut){
+void test_set_get_spawn_id(UnitTest &ut) {
   uint32_t const seed = 1;
   uint64_t const streamnum = 2;
   uint64_t const time_step = 349;
@@ -128,7 +128,7 @@ void test_set_get_spawn_id(UnitTest &ut){
     PASSMSG("test_set_get_spawn_id passed");
 } // test_set_get_spawn_id
 
-void test_increment_CBRNG2_step_counter(UnitTest &ut){
+void test_increment_CBRNG2_step_counter(UnitTest &ut) {
   uint64_t const ctr1 = 0xFFFFFFFF00000000;
   uint64_t const inc1 = increment_CBRNG2_step_counter(ctr1);
   FAIL_IF_NOT(inc1 == ctr1 + 1);
@@ -243,8 +243,8 @@ void test_equality(UnitTest &ut) {
   if (rng5 != rng5)
     ITFAILS;
 
-  // TK: I cut a test that was based on manually manipulating the RNG
-  // state. Pls don't manually manipulate the RNG state as an array of ints.
+    // TK: I cut a test that was based on manually manipulating the RNG
+    // state. Pls don't manually manipulate the RNG state as an array of ints.
 
 // Try to create a Counter_RNG2 from a data array that's too short.
 // 1. Only test exceptions if DbC is enabled.
@@ -372,7 +372,7 @@ void test_alias(UnitTest &ut) {
   Counter_RNG2 rng(0x1111, streamnum, time_step);
   Counter_RNG2 rng2(0x1111, streamnum, time_step);
   Counter_RNG2 rng3(0x2222, streamnum, time_step);
-  Counter_RNG2 rng4(0x3333, streamnum+1, time_step);
+  Counter_RNG2 rng4(0x3333, streamnum + 1, time_step);
 
   if (rng.get_stream_number() != rng2.get_stream_number())
     ITFAILS;
@@ -594,9 +594,8 @@ void test_rollover(UnitTest &ut) {
   rng.set_time_step(time_step);
   rng.set_stream_number(stream_number);
   // convenient lambda for testing
-  auto rest_unchanged = [=](Counter_RNG2 const &rng){
-    return seed == rng.get_seed() &&
-           time_step == rng.get_time_step() &&
+  auto rest_unchanged = [=](Counter_RNG2 const &rng) {
+    return seed == rng.get_seed() && time_step == rng.get_time_step() &&
            stream_number == rng.get_stream_number();
   };
 
@@ -699,7 +698,7 @@ void test_spawn(UnitTest &ut) {
 
   FAIL_IF_NOT(rng_ref.can_spawn());
   Counter_RNG2 rng_child2;
-  rng_ref.spawn(rng_child2,2ull);
+  rng_ref.spawn(rng_child2, 2ull);
 
   // rng_child2 should have the same stream number as rng and rng_child1 but
   // should not be identical to either previous generator.
@@ -709,36 +708,36 @@ void test_spawn(UnitTest &ut) {
   // Spawn a generator from rng_child1.
   FAIL_IF_NOT(rng_child1.can_spawn());
   Counter_RNG2 rng_grandchild1;
-  rng_child1.spawn(rng_grandchild1,3);
+  rng_child1.spawn(rng_grandchild1, 3);
   close_but_not_too_close(rng_grandchild1, rng_child1);
   close_but_not_too_close(rng_grandchild1, rng);
 
   // Spawn a generator from rng_child2.
   FAIL_IF_NOT(rng_child2.can_spawn());
   Counter_RNG2 rng_grandchild2;
-  rng_child2.spawn(rng_grandchild2,4);
+  rng_child2.spawn(rng_grandchild2, 4);
   close_but_not_too_close(rng_grandchild2, rng_child2);
 
   // ensure that RNG::can_spawn returns false after the right number of gens
   uint32_t const mx_gens = max_gens();
-  std::vector<Counter_RNG2> rngs(mx_gens+1);
-  for(size_t i = 0; i < mx_gens; ++i){
+  std::vector<Counter_RNG2> rngs(mx_gens + 1);
+  for (size_t i = 0; i < mx_gens; ++i) {
     Counter_RNG2 &g = rngs[i];
-    Counter_RNG2 &parent = i == 0 ? rng : rngs[i-1];
+    Counter_RNG2 &parent = i == 0 ? rng : rngs[i - 1];
 
-    parent.spawn(g,i+1);
-    if(i < mx_gens-1){
+    parent.spawn(g, i + 1);
+    if (i < mx_gens - 1) {
       FAIL_IF_NOT(g.can_spawn());
-    }
-    else{
+    } else {
       FAIL_IF(g.can_spawn());
       /* should never get here--if it does, interrogate a bit */
-      if(g.can_spawn()){
-        printf("%s:%i i = %lu, mx_gens = %u\n",__FUNCTION__,__LINE__,i,mx_gens);
+      if (g.can_spawn()) {
+        printf("%s:%i i = %lu, mx_gens = %u\n", __FUNCTION__, __LINE__, i,
+               mx_gens);
       }
     }
   }
-printf("%s:%i \n",__FUNCTION__,__LINE__);
+  printf("%s:%i \n", __FUNCTION__, __LINE__);
   if (ut.numFails == 0)
     PASSMSG("test_spawn passed");
 }


### PR DESCRIPTION
### Background

* The goal is to add a new implementation of Counter_RNG (called Counter_RNG2) that represents application level information differently in the Random123 key and counter state. This is in support of eliminating the RNG-NR capability. The unique per-particle state is limited to 16B. It also takes the opportunity to introduce the time step to the key, which might support further reduction in state size.

### Purpose of Pull Request

* Adds new counter-based RNG implementation while leaving the existing implementation untouched.
* Adds new spawn implementation.
* Represents particle id, spawn id, time step, user seed. and step counter.

### Description of changes

* Adds new classes Counter_RNG2 and Counter_RNG2_Ref, along with unit tests.
* Unit tests are expanded.
* Interface is expanded--new setters and getters to encapsulate the representation of the state.
* Added unit test that compares RNG2 with original.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
