### PR TITLE
WIP: Clean up CAFS portion of build system to support x86 and x64.

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -2,21 +2,22 @@
 # CMakeAddFortranSubdirectory
 # ---------------------------
 #
-# Use a version of gfortran that is not available from within the current project.  For
-# example, use MinGW gfortran from Visual Studio if a Fortran compiler is not found, or
-# use GNU gfortran from a XCode/clang build project.
+# Use a version of gfortran that is not available from within the current
+# project.  For example, use MinGW gfortran from Visual Studio if a Fortran
+# compiler is not found, or use GNU gfortran from a XCode/clang build project.
 #
-# The 'add_fortran_subdirectory' function adds a subdirectory to a project that contains a
-# Fortran only sub-project.  The module will check the current compiler and see if it can
-# support Fortran.  If no Fortran compiler is found and the compiler is MSVC or if the
-# Generator is XCode, then this module will try to find a gfortran compiler in local
-# environment (e.g.: MinGW gfortran).  It will then use an external project to build with
-# alternate (MinGW/Unix) tools.  It will also create imported targets for the libraries
-# created.
+# The 'add_fortran_subdirectory' function adds a subdirectory to a project
+# that contains a Fortran only sub-project.  The module will check the
+# current compiler and see if it can support Fortran.  If no Fortran compiler
+# is found and the compiler is MSVC or if the Generator is XCode, then this
+# module will try to find a gfortran compiler in local environment (e.g.:
+# MinGW gfortran).  It will then use an external project to build with
+# alternate (MinGW/Unix) tools.  It will also create imported targets for the
+# libraries created.
 #
-# For visual studio, this will only work if the Fortran code is built into a dll, so
-# BUILD_SHARED_LIBS is turned on in the project. In addition the CMAKE_GNUtoMS option is
-# set to on, so that the MS .lib files are created.
+# For visual studio, this will only work if the Fortran code is built into a
+# dll, so BUILD_SHARED_LIBS is turned on in the project. In addition the
+# CMAKE_GNUtoMS option is set to on, so that the MS .lib files are created.
 #
 # Usage is as follows:
 #
@@ -25,37 +26,42 @@
 #   cmake_add_fortran_subdirectory(
 #    <subdir>                # name of subdirectory
 #    PROJECT <project_name>  # project name in subdir top CMakeLists.txt
-#                            # recommendation: use the same project name as listed in
-#                            # <subdir>/CMakeLists.txt
+#                            # recommendation: use the same project name as
+#                            # listed in <subdir>/CMakeLists.txt
 #    ARCHIVE_DIR <dir>       # dir where project places .lib files
 #    RUNTIME_DIR <dir>       # dir where project places .dll files
 #    LIBRARIES <lib>...      # names of library targets to import
-#    TARGET_NAMES <string>...# target names assigned to the libraries listed above available
-#                              in the primary project.
+#    TARGET_NAMES <string>...# target names assigned to the libraries listed
+#                            # above available in the primary project.
 #    LINK_LIBRARIES          # link interface libraries for LIBRARIES
 #     [LINK_LIBS <lib> <dep>...]...
-#    DEPENDS                 # Register dependencies external for this AFSD project.
+#    DEPENDS                 # Register dependencies external for this AFSD
+#                            # project.
 #    CMAKE_COMMAND_LINE ...  # extra command line flags to pass to cmake
 #    NO_EXTERNAL_INSTALL     # skip installation of external project
 #    )
 #
-# Relative paths in ARCHIVE_DIR and RUNTIME_DIR are interpreted with respect to the build
-# directory corresponding to the source directory in which the function is invoked.
+# Relative paths in ARCHIVE_DIR and RUNTIME_DIR are interpreted with respect
+# to the build directory corresponding to the source directory in which the
+# function is invoked.
 #
 # Limitations:
 #
-# NO_EXTERNAL_INSTALL is required for forward compatibility with a future version that
-# supports installation of the external project binaries during "make install".
+# NO_EXTERNAL_INSTALL is required for forward compatibility with a future
+# version that supports installation of the external project binaries during "
+# make install".
 
 #=============================================================================
-# This is a heavily modified version of CMakeAddFortranSubdirectory.cmake that is
-# distributed with CMake - Copyright 2011-2012 Kitware, Inc.
+# This is a heavily modified version of CMakeAddFortranSubdirectory.cmake that
+# is distributed with CMake - Copyright 2011-2012 Kitware, Inc.
 
 set(_CAFS_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
 include(CheckLanguage)
 include(ExternalProject)
 
-###--------------------------------------------------------------------------------####
+#-------------------------------------------------------------------------------#
+# Find gfortran and check/setup x86/x64 information.
+#-------------------------------------------------------------------------------#
 function(_setup_cafs_config_and_build source_dir build_dir)
 
   # Try to find a Fortran compiler (use MinGW gfortran for MSVC).
@@ -156,7 +162,8 @@ execute_process( COMMAND \"${CMAKE_COMMAND}\" ${build_command_args} )
   file(WRITE "${build_dir}/build_cafs_proj.cmake" ${build_cafs_proj_command})
 endfunction()
 
-###--------------------------------------------------------------------------------####
+#-------------------------------------------------------------------------------#
+#-------------------------------------------------------------------------------#
 function(_add_fortran_library_link_interface library depend_library)
   set_target_properties(${library} PROPERTIES
     IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG "${depend_library}")
@@ -168,17 +175,19 @@ function(_add_fortran_library_link_interface library depend_library)
   endif()
 endfunction()
 
-###--------------------------------------------------------------------------------####
-### This is the main function.  This generates the required external_project pieces
-### that will be run under a different generator (MinGW Makefiles).
-###--------------------------------------------------------------------------------####
+#-------------------------------------------------------------------------------#
+# This is the main function.  This generates the required external_project
+# pieces that will be run under a different generator (MinGW Makefiles).
+#-------------------------------------------------------------------------------#
 function(cmake_add_fortran_subdirectory subdir)
 
   # Parse arguments to function
   set(options NO_EXTERNAL_INSTALL VERBOSE)
   set(oneValueArgs PROJECT ARCHIVE_DIR RUNTIME_DIR)
-  set(multiValueArgs LIBRARIES TARGET_NAMES LINK_LIBRARIES DEPENDS CMAKE_COMMAND_LINE)
-  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(multiValueArgs LIBRARIES TARGET_NAMES LINK_LIBRARIES DEPENDS
+    CMAKE_COMMAND_LINE)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
+    ${ARGN})
   if(NOT ARGS_NO_EXTERNAL_INSTALL)
     message("
 -- The external_project ${ARGS_PROJECT} will be installed to the location
@@ -188,8 +197,8 @@ function(cmake_add_fortran_subdirectory subdir)
    ")
   endif()
 
-  # If the current generator/system already supports Fortran, then simply add the
-  # requested directory to the project.
+  # If the current generator/system already supports Fortran, then simply add
+  # the requested directory to the project.
   if( _LANGUAGES_ MATCHES Fortran OR
       (MSVC AND "${CMAKE_Fortran_COMPILER}" MATCHES ifort ) )
     add_subdirectory(${subdir})
@@ -223,10 +232,10 @@ function(cmake_add_fortran_subdirectory subdir)
   endforeach()
   # create build and configure wrapper scripts
   _setup_cafs_config_and_build("${source_dir}" "${build_dir}")
-  # If the current build tool has multiple configurations, use the
-  # generator expression $<CONFIG> to drive the build type for the
-  # Fortran subproject.  Otherwise, force the Fortran subproject to
-  # use the same build type as the main project.
+  # If the current build tool has multiple configurations, use the generator
+  # expression $<CONFIG> to drive the build type for the Fortran subproject.
+  # Otherwise, force the Fortran subproject to use the same build type as the
+  # main project.
   if( CMAKE_CONFIGURATION_TYPES )
      set(ep_build_type "$<CONFIG>")
   else()
@@ -237,7 +246,8 @@ function(cmake_add_fortran_subdirectory subdir)
     DEPENDS           ${ARGS_DEPENDS}
     SOURCE_DIR        ${source_dir}
     BINARY_DIR        ${build_dir}
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=${ep_build_type} -P ${build_dir}/config_cafs_proj.cmake
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=${ep_build_type}
+                      -P ${build_dir}/config_cafs_proj.cmake
     BUILD_COMMAND     ${CMAKE_COMMAND} -P ${build_dir}/build_cafs_proj.cmake
     INSTALL_COMMAND   ""
     )
@@ -290,11 +300,10 @@ function(cmake_add_fortran_subdirectory subdir)
       set_target_properties(${tgt} PROPERTIES
         IMPORTED_IMPLIB "${library_dir}/lib${lib}${CMAKE_STATIC_LIBRARY_SUFFIX}" )
     endif()
-    # [2015-01-29 KT/Wollaber: We don't understand why this is needed,
-    # but adding IMPORTED_LOCATION_DEBUG to the target_properties
-    # fixes a missing RPATH problem for Xcode builds.  Possibly, this
-    # is related to the fact that the Fortran project is always built
-    # in Debug mode.
+    # [2015-01-29 KT/Wollaber: We don't understand why this is needed, but
+    # adding IMPORTED_LOCATION_DEBUG to the target_properties fixes a missing
+    # RPATH problem for Xcode builds.  Possibly, this is related to the fact
+    # that the Fortran project is always built in Debug mode.
     if( APPLE )
       set_target_properties(${tgt} PROPERTIES
         IMPORTED_LOCATION_DEBUG "${binary_dir}/lib${lib}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
@@ -302,11 +311,12 @@ function(cmake_add_fortran_subdirectory subdir)
     add_dependencies( ${tgt} ${project_name}_build )
 
     # The Ninja Generator appears to want to find the imported library
-    # ${binary_dir}/lib${lib}${CMAKE_SHARED_LIBRARY_SUFFIX or a rule to generate this
-    # target before it runs any build commands.  Since this library will not exist until
-    # the external project is built, we need to trick Ninja by creating a place-holder
-    # file to satisfy Ninja's dependency checker.  This library will be overwritten during
-    # the actual build.
+    # ${binary_dir}/lib${lib}${CMAKE_SHARED_LIBRARY_SUFFIX or a rule to
+    # generate this target before it runs any build commands.  Since this
+    # library will not exist until the external project is built, we need to
+    # trick Ninja by creating a place-holder file to satisfy Ninja's
+    # dependency checker.  This library will be overwritten during the actual
+    # build.
     if( ${CMAKE_GENERATOR} MATCHES Ninja )
       # artificially create some targets to help Ninja resolve dependencies.
       execute_process( COMMAND ${CMAKE_COMMAND} -E touch
@@ -372,8 +382,72 @@ cmake_add_fortran_subdirectory
   endif()
 endfunction()
 
-###--------------------------------------------------------------------------------####
+#-----------------------------------------------------------------------------#
+# When generating Visual Studio projects and using MSYS/MinGW gfortran for CAFS
+# -based Fortran subprojects, you must link to an MSYS/MinGW style '.a' library
+# instead of msmpi.lib (implementation portion of msmpi.dll). This macro
+# provides this fix (call this from the CMakeLists.txt found in the CAFS
+# subproject.
+#
+# Don't link to the C++ MS-MPI library when compiling with MinGW gfortran.
+# Instead, link to libmsmpi.a that was created via gendef.exe and dlltool.exe
+# from msmpi.dll.  Ref:
+# - https://github.com/KineticTheory/Linux-HPC-Env/wiki/Setup-Win32-development-environment,
+# - http://www.geuz.org/pipermail/getdp/2012/001519.html
+#
+# There are also issues with MS-MPI's mpif.h when using gfortran's
+# '-frange-check' compiler flag.  If this compiler option is enabled, remove
+# it.
+#-----------------------------------------------------------------------------#
+function( cafs_fix_mpi_library )
 
+  # MS-MPI and gfortran do not play nice together...
+  if(WIN32)
+
+    if( "${MPI_Fortran_LIBRARIES}none" STREQUAL "none" OR
+        "${MPI_Fortran_LIBRARIES}" MATCHES "msmpi.lib" )
+      # should be located in ENV{PATH} at c:/Program Files/Microsoft MPI/Bin/
+      # or C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\[x86|x64]
+      if( MPI_msmpi_LIBRARY )
+        # FindMPI.cmake should have set $MPI_msmpi_LIBRARY.
+        get_filename_component( MSMPI_SDK_DIR ${MPI_msmpi_LIBRARY} DIRECTORY)
+        find_library( MPI_gfortran_LIBRARIES
+          NAMES "libmsmpi.a"
+          HINTS ${MSMPI_SDK_DIR} )
+        unset(MSMPI_SDK_DIR)
+      else()
+        find_file( MPI_gfortran_LIBRARIES NAMES "libmsmpi.a" )
+      endif()
+      if( MPI_gfortran_LIBRARIES )
+        set( MPI_Fortran_LIBRARIES ${MPI_gfortran_LIBRARIES} CACHE FILEPATH
+          "msmpi for gfortran" FORCE )
+      else()
+        message( FATAL_ERROR "Unable to find libmsmpi.a. This library must"
+        " be created from msmpi.dll and saved as a MinGW library. ")
+      endif()
+    endif()
+
+    # Force '-fno-range-check' gfortran compiler flag
+    foreach( comp_opt FLAGS FLAGS_DEBUG FLAGS_RELEASE FLAGS_RELWITHDEBINFO MINSIZEREL )
+      if( "${CMAKE_Fortran_${comp_opt}}" MATCHES "frange-check" )
+        string(REPLACE "range-check" "no-range-check" CMAKE_Fortran_${comp_opt}
+          ${CMAKE_Fortran_${comp_opt}} )
+      else()
+        set( CMAKE_Fortran_FLAGS_${comp_opt}
+          "${CMAKE_Fortran_FLAGS_${comp_opt}} -fno-range-check")
+      endif()
+      set( CMAKE_Fortran_${comp_opt} "${CMAKE_Fortran_${comp_opt}}"
+        CACHE STRING "Compiler flags." FORCE )
+    endforeach()
+
+  endif(WIN32)
+  
+endfunction(cafs_fix_mpi_library)
+
+#-------------------------------------------------------------------------------#
+# Create imported libraries owned by the Visual Studio project to be used in the
+# CAFS subproject.
+#-------------------------------------------------------------------------------#
 function( cafs_create_imported_targets targetName libName targetPath linkLang)
 
   get_filename_component( pkgloc "${targetPath}" ABSOLUTE )
@@ -429,3 +503,7 @@ function( cafs_create_imported_targets targetName libName targetPath linkLang)
   unset(lib CACHE)
   unset(lib_debug CACHE)
 endfunction()
+
+#-------------------------------------------------------------------------------#
+# End of CMakeAddFortranSubdirectory.cmake
+#-------------------------------------------------------------------------------#

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -615,8 +615,7 @@ macro( toggle_compiler_flag switch compiler_flag
   # generate names that are safe for CMake RegEx MATCHES commands
   string(REPLACE "+" "x" safe_compiler_flag ${compiler_flag})
 
-  # Loop over types of variables to check: CMAKE_C_FLAGS,
-  # CMAKE_CXX_FLAGS, etc.
+  # Loop over types of variables to check: CMAKE_C_FLAGS, CMAKE_CXX_FLAGS, etc.
   foreach( comp ${compiler_flag_var_names} )
 
     # sanity check

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -469,7 +469,7 @@ macro( setupMPILibrariesWindows )
       message(STATUS "Looking for MPI...")
       find_package( MPI QUIET )
 
-      # For MS-MPI 5, mpifptr.h is architecture dependent. Figure out
+      # For MS-MPI, mpifptr.h is architecture dependent. Figure out
       # what arch this is and save this path to MPI_Fortran_INCLUDE_PATH
       list( GET MPI_CXX_LIBRARIES 0 first_cxx_mpi_library )
       if( first_cxx_mpi_library AND NOT MPI_Fortran_INCLUDE_PATH )
@@ -516,9 +516,8 @@ macro( setupMPILibrariesWindows )
         )
 
       # Check flavor and add optional flags
-      if("${MPIEXEC_EXECUTABLE}" MATCHES "Microsoft HPC" OR
-          "${MPIEXEC_EXECUTABLE}" MATCHES "Microsoft MPI")
-         set( MPI_FLAVOR "MicrosoftHPC" CACHE STRING "Flavor of MPI." )
+      if("${MPIEXEC_EXECUTABLE}" MATCHES "Microsoft MPI")
+         set( MPI_FLAVOR "MicrosoftMPI" CACHE STRING "Flavor of MPI." )
 
          # Use wmic to learn about the current machine
          execute_process(
@@ -588,7 +587,8 @@ macro( setupMPILibrariesWindows )
    # Don't link to the C++ MS-MPI library when compiling with MinGW gfortran.
    # Instead, link to libmsmpi.a that was created via gendef.exe and
    # dlltool.exe from msmpi.dll.  Ref:
-   # http://www.geuz.org/pipermail/getdp/2012/001520.html
+   # http://www.geuz.org/pipermail/getdp/2012/001520.html, or
+   # https://github.com/KineticTheory/Linux-HPC-Env/wiki/Setup-Win32-development-environment
 
    # Preparing Microsoft's MPI to work with x86_64-w64-mingw32-gfortran by
    # creating libmsmpi.a. (Last tested: 2017-08-31)

--- a/src/FortranChecks/f90sub/CMakeLists.txt
+++ b/src/FortranChecks/f90sub/CMakeLists.txt
@@ -68,40 +68,9 @@ if(NOT TARGET Lib_dsxx)
   include( vendor_libraries )
   setupVendorLibraries()
 
-  if(WIN32)
-    # MS-MPI and gfortran do not play nice together...
-    if( "${CMAKE_BUILD_TYPE}x" STREQUAL "x")
-      message( FATAL_ERROR
-        "In ftest/CMakeLists.txt, CMAKE_BUILD_TYPE must be set."
-        "Note: for multi-config build tools, CMakeAddFortranSubdirectory will "
-        "set this for you.")
-    endif()
-    string( TOUPPER ${CMAKE_BUILD_TYPE} ucbt )
-    if( "${CMAKE_Fortran_FLAGS_${ucbt}}" MATCHES "frange-check" )
-      string(REPLACE "range-check" "no-range-check" CMAKE_Fortran_FLAGS_DEBUG
-        ${CMAKE_Fortran_FLAGS_DEBUG} )
-    else()
-      set( CMAKE_Fortran_FLAGS_${ucbt}
-        "${CMAKE_Fortran_FLAGS_${ucbt}} -fno-range-check")
-    endif()
-
-    # Don't link to the C++ MS-MPI library when compiling with MinGW
-    # gfortran. Instead, link to libmsmpi.a that was created via gendef.exe and
-    # dlltool.exe from msmpi.dll.  Ref:
-    # http://www.geuz.org/pipermail/getdp/2012/001519.html
-    if( "${MPI_Fortran_LIBRARIES}none" STREQUAL "none" OR
-        "${MPI_Fortran_LIBRARIES}" MATCHES "msmpi.lib" )
-      # should be located in ENV{PATH} at c:/Program Files/Microsoft MPI/Bin/
-      find_file( MPI_gfortran_LIBRARIES NAMES "libmsmpi.a" )
-      if( MPI_gfortran_LIBRARIES )
-        set( MPI_Fortran_LIBRARIES ${MPI_gfortran_LIBRARIES} CACHE FILEPATH
-          "msmpi for gfortran" FORCE )
-      else()
-        message( FATAL_ERROR "Unable to find libmsmpi.a. This library must"
-        " be created from msmpi.dll and saved as a MinGW library. ")
-      endif()
-    endif()
-  endif()
+  # link to msys64 formatted msmpi.a instead of VS formatted msmpi.lib/dll,
+  # and ensure that the compiler option '-fno-range-check' is enabled.
+  cafs_fix_mpi_library()
 
 endif()
 

--- a/src/quadrature/ftest/CMakeLists.txt
+++ b/src/quadrature/ftest/CMakeLists.txt
@@ -66,24 +66,9 @@ if(NOT TARGET Lib_dsxx)
   include( vendor_libraries )
   setupVendorLibraries()
 
-  if(WIN32)
-    # MS-MPI 5 and gfortran/4.8 do not play nice together...
-    if( "${CMAKE_BUILD_TYPE}x" STREQUAL "x")
-      message( FATAL_ERROR
-        "In ftest/CMakeLists.txt, CMAKE_BUILD_TYPE must be set."
-        "Note: for multi-config build tools, CMakeAddFortranSubdirectory will "
-        "set this for you.")
-    endif()
-    string( TOUPPER ${CMAKE_BUILD_TYPE} ucbt )
-    # TODO: Can this be removed?
-    if( "${CMAKE_Fortran_FLAGS_${ucbt}}" MATCHES "frange-check" )
-      string(REPLACE "range-check" "no-range-check" CMAKE_Fortran_FLAGS_DEBUG
-        ${CMAKE_Fortran_FLAGS_DEBUG} )
-    else()
-      set( CMAKE_Fortran_FLAGS_${ucbt}
-        "${CMAKE_Fortran_FLAGS_${ucbt}} -fno-range-check")
-    endif()
-  endif()
+  # link to msys64 formatted msmpi.a instead of VS formatted msmpi.lib/dll,
+  # and ensure that the compiler option '-fno-range-check' is enabled.
+  cafs_fix_mpi_library()
 
 endif()
 
@@ -98,8 +83,8 @@ set( f90sources
 # Build library for test directory
 # ---------------------------------------------------------------------------- #
 
-# Xcode: Since cafs_create_imported_targets does not set all of the dependencies
-# between the imported libraries, we need to list them explicitly.
+# Xcode: Since cafs_create_imported_targets does not set all of the 
+# dependencies between the imported libraries, we need to list them explicitly.
 set(target_deps
     Lib_quadrature_test
     Lib_quadrature


### PR DESCRIPTION
### Background

+ Our build system support for MSYS2 gfortran subprojects underneath a Visual Studio configuration is still a bit fragile.  This PR slightly improves this situation be consolidating the configuration of Microsoft MPI when used by a CMakeAddFortranSubdirectory subproject.

### Description of changes

+ Add a new function to `CMakeAddFortranSubdirectory.cmake` to ensure `gfortran` configuration is compatible with Microsoft MPI for both x86 and x64 configurations.  This replaces code blocks that were duplicated in `FortranChecks/f90sub/CMakeLists.txt` and `quadrature/ftest/CMakeLists.txt`.
+ Fix comment blocks.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
