### PR TITLE
Fix some issues in ofpstream that were causing McGrid to fail.

### DIFF
--- a/src/c4/Compare.cc
+++ b/src/c4/Compare.cc
@@ -3,12 +3,8 @@
  * \file   c4/Compare.cc
  * \author Mike Buksas
  * \date   Thu May  1 14:42:10 2008
- * \brief  
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "Compare.hh"
@@ -26,7 +22,7 @@ namespace rtt_c4 {
  * integer across all processors.  This is used for Design By Contract
  * analysis in the Source_Builder codes.
  *
- * \param local_value integer value to check against
+ * \param[in] local_value integer value to check against
  * \return true if equivalent across all processors; false if not
  */
 bool check_global_equiv(int local_value) {
@@ -77,7 +73,7 @@ bool check_global_equiv(int local_value) {
  * integer across all processors.  This is used for Design By Contract
  * analysis in the Source_Builder codes.
  *
- * \param local_value integer value to check against
+ * \param[in] local_value integer value to check against
  * \return true if equivalent across all processors; false if not
  */
 bool check_global_equiv(unsigned long local_value) {
@@ -128,7 +124,7 @@ bool check_global_equiv(unsigned long local_value) {
  * integer across all processors.  This is used for Design By Contract
  * analysis in the Source_Builder codes.
  *
- * \param local_value integer value to check against
+ * \param[in] local_value integer value to check against
  * \return true if equivalent across all processors; false if not
  */
 bool check_global_equiv(unsigned long long local_value) {
@@ -179,7 +175,7 @@ bool check_global_equiv(unsigned long long local_value) {
  * integer across all processors.  This is used for Design By Contract
  * analysis in the Source_Builder codes.
  *
- * \param local_value integer value to check against
+ * \param[in] local_value integer value to check against
  * \return true if equivalent across all processors; false if not
  */
 bool check_global_equiv(long local_value) {
@@ -230,7 +226,7 @@ bool check_global_equiv(long local_value) {
  * integer across all processors.  This is used for Design By Contract
  * analysis in the Source_Builder codes.
  *
- * \param local_value integer value to check against
+ * \param[in] local_value integer value to check against
  * \return true if equivalent across all processors; false if not
  */
 bool check_global_equiv(long long local_value) {
@@ -279,8 +275,8 @@ bool check_global_equiv(long long local_value) {
  * This function is the same as check_global_equiv(int) except that doubles
  * are compared to precision eps.
  *
- * \param local_value integer value to check against
- * \param eps precision of double, default 1e-8
+ * \param[in] local_value integer value to check against
+ * \param[in] eps precision of double, default 1e-8
  * \return true if equivalent across all processors; false if not 
  */
 bool check_global_equiv(double local_value, double eps) {

--- a/src/c4/ofpstream.cc
+++ b/src/c4/ofpstream.cc
@@ -8,10 +8,8 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <iostream>
-
-#include "C4_Functions.hh"
 #include "ofpstream.hh"
+#include "C4_Functions.hh"
 
 namespace rtt_c4 {
 using namespace std;
@@ -22,9 +20,9 @@ using namespace std;
  * Create an ofpstream that synchronizes output to the specified file by MPI
  * rank.
  *
- * \param filename Name of the file to which synchronized output is to be
+ * \param[in] filename Name of the file to which synchronized output is to be
  * written.
- * \param (optional) mode File write mode (ascii/binary)-- defaults to ascii
+ * \param[in] (optional) mode File write mode (ascii/binary)-- defaults to ascii
  */
 ofpstream::ofpstream(std::string const &filename, ios_base::openmode const mode)
     : std::ostream(&sb_) {
@@ -44,32 +42,40 @@ ofpstream::ofpstream(std::string const &filename, ios_base::openmode const mode)
 void ofpstream::mpibuf::send() {
   unsigned const pid = rtt_c4::node();
   if (pid == 0) {
-    if (mode_ == ios_base::binary)
-      out_.write(&buffer_[0], buffer_.size());
-    else {
-      buffer_.push_back('\0');
+    if (mode_ == ios_base::binary) {
+      if (buffer_.size() > 0) {
+        out_.write(&buffer_[0], buffer_.size());
+      }
+    } else {
+      buffer_.push_back('\0'); // guarantees that buffer_.size() > 0
       out_ << &buffer_[0];
     }
     buffer_.clear();
     unsigned const pids = rtt_c4::nodes();
     for (unsigned i = 1; i < pids; ++i) {
-      unsigned N;
+      unsigned N(0);
       receive(&N, 1, i);
-      buffer_.resize(N);
-      rtt_c4::receive(&buffer_[0], N, i);
-      if (mode_ == ios_base::binary)
-        out_.write(&buffer_[0], buffer_.size());
-      else {
-        buffer_.push_back('\0');
+      if (N > 0) {
+        buffer_.resize(N); // N could be 0
+        rtt_c4::receive(&buffer_[0], N, i);
+      }
+      if (mode_ == ios_base::binary) {
+        if (buffer_.size() > 0) {
+          out_.write(&buffer_[0], buffer_.size());
+        }
+      } else {
+        buffer_.push_back('\0'); // guarantees that buffer_.size() > 0
         out_ << &buffer_[0];
       }
     }
+
   } else {
 
     Check(buffer_.size() < UINT_MAX);
     unsigned N = static_cast<unsigned>(buffer_.size());
     rtt_c4::send(&N, 1, 0);
-    rtt_c4::send(&buffer_[0], N, 0);
+    if (N > 0)
+      rtt_c4::send(&buffer_[0], N, 0);
   }
   buffer_.clear();
   out_.flush();
@@ -84,13 +90,13 @@ void ofpstream::mpibuf::send() {
  * internal buffer. This is not actually that inefficient for this class,
  * since it means that when the stream using the buffer wants to insert
  * data, it checks the buffer's cursor pointer, always finds that it is null,
- * and and calls overlow intead. These are not expensive operations. Should
- * we see any evidene this class is taking significant time, which should not
+ * and calls overflow instead. These are not expensive operations. Should
+ * we see any evidence this class is taking significant time, which should not
  * happen for its intended use (synchronizing diagnostic output), we can
- * reimplement to let the stream do explicitly buffered insertions without
+ * re-implement to let the stream do explicitly buffered insertions without
  * this change affecting any user code -- this interface is all private.
  *
- * \param c Next character to add to the internal buffer.
+ * \param[in] c Next character to add to the internal buffer.
  *
  * \return Integer representation of the character just added to the buffer.
  */

--- a/src/c4/opstream.cc
+++ b/src/c4/opstream.cc
@@ -8,10 +8,8 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <iostream>
-
-#include "C4_Functions.hh"
 #include "opstream.hh"
+#include "C4_Functions.hh"
 
 namespace rtt_c4 {
 using namespace std;
@@ -26,25 +24,28 @@ using namespace std;
 void opstream::mpibuf::send() {
   unsigned const pid = rtt_c4::node();
   if (pid == 0) {
-    buffer_.push_back('\0');
+    buffer_.push_back('\0'); // guarantees that buffer_.size() > 0
     cout << &buffer_[0];
     buffer_.clear();
 
     unsigned const pids = rtt_c4::nodes();
     for (unsigned i = 1; i < pids; ++i) {
-      unsigned N;
+      unsigned N(0);
       receive(&N, 1, i);
-      buffer_.resize(N);
-      rtt_c4::receive(&buffer_[0], N, i);
+      if (N > 0) {
+        buffer_.resize(N);
+        rtt_c4::receive(&buffer_[0], N, i);
+      }
       buffer_.push_back('\0');
-      cout << &buffer_[0];
+      cout << &buffer_[0]; // guarantees that buffer_.size() > 0
     }
   } else {
 
     Check(buffer_.size() < UINT_MAX);
     unsigned N = static_cast<unsigned>(buffer_.size());
     rtt_c4::send(&N, 1, 0);
-    rtt_c4::send(&buffer_[0], N, 0);
+    if (N > 0)
+      rtt_c4::send(&buffer_[0], N, 0);
   }
   buffer_.clear();
   rtt_c4::global_barrier();
@@ -58,13 +59,13 @@ void opstream::mpibuf::send() {
  * internal buffer. This is not actually that inefficient for this class,
  * since it means that when the stream using the buffer wants to insert
  * data, it checks the buffer's cursor pointer, always finds that it is null,
- * and and calls overlow intead. These are not expensive operations. Should
- * we see any evidene this class is taking significant time, which should not
+ * and calls overflow instead. These are not expensive operations. Should
+ * we see any evidence this class is taking significant time, which should not
  * happen for its intended use (synchronizing diagnostic output), we can
- * reimplement to let the stream do explicitly buffered insertions without
+ * re-implement to let the stream do explicitly buffered insertions without
  * this change affecting any user code -- this interface is all private.
  *
- * \param c Next character to add to the internal buffer.
+ * \param[in] c Next character to add to the internal buffer.
  *
  * \return Integer representation of the character just added to the buffer.
  */

--- a/src/c4/opstream.hh
+++ b/src/c4/opstream.hh
@@ -4,18 +4,15 @@
  * \author Kent G. Budge
  * \brief  Define class opstream
  * \note   Copyright (C) 2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef c4_opstream_hh
 #define c4_opstream_hh
 
-#include <vector>
-
 #include "c4/config.h"
+#include <iostream>
+#include <vector>
 
 namespace rtt_c4 {
 
@@ -64,20 +61,22 @@ namespace rtt_c4 {
 class opstream : public std::ostream {
 public:
   //! Create a synchronized stream tied to the console.
-  opstream() : std::ostream(&sb_) {}
+  opstream() : std::ostream(&sb_) { /* empty */
+  }
 
   //! Send all buffered data synchronously to the console.
   void send() { sb_.send(); }
+
   //! Shrink the internal buffer to fit the current buffered data.
   void shrink_to_fit() { sb_.shrink_to_fit(); }
 
 private:
   struct mpibuf : public std::streambuf {
 
-    DLL_PUBLIC_c4 void send();
-    DLL_PUBLIC_c4 void shrink_to_fit();
+    void send();
+    void shrink_to_fit();
 
-    DLL_PUBLIC_c4 virtual int_type overflow(int_type c);
+    virtual int_type overflow(int_type c);
 
     std::vector<char> buffer_;
   };

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -109,7 +109,7 @@ auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t;
 // On Linux, it appears that long == 'int64_t' if Linux is 64-bit
 // (__WORDSIZE == 64).
 //
-// If we are using Visual Studio, we need these defintions. I expect that they
+// If we are using Visual Studio, we need these definitions. I expect that they
 // will be needed for 32-bit Linux as well, but I can't test that.
 // Might need to add "|| (defined(__GNUC__) && __WORDSIZE != 64)"
 #if defined(WIN32)


### PR DESCRIPTION
### Background

* While working through runtime issues in McGrid, I realized that some issues were caused by out-of-range array access in `ofpstream` and `opstream`.  

### Description of changes

+ Provide logic to avoid `&vector[0]` dereference operations when the vector has zero length.
+ Fix comment blocks, spelling errors, etc.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
