### PR TITLE
Generalize X3D boundary condition specification.

### DIFF
--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -57,6 +57,9 @@ private:
   //! Boundary file names (optional data)
   const std::vector<std::string> bdy_filenames;
 
+  //! Boundary conditions per bdy file (optional data)
+  const std::vector<unsigned> bdy_flags;
+
   //! Vector of all parsed key-value data pairs (includes valueless delimiters)
   Parsed_Elements parsed_pairs;
 
@@ -75,11 +78,15 @@ private:
   //! Side-to-node map (0-based indices, unlike other maps)
   std::map<int, std::vector<unsigned>> x3d_sidenode_map;
 
+  //! Side-to-flag map
+  std::map<int, unsigned> x3d_sideflag_map;
+
 public:
   //! Constructor
   DLL_PUBLIC_mesh
   X3D_Draco_Mesh_Reader(const std::string &filename_,
-                        const std::vector<std::string> &bdy_filenames_ = {});
+                        const std::vector<std::string> &bdy_filenames_ = {},
+                        const std::vector<unsigned> &bdy_flags_ = {});
 
   // >>> SERVICES
 
@@ -109,14 +116,16 @@ public:
   unsigned get_celltype(size_t cell) const;
   std::vector<unsigned> get_cellnodes(size_t cell) const;
 
-  // data needed from x3d boundary file (?)
-  // \todo: parse x3d boundary file
+  // data needed from x3d boundary file
   size_t get_numsides() const { return x3d_sidenode_map.size(); }
   size_t get_sidetype(size_t side) const {
     Check(side < INT_MAX);
     return x3d_sidenode_map.at(static_cast<int>(side)).size();
   }
-  unsigned get_sideflag(size_t /*side*/) const { return 0; }
+  unsigned get_sideflag(size_t side) const {
+    Check(side < INT_MAX);
+    return x3d_sideflag_map.at(static_cast<int>(side));
+  }
   std::vector<unsigned> get_sidenodes(size_t side) const {
     Check(side < INT_MAX);
     return x3d_sidenode_map.at(static_cast<int>(side));

--- a/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
+++ b/src/mesh/test/tstX3D_Draco_Mesh_Reader.cc
@@ -33,10 +33,11 @@ void read_x3d_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
   const std::vector<std::string> bdy_filenames = {
       inputpath + "x3d.mesh.bdy1.in", inputpath + "x3d.mesh.bdy2.in",
       inputpath + "x3d.mesh.bdy3.in", inputpath + "x3d.mesh.bdy4.in"};
+  const std::vector<unsigned> bdy_flags = {3, 1, 0, 2};
 
   // construct reader
   std::shared_ptr<X3D_Draco_Mesh_Reader> x3d_reader(
-      new X3D_Draco_Mesh_Reader(filename, bdy_filenames));
+      new X3D_Draco_Mesh_Reader(filename, bdy_filenames, bdy_flags));
 
   // read mesh
   x3d_reader->read_mesh();
@@ -89,7 +90,8 @@ void read_x3d_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
       ITFAILS;
 
     // boundary conditions are not supplied in X3D
-    if (x3d_reader->get_sideflag(side) != 0)
+    // (note this check is specialized for the 1-cell mesh)
+    if (x3d_reader->get_sideflag(side) != bdy_flags[side])
       ITFAILS;
 
     // check node indices


### PR DESCRIPTION
### Background

* X3D format does not appear to permit specification of side flags, for boundary condition (B.C.).
* The X3D `Draco_Mesh` reader set the side flag to 0, for only one B.C in `Draco_Mesh`.
* It can be useful to have the B.C.s specified in the `Draco_Mesh` container.

### Purpose of Pull Request

* Permit `Draco_Mesh` to obtain non-trivial side flags from the X3D parser.
* [Concerns Redmine Issue #1182](https://rtt.lanl.gov/redmine/issues/1182)

### Description of changes

+ Add optional side flag index vector to X3D reader constructor.
+ Map of side index to flag index for parsed boundary (bdy) files.
+ Update X3D parser test.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
