### PR TITLE
Add binary capability to Kent's parallel output file writer

### DIFF
--- a/src/c4/ofpstream.cc
+++ b/src/c4/ofpstream.cc
@@ -28,9 +28,11 @@ using namespace std;
  * \param filename Name of the file to which synchronized output is to be
  * written.
  */
-ofpstream::ofpstream(std::string const &filename) : std::ostream(&sb_) {
+ofpstream::ofpstream(std::string const &filename, ios_base::openmode const mode)
+    : std::ostream(&sb_) {
+  sb_.mode_ = mode;
   if (rtt_c4::node() == 0) {
-    sb_.out_.open(filename);
+    sb_.out_.open(filename, mode);
   }
 }
 
@@ -44,18 +46,25 @@ ofpstream::ofpstream(std::string const &filename) : std::ostream(&sb_) {
 void ofpstream::mpibuf::send() {
   unsigned const pid = rtt_c4::node();
   if (pid == 0) {
-    buffer_.push_back('\0');
-    out_ << &buffer_[0];
+    if (mode_ == ios_base::binary)
+      out_.write(&buffer_[0], buffer_.size());
+    else {
+      buffer_.push_back('\0');
+      out_ << &buffer_[0];
+    }
     buffer_.clear();
-
     unsigned const pids = rtt_c4::nodes();
     for (unsigned i = 1; i < pids; ++i) {
       unsigned N;
       receive(&N, 1, i);
       buffer_.resize(N);
       rtt_c4::receive(&buffer_[0], N, i);
-      buffer_.push_back('\0');
-      out_ << &buffer_[0];
+      if (mode_ == ios_base::binary)
+        out_.write(&buffer_[0], buffer_.size());
+      else {
+        buffer_.push_back('\0');
+        out_ << &buffer_[0];
+      }
     }
   } else {
     unsigned N = buffer_.size();

--- a/src/c4/ofpstream.hh
+++ b/src/c4/ofpstream.hh
@@ -63,7 +63,9 @@ namespace rtt_c4 {
 
 class ofpstream : public std::ostream {
 public:
-  DLL_PUBLIC_c4 explicit ofpstream(std::string const &filename);
+  //! Constructor -- default to standard output mode (ascii)
+  DLL_PUBLIC_c4 ofpstream(std::string const &filename,
+                          ios_base::openmode const mode = ios_base::out);
 
   //! Write all buffered output to the file stream, in MPI rank order.
   void send() { sb_.send(); }
@@ -79,6 +81,7 @@ private:
     DLL_PUBLIC_c4 virtual int_type overflow(int_type c);
 
     std::vector<char> buffer_;
+    ios_base::openmode mode_;
     std::ofstream out_;
   };
 

--- a/src/c4/test/tstofpstream.cc
+++ b/src/c4/test/tstofpstream.cc
@@ -44,12 +44,48 @@ void tstofpstream(UnitTest &ut) {
   ut.passes("completed serialized write without hanging or segfaulting");
 }
 
+void tstofpstream_bin(UnitTest &ut) {
+
+  int pid = rtt_c4::node();
+
+  // Binary write rank ids to file using ofpstream:
+  {
+    ofpstream out("tstofpstream_bin.txt", std::ofstream::binary);
+
+    out.write(reinterpret_cast<const char *>(&pid), sizeof(int));
+
+    out.send();
+
+    out.shrink_to_fit();
+
+    out << "MPI rank " << pid << " reporting a second time ..." << endl;
+
+    out.shrink_to_fit();
+    out.send();
+  }
+
+  // Read file on head rank, check for correct conversion and ordering
+  if (pid == 0) {
+    ifstream in("tstofpstream_bin.txt", std::ofstream::binary);
+    int this_pid;
+    for (int a = 0; a < rtt_c4::nodes(); a++) {
+      in.read(reinterpret_cast<char *>(&this_pid), sizeof(int));
+      if (this_pid != a) {
+        ITFAILS;
+      }
+    }
+  }
+
+  ut.passes("completed serialized binary write without hanging or segfaulting");
+}
+
 //---------------------------------------------------------------------------//
 
 int main(int argc, char *argv[]) {
   rtt_c4::ParallelUnitTest ut(argc, argv, release);
   try {
     tstofpstream(ut);
+    tstofpstream_bin(ut);
   }
   UT_EPILOG(ut);
 }


### PR DESCRIPTION


### Background

* I've been using Kent's ofpstream with great success to write restart dumps for the upcoming IMC driver refactor/replacement
* However, I needed a way to write unformatted binary data (using write(), not the stream operator <<), so I added this functionality
* If anyone has a more elegant way to incorporate this, just let me know

### Purpose of Pull Request

* Enable binary writes for ofpstream, which serializes output file writes in a rank-ordered fashion

### Description of changes

* Modify constructor to take optional file open mode argument
* Add if() statements to toggle between << and write() functions
* Add minimal test for binary mode

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation