### PR TITLE
WIP: Improve code coverage for memory and timestep packages.

### DIFF
--- a/src/cdi_analytic/Pseudo_Line_Base.cc
+++ b/src/cdi_analytic/Pseudo_Line_Base.cc
@@ -107,11 +107,6 @@ Pseudo_Line_Base::Pseudo_Line_Base(
 }
 
 //----------------------------------------------------------------------------//
-// Pseudo_Line_Base::Pseudo_Line_Base(const string &cont_file, int number_of_lines,
-//                                    double line_peak, double line_width,
-//                                    int number_of_edges, double edge_ratio,
-//                                    double Tref, double Tpow, double emin,
-//                                    double emax, unsigned seed)
 Pseudo_Line_Base::Pseudo_Line_Base(const string &cont_file, int number_of_lines,
                                    double line_peak, double line_width,
                                    int number_of_edges, double edge_ratio,

--- a/src/memory/memory.hh
+++ b/src/memory/memory.hh
@@ -23,6 +23,7 @@ uint64_t total_allocation();
 uint64_t peak_allocation();
 uint64_t largest_allocation();
 
+//! Untested functions, commented out.
 void report_leaks(std::ostream &);
 
 //! Register rtt_dsxx::print_stacktrace() as the respose to std::bad_alloc.


### PR DESCRIPTION
### Background

* Improve code coverage of timestep and memory packages by removing features.
* Related to #465 
* *WARNING* - Capsaicin will need to be modified if this PR is merged as-is. A better solution is to provide realistic unit tests for the two untested functions in the memory package.

### Description of changes

+ `memory`'s `report_leaks(ostream)` and `out_of_memory_handler()` functions are untested so I've commented them out. However, these appear to be used in Capsaicin.  So, we should either remove them from Capsaicin or provide unit tests and more documentation in Draco.
+ The `activate` and `set_fixed_value` member functions of `ts_advisor` are untested.  They have been commented out.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
