### PR TITLE
Fix warnings/errors reported in Visual Studio regressions.

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -406,6 +406,7 @@ function( cafs_fix_mpi_library )
 
     if( "${MPI_Fortran_LIBRARIES}none" STREQUAL "none" OR
         "${MPI_Fortran_LIBRARIES}" MATCHES "msmpi.lib" )
+        message("cafs_fix_mpi_library")
       # should be located in ENV{PATH} at c:/Program Files/Microsoft MPI/Bin/
       # or C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\[x86|x64]
       if( MPI_msmpi_LIBRARY )
@@ -433,8 +434,8 @@ function( cafs_fix_mpi_library )
         string(REPLACE "range-check" "no-range-check" CMAKE_Fortran_${comp_opt}
           ${CMAKE_Fortran_${comp_opt}} )
       else()
-        set( CMAKE_Fortran_FLAGS_${comp_opt}
-          "${CMAKE_Fortran_FLAGS_${comp_opt}} -fno-range-check")
+        set( CMAKE_Fortran_${comp_opt}
+          "${CMAKE_Fortran_${comp_opt}} -fno-range-check")
       endif()
       set( CMAKE_Fortran_${comp_opt} "${CMAKE_Fortran_${comp_opt}}"
         CACHE STRING "Compiler flags." FORCE )

--- a/src/rng/test/kat_c.c
+++ b/src/rng/test/kat_c.c
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4127)
+#pragma warning(disable : 4521 4244 4204 4127)
 #endif
 
 #include "kat_main.h"

--- a/src/rng/test/time_serial.h
+++ b/src/rng/test/time_serial.h
@@ -17,10 +17,20 @@
 #pragma GCC system_header
 #endif
 
+#ifdef _MSC_FULL_VER
+// - 4204 :: nonstandard extension used: non-constant aggregate initializer.
+#pragma warning(push)
+#pragma warning(disable : 4204)
+#endif
+
 #include <Random123/aes.h>
 #include <Random123/ars.h>
 #include <Random123/philox.h>
 #include <Random123/threefry.h>
+
+#ifdef _MSC_FULL_VERf
+#pragma warning(pop)
+#endif
 
 #endif /* rng_time_serial_h */
 

--- a/src/rng/test/ut_gsl.c
+++ b/src/rng/test/ut_gsl.c
@@ -29,13 +29,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#include "rng/config.h"
-
-#include "Random123/conventional/gsl_cbrng.h"
-#include "ut_gsl.h"
-#include <assert.h>
-#include <gsl/gsl_randist.h>
-#include <stdio.h>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -43,9 +36,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef _MSC_FULL_VER
-// 'type cast': pointer truncation from 'char[54]' to 'long'
-#pragma warning(disable : 4311)
+// 4311 - 'type cast': pointer truncation from 'char[54]' to 'long'
+// 4202 - nonstandard extension used: non-constant aggregate initializer
+#pragma warning(push)
+#pragma warning(disable : 4311 4204)
 #endif
+
+#include "rng/config.h"
+
+#include "Random123/conventional/gsl_cbrng.h"
+#include "ut_gsl.h"
+#include <assert.h>
+#include <gsl/gsl_randist.h>
+#include <stdio.h>
 
 /* Exercise the GSL_CBRNG macro */
 
@@ -130,6 +133,10 @@ int main(int argc, char **argv) {
   printf("ut_gsl: OK\n");
   return 0;
 }
+
+#ifdef _MSC_FULL_VER
+#pragma warning(pop)
+#endif
 
 #ifdef __GNUC__
 // Restore GCC diagnostics to previous state.

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -53,7 +53,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4127)
+#pragma warning(disable : 4521 4244 4204 4127)
 #endif
 
 #if (DBS_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)


### PR DESCRIPTION
### Background

* A few build warnings were introduced into the Visual Studio regression builds after a recent merge.  These were not caught be CI because the CI doesn't link against MPI and because the CI does a 32-bit build instead instead of 64-bit like the nightly regression testing.

### Description of changes

+ Ensure that gfortran uses `-fno-range-check` compiler options to avoid a problem with MS MPI.
+ Suppress build warnings in Random123 headers and related to rng unit tests.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
