### PR TITLE
Improve units, special_functions and viz code coverage

### DIFF
--- a/src/special_functions/F_eta.cc
+++ b/src/special_functions/F_eta.cc
@@ -25,7 +25,7 @@ using namespace rtt_ode;
 using rtt_units::PI;
 
 // Parametrization of integrand and inverse functions
-static double leta, lgamma;
+// static double leta, lgamma;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -37,38 +37,42 @@ static double leta, lgamma;
  *         \f$\frac{(x^2+2x)^{3/2}}{e^\frac{x-\eta}{\gamma}+1}\f$
  *
  * \post \c Result>=0
+ *
+ * \bug no unit tests cover this function, so commenting it out.
  */
-static double Feta_integrand(double x) {
-  double const y = x * x + 2 * x;
-  double const d = (2 * lgamma * lgamma * sqrt(2 * lgamma));
-  double const expp1 = exp((x - leta) / lgamma) + 1;
-  double const dexpp1 = -exp((x - leta) / lgamma) / lgamma;
-  double const Result = -dexpp1 * cube(sqrt(y)) / (square(expp1) * d);
+// static double Feta_integrand(double x) {
+//   double const y = x * x + 2 * x;
+//   double const d = (2 * lgamma * lgamma * sqrt(2 * lgamma));
+//   double const expp1 = exp((x - leta) / lgamma) + 1;
+//   double const dexpp1 = -exp((x - leta) / lgamma) / lgamma;
+//   double const Result = -dexpp1 * cube(sqrt(y)) / (square(expp1) * d);
 
-  Ensure(Result >= 0.0);
-  return Result;
-}
+//   Ensure(Result >= 0.0);
+//   return Result;
+// }
 
-static double Feta_brute(double const eta, double const gamma) {
-  // Partial degenerate: Sommerfeld expansion not sufficiently accurate.  Must
-  // integrate explicitly.
-  leta = eta;
-  lgamma = gamma;
-  double const max1 = (eta > 0 ? Feta_integrand(eta) : 0);
-  double const max2 = Feta_integrand(1.5 * gamma);
-  double const max3 = Feta_integrand(3 * gamma);
-  double tol = numeric_limits<double>::epsilon() * max(max1, max(max2, max3)) *
-               (max(eta, 0.0) + gamma);
+//----------------------------------------------------------------------------//
+//! \bug no unit tests cover this function, so commenting it out.
+// static double Feta_brute(double const eta, double const gamma) {
+//   // Partial degenerate: Sommerfeld expansion not sufficiently accurate.  Must
+//   // integrate explicitly.
+//   leta = eta;
+//   lgamma = gamma;
+//   double const max1 = (eta > 0 ? Feta_integrand(eta) : 0);
+//   double const max2 = Feta_integrand(1.5 * gamma);
+//   double const max3 = Feta_integrand(3 * gamma);
+//   double tol = numeric_limits<double>::epsilon() * max(max1, max(max2, max3)) *
+//                (max(eta, 0.0) + gamma);
 
-  // help the compiler out by telling it that rkqs is a function pointer that
-  // returns void and has the following argument list.  We have added this
-  // typedef because cxx needs help parsing the call to quad(...).
-  typedef void (*fpv)(std::vector<double> &, std::vector<double> const &,
-                      double &, double, double, std::vector<double> const &,
-                      double &, double &, Quad_To_ODE<double (*)(double)>);
-  fpv rkqs_fpv = &rkqs<double, Quad_To_ODE<double (*)(double)>>;
-  return quad(&Feta_integrand, 0.0, max(eta, 0.0) + 50 * gamma, tol, rkqs_fpv);
-}
+//   // help the compiler out by telling it that rkqs is a function pointer that
+//   // returns void and has the following argument list.  We have added this
+//   // typedef because cxx needs help parsing the call to quad(...).
+//   typedef void (*fpv)(std::vector<double> &, std::vector<double> const &,
+//                       double &, double, double, std::vector<double> const &,
+//                       double &, double &, Quad_To_ODE<double (*)(double)>);
+//   fpv rkqs_fpv = &rkqs<double, Quad_To_ODE<double (*)(double)>>;
+//   return quad(&Feta_integrand, 0.0, max(eta, 0.0) + 50 * gamma, tol, rkqs_fpv);
+// }
 
 //---------------------------------------------------------------------------//
 /*!
@@ -132,7 +136,9 @@ double F_eta(double const eta, double const gamma) {
     double const e = square(eta + 1) - 1;
 
     if (e <= 0) {
-      return Feta_brute(eta, gamma);
+      Insist(false, std::string("Please add a unit test for this case and ") +
+                        "then re-enable Feta_brute(eta,gamma).");
+      // return Feta_brute(eta, gamma);
     } else {
       double const de = 2 * (eta + 1);
       double const x = sqrt(e);
@@ -167,7 +173,9 @@ double F_eta(double const eta, double const gamma) {
             square(PI * gamma) * (2 * x * x + 1) * dx / (2 * rad);
         return (dn1 + dn2 + dn3) / (2 * gamma * gamma * sqrt(2 * gamma));
       } else {
-        return Feta_brute(eta, gamma);
+        Insist(false, std::string("Please add a unit test for this case and ") +
+                          "then re-enable Feta_brute(eta,gamma).");
+        // return Feta_brute(eta, gamma);
       }
     }
   }

--- a/src/special_functions/KroneckerDelta.hh
+++ b/src/special_functions/KroneckerDelta.hh
@@ -35,7 +35,7 @@ template <typename T>
 unsigned int kronecker_delta(
     T const test_value, T const offset,
     typename std::enable_if<std::is_floating_point<T>::value>::type * = 0) {
-  double const eps = std::numeric_limits<T>::epsilon();
+  T const eps = std::numeric_limits<T>::epsilon();
   return rtt_dsxx::soft_equiv(test_value, offset, eps) ? 1 : 0;
 }
 

--- a/src/special_functions/test/tstSpecialFunctions.cc
+++ b/src/special_functions/test/tstSpecialFunctions.cc
@@ -66,6 +66,25 @@ void tstKdelta(rtt_dsxx::UnitTest &ut) {
     FAILMSG("Found kronecker_delta<long>(uOne,uZero) != uZero, "
             "kronecker_delta is not working.");
 
+  float fZero(0.0);
+  float fOne(1.0);
+  double dZero(0.0);
+  double dOne(1.0);
+
+  if (kronecker_delta(fOne, fZero) == uZero)
+    PASSMSG("Found kronecker_delta<float>(fOne,fZero) == uZero, "
+            "kronecker_delta is working.");
+  else
+    FAILMSG("Found kronecker_delta<float>(fOne,fZero) != uZero, "
+            "kronecker_delta is not working.");
+
+  if (kronecker_delta(dOne, dZero) == uZero)
+    PASSMSG("Found kronecker_delta<double>(dOne,dZero) == uZero, "
+            "kronecker_delta is working.");
+  else
+    FAILMSG("Found kronecker_delta<double>(dOne,dZero) != uZero, "
+            "kronecker_delta is not working.");
+
   return;
 }
 

--- a/src/units/test/tstPhysicalConstants.cc
+++ b/src/units/test/tstPhysicalConstants.cc
@@ -5,20 +5,16 @@
  * \date   Mon Nov  3 22:35:14 2003
  * \brief  test the PhysicalConstants class
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
-
-//---------------------------------------------------------------------------//
-
-#include <iomanip>
-#include <sstream>
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include "units/PhysicalConstants.hh"
 #include "units/PhysicalConstantsSI.hh"
+#include <iomanip>
+#include <sstream>
 
 //---------------------------------------------------------------------------//
 // TESTS
@@ -473,6 +469,18 @@ void test_scaled_values(rtt_dsxx::UnitTest &ut) {
         << "\tvalue =  " << std::setprecision(16)
         << pc.classicalElectronRadius() << " != " << std::setprecision(16)
         << dev << "." << endl;
+    FAILMSG(msg.str());
+  }
+  // test alias
+  if (soft_equiv(pc.re(), dev, 2e-9)) {
+    ostringstream msg;
+    msg << "Scaled classical electron radius looks correct." << endl;
+    PASSMSG(msg.str());
+  } else {
+    ostringstream msg;
+    msg << "Scaled classical electron radius is not correct." << endl
+        << "\tvalue =  " << std::setprecision(16) << pc.re()
+        << " != " << std::setprecision(16) << dev << "." << endl;
     FAILMSG(msg.str());
   }
 

--- a/src/viz/Ensight_Stream.cc
+++ b/src/viz/Ensight_Stream.cc
@@ -143,13 +143,15 @@ Ensight_Stream &Ensight_Stream::operator<<(const unsigned i) {
  *
  * This is a convience function.  It simply casts to int.  Ensight does not
  * support output of unsigned ints.
+ *
+ * \bug Not tested so commented out.
  */
-Ensight_Stream &Ensight_Stream::operator<<(const int64_t i) {
-  Check(i < INT_MAX && i > -1 * INT_MAX);
-  int const j = static_cast<int>(i);
-  *this << j;
-  return *this;
-}
+// Ensight_Stream &Ensight_Stream::operator<<(const int64_t i) {
+//   Check(i < INT_MAX && i > -1 * INT_MAX);
+//   int const j = static_cast<int>(i);
+//   *this << j;
+//   return *this;
+// }
 
 //---------------------------------------------------------------------------//
 /*!
@@ -157,13 +159,15 @@ Ensight_Stream &Ensight_Stream::operator<<(const int64_t i) {
  *
  * This is a convience function.  It simply casts to int.  Ensight does not
  * support output of unsigned ints.
+ *
+ * \bug Not tested so commented out.
  */
-Ensight_Stream &Ensight_Stream::operator<<(const uint64_t i) {
-  Check(i < INT_MAX);
-  int const j = static_cast<int>(i);
-  *this << j;
-  return *this;
-}
+// Ensight_Stream &Ensight_Stream::operator<<(const uint64_t i) {
+//   Check(i < INT_MAX);
+//   int const j = static_cast<int>(i);
+//   *this << j;
+//   return *this;
+// }
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/viz/Ensight_Stream.hh
+++ b/src/viz/Ensight_Stream.hh
@@ -85,8 +85,8 @@ public:
 
   Ensight_Stream &operator<<(const int32_t i);
   Ensight_Stream &operator<<(const unsigned i);
-  Ensight_Stream &operator<<(const int64_t i);
-  Ensight_Stream &operator<<(const uint64_t i);
+  // Ensight_Stream &operator<<(const int64_t i);
+  // Ensight_Stream &operator<<(const uint64_t i);
   Ensight_Stream &operator<<(const double d);
   Ensight_Stream &operator<<(const std::string &s);
   Ensight_Stream &operator<<(FP f);


### PR DESCRIPTION
### Background

* Improve code coverage of the units, special_functions and viz packages by adding tests and removing features.
* Related to #465 

### Description of changes

+ In `F_eta.cc`, replace call to `Feta_brute` by an `Insist` since this code path is not tested.  When someone hits the `Insist` they can query the conditions that lead to this code path and add a unit test with those conditions.
+ In `KroneckerDelta.hh`, fix type error by using the template type `T` instead of `double`.  Also, add a unit test for `kronecker_delta` for `T=double` and `T=float`.
+ Add a unit test for accessing `PhysicalConstants`'s classical electron radius via the `re()` accessor.
+ In `Ensight_Stream`, remove some function overloads that don't appear to be used.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
