### PR TITLE
Add more pragmas to suppress warnings found in R123 headers.

### DIFF
--- a/src/rng/test/kat_c.c
+++ b/src/rng/test/kat_c.c
@@ -36,8 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // - 4244: possible loss of data when converting between int types.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
+// - 4100: unreferenced formal parameter
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4204 4127)
+#pragma warning(disable : 4521 4244 4204 4127 4100)
 #endif
 
 #include "kat_main.h"

--- a/src/rng/test/kat_cpp.cpp
+++ b/src/rng/test/kat_cpp.cpp
@@ -34,8 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // - 4244: possible loss of data when converting between int types.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
+// - 4100: unreferenced formal parameter
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4127)
+#pragma warning(disable : 4521 4244 4127 4100)
 #endif
 
 #include "kat_main.h"

--- a/src/rng/test/time_serial.h
+++ b/src/rng/test/time_serial.h
@@ -20,7 +20,7 @@
 #ifdef _MSC_FULL_VER
 // - 4204 :: nonstandard extension used: non-constant aggregate initializer.
 #pragma warning(push)
-#pragma warning(disable : 4204)
+#pragma warning(disable : 4204 4100)
 #endif
 
 #include <Random123/aes.h>

--- a/src/rng/test/ut_Engine.cpp
+++ b/src/rng/test/ut_Engine.cpp
@@ -37,8 +37,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // - 4244: possible loss of data when converting between int types.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
+// - 4100: unreferenced formal parameter
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4127)
+#pragma warning(disable : 4521 4244 4127 4100)
 #endif
 
 #ifdef __GNUC__

--- a/src/rng/test/ut_aes.cpp
+++ b/src/rng/test/ut_aes.cpp
@@ -39,8 +39,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // - 4244: possible loss of data when converting between int types.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
+// - 4100: unreferenced formal parameter
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4127)
+#pragma warning(disable : 4521 4244 4127 4100)
 #endif
 
 #include "ut_aes.hh"

--- a/src/rng/test/ut_carray.cpp
+++ b/src/rng/test/ut_carray.cpp
@@ -32,13 +32,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rng/config.h"
 
 #ifdef _MSC_FULL_VER
+// - 4701: potentially uninitialized local variable used
 // - 4521: Engines have multiple copy constructors, quite legal C++, disable
 //         MSVC complaint.
 // - 4244: possible loss of data when converting between int types.
 // - 4204: nonstandard extension used - non-constant aggregate initializer
 // - 4127: conditional expression is constant
+// - 4100: unreferenced formal parameter
 #pragma warning(push)
-#pragma warning(disable : 4521 4244 4127)
+#pragma warning(disable : 4701 4521 4244 4127 4100)
 #endif
 
 #include "ut_carray.hh"


### PR DESCRIPTION
### Background

* The Release builds had a few more warnings that I needed suppress.  These warnings are for unused or unset variables that are used in the Debug version by assert and DbC checks.

### Description of changes

* Added `#pragma warning(disable: 4100)` to several unit tests in _rng_.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
