### PR TITLE
Provide helper scripts for checking code style.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-*.pyc
 *.elc
+*.pyc
 *~
-TAGS
-GPATH
-GTAGS
-GRTAGS
+.settings/
+build*/
+.*.sw[a-p]
 .nfs*
+GPATH
+GRTAGS
+GTAGS
+TAGS

--- a/environment/elisp/format-f90.el
+++ b/environment/elisp/format-f90.el
@@ -1,0 +1,43 @@
+;;; File  : format-f90.el
+;;; Author: Kelly Thompson, kgt@lanl.gov
+;;; Date  : Wednesday, Sep 05, 2018, 16:01 pm
+
+;;; Description:
+
+;;; With format-f90.sh, laod a file in Emacs, apply standard Draco
+;;; formatting rules, save and exit Emacs via a non-interactive batch
+;;; process.
+
+;;; Use with format-f90.sh.
+;;;----------------------------------------------------------------------------
+
+(defun collapse-blank-lines
+  (start end)
+  (interactive "r")
+  (replace-regexp "^\n\\{2,\\}" "\n" nil start end)
+)
+
+(defun emacs-format-f90-sources ()
+   "Format the whole buffer accourding to Draco F90 rules."
+   ;; For more information about f90-mode settins in Emacs:
+   ;; 1. M-x f90-mode
+   ;; 2. C-h m
+   (set-fill-column 80)
+   (turn-on-auto-fill)
+   (setq f90-beginning-ampersand nil)
+   (setq f90-associate-indent 0)
+   ;; (setq f90-do-indent 3)
+   ;; (setq f90-if-indent 3)
+   ;; (setq f90-type-indent 3)
+   ;; (setq f90-program-indent 2)
+   ;; (setq f90-critical-indent 2)
+   ;; (setq f90-continuation-indent 5)
+   ;; (setq f90-indented-comment-re "!")
+   ;; (setq f90-break-delimiters "[-+*/><=,% \t]")
+   ;; (setq f90-break-before-delimiters t)
+   ;; (setq f90-auto-keyword-case 'downcase-word)
+   (indent-region (point-min) (point-max) nil)
+   (untabify (point-min) (point-max))
+   (collapse-blank-lines (point-min) (point-max))
+   (save-buffer)
+)

--- a/environment/elisp/format-f90.sh
+++ b/environment/elisp/format-f90.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# File  : format-f90
+# Author: Kelly Thompson, kgt@lanl.gov
+# Date  : Wednesday, Sep 05, 2018, 16:01 pm
+
+# Description:
+
+# This small script will apply Emacs f90 formatting to the specified file.
+
+# Usage:
+#   ./format-f90.sh [-h] [file.f90]
+#
+# Args:
+#   -h          Help message
+#   -i          Don't do anything, just echo the commands
+#-------------------------------------------------------------------------------
+
+# Where am I?
+export rscriptdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" )
+if ! [[ -d $rscriptdir ]]; then
+  export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
+
+# Defaults
+EMACS=emacs
+
+print_use()
+{
+  echo " "
+  echo "This small script will apply Emacs formatting to the specified file."
+  echo " "
+  echo "Usage:"
+  echo "  ./format-f90.sh [-hi] -f file.f90"
+  echo " "
+  echo "Args:"
+  echo "  -f file.f90 The file you want to process."
+  echo "  -h          Help message"
+  echo "  -i          Only echo the commands, do not actually do anything."
+}
+
+# Parse arguments
+f90source=""
+while getopts "f:hi" opt; do
+  case $opt in
+    f) f90source=${OPTARG} ;;
+    i) echoonly=echo ;;
+    h) print_use; exit 0 ;;
+    \?) echo "" ;echo "invalid option: -$OPTARG"; print_use; exit 1 ;;
+    :)  echo "" ;echo "option -$OPTARG requires an argument."; print_use; exit 1 ;;
+
+  esac
+done
+
+if ! [[ $f90source ]]; then
+  echo -e "\nERROR: You must provide at least one file to format."
+  print_use
+  exit 1
+fi
+
+if [[ $echoonly ]]; then
+  $echoonly $EMACS -batch ${f90source} -l ${rscriptdir}/format-f90.el -f emacs-format-f90-sources
+else
+  $EMACS -batch ${f90source} -l ${rscriptdir}/format-f90.el -f emacs-format-f90-sources &> /dev/null
+fi

--- a/environment/vim/.vimrc
+++ b/environment/vim/.vimrc
@@ -23,9 +23,10 @@ fun! RemoveTrailing()
     call setpos('.', l:save_cursor)
 endfun
 
-" fix trailing spaces when you write a file
+" Remove trailing spaces when you write a file
 autocmd BufWritePre * :call RemoveTrailing()
 
+" ----------------------------------------------------------------------
 " sets a gray warning line at 81 columns
 if exists('+colorcolumn')
   highlight ColorColumn ctermbg=gray
@@ -33,3 +34,29 @@ if exists('+colorcolumn')
 else
   au BufWinEnter * let w:m2=matchadd('ErrorMsg', '\%>80v.\+', -1)
 endif
+
+" --------------------------------------------------------------------
+" fprettify
+" https://github.com/pseewald/fprettify
+" Use: 'gq'
+" autocmd Filetype fortran setlocal formatprg=fprettify\ --silent
+
+" ----------------------------------------------------------------------
+" clang-format integrations
+" https://clang.llvm.org/docs/ClangFormat.html#vim-integration
+" Requires:
+"  - Python 3 or later.
+"  - clang-format.py, which is located at $LLVM_ROOT/share/clang/clang-format.py
+"  - export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}$LLVM_ROOT/share/clang
+" Use: 'C-I' to format current line
+
+map <C-I> :pyf ${LLVM_ROOT}/share/clang/clang-format.py<cr>
+imap <C-I> <c-o>:pyf ${LLVM_ROOT}/share/clang/clang-format.py<cr>
+
+fun! CFonsave()
+  let l:lines="all"
+  pyf ${LLVM_ROOT}/share/clang/clang-format.py
+endfun
+
+" Run clang-format when you write a file.
+autocmd BufWritePre *.h,*.hh,*.cc,*.cpp :call CFonsave()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 #    that require Fortran.
 if( NOT DEFINED ENV{APPVEYOR} )
   add_dir_if_exists( device )       # needs ds++
-  add_dir_if_exists( compton )      # needs ds++
+  add_dir_if_exists( compton )      # needs c4, CSK
   if( HAVE_Fortran )
     add_dir_if_exists( lapack_wrap )  # needs ds++
   endif()
@@ -83,20 +83,20 @@ endif()
 # Level 4
 message(" ")
 message( STATUS "Configuring Level 4 packages --" )
-add_dir_if_exists( special_functions ) # needs roots, units, ode
-add_dir_if_exists( cdi_analytic )      # needs parser, ode, cdi
+add_dir_if_exists( special_functions ) # needs roots, units, GSL
+add_dir_if_exists( cdi_analytic )      # needs parser, roots, ode, cdi
 add_dir_if_exists( RTT_Format_Reader)  # needs meshReaders
 if( NOT DEFINED ENV{APPVEYOR} AND NOT DEFINED ENV{TRAVIS} )
   add_dir_if_exists( cdi_eospac )      # needs parser, ode, cdi
 endif()
 
 # Level 5
+message(" ")
+message( STATUS "Configuring Level 5 packages --" )
 if( NOT DEFINED ENV{APPVEYOR} )
-  message(" ")
-  message( STATUS "Configuring Level 5 packages --" )
-  add_dir_if_exists( quadrature )   # needs mesh_element, parser, special_functions
-  add_dir_if_exists( mesh )         # needs c4, ds++, mesh_element
+  add_dir_if_exists( quadrature ) # needs mesh_element, parser, special_functions
 endif()
+add_dir_if_exists( mesh )         # needs c4, ds++, mesh_element
 
 # Summary
 

--- a/src/ds++/DracoStrings.cc
+++ b/src/ds++/DracoStrings.cc
@@ -3,7 +3,7 @@
  * \file   ds++/DracoStrings.cc
  * \author Kelly G. Thompson <kgt@lanl.gov
  * \date   Wednesday, Aug 23, 2017, 12:48 pm
- * \brief  Enscapulates common string manipulations (implementation).
+ * \brief  Encapsulates common string manipulations (implementation).
  * \note   Copyright (C) 2017-2018 Los Alamos National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
@@ -19,21 +19,28 @@ namespace rtt_dsxx {
 // Definitions for fully specialized template functions
 //----------------------------------------------------------------------------//
 
-template <> auto parse_number_impl<int>(std::string const &str) -> int {
+template <> auto parse_number_impl<int32_t>(std::string const &str) -> int32_t {
   return std::stoi(str);
 }
-template <>
-auto parse_number_impl<unsigned long long>(std::string const &str)
-    -> unsigned long long {
-  return std::stoull(str);
-}
-template <> auto parse_number_impl<long>(std::string const &str) -> long {
+template <> auto parse_number_impl<int64_t>(std::string const &str) -> int64_t {
   return std::stol(str);
 }
 template <>
-auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long {
+auto parse_number_impl<uint32_t>(std::string const &str) -> uint32_t {
   return std::stoul(str);
 }
+template <>
+auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t {
+  return std::stoull(str); // use stoull or stul?
+}
+template <> auto parse_number_impl<long>(std::string const &str) -> long {
+  return std::stol(str); // use stoull or stul?
+}
+template <>
+auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long {
+  return std::stoul(str); // use stoull or stul?
+}
+
 template <> auto parse_number_impl<float>(std::string const &str) -> float {
   return std::stof(str);
 }
@@ -74,7 +81,7 @@ std::vector<std::string> tokenize(std::string const &str,
   std::vector<std::string> retval; // Storage for the result
   // convert a string into a stream to be processed by getline.
 
-  // Simple implementaiton if only one delimiter
+  // Simple implementation if only one delimiter
   if (delimiters.size() == 1) {
     std::istringstream iss(str);
     std::string single_word; // local storage
@@ -99,7 +106,7 @@ std::vector<std::string> tokenize(std::string const &str,
 
 //----------------------------------------------------------------------------//
 /*!
- * \brief Parse msg to provide a list of words and the number of occurances of
+ * \brief Parse msg to provide a list of words and the number of occurrences of
  *        each.
  */
 std::map<std::string, unsigned> get_word_count(std::ostringstream const &msg,
@@ -113,7 +120,7 @@ std::map<std::string, unsigned> get_word_count(std::ostringstream const &msg,
   string msgbuf(msg.str());
   string delims(" \n\t:,.;");
 
-  { // Build a list of words found in msgbuf.  Count the number of occurances.
+  { // Build a list of words found in msgbuf.  Count the number of occurrences.
 
     // Find the beginning of the first word.
     string::size_type begIdx = msgbuf.find_first_not_of(delims);
@@ -139,7 +146,7 @@ std::map<std::string, unsigned> get_word_count(std::ostringstream const &msg,
 
   if (verbose) {
     cout << "The messages from the message stream contained the following "
-         << "words/occurances." << endl;
+         << "words/occurrences." << endl;
     // print the word_list
     for (auto it : word_list)
       cout << it.first << ": " << it.second << endl;
@@ -151,7 +158,7 @@ std::map<std::string, unsigned> get_word_count(std::ostringstream const &msg,
 //----------------------------------------------------------------------------//
 /*!
  * \brief Parse text file to provide a list of words and the number of
- *        occurances of each.
+ *        occurrences of each.
  */
 std::map<std::string, unsigned> get_word_count(std::string const &filename,
                                                bool verbose) {

--- a/src/ds++/DracoStrings.cc
+++ b/src/ds++/DracoStrings.cc
@@ -33,6 +33,10 @@ template <>
 auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t {
   return std::stoull(str); // use stoull or stul?
 }
+
+// See notes in DracoStrings.hh about this CPP block
+#if defined(WIN32)
+
 template <> auto parse_number_impl<long>(std::string const &str) -> long {
   return std::stol(str); // use stoull or stul?
 }
@@ -40,6 +44,7 @@ template <>
 auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long {
   return std::stoul(str); // use stoull or stul?
 }
+#endif
 
 template <> auto parse_number_impl<float>(std::string const &str) -> float {
   return std::stof(str);

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -100,9 +100,26 @@ template <>
 auto parse_number_impl<uint32_t>(std::string const &str) -> uint32_t;
 template <>
 auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t;
+
+// I'm having trouble finding a generic solution for an issue where some
+// compilers require separate specialization for 'long' and 'int64_t'
+// (i.e. Visual Studio) while for other compilers these types are identical.
+// So, I'm using some info pulled from <stdint.h> on Linux.
+//
+// On Linux, it appears that long == 'int64_t' if Linux is 64-bit
+// (__WORDSIZE == 64).
+//
+// If we are using Visual Studio, we need these defintions. I expect that they
+// will be needed for 32-bit Linux as well, but I can't test that.
+// Might need to add "|| (defined(__GNUC__) && __WORDSIZE != 64)"
+#if defined(WIN32)
+
 template <> auto parse_number_impl<long>(std::string const &str) -> long;
 template <>
 auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long;
+
+#endif
+
 template <> auto parse_number_impl<float>(std::string const &str) -> float;
 template <> auto parse_number_impl<double>(std::string const &str) -> double;
 

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -3,7 +3,7 @@
  * \file   ds++/DracoStrings.hh
  * \author Kelly G. Thompson <kgt@lanl.gov
  * \date   Wednesday, Aug 23, 2017, 12:48 pm
- * \brief  Enscapulates common string manipulations.
+ * \brief  Encapsulates common string manipulations.
  * \note   Copyright (C) 2017-2018 Los Alamos National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
@@ -51,8 +51,7 @@ std::string to_string(T const num, unsigned int const precision = 23) {
  * \return A new, probably shortened, string without unwanted leading/training
  *         characters.
  */
-DLL_PUBLIC_dsxx std::string trim(std::string const &str,
-                                 std::string const &whitespace = " \t");
+std::string trim(std::string const &str, std::string const &whitespace = " \t");
 
 //----------------------------------------------------------------------------//
 /*!
@@ -64,8 +63,8 @@ DLL_PUBLIC_dsxx std::string trim(std::string const &str,
  * \return A new, possibly shortened, string that does not contain the unwanted
  *         characters.
  */
-DLL_PUBLIC_dsxx std::string prune(std::string const &orig_str,
-                                  std::string const &chars_to_remove);
+std::string prune(std::string const &orig_str,
+                  std::string const &chars_to_remove);
 
 //----------------------------------------------------------------------------//
 /*!
@@ -78,9 +77,9 @@ DLL_PUBLIC_dsxx std::string prune(std::string const &orig_str,
  *                 (default: false)
  * \return a vector of strings. The delimiter is always removed.
  */
-DLL_PUBLIC_dsxx std::vector<std::string>
-tokenize(std::string const &str, std::string const &delimiters = " ",
-         bool keepEmptyStrings = false);
+std::vector<std::string> tokenize(std::string const &str,
+                                  std::string const &delimiters = " ",
+                                  bool keepEmptyStrings = false);
 
 //----------------------------------------------------------------------------//
 /*!
@@ -94,19 +93,18 @@ tokenize(std::string const &str, std::string const &delimiters = " ",
  */
 template <typename T> auto parse_number_impl(std::string const &str) -> T;
 
-// specializations for these types are devined in DracoStrings.cc
+// specializations for these types are defined in DracoStrings.cc
+template <> auto parse_number_impl<int32_t>(std::string const &str) -> int32_t;
+template <> auto parse_number_impl<int64_t>(std::string const &str) -> int64_t;
 template <>
-DLL_PUBLIC_dsxx auto parse_number_impl<int>(std::string const &str) -> int;
+auto parse_number_impl<uint32_t>(std::string const &str) -> uint32_t;
 template <>
-DLL_PUBLIC_dsxx auto parse_number_impl<long>(std::string const &str) -> long;
+auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t;
+template <> auto parse_number_impl<long>(std::string const &str) -> long;
 template <>
-DLL_PUBLIC_dsxx auto parse_number_impl<unsigned long>(std::string const &str)
-    -> unsigned long;
-template <>
-DLL_PUBLIC_dsxx auto parse_number_impl<float>(std::string const &str) -> float;
-template <>
-DLL_PUBLIC_dsxx auto parse_number_impl<double>(std::string const &str)
-    -> double;
+auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long;
+template <> auto parse_number_impl<float>(std::string const &str) -> float;
+template <> auto parse_number_impl<double>(std::string const &str) -> double;
 
 //----------------------------------------------------------------------------//
 /*!
@@ -160,7 +158,7 @@ auto parse_number(std::string const &str, bool verbose = true) -> T;
  *        values.
  *
  * \param[in] str The string that contains a number.
- * \param[in] range_symbols Parenthesis or brances that mark the begining or end
+ * \param[in] range_symbols Parenthesis or braces that mark the beginning or end
  *                 of the value range. (default: "{}")
  * \param[in] delimiter A character that separates each numeric entry.
  *                 (default: ",")
@@ -186,8 +184,8 @@ std::vector<T> string_to_numvec(std::string const &str,
  *                 (default: false).
  * \return a map<string,uint> that contains [word]:[num_occurances]
  */
-DLL_PUBLIC_dsxx std::map<std::string, unsigned>
-get_word_count(std::ostringstream const &data, bool verbose = false);
+std::map<std::string, unsigned> get_word_count(std::ostringstream const &data,
+                                               bool verbose = false);
 
 //----------------------------------------------------------------------------//
 /*!
@@ -199,8 +197,8 @@ get_word_count(std::ostringstream const &data, bool verbose = false);
  *                 (default: false).
  * \return a map<string,uint> that contains [word]:[num_occurances]
  */
-DLL_PUBLIC_dsxx std::map<std::string, unsigned>
-get_word_count(std::string const &filename, bool verbose = false);
+std::map<std::string, unsigned> get_word_count(std::string const &filename,
+                                               bool verbose = false);
 
 } // namespace rtt_dsxx
 

--- a/src/ds++/test/tstDracoStrings.cc
+++ b/src/ds++/test/tstDracoStrings.cc
@@ -102,6 +102,10 @@ void test_parse_number(UnitTest &ut) {
   FAIL_IF_NOT(parse_number<int>(case1) == 1);
   FAIL_IF_NOT(parse_number<long>(case1) == 1l);
   FAIL_IF_NOT(parse_number<unsigned long>(case1) == 1ul);
+  FAIL_IF_NOT(parse_number<int32_t>(case1) == 1);
+  FAIL_IF_NOT(parse_number<int64_t>(case1) == 1l);
+  FAIL_IF_NOT(parse_number<uint32_t>(case1) == 1u);
+  FAIL_IF_NOT(parse_number<uint64_t>(case1) == 1ul);
   FAIL_IF_NOT(soft_equiv(parse_number<float>(case1), 1.0f, feps));
   FAIL_IF_NOT(soft_equiv(parse_number<double>(case1), 1.0, deps));
 

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -23,7 +23,7 @@ file( GLOB headers *.hh )
 
 add_component_library(
    TARGET       Lib_mesh
-   TARGET_DEPS  "Lib_dsxx;Lib_mesh_element;Lib_RTT_Format_Reader;Lib_parser"
+   TARGET_DEPS  "Lib_RTT_Format_Reader;Lib_parser"
    LIBRARY_NAME ${PROJECT_NAME}
    SOURCES      "${sources}"
    HEADERS      "${headers}"


### PR DESCRIPTION
### Background

* We require C/C++ code to conform to the style enforced by `clang-format`, but until now we didn't provide an easy way for _vi(m)_ users to automatically apply the style to files that are being edited.  This PR demonstrates how to use an _optional_ add-in for _vi(m)_ that provides this capability.  `<control>-i` can be used to format the current line.  A hook can also be added that will reformat the whole file upon write.
* We are evaluating tools that will help us enforce a common style for F90 code. An Emacs based solution is provided for early testing
* We would like the Appveyor CI to run more tests (begin testing the _mesh_ package).

### Purpose of Pull Request

* [Related to Redmine Issue #1250](https://rtt.lanl.gov/redmine/issues/1250) - f90 formatter
* [Related to Redmine Issue #1207](https://rtt.lanl.gov/redmine/issues/1207) - more tests for appveyor CI

### Description of changes

+ Provide new sample scripts for `.vimrc` that allow developers who use _vi(m)_ to:
  - Use key command `<control>-i` to format the current line according to clang-format.
  - Apply clang-format when the file is written.
+ Add a file regex pattern to `.gitignore` for vim swap files.
+ Provide a shell script, `format-f90.sh`, that will be tested as a code style formatter for F90 code.  If this works well, a git-commit-hook will be added. This shell script uses emacs in batch mode along with the associated emacs lisp code found in `format-f90.el`.
+ Add a declaration in `DracoStrings.hh` that matches the explicit instantiation found in `DracoStrings.cc`. This missing declaration was causing an issue for the Appveyor CI build. Also change explicit specializations from {int, unsigned, long, unsigned long} to {int32_t, uint32_t, int64_t, uint64_t, long}
  and remove unnecessary `DLL_PUBLIC_dsxx` CPP macros.
+ Add some new checks to `tstDracoStrings`.
+ Change `tstPrefetch.cc` for Debug builds to reduce run times.
+ Update two `CMakeLists.txt` files:
  - Add the `mesh` package to the CI tests run by Appveyor.
  - Modify the `mesh` package's library dependencies.
  - Update some comments and fix spelling errors.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
