### PR TITLE
Fix broken draco_info tool.

### DIFF
--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -11,10 +11,12 @@
 #include "draco_info.hh"
 #include "c4/config.h"
 #include "diagnostics/config.h"
+#include "ds++/DracoStrings.hh"
 #include "ds++/Release.hh"
 #include "ds++/UnitTest.hh"
 #include <algorithm> // tolower
 #include <iostream>
+#include <iterator>
 #include <sstream>
 
 namespace rtt_diagnostics {
@@ -33,8 +35,8 @@ DracoInfo::DracoInfo(void)
 #ifdef DRACO_SHARED_LIBS
   library_type = "Shared";
 #endif
-#ifdef draco_isLinux
-  system_type = "Linux";
+#ifdef CMAKE_SYSTEM_NAME
+  system_type = CMAKE_SYSTEM_NAME_STRING;
 #endif
 #ifdef SITENAME
   site_name = SITENAME;
@@ -64,6 +66,9 @@ DracoInfo::DracoInfo(void)
   if (build_type == std::string("Release")) {
     cxx_flags += CMAKE_CXX_FLAGS_RELEASE;
     cc_flags += CMAKE_C_FLAGS_RELEASE;
+  } else if (build_type == std::string("RelWithDebInfo")) {
+    cxx_flags += CMAKE_CXX_FLAGS_RELWITHDEBINFO;
+    cc_flags += CMAKE_C_FLAGS_RELWITHDEBINFO;
   } else if (build_type == std::string("Debug")) {
     cxx_flags += CMAKE_CXX_FLAGS_DEBUG;
     cc_flags += CMAKE_C_FLAGS_DEBUG;
@@ -79,11 +84,51 @@ DracoInfo::DracoInfo(void)
 }
 
 //---------------------------------------------------------------------------//
+void print_text_with_word_wrap(std::string const &longstring,
+                               size_t const indent_column,
+                               size_t const max_width, std::ostringstream &msg,
+                               std::string const &delimiters = " ") {
+  std::vector<std::string> const tokens =
+      rtt_dsxx::tokenize(longstring, delimiters);
+  std::string const delimiter(delimiters.substr(0, 1));
+  size_t i(indent_column);
+  for (auto item : tokens) {
+    if (i + item.length() + 1 > max_width) {
+      msg << "\n" << std::string(indent_column, ' ');
+      i = indent_column;
+    }
+    msg << item;
+    if (item != tokens.back())
+      msg << delimiter;
+    i += item.length() + 1;
+  }
+}
+
+//---------------------------------------------------------------------------//
 std::string DracoInfo::fullReport(void) {
   using std::cout;
   using std::endl;
 
   std::ostringstream infoMessage;
+
+  // Create a list of features for DbC
+  std::vector<std::string> dbc_info;
+  dbc_info.push_back("Insist");
+#ifdef REQUIRE_ON
+  dbc_info.push_back("Require");
+#endif
+#ifdef CHECK_ON
+  dbc_info.push_back("Check");
+#endif
+#ifdef ENSURE_ON
+  dbc_info.push_back("Ensure");
+#endif
+#if DBC & 8
+  dbc_info.push_back("no-throw version");
+#endif
+#if DBC & 16
+  dbc_info.push_back("check-deferred version");
+#endif
 
   // Print version and copyright information to the screen:
   infoMessage << briefReport();
@@ -92,30 +137,42 @@ std::string DracoInfo::fullReport(void) {
   //------------------
 
   infoMessage << "Build information:"
-              << "\n    Build type     : " << build_type
-              << "\n    Library type   : " << library_type
-              << "\n    System type    : " << system_type
-              << "\n    Site name      : " << site_name
-              << "\n    CUDA support   : " << (cuda ? "enabled" : "disabled")
-              << "\n    MPI support    : "
+              << "\n    Build type        : " << build_type
+              << "\n    Library type      : " << library_type
+              << "\n    System type       : " << system_type
+              << "\n    Site name         : " << site_name
+              << "\n    CUDA support      : " << (cuda ? "enabled" : "disabled")
+              << "\n    MPI support       : "
               << (mpi ? "enabled" : "disabled (c4 scalar mode)");
 
   if (mpi)
-    infoMessage << "\n      mpirun cmd   : " << mpirun_cmd;
+    infoMessage << "\n      mpirun cmd      : " << mpirun_cmd;
 
-  infoMessage << "\n    OpenMP support : " << (openmp ? "enabled" : "disabled")
-              << "\n    Diagnostics    : " << diagnostics_level
+  infoMessage << "\n    OpenMP support    : "
+              << (openmp ? "enabled" : "disabled")
+              << "\n    Design-by-Contract: " << DBC << ", features = ";
+  std::copy(dbc_info.begin(), dbc_info.end() - 1,
+            std::ostream_iterator<std::string>(infoMessage, ", "));
+  infoMessage << dbc_info.back();
+  infoMessage << "\n    Diagnostics       : " << diagnostics_level
               << "\n    Diagnostics Timing: "
               << (diagnostics_timing ? "enabled" : "disabled");
 
   // Compilers and Flags
-
-  infoMessage << "\n    CXX Compiler      : " << cxx
-              << "\n    CXX_FLAGS         : " << cxx_flags
-              << "\n    C Compiler        : " << cc
-              << "\n    C_FLAGS           : " << cc_flags
-              << "\n    Fortran Compiler  : " << fc
-              << "\n    Fortran_FLAGS     : " << fc_flags;
+  size_t const max_width(80);
+  size_t const hanging_indent(std::string("    CXX Compiler      : ").length());
+  infoMessage << "\n    CXX Compiler      : ";
+  print_text_with_word_wrap(cxx, hanging_indent, max_width, infoMessage, "/");
+  infoMessage << "\n    CXX_FLAGS         : ";
+  print_text_with_word_wrap(cxx_flags, hanging_indent, max_width, infoMessage);
+  infoMessage << "\n    C Compiler        : ";
+  print_text_with_word_wrap(cc, hanging_indent, max_width, infoMessage, "/");
+  infoMessage << "\n    C_FLAGS           : ";
+  print_text_with_word_wrap(cc_flags, hanging_indent, max_width, infoMessage);
+  infoMessage << "\n    Fortran Compiler  : ";
+  print_text_with_word_wrap(fc, hanging_indent, max_width, infoMessage, "/");
+  infoMessage << "\n    Fortran_FLAGS     : ";
+  print_text_with_word_wrap(fc_flags, hanging_indent, max_width, infoMessage);
 
   infoMessage << "\n" << endl;
 
@@ -127,12 +184,9 @@ std::string DracoInfo::briefReport(void) {
   std::ostringstream infoMessage;
 
   // Print version and copyright information to the screen:
-  infoMessage << "\n"
-              << release << "\n\n"
-              << copyright << "\n"
-              << contact << "\n"
-              << std::endl;
-
+  infoMessage << "\n";
+  print_text_with_word_wrap(release, 5, 80, infoMessage, ";");
+  infoMessage << "\n\n" << copyright << "\n" << contact << "\n" << std::endl;
   return infoMessage.str();
 }
 
@@ -140,7 +194,8 @@ std::string DracoInfo::briefReport(void) {
 //! extract the single-line version info from release and return it
 std::string DracoInfo::versionReport(void) {
   std::ostringstream infoMessage;
-  infoMessage << release << "\n" << std::endl;
+  print_text_with_word_wrap(release, 5, 80, infoMessage, ";");
+  infoMessage << "\n" << std::endl;
   return infoMessage.str();
 }
 

--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -79,6 +79,9 @@ list( APPEND headers
    ${PROJECT_BINARY_DIR}/ds++/dll_declspec.h )
 list( REMOVE_ITEM headers ${template_implementations} )
 
+set_source_files_properties( Release.cc PROPERTIES 
+  COMPILE_DEFINITIONS BUILD_TYPE="$<CONFIG>" )
+
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #

--- a/src/ds++/Release.cc
+++ b/src/ds++/Release.cc
@@ -65,8 +65,8 @@ const std::string release() {
               << "_" << Draco_VERSION_PATCH;
 
   // build date and type
-  std::string const build_date(DRACO_BUILD_DATE);
-  std::string const build_type(DRACO_BUILD_TYPE);
+  std::string const build_date(Draco_BUILD_DATE);
+  std::string const build_type(BUILD_TYPE);
   pkg_release << ", build date " << build_date << "; build type: " << build_type
 #ifdef DBC
               << "; DBC: " << DBC
@@ -110,7 +110,6 @@ const std::string author_list() {
   current_developers.insert(fomdev(130, "Ryan T. Wollaeger"));
   current_developers.insert(fomdev(85, "Andrew T. Till"));
   current_developers.insert(fomdev(25, "Daniel Holladay"));
-  current_developers.insert(fomdev(9, "Massimiliano Rosa"));
   current_developers.insert(fomdev(1, "Kris C. Garrett"));
 
   mmdevs prior_developers;
@@ -125,6 +124,7 @@ const std::string author_list() {
   // < 100 lines
   // prior_developers.insert(fomdev(82, "Peter Ahrens"));
   // prior_developers.insert(fomdev(44, "Nick Myers"));
+  // prior_developers.insert(fomdev(9, "Massimiliano Rosa"));
   // prior_developers.insert(fomdev(7, "Todd J. Urbatsch"));
 
   // Previous authors with no current LOC attribution: Tom Evans, Todd Adams,

--- a/src/ds++/Release.hh
+++ b/src/ds++/Release.hh
@@ -24,11 +24,11 @@ typedef std::multimap<int, std::string, std::greater<int>> mmdevs;
 typedef std::pair<int, std::string> fomdev;
 
 //! Query package for the release number.
-DLL_PUBLIC_dsxx const std::string release();
+const std::string release();
 //! Return a list of Draco authors
-DLL_PUBLIC_dsxx const std::string author_list();
+const std::string author_list();
 //! Return a list of Draco authors
-DLL_PUBLIC_dsxx const std::string copyright();
+const std::string copyright();
 
 //---------------------------------------------------------------------------//
 /*!
@@ -40,14 +40,13 @@ DLL_PUBLIC_dsxx const std::string copyright();
  * \arg[in] list of developers
  * \return A formatted message.
  */
-DLL_PUBLIC_dsxx std::string print_devs(size_t const maxlinelen,
-                                       std::string const &line_name,
-                                       mmdevs const &devs);
+std::string print_devs(size_t const maxlinelen, std::string const &line_name,
+                       mmdevs const &devs);
 
 } // namespace rtt_dsxx
 
 //! This version can be called by Fortran and wraps the C++ version.
-extern "C" DLL_PUBLIC_dsxx void ec_release(char *release_string, size_t maxlen);
+extern "C" void ec_release(char *release_string, size_t maxlen);
 
 #endif // rtt_ds_Release_hh
 

--- a/src/ds++/bin/CMakeLists.txt
+++ b/src/ds++/bin/CMakeLists.txt
@@ -2,7 +2,7 @@
 # file   ds++/bin/CMakeLists.txt
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2013 Nov 6
-# brief  Provide.
+# brief  Provide a sample crash handler for Windows.
 # note   Copyright (C) 2016-2018, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
@@ -30,6 +30,23 @@ install( TARGETS Exe_testCrashHandler EXPORT draco-targets
   DESTINATION ${DBSCFGDIR}bin )
 
 endif() # WIN32
+
+# ---------------------------------------------------------------------------- #
+# Build binaries
+# ---------------------------------------------------------------------------- #
+
+add_component_executable(
+  TARGET      Exe_query_cpu
+  TARGET_DEPS Lib_dsxx
+  SOURCES     ${Draco_SOURCE_DIR}/config/query_fma.cc
+  PREFIX      Draco )
+
+# ---------------------------------------------------------------------------- #
+# Installation instructions
+# ---------------------------------------------------------------------------- #
+
+install( TARGETS Exe_query_cpu EXPORT draco-targets
+  DESTINATION ${DBSCFGDIR}bin )
 
 # ---------------------------------------------------------------------------- #
 # end ds++/bin/CMakeLists.txt

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -23,8 +23,8 @@
 #cmakedefine DRACO_SHARED_LIBS @DRACO_SHARED_LIBS@
 
 /* Version Inforation */
-#define DRACO_BUILD_DATE "@DRACO_BUILD_DATE@"
-#define DRACO_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
+#define Draco_BUILD_DATE "@Draco_BUILD_DATE@"
+#define Draco_BUILD_TYPE "@Draco_BUILD_TYPE@"
 #cmakedefine Draco_VERSION @Draco_VERSION@
 #cmakedefine Draco_VERSION_FULL @Draco_VERSION_FULL@
 #define Draco_VERSION_MAJOR "@Draco_VERSION_MAJOR@"
@@ -50,6 +50,10 @@
 #cmakedefine MSVC @MSVC@
 #cmakedefine MSVC_IDE @MSVC_IDE@
 #cmakedefine MSVC_VERSION @MSVC_VERSION@
+#cmakedefine CMAKE_SYSTEM_NAME @CMAKE_SYSTEM_NAME@
+#ifdef CMAKE_SYSTEM_NAME
+#define CMAKE_SYSTEM_NAME_STRING "@CMAKE_SYSTEM_NAME@"
+#endif
 #cmakedefine UNIX @UNIX@
 #cmakedefine draco_isLinux
 #cmakedefine draco_isOSF1
@@ -75,6 +79,7 @@
 
 /* Does this machine support hardware FMA? */
 #cmakedefine HAVE_HARDWARE_FMA @HAVE_HARDWARE_FMA@
+#cmakedefine HAVE_HARDWARE_AVX2 @HAVE_HARDWARE_AVX2@
 
 /* Support for C99's restrict keyword */
 #cmakedefine HAVE_RESTRICT
@@ -203,19 +208,19 @@
 #cmakedefine CMAKE_CXX_FLAGS         "@CMAKE_CXX_FLAGS@"
 #cmakedefine CMAKE_CXX_FLAGS_DEBUG   "@CMAKE_CXX_FLAGS_DEBUG@"
 #cmakedefine CMAKE_CXX_FLAGS_RELEASE "@CMAKE_CXX_FLAGS_RELEASE@"
-#cmakedefine CMAKE_CXX_FLAGS_RELWITHDEBINFO "@CMAKE_CXX_FLAGS_RELWITHDEBINFO"
+#cmakedefine CMAKE_CXX_FLAGS_RELWITHDEBINFO "@CMAKE_CXX_FLAGS_RELWITHDEBINFO@"
 #cmakedefine CMAKE_CXX_FLAGS_MINSIZEREL     "@CMAKE_CXX_FLAGS_MINSIZEREL@"
 #cmakedefine CMAKE_C_COMPILER        "@CMAKE_C_COMPILER@"
 #cmakedefine CMAKE_C_FLAGS           "@CMAKE_C_FLAGS@"
 #cmakedefine CMAKE_C_FLAGS_DEBUG     "@CMAKE_C_FLAGS_DEBUG@"
 #cmakedefine CMAKE_C_FLAGS_RELEASE   "@CMAKE_C_FLAGS_RELEASE@"
-#cmakedefine CMAKE_C_FLAGS_RELWITHDEBINFO "@CMAKE_C_FLAGS_RELWITHDEBINFO"
+#cmakedefine CMAKE_C_FLAGS_RELWITHDEBINFO "@CMAKE_C_FLAGS_RELWITHDEBINFO@"
 #cmakedefine CMAKE_C_FLAGS_MINSIZEREL     "@CMAKE_C_FLAGS_MINSIZEREL@"
 #cmakedefine CMAKE_Fortran_COMPILER  "@CMAKE_Fortran_COMPILER@"
 #cmakedefine CMAKE_Fortran_FLAGS     "@CMAKE_Fortran_FLAGS@"
 #cmakedefine CMAKE_Fortran_FLAGS_DEBUG     "@CMAKE_Fortran_FLAGS_DEBUG@"
 #cmakedefine CMAKE_Fortran_FLAGS_RELEASE   "@CMAKE_Fortran_FLAGS_RELEASE@"
-#cmakedefine CMAKE_Fortran_FLAGS_RELWITHDEBINFO "@CMAKE_Fortran_FLAGS_RELWITHDEBINFO"
+#cmakedefine CMAKE_Fortran_FLAGS_RELWITHDEBINFO "@CMAKE_Fortran_FLAGS_RELWITHDEBINFO@"
 #cmakedefine CMAKE_Fortran_FLAGS_MINSIZEREL     "@CMAKE_Fortran_FLAGS_MINSIZEREL@"
 #cmakedefine CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
 

--- a/src/ds++/test/tstPacking_Utils.cc
+++ b/src/ds++/test/tstPacking_Utils.cc
@@ -121,7 +121,9 @@ void compute_buffer_size_test(rtt_dsxx::UnitTest &ut) {
     uint32_t buffer_size(static_cast<unsigned>(vd.size() * sizeof(double)));
     vector<char> buffer(buffer_size);
     bool byte_swap = false;
-    rtt_dsxx::pack_vec_double(&vd[0], &buffer[0], vd.size(), byte_swap);
+    Check(vd.size() < UINT32_MAX);
+    rtt_dsxx::pack_vec_double(&vd[0], &buffer[0],
+                              static_cast<uint32_t>(vd.size()), byte_swap);
 
     Unpacker u;
     u.set_buffer(buffer.size(), &buffer[0]);

--- a/src/quadrature/test/tstTri_Chebyshev_Legendre.cc
+++ b/src/quadrature/test/tstTri_Chebyshev_Legendre.cc
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \date   Tue Nov  6 13:08:49 2012
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: template_test.cc 5830 2011-05-05 19:43:43Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "quadrature_test.hh"


### PR DESCRIPTION
### Background

+ The `draco_info` executable had become disconnected from the build system. Several fields were printing blank or incomplete information.  This PR attempts to update `draco_info` so it works properly.
+ Replaces a portion of #479

### Description of changes

+ Use `CMAKE_SYSTEM_NAME` for the *system type* field.
+ When printing compiler flags, ensure that the current flags are printed when the build type is `RelWithDebInfo`.
+ When printing the Design-by-Contract level, also print a string to indicate enabled modes.
+ When printing paths to compilers and the list of compiler flags, format the text to have a maximum width and use a hanging-indent.
+ Add support for Multi-config build systems (Xcode, VS) by adding a compile definition `$<CONFIG>`.
+ Use renamed CPP macros for `build_type` and `build_date`.
+ Since I'm editing `Release.cc`, remove developers from the current_devs list if they are not currently working on Draco.
+ Remove `DLL_PUBLIC_dsxx` decoration where it is no longer needed.
+ Build and install the `query_cpu` executable that will identify CPUs that support 4th generation instructions (AVX2, FMA, etc.)
+ Fix a typecast warning in `tstPacking_Utils.cc`.
+ Update the file header in `tstTri_Chebyshev_Legendre.cc`

### Example output:

```
F:\work\vs2017\d>Debug\draco_info.exe

Draco-6_24_20180924, build date 2018/09/24;build type: Debug;DBC: 7;
     DRACO_DIAGNOSTICS: 0

CCS-2 Draco Team: Kelly G. Thompson, Kent G. Budge, James S. Warsa,
     Alex R. Long, Kendra P. Keady, Jae H. Chang, Matt A. Cleveland,
     Ryan T. Wollaeger, Andrew T. Till, Daniel Holladay, and Kris C. Garrett.
Prior Contributers: Jeff D. Densmore, Gabriel M. Rockefeller,
     Allan B. Wollaber, Rob B. Lowrie, Lori A. Pritchett-Sheats,
     Paul W. Talbot, and Katherine J. Wang.

Copyright (C) 2016-2018 Los Alamos National Security, LLC. (LA-CC-16-016)

For information, send e-mail to draco@lanl.gov.

Build information:
    Build type        : Debug
    Library type      : Shared
    System type       : Windows
    Site name         : SILVERTUOR
    CUDA support      : disabled
    MPI support       : enabled
      mpirun cmd      : C:/Program Files/Microsoft MPI/Bin/mpiexec.exe -n <N>
    OpenMP support    : enabled
    Design-by-Contract: 7, features = Insist, Require, Check, Ensure
    Diagnostics       : 0
    Diagnostics Timing: disabled
    CXX Compiler      : C:/Program Files (x86)/Microsoft Visual Studio/2017/
                        Community/VC/Tools/MSVC/14.15.26726/bin/Hostx86/x64/
                        cl.exe
    CXX_FLAGS         : /W3 /Gy /fp:precise /arch:AVX2 /DWIN32 /D_WINDOWS /MP
                        /wd4251 /D_CRT_SECURE_NO_DEPRECATE
                        /D_SCL_SECURE_NO_DEPRECATE /D_SECURE_SCL=0 /EHa -openmp
                        /MDd /Od /Zi /DDEBUG /D_DEBUG
    C Compiler        : C:/Program Files (x86)/Microsoft Visual Studio/2017/
                        Community/VC/Tools/MSVC/14.15.26726/bin/Hostx86/x64/
                        cl.exe
    C_FLAGS           : /W3 /Gy /fp:precise /arch:AVX2 /DWIN32 /D_WINDOWS /MP
                        /wd4251 /D_CRT_SECURE_NO_DEPRECATE
                        /D_SCL_SECURE_NO_DEPRECATE /D_SECURE_SCL=0 -openmp /MDd
                        /Od /Zi /DDEBUG /D_DEBUG
    Fortran Compiler  : none
    Fortran_FLAGS     : none
```

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
