### PR TITLE
Fix a compatibility issue related to Python3

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -82,6 +82,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # -Wfloat-equal
   # -Werror
   # -Wconversion
+  # -Winline
   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -D_FORTIFY_SOURCE=2 -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -Wno-expansion-to-defined -funroll-loops" )

--- a/config/unix-ifort.cmake
+++ b/config/unix-ifort.cmake
@@ -23,12 +23,18 @@ if( NOT Fortran_FLAGS_INITIALIZED )
   #    '-ip' is turned on and a library has unresolved symbols (this occurs when
   #    capsaicin links to openmpi/1.10.3 on snow/fire/ice).
   #    Ref: https://github.com/open-mpi/ompi/issues/251
+  # [KT 2018-03-14] '-assume nostd_mod_proc_name' --  discussion with G.
+  #    Rockefeller and S. Nolen aobut ifort's non-standard name mangling for
+  #    module procedures. Not sure if we need this yet.
+
   set( CMAKE_Fortran_FLAGS
     "-warn  -fpp -implicitnone -diag-disable 11060" )
   set( CMAKE_Fortran_FLAGS_DEBUG
     "-g -O0 -traceback -ftrapuv -check -DDEBUG" )
   set( CMAKE_Fortran_FLAGS_RELEASE
-    "-O2 -inline-level=2 -fp-speculation fast -fp-model fast -align array32byte -funroll-loops -diag-disable 11021 -DNDEBUG" )
+    "-O2 -inline-level=2 -fp-speculation fast -fp-model fast" )
+  string(APPEND CMAKE_Fortran_FLAGS_RELEASE
+    " -align array32byte -funroll-loops -diag-disable 11021 -DNDEBUG" )
   set( CMAKE_Fortran_FLAGS_MINSIZEREL
     "${CMAKE_Fortran_FLAGS_RELEASE}" )
   set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -51,6 +51,9 @@ endif()
 if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
+  # Alternative for per-directory, or per-target specific flags:
+  # add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/MP>")
+
   # Notes on options:
   # - /wd 4251 disable warning #4251: 'identifier' : class 'type' needs to have
   #   dll-interface to be used by clients of class 'type2'

--- a/environment/elisp/format-f90.el
+++ b/environment/elisp/format-f90.el
@@ -4,7 +4,7 @@
 
 ;;; Description:
 
-;;; With format-f90.sh, laod a file in Emacs, apply standard Draco
+;;; With format-f90.sh, load a file in Emacs, apply standard Draco
 ;;; formatting rules, save and exit Emacs via a non-interactive batch
 ;;; process.
 


### PR DESCRIPTION
### Background

* The default developer environment on ccs-net machines started using Python3 instead of Python2 about a week ago.  Capsaicin tests that use python to run `gdiff` are failing due to a Python 2->3 compatibility oversight.  This PR attempts to fix this issue.

### Description of changes

+ The `run_gdiff` function from `application_unit_test.py` wasn't working correctly with Python3 because `subprocess.communicate()` was returning a byte array instead of a character string. This is related to Python3's support for unicode character sets. A `decode('UTF-8')` operation was added convert the data stream to a set of strings.  The new code was tested with both Python2 and Python3.
+ The `capsaicin_output_check` function from `application_unit_test.py` was updated to simplify how false-positives are detected.  The new algorithm is based on python code found in Capsaicin.
+ Other changes in this commit do not change code. Comments are updated or added in a few files and one long line of cmake code is split to keep commands under 80 columns.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
