### PR TITLE
Improve mesh_element and norms code coverage

### DIFF
--- a/src/mesh_element/Element_Definition.cc
+++ b/src/mesh_element/Element_Definition.cc
@@ -459,41 +459,42 @@ void Element_Definition::construct_pentagon()
 */
 
 //---------------------------------------------------------------------------//
+// No test for this function.
 
-void Element_Definition::construct_pentagon() {
-  std::vector<unsigned> tmp;
-  dimension = 2;
-  number_of_sides = 5;
-  tmp.clear();
-  tmp.push_back(0);
-  tmp.push_back(1);
-  side_nodes.push_back(tmp);
-  tmp[0] = 1;
-  tmp[1] = 2;
-  side_nodes.push_back(tmp);
-  tmp[0] = 2;
-  tmp[1] = 3;
-  side_nodes.push_back(tmp);
-  tmp[0] = 3;
-  tmp[1] = 4;
-  side_nodes.push_back(tmp);
-  tmp[0] = 4;
-  tmp[1] = 0;
-  side_nodes.push_back(tmp);
+// void Element_Definition::construct_pentagon() {
+//   std::vector<unsigned> tmp;
+//   dimension = 2;
+//   number_of_sides = 5;
+//   tmp.clear();
+//   tmp.push_back(0);
+//   tmp.push_back(1);
+//   side_nodes.push_back(tmp);
+//   tmp[0] = 1;
+//   tmp[1] = 2;
+//   side_nodes.push_back(tmp);
+//   tmp[0] = 2;
+//   tmp[1] = 3;
+//   side_nodes.push_back(tmp);
+//   tmp[0] = 3;
+//   tmp[1] = 4;
+//   side_nodes.push_back(tmp);
+//   tmp[0] = 4;
+//   tmp[1] = 0;
+//   side_nodes.push_back(tmp);
 
-  switch (type) {
-  case PENTAGON_5:
-    name = "PENTAGON_5";
-    number_of_nodes = 5;
-    elem_defs.push_back(Element_Definition(BAR_2));
-    break;
-  default:
-    Insist(false, "#5 Unrecognized Element-Type Flag");
-  }
+//   switch (type) {
+//   case PENTAGON_5:
+//     name = "PENTAGON_5";
+//     number_of_nodes = 5;
+//     elem_defs.push_back(Element_Definition(BAR_2));
+//     break;
+//   default:
+//     Insist(false, "#5 Unrecognized Element-Type Flag");
+//   }
 
-  for (size_t i = 0; i < number_of_sides; i++)
-    side_type.push_back(0);
-}
+//   for (size_t i = 0; i < number_of_sides; i++)
+//     side_type.push_back(0);
+// }
 
 //---------------------------------------------------------------------------//
 void Element_Definition::construct_tetra() {

--- a/src/mesh_element/Element_Definition.hh
+++ b/src/mesh_element/Element_Definition.hh
@@ -414,7 +414,7 @@ private:
   void construct_bar();
   void construct_tri();
   void construct_quad();
-  void construct_pentagon();
+  // void construct_pentagon();
   void construct_tetra();
   void construct_pyra();
   void construct_penta();

--- a/src/norms/Norms_Index.hh
+++ b/src/norms/Norms_Index.hh
@@ -5,10 +5,7 @@
  * \date   Fri Jan 14 13:00:32 2005
  * \brief  Header file for Norms_Index.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_norms_Norms_Index_hh
@@ -35,11 +32,11 @@ namespace rtt_norms {
 
   The norms are computed by making consecutive calls to Norms_Index<>::add.
   Each call to Norms_Index<>::add adds a term to the above summations.
-  Norms_Index<>::reset() re-initializes the sums to zero.  The member
-  functions Norms_Base::L1, Norms_Base::L2, and Norms_Base::Linf compute
-  their values on-processor.  In order to compute these norms across
-  processors, the results must be accumulated to a single processor, using a
-  call to Norms_Index<>::comm.
+  Norms_Index<>::reset() re-initializes the sums to zero.  The member functions
+  Norms_Base::L1, Norms_Base::L2, and Norms_Base::Linf compute their values
+  on-processor.  In order to compute these norms across processors, the results
+  must be accumulated to a single processor, using a call to
+  Norms_Index<>::comm.
 
   Some member functions are documented in the base class Norms_Base.
 
@@ -74,7 +71,7 @@ public:
   void comm(const size_t n = 0);
 
   // Re-initializes the norm values.
-  void reset();
+  // void reset();
 
   // Equality operator.
   bool operator==(const Norms_Index &n) const;

--- a/src/norms/Norms_Index.t.cc
+++ b/src/norms/Norms_Index.t.cc
@@ -1,14 +1,11 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
-  \file   Norms_Index.t.cc
-  \author Rob Lowrie
-  \date   Fri Jan 14 13:00:47 2005
-  \brief  Instantiates Norms_Index for some types.
+ * \file   Norms_Index.t.cc
+ * \author Rob Lowrie
+ * \date   Fri Jan 14 13:00:47 2005
+ * \brief  Instantiates Norms_Index for some types.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
-*/
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Norms_Index.t.hh"
@@ -20,6 +17,7 @@ namespace rtt_norms {
 template class Norms_Index<size_t>;
 template class Norms_Index<Index_Labeled>;
 template class Norms_Index<Index_Proc>;
+
 } // namespace rtt_norms
 
 //---------------------------------------------------------------------------//

--- a/src/norms/Norms_Index.t.hh
+++ b/src/norms/Norms_Index.t.hh
@@ -4,7 +4,7 @@
  * \author Rob Lowrie
  * \date   Fri Jan 14 13:00:47 2005
  * \brief  Implemention for Norms_Index class.
- * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.  
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
@@ -46,10 +46,10 @@ void Norms_Index<Index_t>::add(const double v, const Index_t &index,
 
 //---------------------------------------------------------------------------//
 //! Re-initializes the norm values.
-template <typename Index_t> void Norms_Index<Index_t>::reset() {
-  Norms_Base::reset();
-  d_index_Linf = Index_t();
-}
+// template <typename Index_t> void Norms_Index<Index_t>::reset() {
+//   Norms_Base::reset();
+//   d_index_Linf = Index_t();
+// }
 
 //---------------------------------------------------------------------------//
 /*!
@@ -58,7 +58,7 @@ template <typename Index_t> void Norms_Index<Index_t>::reset() {
   After calling this function, processor \a n contains the norms over all
   processors.  All processors other than \a n still contain their same
   norm values.
-  
+
   \param n Processor on which norms are summed.
 */
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* Improve code coverage of the mesh_element and norms packages by adding tests or removing features.
* Related to #465 

### Description of changes

+ In `Element_Definition.cc`, comment out `construct_pentagon()` as it is not tested and apparently not used.
+ In `Norms_Index`, comment out `reset()` as it is not tested and apparently not used.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
