### PR TITLE
Clean up build warnings reported by VS and fix some regression scripts

### DIFF
--- a/regression/win32-regression-master.bat
+++ b/regression/win32-regression-master.bat
@@ -17,6 +17,10 @@ rem c:\myscript.%date:~-4%%date:~4,2%%date:~7,2%.%time::=%.log 2>&1
 
 set logdir=c:\regress\logs
 
+rem Try to avoid LNK1109 errors (cannot remove file).
+set TEMP=c:\work\temp
+set TMP=c:\work\temp
+
 rem Ensure Git/bin/sh.exe is not in the PATH.  It interferes with mingw operations.
 rem set PATH=%PATH:c:\Program Files\Git\bin;=%
 set PATH=%PATH:C:\Users\107638\AppData\Local\Programs\Git\bin\;=%
@@ -26,6 +30,8 @@ C:\Users\107638\AppData\Local\Programs\Git\bin\git.exe config --global http.prox
 rem Don't set these because they prevent posting to rtt.lanl.gov/cdash.
 rem set HTTP_PROXY=http://proxyout.lanl.gov:8080
 rem set HTTPS_PROXY=http://proxyout.lanl.gov:8080
+set HTTP_PROXY=
+set HTTPS_PROXY=
 
 rem Change '/c' to '/k' to keep the command window open after these commands 
 rem finish.

--- a/src/VendorChecks/test/tstParmetis.cc
+++ b/src/VendorChecks/test/tstParmetis.cc
@@ -3,9 +3,8 @@
  * \file   VendorChecks/test/tstParmetis.cc
  * \date   Monday, May 16, 2016, 16:30 pm
  * \brief  Attempt to link to libparmetis and run a simple problem.
- * \note   Copyright (C) 2016, Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ * \note   Copyright (C) 2016-2018, Los Alamos National Security, LLC.
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
@@ -55,7 +54,7 @@ void test_parmetis(rtt_c4::ParallelUnitTest &ut) {
   // balance constraint. If all of the sub-domains are to be of the same size
   // for every vertex weight, then each of the ncon × nparts elements should
   // be set to a value of 1/nparts.
-  std::vector<real_t> tpwgts(ncon * nparts, 1.0 / static_cast<double>(nparts));
+  std::vector<real_t> tpwgts(ncon * nparts, static_cast<real_t>(1.0 / nparts));
   // An array of size ncon that is used to specify the imbalance tolerance for
   // each vertex weight, with 1 being perfect balance and nparts being perfect
   // imbalance. A value of 1.05 for each of the ncon weights is recommended.
@@ -72,15 +71,12 @@ void test_parmetis(rtt_c4::ParallelUnitTest &ut) {
   // This is an array of size equal to the number of locally-stored
   // vertices. Upon successful completion the partition vector of the
   // locally-stored vertices is written to this array.
-  std::vector<idx_t> part(5, MPI_PROC_ID);
+  Check(MPI_PROC_ID < INT_MAX);
+  std::vector<idx_t> part(5, static_cast<idx_t>(MPI_PROC_ID));
 
   // This array describes how the vertices of the graph are distributed among
   // the processors. Its contents are identical for every processor.
-  std::vector<idx_t> vtxdist(4);
-  vtxdist[0] = 0;
-  vtxdist[1] = 5;
-  vtxdist[2] = 10;
-  vtxdist[3] = 15;
+  std::vector<idx_t> vtxdist = {0, 5, 10, 15};
 
   // Dependent on each processor
   if (MPI_PROC_ID == 0) {

--- a/src/ds++/test/do_exception.cc
+++ b/src/ds++/test/do_exception.cc
@@ -18,6 +18,13 @@
 #include <sstream>
 #include <vector>
 
+#if defined(MSVC)
+#pragma warning(push)
+// This test deliberately divides by zero to test trapping of IEEE errors.
+// Silence the warning from MSVC about this issue.
+#pragma warning(disable : 4723)
+#endif
+
 using namespace std;
 
 //---------------------------------------------------------------------------//
@@ -73,11 +80,11 @@ void run_test(int /*argc*/, char *argv[]) {
   double neg(-1.0); // for sqrt(-1.0)
   double result(-1.0);
 
-  // Certain tests may be optimized away by the compiler, by recogonizing the
+  // Certain tests may be optimized away by the compiler, by recognizing the
   // constants set above and precomputing the results below.  So do something
   // here to hopefully avoid this.  This tricks the optimizer, at least for gnu
   // and KCC. [2018-02-09 KT -- some web posts hint that marking zero and neg as
-  // 'volitile' may also prevent removal of logic due to optimization.]
+  // 'volatile' may also prevent removal of logic due to optimization.]
 
   if (test < -100) { // this should never happen
     Insist(0, "Something is very wrong.");
@@ -143,6 +150,12 @@ int main(int argc, char *argv[]) {
   }
   return 0;
 }
+
+//----------------------------------------------------------------------------//
+
+#if defined(MSVC)
+#pragma warning(pop)
+#endif
 
 //---------------------------------------------------------------------------//
 // end of do_exception.cc


### PR DESCRIPTION
### Background

* We are seeing a few build warnings on CDash for the nightly Visual Studio regression suite.  This PR attempts to eliminate those build warnings.

### Description of changes

+ Update `tstParmetis.cc` to eliminate warnings about type conversion.
+ Update `do_exception.cc` to eliminate warning about division by zero.

Also:

+ Update `draco_regression_macros.cmake` to enable parallel compiles for the Win32 regression system.
+ Fix some environment variables used by the regression system on Win32.
+ Fix some spelling errors.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
