### PR TITLE
Restore the prune function to Ordinate_Space.

### DIFF
--- a/src/quadrature/Galerkin_Ordinate_Space.hh
+++ b/src/quadrature/Galerkin_Ordinate_Space.hh
@@ -75,7 +75,13 @@ public:
   //! Return the moment to discrete transform matrix
   virtual vector<double> M() const;
 
-  bool prune() const { return method_ != GQF; }
+  bool prune() const {
+    // Prune any moments beyond the user-specified expansion order. Such
+    // moments are included in Galerkin methods for purposes of computing
+    // the M and D matrices, but are then removed from the moment space
+    // unless the GQF interpolation model has been specified.
+    return method_ != GQF;
+  }
 
   // STATICS
 

--- a/src/quadrature/Ordinate_Space.cc
+++ b/src/quadrature/Ordinate_Space.cc
@@ -322,9 +322,7 @@ void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class,
     number_of_moments_ = 0;
     for (unsigned n = 0; n < moments_.size(); ++n) {
       int const l = moments_[n].L();
-      // member function prune() always returns true?
-      // if (l <= Lmax || !prune()) {
-      if (l <= Lmax) {
+      if (l <= Lmax || !prune()) {
         if (l > Lmax) {
           Lmax = l;
           moments_per_order_.resize(Lmax + 1, 0U);

--- a/src/quadrature/Ordinate_Space.cc
+++ b/src/quadrature/Ordinate_Space.cc
@@ -322,7 +322,7 @@ void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class,
     number_of_moments_ = 0;
     for (unsigned n = 0; n < moments_.size(); ++n) {
       int const l = moments_[n].L();
-      if (l <= Lmax || !prune()) {
+      if (!prune() || l <= Lmax) {
         if (l > Lmax) {
           Lmax = l;
           moments_per_order_.resize(Lmax + 1, 0U);

--- a/src/quadrature/Ordinate_Space.hh
+++ b/src/quadrature/Ordinate_Space.hh
@@ -215,13 +215,11 @@ public:
   virtual vector<double> M() const = 0;
 
   //! Should the moment space be pruned to the specified order?
-  // virtual bool prune() const {
-  //   return true;
-  //   // By default, prune any moments beyond the user-specified expansion
-  //   // order. Such moments are included in Galerkin methods for purposes of
-  //   // computing the M and D matrices, but are then removed from the moment
-  //   // space unless the GQF interpolation model has been specified.
-  // }
+  virtual bool prune() const {
+    return true;
+    // By default, prune any moments beyond the user-specified expansion order.
+    // Overridden by Galerkin_Ordinate_Space::prune().
+  }
 
   //! Return the scattering moment to flux map.
   virtual void moment_to_flux(unsigned flux_map[3], double flux_fact[3]) const;

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -608,6 +608,14 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature) {
                  false, // add_extra_directions,
                  Ordinate_Set::LEVEL_ORDERED);
 
+    test_no_axis(ut, quadrature,
+                 1U, // dimension,
+                 rtt_mesh_element::CARTESIAN,
+                 1U, // expansion_order,
+                 "GQF",
+                 false, // add_extra_directions,
+                 Ordinate_Set::LEVEL_ORDERED);
+
     if (quadrature.is_open_interval()) {
       // Our curvilinear angular operator algorithm doesn't work with closed
       // interval quadratures (those for which mu=-1 is part of the set).


### PR DESCRIPTION
The prune function of Ordinate_Space always returns true, and on this basis it was removed from the class. However, this is a virtual function that is nontrivially overridden by Galerkin_Ordinate_Space, and its removal changes the solution slightly in one of the Capsaicin benchmarks.

The difference is quite small, but until I can better recall why this was done in the first place, I suggest we restore the Ordinate_Space::prune function and restore the if-test using prune.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
