### PR TITLE
Update ds++/config.h to provide draco_isKNL.

### DIFF
--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -33,6 +33,7 @@ elseif( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
    else()
       set( FPETRAP_DARWIN_INTEL 1 )
    endif()
+
 elseif( ${CMAKE_SYSTEM_NAME} MATCHES "Windows" )
    set( FPETRAP_WINDOWS_X86 1 )
 endif()
@@ -52,6 +53,11 @@ set_property( CACHE DRACO_DIAGNOSTICS PROPERTY STRINGS 0 1 2 3 4 5 6 7 )
 # Provide an enum from CMAKE_CXX_COMPILER_VERSION
 string( REPLACE "." "" CMAKE_CXX_COMPILER_VERSION_ENUM
   ${CMAKE_CXX_COMPILER_VERSION} )
+
+# Is this a KNL
+if( CRAY_PE AND "$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl" )
+  set( draco_isKNL ON )
+endif()
 
 # Create ds++/config.h
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/ds++/config.h )

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -32,6 +32,21 @@
 #define Draco_VERSION_PATCH "@Draco_VERSION_PATCH@"
 
 /* System Type */
+
+/*
+ * Commonly defined CPP symbols:
+ *
+ * __GNUC__
+ * __clang__
+ * __ICC
+ * NVCC
+ * APPLE
+ * _MSC_FULL_VER, _MSC_VER
+ * _WIN32
+ * __CYGWIN__
+ */
+
+#cmakedefine CMAKE_C_COMPILER_ID @CMAKE_C_COMPILER_ID@
 #cmakedefine MSVC @MSVC@
 #cmakedefine MSVC_IDE @MSVC_IDE@
 #cmakedefine MSVC_VERSION @MSVC_VERSION@
@@ -43,10 +58,16 @@
 #cmakedefine draco_isLinux_with_aprun
 #cmakedefine draco_isCatamount
 #cmakedefine draco_isPGI
+#cmakedefine draco_isKNL
 #cmakedefine DRACO_UNAME @DRACO_UNAME@
 #cmakedefine HAVE_CUDA @HAVE_CUDA@
 #cmakedefine APPLE @APPLE@
 #cmakedefine SITENAME "@SITENAME@"
+
+#ifdef __GNUC__
+#define DBS_GNUC_VERSION \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
 
 /*---------------------------------------------------------------------------*/
 /* Platform checks */

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -28,13 +28,13 @@
 #if defined(__GNUC__) && !defined(__clang__)
 
 /*
-#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (DBS_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
 */
 #pragma GCC diagnostic push
-#if (RNG_GNUC_VERSION >= 70000)
+#if (DBS_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -56,9 +56,9 @@
 #pragma clang diagnostic pop
 #endif
 
-/* #if (RNG_GNUC_VERSION >= 40600) */
+/* #if (DBS_GNUC_VERSION >= 40600) */
 #if defined(__GNUC__) && !defined(__clang__)
-/* && (RNG_GNUC_VERSION >= 70000) */
+/* && (DBS_GNUC_VERSION >= 70000) */
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/config.h.in
+++ b/src/rng/config.h.in
@@ -10,6 +10,8 @@
 #ifndef rtt_rng_config_h
 #define rtt_rng_config_h
 
+#include "ds++/config.h"
+
 /* Enable Random123 C++11 support */
 #cmakedefine R123_USE_CXX11 @R123_USE_CXX11@
 
@@ -18,12 +20,6 @@
 #ifndef __STDC__
 #define __STDC__
 #endif
-#endif
-
-/* If GNU, then define GNU_VERSION */
-#ifdef __GNUC__
-#define RNG_GNUC_VERSION                                                           \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
 /* Use a unique name for this Remember macro */

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -82,6 +82,7 @@ add_component_executable(
 target_include_directories( Exe_time_serial
   PRIVATE
     $<BUILD_INTERFACE:${rng_BINARY_DIR}>
+    $<BUILD_INTERFACE:${dsxx_BINARY_DIR}>
     ${RANDOM123_INCLUDE_DIR} )
 
 configure_file( ${PROJECT_SOURCE_DIR}/kat_vectors

--- a/src/rng/test/kat_cpp.cpp
+++ b/src/rng/test/kat_cpp.cpp
@@ -41,11 +41,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // complaint
 #pragma warning(disable : 4521)
 #endif
-#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (DBS_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
-#if (RNG_GNUC_VERSION >= 40600)
+#if (DBS_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -60,7 +60,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <utility>
 
-#if (RNG_GNUC_VERSION >= 40600)
+#if (DBS_GNUC_VERSION >= 40600)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/time_initkeyctr.h
+++ b/src/rng/test/time_initkeyctr.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TIME_INITKEYCTR_H__ 1
 
 #ifdef __GNUC__
-#if (RNG_GNUC_VERSION >= 70000)
+#if (DBS_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
@@ -150,7 +150,7 @@ static aesni4x32_ctr_t good_aesni4x32_10 = {
 #endif
 
 #ifdef __GNUC__
-#if (RNG_GNUC_VERSION >= 70000)
+#if (DBS_GNUC_VERSION >= 70000)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/ut_Engine.cpp
+++ b/src/rng/test/ut_Engine.cpp
@@ -37,9 +37,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4521)
 #endif
 #ifdef __GNUC__
-#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (DBS_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused variable" warning.
-#if (RNG_GNUC_VERSION >= 40600)
+#if (DBS_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
 #endif
 #pragma GCC diagnostic ignored "-Wunused-variable"
@@ -270,7 +270,7 @@ int main(int, char **) {
 #endif
 
 #ifdef __GNUC__
-#if (RNG_GNUC_VERSION >= 40600)
+#if (DBS_GNUC_VERSION >= 40600)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -46,11 +46,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rng/config.h"
 
-#if (RNG_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+#if (DBS_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
-#if (RNG_GNUC_VERSION >= 40600)
+#if (DBS_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -76,7 +76,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic pop
 #endif
 
-#if (RNG_GNUC_VERSION >= 40600)
+#if (DBS_GNUC_VERSION >= 40600)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/util_expandtpl.h
+++ b/src/rng/test/util_expandtpl.h
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
-#if (RNG_GNUC_VERSION >= 70000)
+#if (DBS_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
 #endif

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -73,7 +73,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rng/config.h"
 
 #if defined(__GNUC__) && !defined(__clang__)
-#if (RNG_GNUC_VERSION >= 70000)
+#if (DBS_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
@@ -208,17 +208,17 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
       std::numeric_limits<Utype>::digits - std::numeric_limits<Ftype>::digits;
   if (excess >= 0) {
 
-// 2015-09-26 KT - Suppress warnings for the following expressions (see https://rtt.lanl.gov/redmine/issues/416)
-//
-// Basically, GCC under BullseyeCoverage issues the following warning every time this file is included:
-//
-// Counter_RNG.hh:124:65:   required from here
-// uniform.hpp:200:48: warning: second operand of conditional expression has no effect [-Wunused-value]
-//         R123_CONSTEXPR int ex_nowarn = (excess>=0) ? excess : 0;
-//
-// Unfortunately, if this expression is simplified (see r7628) some compilers will not compile the code because the RHS of the
-// assignment may contain values that are not known at comile time (not constexpr).  We don't want to spend to much time debugging
-// this issue because the code is essentially vendor owned (Random123).
+    // 2015-09-26 KT - Suppress warnings for the following expressions (see https://rtt.lanl.gov/redmine/issues/416)
+    //
+    // Basically, GCC under BullseyeCoverage issues the following warning every time this file is included:
+    //
+    // Counter_RNG.hh:124:65:   required from here
+    // uniform.hpp:200:48: warning: second operand of conditional expression has no effect [-Wunused-value]
+    //         R123_CONSTEXPR int ex_nowarn = (excess>=0) ? excess : 0;
+    //
+    // Unfortunately, if this expression is simplified (see r7628) some compilers will not compile the code because the RHS of the
+    // assignment may contain values that are not known at comile time (not constexpr).  We don't want to spend to much time debugging
+    // this issue because the code is essentially vendor owned (Random123).
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push


### PR DESCRIPTION
### Background

+ Kent needs KNL specific CPP macros to control when prefetch commands are injected into the code.

### Purpose of Pull Request

* [Fixes Redmine Issue #1245](https://rtt.lanl.gov/redmine/issues/1245)

### Description of changes

+ Use *CRAYPE* specific environments to detect if we are targeting a *mic-knl* node.  If so, set `draco_isKNL` and save this value in `ds++/config.h`.
  + Also save `CMAKE_C_COMPILER_ID` to `ds++/config.h`.
+ Move `DBS_GNUC_VERSION` from `rng/config.h` to `ds++/config.h` and update sources in *rng* to use the new definition.
+ on ccs-net, the generated `ds++/config.h` will look something like this:

```cxx
#define CMAKE_C_COMPILER_ID GNU
/* #undef MSVC */
/* #undef MSVC_IDE */
/* #undef MSVC_VERSION */
#define UNIX 1
#define draco_isLinux
/* #undef draco_isOSF1 */
/* #undef draco_isDarwin */
/* #undef draco_isAIX */
/* #undef draco_isLinux_with_aprun */
/* #undef draco_isCatamount */
/* #undef draco_isPGI */
/* #undef draco_isKNL */
#define DRACO_UNAME Linux
/* #undef HAVE_CUDA */
/* #undef APPLE */
#define SITENAME "ccscs3"

#ifdef __GNUC__
#define DBS_GNUC_VERSION \
  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
#endif
```

On KNL, `ds++/config.h` has this content:

```cxx
#define CMAKE_C_COMPILER_ID Intel
/* #undef MSVC */
/* #undef MSVC_IDE */
/* #undef MSVC_VERSION */
#define UNIX 1
#define draco_isLinux
/* #undef draco_isOSF1 */
/* #undef draco_isDarwin */
/* #undef draco_isAIX */
/* #undef draco_isLinux_with_aprun */
/* #undef draco_isCatamount */
/* #undef draco_isPGI */
#define draco_isKNL
#define DRACO_UNAME Linux
/* #undef HAVE_CUDA */
/* #undef APPLE */
#define SITENAME "Trinitite"
```

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
