### PR TITLE
Fix ambiguous type conversion issue when compiling on a MAC

### DIFF
--- a/src/viz/Ensight_Translator.i.hh
+++ b/src/viz/Ensight_Translator.i.hh
@@ -421,7 +421,7 @@ void Ensight_Translator::write_geom(const uint32_t part_num,
   d_geom_out << part_num << endl;
   d_geom_out << part_name << endl;
   d_geom_out << "coordinates" << endl;
-  d_geom_out << nvertices << endl; // #vertices in this part
+  d_geom_out << int(nvertices) << endl; // #vertices in this part
 
   // output the global vertex indices and form ens_vertex.  Enight demands that
   // vertices be numbered from 1 to the number of vertices *for this part*
@@ -456,7 +456,7 @@ void Ensight_Translator::write_geom(const uint32_t part_num,
 
     if (num_elem > 0) {
       d_geom_out << d_cell_names[type] << endl;
-      d_geom_out << num_elem << endl;
+      d_geom_out << int(num_elem) << endl;
 
       for (size_t i = 0; i < num_elem; ++i)
         d_geom_out << g_cell_indices[c[i]] << endl;


### PR DESCRIPTION
### Background

* Fix ambiguous type conversion issue when compiling on a MAC

### Purpose of Pull Request

* Fix ambiguous type conversion issue when compiling on a MAC

### Description of changes

* Fix ambiguous type conversion issue when compiling on a MAC

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
