### PR TITLE
Fix build failure on Mac's associated with parse_number_impl

### DIFF
--- a/src/ds++/DracoStrings.cc
+++ b/src/ds++/DracoStrings.cc
@@ -35,7 +35,7 @@ auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t {
 }
 
 // See notes in DracoStrings.hh about this CPP block
-#if defined(WIN32)
+#if defined(WIN32) || defined(APPLE)
 
 template <> auto parse_number_impl<long>(std::string const &str) -> long {
   return std::stol(str); // use stoull or stul?

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -112,7 +112,7 @@ auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t;
 // If we are using Visual Studio, we need these definitions. I expect that they
 // will be needed for 32-bit Linux as well, but I can't test that.
 // Might need to add "|| (defined(__GNUC__) && __WORDSIZE != 64)"
-#if defined(WIN32)
+#if defined(WIN32) || defined(APPLE)
 
 template <> auto parse_number_impl<long>(std::string const &str) -> long;
 template <>


### PR DESCRIPTION
### Description of changes

* Fix build failure on Mac's associated with parse_number_impl

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
