### PR TITLE
Remove extraneous paren in .bash_slurm

### DIFF
--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -179,7 +179,7 @@ case ${-} in
    }
 
    export host=`uname -n | sed -e 's/[.].*//g'`
-   case $host in)
+   case $host in
    tt*|tr*) alias salloc='salloc --gres=craynetwork:0' ;;
    esac
    ;; # end case 'interactive'


### PR DESCRIPTION
### Description of changes

* A bug was introduced into the draco dev environment for trinitite.  This one-char delta fixes the problem.
