### PR TITLE
Extend rtt_viz::Ensight_Translator's ensight_dump function.

### DIFF
--- a/src/ds++/UnitTest.hh
+++ b/src/ds++/UnitTest.hh
@@ -165,7 +165,7 @@ public:
   }
   /*!
    * \brief Returns the path of the test source directory (useful for locating
-   * input files).
+   *        input files).
    *
    * This function depends on the cmake build system setting the
    * COMPILE_DEFINITIONS target property. This should be done in

--- a/src/units/MathConstants.hh
+++ b/src/units/MathConstants.hh
@@ -5,10 +5,7 @@
  *          light, etc) are defined.
  *  \date   Fri Nov 07 10:04:52 2003
  *  \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *          All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: MathConstants.hh 7431 2015-02-24 17:10:44Z kellyt $
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __units_MathConstants_hh__

--- a/src/viz/Ensight_Translator.cc
+++ b/src/viz/Ensight_Translator.cc
@@ -169,8 +169,8 @@ void Ensight_Translator::create_filenames(const std_string &prefix) {
 /*!
  * \brief Common initializer for constructors.
  *
- * \param graphics_continue If true, use existing ensight directory.
- * If false, create or wipe out the existing directory.
+ * \param[in] graphics_continue If true, use existing ensight directory. If
+ *               false, create or wipe out the existing directory.
  */
 void Ensight_Translator::initialize(const bool graphics_continue) {
   using std::strerror;
@@ -232,8 +232,8 @@ void Ensight_Translator::initialize(const bool graphics_continue) {
 
   // build the ensight directory if this is not a continuation
   if (!graphics_continue) {
-    // We have guaranteed that our prefix directory exists at this
-    // point.  Now, wipe out files that we might have created in there...
+    // We have guaranteed that our prefix directory exists at this point.  Now,
+    // wipe out files that we might have created in there...
     if (!stat_ret) {
       rtt_dsxx::draco_remove_dir(d_prefix);
       rtt_dsxx::draco_mkdir(d_prefix);

--- a/src/viz/Ensight_Translator.i.hh
+++ b/src/viz/Ensight_Translator.i.hh
@@ -189,12 +189,10 @@ void Ensight_Translator::ensight_dump(
   Require(rgn_numbers.size() == nrgn);
 
   // create the parts list
-  vector<int>::const_iterator find_location_c;
-  vector<int>::iterator find_location;
-  vector<int> parts_list;
+  ISF parts_list;
 
   for (size_t i = 0; i < ncells; ++i) {
-    find_location =
+    auto const find_location =
         find(parts_list.begin(), parts_list.end(), cell_rgn_index[i]);
 
     if (find_location == parts_list.end())
@@ -208,7 +206,7 @@ void Ensight_Translator::ensight_dump(
   vector<string> part_names;
 
   for (size_t i = 0; i < nparts; ++i) {
-    find_location_c =
+    auto const find_location_c =
         find(rgn_numbers.begin(), rgn_numbers.end(), parts_list[i]);
 
     if (find_location_c != rgn_numbers.end()) {
@@ -237,13 +235,14 @@ void Ensight_Translator::ensight_dump(
   // Initialize cells_of_type and vertices_of_part.
 
   for (size_t i = 0; i < ncells; ++i) {
-    find_location =
+    auto const find_location =
         find(parts_list.begin(), parts_list.end(), cell_rgn_index[i]);
 
     Check(find_location != parts_list.end());
-    Check(iel_type[i] < static_cast<int>(d_num_cell_types));
+    Check(iel_type[i] >= 0);
+    Check(static_cast<unsigned>(iel_type[i]) < d_num_cell_types);
 
-    auto ipart = find_location - parts_list.begin();
+    auto const ipart = find_location - parts_list.begin();
 
     Check(i < INT_MAX);
     cells_of_type[ipart][iel_type[i]].push_back(static_cast<int>(i));
@@ -365,7 +364,8 @@ void Ensight_Translator::write_part(
   sf2_int cells_of_type(d_num_cell_types);
 
   for (size_t i = 0; i < ncells; ++i) {
-    Check(iel_type[i] < static_cast<int>(d_num_cell_types));
+    Check(iel_type[i] >= 0);
+    Check(static_cast<unsigned>(iel_type[i]) < d_num_cell_types);
     Check(i < INT_MAX);
     cells_of_type[iel_type[i]].push_back(static_cast<int>(i));
   }

--- a/src/viz/test/tstEnsight_Translator.cc
+++ b/src/viz/test/tstEnsight_Translator.cc
@@ -1,6 +1,6 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   viz/test/tstEnsightTranslator.cc
+ * \file   viz/test/tstEnsight_Translator.cc
  * \author Thomas M. Evans
  * \date   Mon Jan 24 11:12:59 2000
  * \brief  Ensight_Translator test.
@@ -18,6 +18,7 @@ using namespace std;
 using rtt_viz::Ensight_Translator;
 
 //---------------------------------------------------------------------------//
+template <typename IT>
 void ensight_dump_test(rtt_dsxx::UnitTest &ut, bool const binary) {
   if (binary)
     cout << "\nGenerating binary files...\n" << endl;
@@ -33,7 +34,7 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, bool const binary) {
   size_t nrgn = 2;
 
   typedef vector<string> vec_s;
-  typedef vector<int> vec_i;
+  typedef vector<IT> vec_i;
   typedef vector<vec_i> vec2_i;
   typedef vector<vec2_i> vec3_i;
   typedef vector<double> vec_d;
@@ -157,10 +158,7 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, bool const binary) {
 
       for (size_t k = 0; k < ipar[g].size(); k++) {
         int tmp = ipar[g][k] - 1;
-
-        vector<int>::iterator f =
-            find(g_vrtx_indices[i].begin(), g_vrtx_indices[i].end(), tmp);
-
+        auto f = find(g_vrtx_indices[i].begin(), g_vrtx_indices[i].end(), tmp);
         Require(f != g_vrtx_indices[i].end());
         p_ipar[i][j][k] = static_cast<int>(f - g_vrtx_indices[i].begin() + 1);
       }
@@ -235,11 +233,15 @@ int main(int argc, char *argv[]) {
   try {
     // ASCII dumps
     bool binary(false);
-    ensight_dump_test(ut, binary);
+    ensight_dump_test<int>(ut, binary);
 
     // Binary dumps
     binary = true;
-    ensight_dump_test(ut, binary);
+    ensight_dump_test<int>(ut, binary);
+
+    // ASCII dumps with unsigned integer data
+    binary = false;
+    ensight_dump_test<uint32_t>(ut, binary);
   }
   UT_EPILOG(ut);
 }


### PR DESCRIPTION
### Background

* Jayenne requires extended functionality of the _viz_ package. 

### Description of changes

+ Allow the `ensight_dump` function to accept `vector<unsigned>` containers in addition to `vector<int>`. This required a little bit of cleanup in the function to keep all of the data types compatible.
+ Add a unit test for the new `ensight_dump` signature.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
