### PR TITLE
Improve quadrature coverage by adding tests or removing features.

### DIFF
--- a/src/quadrature/Galerkin_Ordinate_Space.cc
+++ b/src/quadrature/Galerkin_Ordinate_Space.cc
@@ -16,38 +16,38 @@
 #include <iomanip>
 #include <iostream>
 
-// static
-// void print_matrix( std::string const & matrix_name,
-//                    std::vector<double> const & x,
-//                    std::vector<unsigned> const & dims )
-// {
-//     using std::cout;
-//     using std::endl;
-//     using std::string;
-
-//     Require( dims[0]*dims[1] == x.size() );
-
-//     unsigned pad_len( matrix_name.length()+2 );
-//     string padding( pad_len, ' ' );
-//     cout << matrix_name << " =";
-//     // row
-//     for( unsigned i=0; i<dims[1]; ++i )
-//     {
-//         if( i != 0 ) cout << padding;
-
-//         cout << "{ ";
-
-//         for( unsigned j=0; j<dims[0]-1; ++j )
-//             cout << std::setprecision(10) << x[j+dims[0]*i] << ", ";
-
-//         cout << std::setprecision(10) << x[dims[0]-1+dims[0]*i] << " }."
-//              << endl;
-//     }
-//     cout << endl;
-//     return;
-// }
-
 using namespace rtt_units;
+
+/*
+static void print_matrix(std::string const &matrix_name,
+                         std::vector<double> const &x,
+                         std::vector<unsigned> const &dims) {
+  using std::cout;
+  using std::endl;
+  using std::string;
+
+  Require(dims[0] * dims[1] == x.size());
+
+  unsigned pad_len(matrix_name.length() + 2);
+  string padding(pad_len, ' ');
+  cout << matrix_name << " =";
+  // row
+  for (unsigned i = 0; i < dims[1]; ++i) {
+    if (i != 0)
+      cout << padding;
+
+    cout << "{ ";
+
+    for (unsigned j = 0; j < dims[0] - 1; ++j)
+      cout << std::setprecision(10) << x[j + dims[0] * i] << ", ";
+
+    cout << std::setprecision(10) << x[dims[0] - 1 + dims[0] * i] << " }."
+         << endl;
+  }
+  cout << endl;
+  return;
+}
+*/
 
 namespace rtt_quadrature {
 
@@ -160,23 +160,16 @@ vector<Moment> Galerkin_Ordinate_Space::compute_n2lk_3D_(Quadrature_Class,
 
 //----------------------------------------------------------------------------//
 /*!
- *
  * \param dimension Dimension of the physical problem space (1, 2, or 3)
- *
  * \param geometry Geometry of the physical problem space (spherical,
  *             axisymmetric, Cartesian)
- *
  * \param ordinates Set of ordinate directions
- *
  * \param quadrature_class Class of the quadrature used to generate the ordinate
  *             set. At presente, only TRIANGLE_QUADRATURE is supported.
- *
  * \param sn_order Order of the quadrature. This is equal to the number of
  *             levels for triangular and square quadratures.
- *
  * \param expansion_order Expansion order of the desired scattering moment
  *             space.
- *
  * \param extra_starting_directions Add extra directions to each level set. In
  *             most geometries, an additional ordinate is added that is opposite
  *             in direction to the starting direction. This is used to implement
@@ -184,10 +177,8 @@ vector<Moment> Galerkin_Ordinate_Space::compute_n2lk_3D_(Quadrature_Class,
  *             that means an additional angle is added at mu=1. In axisymmetric,
  *             that means additional angles are added that are oriented opposite
  *             to the incoming starting direction on each level.
- *
  * \param ordering Ordering into which to sort the ordinates.
  */
-
 Galerkin_Ordinate_Space::Galerkin_Ordinate_Space(
     unsigned const dimension, Geometry const geometry,
     vector<Ordinate> const &ordinates, Quadrature_Class quadrature_class,
@@ -332,6 +323,13 @@ void Galerkin_Ordinate_Space::compute_operators() {
     // first get new ordinate weights from the usual GQ method, needed to
     // accurately integrate all moments
 
+    // This branch is not tested
+    Insist(
+        false,
+        "This branch commented out because there are no supporting unit tests");
+
+    /*
+
     // compute a D matrix by inverting
     Check(numMoments < UINT_MAX);
     Check(numCartesianOrdinates < UINT_MAX);
@@ -372,6 +370,7 @@ void Galerkin_Ordinate_Space::compute_operators() {
     cartesian_M =
         compute_inverse(static_cast<unsigned>(numCartesianOrdinates),
                         static_cast<unsigned>(numMoments), cartesian_D);
+    */
   } else
     Insist(false, "Could not identify Galerkin Quadrature method.");
 
@@ -390,36 +389,31 @@ void Galerkin_Ordinate_Space::compute_operators() {
                    cartesian_D);
   }
 
+  for (unsigned n = 0; n < numMoments; ++n) {
+    unsigned const ell(moments()[n].L());
+    int const k(moments()[n].M());
+
+    std::cout << " moment " << n << "     l = " << ell << " k = " << k
+              << std::endl;
+  }
+
   /*
-    for( unsigned n=0; n<numMoments; ++n )
-    {
-        unsigned const ell ( moments()[n].L() );
-        int      const k   ( moments()[n].M() );
+    std::vector<unsigned> dimsM;
+    dimsM.push_back(numMoments);
+    dimsM.push_back(numOrdinates);
+    print_matrix("M", M_, dimsM);
 
-        std::cout << " moment " << n
-                  << "     l = " << ell << " k = " << k
-                  << std::endl;
-    }
-
-    std::vector< unsigned > dimsM;
-    dimsM.push_back( numMoments );
-    dimsM.push_back( numOrdinates );
-    print_matrix( "M", M_, dimsM );
-
-    std::vector< unsigned > dimsD;
-    dimsD.push_back( numOrdinates );
-    dimsD.push_back( numMoments );
-    print_matrix( "D", D_, dimsD );
+    std::vector<unsigned> dimsD;
+    dimsD.push_back(numOrdinates);
+    dimsD.push_back(numMoments);
+    print_matrix("D", D_, dimsD);
 
     std::cout << " Ordinate Set (may differ from quadrature) " << std::endl;
-    for (unsigned i=0; i<numOrdinates; ++i)
-        std::cout << "   " << i
-                  << "   " << ordinates[i].mu()
-                  << "   " << ordinates[i].eta()
-                  << "   " << ordinates[i].xi()
-                  << "   " << ordinates[i].wt()
-                  << std::endl;
-*/
+    for (unsigned i = 0; i < numOrdinates; ++i)
+      std::cout << "   " << i << "   " << ordinates[i].mu() << "   "
+                << ordinates[i].eta() << "   " << ordinates[i].xi() << "   "
+                << ordinates[i].wt() << std::endl;
+    */
 }
 
 //----------------------------------------------------------------------------//
@@ -516,9 +510,6 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
       {
         double mu(ordinates[m].mu());
         M[n + m * numMoments] = Ylm(ell, k, mu, 0.0, sumwt);
-
-        //                polar = mu;
-        //                azimuthal = 0.0;
       } else {
         double mu(ordinates[m].mu());
         double eta(ordinates[m].eta());
@@ -551,24 +542,17 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
 
           double phi(compute_azimuthalAngle(mu, eta));
           M[n + m * numMoments] = Ylm(ell, k, xi, phi, sumwt);
-
-          //                    polar = xi;
-          //                    azimuthal = phi;
         }
       }
 
       /*
-            if (n == 0)
-                    std::cout << "   " << m
-                              << "   " << ordinates[m].mu()
-                              << "   " << ordinates[m].eta()
-                              << "   " << ordinates[m].xi()
-                              << "   " << ordinates[m].wt()
-                              << "   " << polar
-                              << "   "
-                         << azimuthal*180.0/3.141592653589793238462643383279
-                              << std::endl;
-*/
+      if (n == 0)
+        std::cout << "   " << m << "   " << ordinates[m].mu() << "   "
+                  << ordinates[m].eta() << "   " << ordinates[m].xi() << "   "
+                  << ordinates[m].wt() << "   " << polar << "   "
+                  << azimuthal * 180.0 / 3.141592653589793238462643383279
+                  << std::endl;
+      */
 
     } // ordinate loop
   }   // moment loop
@@ -580,47 +564,47 @@ Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ordinates) {
 /*! This computation uses an existing moment-to-discrete matrix M and ordinate
  *  weights W to compute a discrete-to-moment matrix D = M^{T} W
  */
-vector<double>
-Galerkin_Ordinate_Space::compute_D_SN(vector<Ordinate> const &ordinates,
-                                      vector<double> const &Min) {
+// vector<double>
+// Galerkin_Ordinate_Space::compute_D_SN(vector<Ordinate> const &ordinates,
+//                                       vector<double> const &Min) {
 
-  Insist(!Min.empty(), "The GQ ordinate space computation for the standard SN "
-                       "expression for D requires that M be available.");
+//   Insist(!Min.empty(), "The GQ ordinate space computation for the standard SN "
+//                        "expression for D requires that M be available.");
 
-  vector<Moment> const &n2lk = this->moments();
-  size_t const numMoments = n2lk.size();
-  size_t const numOrdinates = ordinates.size();
+//   vector<Moment> const &n2lk = this->moments();
+//   size_t const numMoments = n2lk.size();
+//   size_t const numOrdinates = ordinates.size();
 
-  // ---------------------------------------------------
-  // Create diagonal matrix of quadrature weights
-  // ---------------------------------------------------
+//   // ---------------------------------------------------
+//   // Create diagonal matrix of quadrature weights
+//   // ---------------------------------------------------
 
-  gsl_matrix *gsl_W = gsl_matrix_alloc(numOrdinates, numOrdinates);
-  gsl_matrix_set_identity(gsl_W);
+//   gsl_matrix *gsl_W = gsl_matrix_alloc(numOrdinates, numOrdinates);
+//   gsl_matrix_set_identity(gsl_W);
 
-  for (unsigned m = 0; m < numOrdinates; ++m)
-    gsl_matrix_set(gsl_W, m, m, ordinates[m].wt());
+//   for (unsigned m = 0; m < numOrdinates; ++m)
+//     gsl_matrix_set(gsl_W, m, m, ordinates[m].wt());
 
-  // ---------------------------------------------------
-  // Create the discrete-to-moment matrix
-  // ---------------------------------------------------
+//   // ---------------------------------------------------
+//   // Create the discrete-to-moment matrix
+//   // ---------------------------------------------------
 
-  std::vector<double> M(Min);
-  gsl_matrix_view gsl_M =
-      gsl_matrix_view_array(&M[0], numOrdinates, numMoments);
+//   std::vector<double> M(Min);
+//   gsl_matrix_view gsl_M =
+//       gsl_matrix_view_array(&M[0], numOrdinates, numMoments);
 
-  std::vector<double> D(numMoments * numOrdinates); // rows x cols
-  gsl_matrix_view gsl_D =
-      gsl_matrix_view_array(&D[0], numMoments, numOrdinates);
+//   std::vector<double> D(numMoments * numOrdinates); // rows x cols
+//   gsl_matrix_view gsl_D =
+//       gsl_matrix_view_array(&D[0], numMoments, numOrdinates);
 
-  unsigned ierr = gsl_blas_dgemm(CblasTrans, CblasNoTrans, 1.0, &gsl_M.matrix,
-                                 gsl_W, 0.0, &gsl_D.matrix);
-  Insist(!ierr, "GSL blas interface error");
+//   unsigned ierr = gsl_blas_dgemm(CblasTrans, CblasNoTrans, 1.0, &gsl_M.matrix,
+//                                  gsl_W, 0.0, &gsl_D.matrix);
+//   Insist(!ierr, "GSL blas interface error");
 
-  gsl_matrix_free(gsl_W);
+//   gsl_matrix_free(gsl_W);
 
-  return D;
-}
+//   return D;
+// }
 
 //----------------------------------------------------------------------------//
 vector<double>

--- a/src/quadrature/Galerkin_Ordinate_Space.hh
+++ b/src/quadrature/Galerkin_Ordinate_Space.hh
@@ -19,14 +19,14 @@ using std::ostream;
 //===========================================================================//
 /*!
  * \class Galerkin_Ordinate_Space
- * \brief Represents ordinate operators for a Galerkin moment space. 
+ * \brief Represents ordinate operators for a Galerkin moment space.
  *
  * The moment space contains all moments (that are not identically zero due to
  * symmetry) up to the specified scattering order, but the moment to discrete
- * operator M and discrete to moment operator D are computed as if enough 
- * additional higher moments are included in the moment space to make D and M 
+ * operator M and discrete to moment operator D are computed as if enough
+ * additional higher moments are included in the moment space to make D and M
  * square. The higher moment terms are then discarded, but the non-square D and
- * M retain the property that DM is the identity. This stabilizes the moment 
+ * M retain the property that DM is the identity. This stabilizes the moment
  * to discrete and discrete to moment operations at high scattering orders.
  *
  * When the additional moments are added, the SN quadrature order is provided,

--- a/src/quadrature/Ordinate_Set_Mapper.hh
+++ b/src/quadrature/Ordinate_Set_Mapper.hh
@@ -5,20 +5,17 @@
  * \date   Mon Mar  7 10:42:56 EST 2016
  * \brief  Declarations for the class rtt_quadrature::Ordinate_Set_Mapper.
  * \note   Copyright (C)  2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: Ordinate.hh 6607 2012-06-14 22:31:45Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef quadrature_OrdinateSetMapper_hh
 #define quadrature_OrdinateSetMapper_hh
 
+#include "Ordinate_Set.hh"
 #include <vector>
 
-#include "Ordinate_Set.hh"
-
 namespace rtt_quadrature {
+
 using rtt_mesh_element::Geometry;
 using std::vector;
 
@@ -40,12 +37,12 @@ public:
     NEAREST_NEIGHBOR,
 
     //! Reallocates weight to nearest three ordinates (at most, must be > 0)
-    //! Note that this uses inverse weighting according to 1-dot product
-    //! so that the closest ordinate is strongly preferred.
+    //! Note that this uses inverse weighting according to 1-dot product so that
+    //! the closest ordinate is strongly preferred.
     NEAREST_THREE,
 
-    //! Currently unimplemented, but would use an interpolating function
-    //! based on a bandwidth dependening on the dot product
+    //! Currently unimplemented, but would use an interpolating function based
+    //! on a bandwidth dependening on the dot product
     KERNEL_DENSITY_ESTIMATOR
   };
 
@@ -58,7 +55,7 @@ public:
   // ACCESSORS
 
   //! Return the ordinate set.
-  Ordinate_Set const &ordinate_set() const { return os_; }
+  // Ordinate_Set const &ordinate_set() const { return os_; }
 
   // SERVICES
 
@@ -78,14 +75,14 @@ private:
 
   // SERVICE CLASSES
   // -------------------------------------------------------------------------
-  // A simple functor to be used in computing a bunch of 3D dot products
-  // between a given ordinate and all the ordinates in a container.
+  // A simple functor to be used in computing a bunch of 3D dot products between
+  // a given ordinate and all the ordinates in a container.
   // -------------------------------------------------------------------------
   struct dot_product_functor_3D {
     dot_product_functor_3D(const Ordinate &o_in) : o1(o_in) {}
 
-    // Returns the 3D dot product of the ordinate passed into the functor
-    // with the local ordinate
+    // Returns the 3D dot product of the ordinate passed into the functor with
+    // the local ordinate
     double operator()(const Ordinate &o2) const {
       return o1.mu() * o2.mu() + o1.eta() * o2.eta() + o1.xi() * o2.xi();
     }
@@ -93,23 +90,22 @@ private:
   };
 
   // -------------------------------------------------------------------------
-  // A simple functor to be used in computing a bunch of 1D dot products
-  // between a given ordinate and all the 1D ordinates in a container.
+  // A simple functor to be used in computing a bunch of 1D dot products between
+  // a given ordinate and all the 1D ordinates in a container.
   // -------------------------------------------------------------------------
   struct dot_product_functor_1D {
     dot_product_functor_1D(const Ordinate &o_in) : o1(o_in) {}
 
-    /*! Returns the dot product of the ordinate passed into the functor
-         *  with the local ordinate. For 1-D we only have the cosine of the
-         *  polar axis for each ordinate, \f$ \theta_1 \f$ and \f$ \theta_2 \f$.
-         *  To obtain the cosine of the angle between them, we need to
-         *  calculate \f$ \cos(\theta) = \cos(\theta_2 - \theta_1) \f$.
-         *  Instead of using a relatively expensive acos() function, we use
-         *  the simple identity,
-         *  \f$ \cos(\theta_2 - \theta_1) = \cos(\theta_1)\cos(\theta_2)
-                                          + \sin(\theta_1)\sin(\theta_2) \, ,\f$
-         *  where \f$ \sin(\theta_1) = \sqrt{1-\mu_1^2} . \f$
-         */
+    /*! Returns the dot product of the ordinate passed into the functor with the
+     *  local ordinate. For 1-D we only have the cosine of the polar axis for
+     *  each ordinate, \f$ \theta_1 \f$ and \f$ \theta_2 \f$.  To obtain the
+     *  cosine of the angle between them, we need to calculate \f$ \cos(\theta)
+     *  = \cos(\theta_2 - \theta_1) \f$.  Instead of using a relatively
+     *  expensive acos() function, we use the simple identity, \f$ \cos(\theta_2
+     *  - \theta_1) = \cos(\theta_1)\cos(\theta_2) +
+     *  \sin(\theta_1)\sin(\theta_2) \, ,\f$ where \f$ \sin(\theta_1) =
+     *  \sqrt{1-\mu_1^2} . \f$
+     */
     double operator()(const Ordinate &o2) const {
       if (soft_equiv(o1.mu(), o2.mu()))
         return 1.0;

--- a/src/quadrature/Ordinate_Space.cc
+++ b/src/quadrature/Ordinate_Space.cc
@@ -288,15 +288,19 @@ Ordinate_Space::compute_n2lk_(Quadrature_Class const quadrature_class,
   if (dim == 3) {
     return compute_n2lk_3D_(quadrature_class, sn_order);
   } else if (dim == 2) {
-    if (geometry == rtt_mesh_element::AXISYMMETRIC)
+    if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+      // Insist(false, std::string("There are no unit tests for this branch, so ")
+      //       + "it was commented out.");
       return compute_n2lk_2Da_(quadrature_class, sn_order);
-    else
+    } else
       return compute_n2lk_2D_(quadrature_class, sn_order);
   } else {
     Check(dim == 1);
-    if (geometry == rtt_mesh_element::AXISYMMETRIC)
+    if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+      // Insist(false, std::string("There are no unit tests for this branch, so ")
+      //       + "it was commented out.");
       return compute_n2lk_1Da_(quadrature_class, sn_order);
-    else
+    } else
       return compute_n2lk_1D_(quadrature_class, sn_order);
   }
 }
@@ -305,7 +309,7 @@ Ordinate_Space::compute_n2lk_(Quadrature_Class const quadrature_class,
 /*! Compute the description of the moment space.
  *
  * N.B. This must not be called in the Ordinate_Space constructor, but in the
- * child class constructor, because it uses virtual functions of the child 
+ * child class constructor, because it uses virtual functions of the child
  * class that are not set up until the child class is constructed.
  */
 void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class,
@@ -318,7 +322,9 @@ void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class,
     number_of_moments_ = 0;
     for (unsigned n = 0; n < moments_.size(); ++n) {
       int const l = moments_[n].L();
-      if (l <= Lmax || !prune()) {
+      // member function prune() always returns true?
+      // if (l <= Lmax || !prune()) {
+      if (l <= Lmax) {
         if (l > Lmax) {
           Lmax = l;
           moments_per_order_.resize(Lmax + 1, 0U);
@@ -402,7 +408,7 @@ double Ordinate_Space::psi_coefficient(unsigned const a) const {
 
 //---------------------------------------------------------------------------//
 /*!
- * The source coefficient is used to compute the previous midpoint angle term 
+ * The source coefficient is used to compute the previous midpoint angle term
  * in the angle derivative term of the streaming operator.
  */
 double Ordinate_Space::source_coefficient(unsigned const a) const {
@@ -497,7 +503,7 @@ void Ordinate_Space::compute_reflection_maps_() {
 /*!
  * Return a mapping from the moments to the components of the astrophysical
  * flux. The astrophysical flux is defined consistently with the mean intensity
- * as \f$ F_i = \frac{1}{4 \pi}\int_{4 \pi}\Omega_i \psi d\omega\f$, that is, 
+ * as \f$ F_i = \frac{1}{4 \pi}\int_{4 \pi}\Omega_i \psi d\omega\f$, that is,
  * it is the physical flux divided by \f$4 \pi\f$.
  *
  * The zeroth moment is presently always assumed to be equal to the mean
@@ -509,7 +515,7 @@ void Ordinate_Space::compute_reflection_maps_() {
  *        corresponding to each astrophysical flux component. That is,
  *        flux_map[i] is the index (starting at zero) of the moment which
  *        corresponds to the ith astrophysical flux component.
- * \param flux_fact On return, contains the normalization factors for 
+ * \param flux_fact On return, contains the normalization factors for
  *        converting the the first moments to astrophysical flux components.
  *
  * Thus, if you are in 2-D Cartesian geometry, and phi contains the moments at

--- a/src/quadrature/Ordinate_Space.hh
+++ b/src/quadrature/Ordinate_Space.hh
@@ -1,14 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   quadrature/Ordinate_Space.hh
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Definition of class Ordinate_Space
- * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC
- */
-//---------------------------------------------------------------------------------------//
-// $Id: Ordinate_Space.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #ifndef quadrature_Ordinate_Space_hh
 #define quadrature_Ordinate_Space_hh
@@ -21,39 +19,39 @@
 namespace rtt_quadrature {
 using std::ostream;
 
-//=======================================================================================//
+//============================================================================//
 /*!
  * \class Ordinate_Space
  * \brief Describes a choice of discrete ordinate and truncated moment
- * representations of ordinate space.
+ *        representations of ordinate space.
  *
  * This class encapsulates descriptions of a discrete ordinate space and a
  * truncated moment space and provides representations of a set of operators
  * operating on these spaces. The moment space is diagonal in any scattering
- * operator for an isotropic material and thus is preferred for coupling to
- * the physics.
+ * operator for an isotropic material and thus is preferred for coupling to the
+ * physics.
  *
  * The discrete ordinate space is described by the methods and data inherited
  * from Ordinate_Set. The heart of this description is the vector<Ordinate>
  * returned by the Ordinate_Set::ordinates method.
  *
- * The moment space is described by the moment to discrete transformation
- * matrix returned by Ordinate_Space::M() and the discrete to moment
- * transformation matrix returned by Ordinate_Space::D(). The moment rank of
- * these matrices is returned by Ordinate_Space::number_of_ordinates while the
- * ordinate rank is given by Ordinate_Set::ordinates().size(). The number of
- * moments of each order in the moment space is returned as a vector<unsigned>
- * by Ordinate_Space::moments_per_order(), and so the size of
+ * The moment space is described by the moment to discrete transformation matrix
+ * returned by Ordinate_Space::M() and the discrete to moment transformation
+ * matrix returned by Ordinate_Space::D(). The moment rank of these matrices is
+ * returned by Ordinate_Space::number_of_ordinates while the ordinate rank is
+ * given by Ordinate_Set::ordinates().size(). The number of moments of each
+ * order in the moment space is returned as a vector<unsigned> by
+ * Ordinate_Space::moments_per_order(), and so the size of
  * Ordinate_Space::moments_per_order() is one more than the moment expansion
  * order. The actual L and M of the spherical harmonic corresponding to each
  * moment is returned by Ordinate_Space::moments().
  *
  * There is a subtlety here: Ordinate_Space::moments.size() is greater than
- * Ordinate_Space::number_of_moments() because the former may contain
- * additional moments, of higher order than the specified expansion order,
- * used to construct the M and D matrices but not included in the actual
- * scattering expansion. See Galerkin_Ordinate_Space for an example where this
- * is done with an explanation of why it is useful.
+ * Ordinate_Space::number_of_moments() because the former may contain additional
+ * moments, of higher order than the specified expansion order, used to
+ * construct the M and D matrices but not included in the actual scattering
+ * expansion. See Galerkin_Ordinate_Space for an example where this is done with
+ * an explanation of why it is useful.
  *
  * The actual spherical harmonic basis used for the moment space is given by
  * rtt_sf::Ylm, which is a real representation in which m=0 is the axially
@@ -68,8 +66,8 @@ using std::ostream;
  * The mu, eta, and xi reflection maps give, for each ordinate i, the index of
  * the ordinate that is the reflection of i in the specified coordinate
  * plane. Thus, on a reflection plane reflecting the first coordinate, the
- * specific intensity of ordinate i is reflected into the specific intensity
- * of ordinate reflec_mu[i]. This greatly simplifies implementing reflection
+ * specific intensity of ordinate i is reflected into the specific intensity of
+ * ordinate reflec_mu[i]. This greatly simplifies implementing reflection
  * boundary conditions.
  *
  * In curvilinear geometry, the streaming operator includes a nontrivial angle
@@ -119,10 +117,9 @@ using std::ostream;
  *
  * \f$\psi_{m+1/2} = B_m\psi_m-(1-B_m)\psi_{m-1/2})\f$
  *
- * Similar expressions can be written for spherical geometry. The
- * Ordinate_Space interface hides these details, presenting only the
- * \f$P_m\f$, \f$S_m\f$, and \f$B_m\f$ coefficients required for actual
- * computation.
+ * Similar expressions can be written for spherical geometry. The Ordinate_Space
+ * interface hides these details, presenting only the \f$P_m\f$, \f$S_m\f$, and
+ * \f$B_m\f$ coefficients required for actual computation.
  *
  * Note that this discretization of the angle derivative terms must still be
  * substituted into the transport equation, which is then further discretized in
@@ -218,13 +215,13 @@ public:
   virtual vector<double> M() const = 0;
 
   //! Should the moment space be pruned to the specified order?
-  virtual bool prune() const {
-    return true;
-    // By default, prune any moments beyond the user-specified expansion
-    // order. Such moments are included in Galerkin methods for purposes
-    // of computing the M and D matrices, but are then removed from the
-    // moment space unless the GQF interpolation model has been specified.
-  }
+  // virtual bool prune() const {
+  //   return true;
+  //   // By default, prune any moments beyond the user-specified expansion
+  //   // order. Such moments are included in Galerkin methods for purposes of
+  //   // computing the M and D matrices, but are then removed from the moment
+  //   // space unless the GQF interpolation model has been specified.
+  // }
 
   //! Return the scattering moment to flux map.
   virtual void moment_to_flux(unsigned flux_map[3], double flux_fact[3]) const;
@@ -284,8 +281,8 @@ private:
   vector<unsigned> reflect_mu_, reflect_eta_, reflect_xi_;
 
   /*! Coefficients for angle derivative terms.  These are defined in
-     * Morel's research note of 12 May 2003 for axisymmetric geometry.
-     */
+   * Morel's research note of 12 May 2003 for axisymmetric geometry.
+   */
   vector<double> alpha_;
   vector<double> tau_;
 

--- a/src/quadrature/QIM.hh
+++ b/src/quadrature/QIM.hh
@@ -1,15 +1,12 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   quadrature/QIM.hh
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Definition of QIM enumeration
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: QIM.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #ifndef quadrature_QIM_hh
 #define quadrature_QIM_hh
@@ -19,28 +16,29 @@
 namespace rtt_quadrature {
 using rtt_parser::Token_Stream;
 
-//! Quadrature Interpolation Model: specifies how to compute the
-//! Discrete-to-Moment operator.
-
+//============================================================================//
+/*!
+ * \class QIM
+ * \brief Quadrature Interpolation Model: Enumerations specify how to compute
+ *        the Discrete-to-Moment operator.
+ */
+//============================================================================//
 enum QIM {
-  SN,  /*!< Use the standard SN method. */
-  GQ1, /*!< Use Morel's Galerkin Quadrature method. */
-  GQ2, /*!< Use Warsa/Prinja Galerkin Quadrature method. */
-  GQF, /*!< Use Morel's Galerkin Quadrature method and retain all moments. */
-  SVD, /*!< Let M be an approximate inverse of D. */
-
+  SN,     /*!< Use the standard SN method. */
+  GQ1,    /*!< Use Morel's Galerkin Quadrature method. */
+  GQ2,    /*!< Use Warsa/Prinja Galerkin Quadrature method. */
+  GQF,    /*!< Use Morel's Galerkin Quadrature method and retain all moments. */
+  SVD,    /*!< Let M be an approximate inverse of D. */
   END_QIM //!< Sentinel value
 };
 
-DLL_PUBLIC_quadrature void parse_quadrature_interpolation_model(Token_Stream &,
-                                                                QIM &);
-
+void parse_quadrature_interpolation_model(Token_Stream &, QIM &);
 std::string quadrature_interpolation_model_as_text(QIM);
 
 } // end namespace rtt_quadrature
 
 #endif // quadrature_QIM_hh
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of quadrature/QIM.hh
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/quadrature/QIM__Parser.cc
+++ b/src/quadrature/QIM__Parser.cc
@@ -1,20 +1,19 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   quadrature/QIM_parser.cc
  * \author Kent Budge
- * \brief  Define a parse routine for quadrature interpolation model specifications.
- * \note   © Copyright 2016 LANSLLC All rights reserved.
- */
-//---------------------------------------------------------------------------------------//
-// $Id: QIM.hh 6718 2012-08-30 20:03:01Z warsa $
-//---------------------------------------------------------------------------------------//
+ * \brief  Define a parse routine for quadrature interpolation model
+ *         specifications.
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
 
 #include "QIM.hh"
 
 namespace rtt_quadrature {
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * /param tokens Token stream from which to parse the specification.
  *
@@ -44,6 +43,8 @@ void parse_quadrature_interpolation_model(Token_Stream &tokens, QIM &qim) {
   }
 }
 
+//----------------------------------------------------------------------------//
+//! Provide a string representation of the provided quadrature enum.
 std::string quadrature_interpolation_model_as_text(QIM q) {
   switch (q) {
   case SN:
@@ -62,6 +63,6 @@ std::string quadrature_interpolation_model_as_text(QIM q) {
 
 } // end namespace rtt_quadrature
 
-//---------------------------------------------------------------------------------------//
-//              end of quadrature/QIM.hh
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
+// end of quadrature/QIM.hh
+//----------------------------------------------------------------------------//

--- a/src/quadrature/test/quadrature_test.hh
+++ b/src/quadrature/test/quadrature_test.hh
@@ -4,8 +4,7 @@
  * \author Kent G. Budge
  * \brief  Define class quadrature_test
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef quadrature_quadrature_test_hh

--- a/src/quadrature/test/tstDouble_Gauss.cc
+++ b/src/quadrature/test/tstDouble_Gauss.cc
@@ -3,10 +3,8 @@
  * \file   quadrature/test/tstDouble_Gauss.cc
  * \author Kent G. Budge
  * \date   Tue Nov  6 13:08:49 2012
- * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC
- */
-//---------------------------------------------------------------------------//
-// $Id: template_test.cc 5830 2011-05-05 19:43:43Z kellyt $
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "quadrature_test.hh"
@@ -30,6 +28,25 @@ int main(int argc, char *argv[]) {
 
     Double_Gauss quad2(2); // SN order = 2
     quadrature_test(ut, quad2);
+
+    // Test
+    {
+      FAIL_IF_NOT(quadrature_interpolation_model_as_text(SN) == "SN");
+      FAIL_IF_NOT(quadrature_interpolation_model_as_text(GQ1) == "GQ1");
+      FAIL_IF_NOT(quadrature_interpolation_model_as_text(GQ2) == "GQ2");
+      FAIL_IF_NOT(quadrature_interpolation_model_as_text(GQF) == "GQF");
+      try {
+        FAIL_IF_NOT(quadrature_interpolation_model_as_text(SVD) == "SVD");
+      } catch (rtt_dsxx::assertion const & /*error*/) {
+        PASSMSG("assertion caught for unlisted QIM == SVD.");
+      }
+      try {
+        FAIL_IF_NOT(quadrature_interpolation_model_as_text(END_QIM) ==
+                    "END_QIM");
+      } catch (rtt_dsxx::assertion const & /*error*/) {
+        PASSMSG("assertion caught for invalid QIM == END_QIM.");
+      }
+    }
   }
   UT_EPILOG(ut);
 }


### PR DESCRIPTION
### Background

* While preparing to review McGrid, I ran into some issues with the code coverage in Draco.  This PR attempts to improve the code coverage statistics for the quadrature package.

### Purpose of Pull Request

* Partial replacement for #465
* [Related to Redmine Issue #1265](https://rtt.lanl.gov/redmine/issues/1265)

### Description of changes

* I've commented out chuncks of code in `Galerkin_Ordinate_Space.cc` because they are untested and replaced that code with an `Insist`.  If this code is needed in the future, it can be reactivated and a unit test should be added.
+ In `Ordinate_Set_Mapper.hh`, I commented out member function `ordinate_set()` as it is untested and unused.
+ While I left this untested code active, we should return to it and add appropriate unit tests (see Redmine issue 1265).
  - compute_n2lk_2Da_
  - compute_n2lk_1Da_
+ In `Ordinate_Space.cc`, I eliminated to the definiton and use of `prune()` because the logic branch where it was used was never called.
+ Note that in `QIM,hh`, there is an enum for SVN that does not considered in `quadrature_interpolation_model_as_text()`.  This is reflected in a modified unit test.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
