### PR TITLE
Avoid compiling for AVX2 instructions on older hardware.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build_script:
 # no MPI installed so force scalar builds.
   - cmake -G "Visual Studio 15 2017" -DDRACO_C4=SCALAR %APPVEYOR_BUILD_FOLDER%
   - cmake --build . --config Debug
-  - ctest -C Debug -j 2 --output-on-failures
+  - ctest -C Debug -j 2 --output-on-failure
 
 #build:
 #  verbosity: minimal

--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -288,7 +288,7 @@ macro( query_have_restrict_keyword )
 endmacro()
 
 #------------------------------------------------------------------------------#
-# Query if hardware has FMA
+# Query if hardware has FMA, AVX2
 #
 # This code is adopted from
 # https://software.intel.com/en-us/node/405250?language=es&wapkw=avx2+cpuid
@@ -314,6 +314,7 @@ macro( query_fma_on_hardware )
         HAVE_HARDWARE_FMA_COMPILE
         ${CMAKE_CURRENT_BINARY_DIR}/config
         ${CMAKE_CURRENT_SOURCE_DIR}/config/query_fma.cc
+        ARGS "-f"
         )
       if( NOT HAVE_HARDWARE_FMA_COMPILE )
         message( FATAL_ERROR "Unable to compile config/query_fma.cc.")
@@ -353,6 +354,33 @@ macro( query_fma_on_hardware )
     #     set(HAS_HARDWARE_FMA ON)
     #   endif()
     # endif()
+
+    message( STATUS "Looking for hardware AVX2 support...")
+
+    if( "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le" )
+      # power8/9 have AVX2 and the check below fails for power architectures, so
+      # we hard code the result here.
+      set(HAVE_HARDWARE_AVX2 TRUE)
+
+    else()
+      unset(HAVE_HARDWARE_AVX2)
+      try_run(
+        HAVE_HARDWARE_AVX2
+        HAVE_HARDWARE_AVX2_COMPILE
+        ${CMAKE_CURRENT_BINARY_DIR}/config
+        ${CMAKE_CURRENT_SOURCE_DIR}/config/query_fma.cc
+        ARGS "-f"
+        )
+      if( NOT HAVE_HARDWARE_AVX2_COMPILE )
+        message( FATAL_ERROR "Unable to compile config/query_fma.cc.")
+      endif()
+    endif()
+
+    if( HAVE_HARDWARE_AVX2 )
+      message( STATUS "Looking for hardware AVX2 support...found AVX2.")
+    else()
+      message( STATUS "Looking for hardware AVX2 support...AVX2 not found.")
+    endif()
 
   endif()
 

--- a/config/query_fma.cc
+++ b/config/query_fma.cc
@@ -11,8 +11,13 @@
  *
  * This code is adopted from
  * https://software.intel.com/en-us/node/405250?language=es&wapkw=avx2+cpuid
+ *
+ * An alternative approach for Visual Studio can be found at
+ * https://docs.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?view=vs-2017
  */
 //---------------------------------------------------------------------------//
+
+#include <string>
 
 //----------------------------------------------------------------------------//
 // Intel Compiler
@@ -43,6 +48,7 @@ int check_4th_gen_intel_core_features() {
 #define MYINT uint32_t
 #endif
 
+//---------------------------------------------------------------------------//
 void run_cpuid(MYINT eax, MYINT ecx, MYINT *abcd) {
 #if defined(_MSC_VER)
   __cpuidex(abcd, eax, ecx);
@@ -64,6 +70,7 @@ void run_cpuid(MYINT eax, MYINT ecx, MYINT *abcd) {
 #endif
 }
 
+//---------------------------------------------------------------------------//
 int check_xcr0_ymm() {
   MYINT xcr0;
 #if defined(_MSC_VER)
@@ -78,26 +85,36 @@ int check_xcr0_ymm() {
           6); /* checking if xmm and ymm state are enabled in XCR0 */
 }
 
-int check_4th_gen_intel_core_features() {
+//---------------------------------------------------------------------------//
+int check_4th_gen_intel_core_features(int const mode = 0) {
   MYINT abcd[4];
   MYINT fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
   MYINT avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
+
+  bool have_fma(false);
+  bool have_avx2(false);
 
   /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1   &&
        CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
        CPUID.(EAX=01H, ECX=0H):ECX.OSXSAVE[bit 27]==1 */
   run_cpuid(1, 0, abcd);
-  if ((abcd[2] & fma_movbe_osxsave_mask) != fma_movbe_osxsave_mask)
-    return 0;
+  if ((abcd[2] & fma_movbe_osxsave_mask) == fma_movbe_osxsave_mask)
+    have_fma = true;
 
-  if (!check_xcr0_ymm())
-    return 0;
+  if (mode == 2)
+    return have_fma ? 1 : 0;
 
   /*  CPUID.(EAX=07H, ECX=0H):EBX.AVX2[bit 5]==1  &&
         CPUID.(EAX=07H, ECX=0H):EBX.BMI1[bit 3]==1  &&
         CPUID.(EAX=07H, ECX=0H):EBX.BMI2[bit 8]==1  */
   run_cpuid(7, 0, abcd);
-  if ((abcd[1] & avx2_bmi12_mask) != avx2_bmi12_mask)
+  if ((abcd[1] & avx2_bmi12_mask) == avx2_bmi12_mask)
+    have_avx2 = true;
+
+  if (mode == 1)
+    return have_avx2 ? 1 : 0;
+
+  if (!check_xcr0_ymm())
     return 0;
 
   /* CPUID.(EAX=80000001H):ECX.LZCNT[bit 5]==1 */
@@ -105,13 +122,34 @@ int check_4th_gen_intel_core_features() {
   if ((abcd[2] & (1 << 5)) == 0)
     return 0;
 
+  // We have 4 of the 4th-gen cpu features!
   return 1;
 }
 
 #endif /* non-Intel compiler */
 
 //---------------------------------------------------------------------------//
-int main(int argc, char *argv[]) { return check_4th_gen_intel_core_features(); }
+/*!
+ * \brief Query the CPU for Gen4 features.
+ *
+ * \return 1 if features are found, else 0.
+ *
+ * Command line options:
+ * -f Only check for FMA
+ * -a Only check for AVX2
+ */
+int main(int argc, char *argv[]) {
+  if (argc == 1)
+    return check_4th_gen_intel_core_features();
+  else {
+    for (int i = 1; i < argc; ++i) {
+      if (std::string(argv[i]) == std::string("-a"))
+        return check_4th_gen_intel_core_features(1);
+      if (std::string(argv[i]) == std::string("-f"))
+        return check_4th_gen_intel_core_features(2);
+    }
+  }
+}
 
 //---------------------------------------------------------------------------//
 // end of query_fma.cc

--- a/config/query_fma.cc
+++ b/config/query_fma.cc
@@ -27,11 +27,18 @@
 
 #include <immintrin.h>
 
-int check_4th_gen_intel_core_features() {
-  const int the_4th_gen_features =
-      (_FEATURE_AVX2 | _FEATURE_FMA | _FEATURE_BMI | _FEATURE_LZCNT |
-       _FEATURE_MOVBE);
-  return _may_i_use_cpu_feature(the_4th_gen_features);
+int check_4th_gen_intel_core_features(int const mode = 0) {
+
+  if (mode == 1)
+    return _may_i_use_cpu_feature(_FEATURE_AVX2);
+  else if (mode == 2)
+    return _may_i_use_cpu_feature(_FEATURE_FMA);
+  else {
+    const int the_4th_gen_features =
+        (_FEATURE_AVX2 | _FEATURE_FMA | _FEATURE_BMI | _FEATURE_LZCNT |
+         _FEATURE_MOVBE);
+    return _may_i_use_cpu_feature(the_4th_gen_features);
+  }
 }
 
 //----------------------------------------------------------------------------//

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -7,6 +7,9 @@
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 
+# Useful reference information:
+# https://docs.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?view=vs-2017
+
 #
 # Sanity Checks
 #
@@ -62,7 +65,10 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # - /std:c++14 (should be added by cmake in compilerEnv.cmake)
   # - /showIncludes
   # - /FC
-  set( CMAKE_C_FLAGS "/W2 /Gy /fp:precise /arch:AVX2 /DWIN32 /D_WINDOWS /MP /wd4251" )
+  set( CMAKE_C_FLAGS "/W2 /Gy /fp:precise /DWIN32 /D_WINDOWS /MP /wd4251" )
+  if(HAVE_HARDWARE_AVX2)
+    string(APPEND CMAKE_C_FLAGS " /arch:AVX2")
+  endif()
   set( CMAKE_C_FLAGS_DEBUG "/${MD_or_MT_debug} /Od /Zi /DDEBUG /D_DEBUG" )
   set( CMAKE_C_FLAGS_RELEASE "/${MD_or_MT} /O2 /DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL "/${MD_or_MT} /O1 /DNDEBUG" )

--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -177,6 +177,14 @@ case ${-} in
      [ -z "$user" ] && user=${USER}
      sreport -t Hours cluster AccountUtilizationByUser user=$user start=$fday end=$lday
    }
+
+   target="`uname -n | sed -e s/[.].*//`"
+   case $target in
+     tt*|tr*)
+       alias salloc='salloc --gres=craynetwork:0'
+       ;;
+   esac
+
    ;; # end case 'interactive'
 
 ##---------------------------------------------------------------------------##

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -26,6 +26,8 @@ if [[ ! ${VENDOR_DIR} ]]; then
    fi
 fi
 
+# alias salloc='salloc --gres=craynetwork:0'
+
 add_to_path $VENDOR_DIR/bin
 
 # If LESS is set, is should include '-R' so that git diff's color

--- a/src/FortranChecks/f90sub/drel.f90
+++ b/src/FortranChecks/f90sub/drel.f90
@@ -7,8 +7,6 @@
 ! note   Copyright (c) 2016-2018 Los Alamos National Security, LLC.
 !        All rights reserved.
 !---------------------------------------------------------------------------
-! $Id$
-!---------------------------------------------------------------------------
 
 ! Ref: http://gcc.gnu.org/onlinedocs/gfortran/Interoperable-Subroutines-and-Functions.html
 !      http://fortranwiki.org/fortran/show/Generating+C+Interfaces


### PR DESCRIPTION
### Background

+ The compile option `/arch:AVX2` was always enabled for Visual Studio, but pre-Haswell hardware does not support AVX2.  While the compiler could still create code, it would fail to run properly. To avoid this, we add a platform check for AVX2 capabilities -- actually the check already existed in `config/query_fma.cc` but it needed a small change to narrow the check to AVX2 only.

### Description of changes

+ Modify `query_fma.cc` to take command line arguments `-f` and `-a`, which limit the check to fma-availability or avx2-availablity only. This code will return `1` if those features are found.
+ Update `platform_checks.cmake` to compile and run `query_fma.cc` and then set the build variables `HAVE_HARDWARE_AVX2` and `HAVE_HARDWARE_FMA`. These values are saved to `ds++/config.h` and are also available when the build system parses `windows-cl.cmake` so that appropriate code paths can be taken.
+ Also:
  + Fix a comment block in `drel.f90`.
  + Fix a typo in `appveyor.yml` that prevented output from failing tests from being printed.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
