### PR TITLE
Ensure csk and ndi are loaded by default on trinity/trinitite.

### DIFF
--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -76,7 +76,7 @@ clang-format eospac/6.3.0 gsl/2.3 metis numdiff random123 \
 parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1"
 
 if [[ `groups | grep -c ccsrad` != 0 ]]; then
-  draco_modules="$draco_modules csk ndi"
+  dracomodules="$dracomodules csk ndi"
 fi
 
 function dracoenv ()


### PR DESCRIPTION
### Description of changes

* Fix bug reported by Kent.
* While csk and ndi were loaded for regression tests, they were not automatically loaded for developers. This PR fixes the problem.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
