### PR TITLE
Minor code cleanup to eliminate build warnings from Visual Studio

### DIFF
--- a/src/parser/Expression.cc
+++ b/src/parser/Expression.cc
@@ -834,15 +834,15 @@ private:
 static pE parse_primary(unsigned const number_of_variables,
                         Variable_Map const &variable_map,
                         Token_Stream &tokens) {
+  pE retvalue;
   if (at_real(tokens)) {
-    return pE(new Constant_Expression(number_of_variables, parse_real(tokens)));
+    retvalue =
+        pE(new Constant_Expression(number_of_variables, parse_real(tokens)));
   } else if (tokens.lookahead().text() == "(") {
     tokens.shift();
-    pE Result = Expression::parse(number_of_variables, variable_map, tokens);
+    retvalue = Expression::parse(number_of_variables, variable_map, tokens);
     if (tokens.shift().text() != ")") {
       tokens.report_syntax_error("missing ')'?");
-    } else {
-      return Result;
     }
   } else {
     Token const variable = tokens.shift();
@@ -859,32 +859,36 @@ static pE parse_primary(unsigned const number_of_variables,
       switch (name[0]) {
       case 'e':
         if (name == "exp") {
-          return pE(new Exp_Expression(argument));
+          retvalue = pE(new Exp_Expression(argument));
         } else {
           tokens.report_semantic_error("unrecognized function");
-          return pE(new Constant_Expression(number_of_variables, 0.0));
+          retvalue = pE(new Constant_Expression(number_of_variables, 0.0));
         }
+        break;
       case 'c':
         if (name == "cos") {
-          return pE(new Cos_Expression(argument));
+          retvalue = pE(new Cos_Expression(argument));
         } else {
           tokens.report_semantic_error("unrecognized function");
-          return pE(new Constant_Expression(number_of_variables, 0.0));
+          retvalue = pE(new Constant_Expression(number_of_variables, 0.0));
         }
+        break;
       case 'l':
         if (name == "log") {
-          return pE(new Log_Expression(argument));
+          retvalue = pE(new Log_Expression(argument));
         } else {
           tokens.report_semantic_error("unrecognized function");
-          return pE(new Constant_Expression(number_of_variables, 0.0));
+          retvalue = pE(new Constant_Expression(number_of_variables, 0.0));
         }
+        break;
       case 's':
         if (name == "sin") {
-          return pE(new Sin_Expression(argument));
+          retvalue = pE(new Sin_Expression(argument));
         } else {
           tokens.report_semantic_error("unrecognized function");
-          return pE(new Constant_Expression(number_of_variables, 0.0));
+          retvalue = pE(new Constant_Expression(number_of_variables, 0.0));
         }
+        break;
       default:
         tokens.report_semantic_error("unrecognized function");
         return pE(new Constant_Expression(number_of_variables, 0.0));
@@ -892,14 +896,12 @@ static pE parse_primary(unsigned const number_of_variables,
     } else
     // a variable or constant name
     {
-
       Variable_Map::const_iterator i = variable_map.find(variable.text());
-
       if (i != variable_map.end()) {
-        return pE(new Variable_Expression(i->second.first, number_of_variables,
-                                          (unit_expressions_are_required()
-                                               ? i->second.second
-                                               : dimensionless)));
+        retvalue = pE(new Variable_Expression(
+            i->second.first, number_of_variables,
+            (unit_expressions_are_required() ? i->second.second
+                                             : dimensionless)));
       } else {
         static map<string, Unit> unit_map;
         if (unit_map.size() == 0) {
@@ -950,17 +952,16 @@ static pE parse_primary(unsigned const number_of_variables,
           if (!unit_expressions_are_required()) {
             units = units.conv * dimensionless;
           }
-          return pE(new Constant_Expression(number_of_variables, units));
+          retvalue = pE(new Constant_Expression(number_of_variables, units));
         } else {
           tokens.report_semantic_error("undefined variable or unit: " +
                                        variable.text());
-          return pE(new Constant_Expression(number_of_variables, 0.0));
+          retvalue = pE(new Constant_Expression(number_of_variables, 0.0));
         }
       }
     }
   }
-  // not reached
-  return pE();
+  return retvalue;
 }
 
 //----------------------------------------------------------------------------//

--- a/src/parser/test/tstConsole_Token_Stream.cc
+++ b/src/parser/test/tstConsole_Token_Stream.cc
@@ -91,12 +91,14 @@ void tstConsole_Token_Stream(rtt_dsxx::UnitTest &ut) {
     else
       PASSMSG("Shift after pushback has correct value");
 
+    bool caught(false);
     try {
       tokens.report_syntax_error(token, "dummy syntax error");
-      FAILMSG("Syntax error NOT correctly thrown");
     } catch (const Syntax_Error & /*msg*/) {
+      caught = true;
       PASSMSG("Syntax error correctly thrown and caught");
     }
+    FAIL_IF_NOT(caught); // FAILMSG("Syntax error NOT correctly thrown");
 
     token = tokens.shift();
     if (token.type() != KEYWORD || token.text() != "COLOR")

--- a/src/parser/test/tstFile_Token_Stream.cc
+++ b/src/parser/test/tstFile_Token_Stream.cc
@@ -115,12 +115,15 @@ void tstFile_Token_Stream(rtt_dsxx::UnitTest &ut) {
     else
       PASSMSG("Shift after pushback has correct value");
 
+    bool caught(false);
     try {
       tokens.report_syntax_error(token, "dummy syntax error");
-      FAILMSG("Syntax error NOT correctly thrown");
     } catch (const Syntax_Error & /*msg*/) {
+      caught = true;
       PASSMSG("Syntax error correctly thrown and caught");
     }
+    FAIL_IF_NOT(caught); // FAILMSG("Syntax error NOT correctly thrown");
+
     try {
       tokens.check_syntax(true, "dummy syntax error");
       PASSMSG("Syntax error correctly checked");

--- a/src/parser/test/tstParallel_File_Token_Stream.cc
+++ b/src/parser/test/tstParallel_File_Token_Stream.cc
@@ -99,15 +99,11 @@ void tstParallel_File_Token_Stream(rtt_dsxx::UnitTest &ut) {
     if (token.type() != OTHER || token.text() != "$")
       ITFAILS;
 
+    bool caught(false);
     try {
       tokens.report_syntax_error(token, "dummy syntax error");
-      {
-        ostringstream msg;
-        msg << "Parallel_File_Token_Stream did not throw an exception when\n"
-            << "\ta syntax error was reported by Token_Stream." << endl;
-        FAILMSG(msg.str());
-      }
     } catch (const Syntax_Error &) {
+      caught = true;
       {
         ostringstream msg;
         msg << "Parallel_File_Token_Stream threw an expected exception when\n"
@@ -115,6 +111,8 @@ void tstParallel_File_Token_Stream(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       }
     }
+    FAIL_IF_NOT(caught);
+
     if (tokens.error_count() != 1)
       ITFAILS;
 

--- a/src/parser/test/tstString_Token_Stream.cc
+++ b/src/parser/test/tstString_Token_Stream.cc
@@ -108,12 +108,15 @@ void tstString_Token_Stream(UnitTest &ut) {
     else
       PASSMSG("Shift after pushback has correct value");
 
+    bool caught(false);
     try {
       tokens.report_syntax_error(token, "dummy syntax error");
-      FAILMSG("Syntax error NOT correctly thrown");
     } catch (const Syntax_Error & /*msg*/) {
+      caught = true;
       PASSMSG("Syntax error correctly thrown and caught");
     }
+    FAIL_IF_NOT(caught); // FAILMSG("Syntax error NOT correctly thrown");
+
     if (tokens.error_count() != 1) {
       FAILMSG("Syntax error NOT correctly counted");
     } else {
@@ -389,7 +392,7 @@ void tstString_Token_Stream(UnitTest &ut) {
     try {
       tokens.shift();
       ut.failure("Did NOT correctly report #include as error");
-    } catch (const Syntax_Error &msg) {
+    } catch (const Syntax_Error & /*msg*/) {
       cout << "expected: " << tokens.messages() << endl;
       PASSMSG("#include not supported error correctly thrown and caught");
     }

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -445,197 +445,199 @@ Unit parse_unit(Token_Stream &tokens);
  * \return The unit.
  */
 static Unit parse_unit_name(Token_Stream &tokens) {
+  // Return value
+  Unit retval;
   Token token = tokens.shift();
   if (token.type() == KEYWORD) {
     string const &u = token.text();
     switch (u[0]) {
     case 'A':
       if (u.size() == 1)
-        return A;
+        retval = A;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'C':
       if (u.size() == 1)
-        return C;
+        retval = C;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'F':
       if (u.size() == 1)
-        return F;
+        retval = F;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'H':
       if (u.size() == 1)
-        return H;
+        retval = H;
       else if (u.size() == 2)
-        return Hz;
+        retval = Hz;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'J':
       if (u.size() == 1)
-        return J;
+        retval = J;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'K':
       if (u.size() == 1)
-        return K;
+        retval = K;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'N':
       if (u.size() == 1)
-        return N;
+        retval = N;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'P':
       if (u.size() == 2)
-        return Pa;
+        retval = Pa;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'S':
       if (u.size() == 1)
-        return S;
+        retval = S;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'T':
       if (u.size() == 1)
-        return T;
+        retval = T;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'V':
       if (u.size() == 1)
-        return V;
+        retval = V;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'W':
       if (u.size() == 1)
-        return W;
+        retval = W;
       else if (token.text() == "Wb")
-        return Wb;
+        retval = Wb;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'c':
       if (token.text() == "cd")
-        return cd;
+        retval = cd;
       else if (token.text() == "cm")
-        return cm;
+        retval = cm;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'd':
       if (token.text() == "dyne")
-        return dyne;
+        retval = dyne;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'e':
       if (token.text() == "erg")
-        return erg;
+        retval = erg;
       else if (token.text() == "eV")
-        return eV;
+        retval = eV;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'f':
       if (token.text() == "foot")
-        return foot;
+        retval = foot;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'g':
       if (u.size() == 1)
-        return g;
+        retval = g;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'i':
       if (token.text() == "inch")
-        return inch;
+        retval = inch;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'k':
       if (token.text() == "kg")
-        return kg;
+        retval = kg;
       else if (token.text() == "keV")
-        return keV;
+        retval = keV;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'l':
       if (token.text() == "lm")
-        return lm;
+        retval = lm;
       else if (token.text() == "lx")
-        return lx;
+        retval = lx;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'm':
       if (u.size() == 1)
-        return m;
+        retval = m;
       else if (token.text() == "mol")
-        return mol;
+        retval = mol;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'o':
       if (token.text() == "ohm")
-        return ohm;
+        retval = ohm;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'p':
       if (token.text() == "pound")
-        return pound;
+        retval = pound;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 'r':
       if (token.text() == "rad")
-        return rad;
+        retval = rad;
       else
         tokens.report_syntax_error("expected a unit");
       break;
 
     case 's':
       if (u.size() == 1)
-        return s;
+        retval = s;
       else if (token.text() == "sr")
-        return sr;
+        retval = sr;
       else
         tokens.report_syntax_error("expected a unit");
       break;
@@ -648,12 +650,13 @@ static Unit parse_unit_name(Token_Stream &tokens) {
     token = tokens.shift();
     if (token.type() != OTHER || token.text() != ")")
       tokens.report_syntax_error("missing ')'");
-    return Result;
+    retval = Result;
   } else {
     tokens.report_syntax_error("expected a unit expression");
   }
   // never reached but causes warnings
-  return dimensionless;
+  // return dimensionless;
+  return retval;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* PR #497 introduced a few build warnings that were not caught by existing CI. This PR addresses those Visual Studio build warnings.
* [Redmine #1207](https://rtt.lanl.gov/redmine/issues/1207) provides a better resolution, but that solution not ready yet.

### Description of changes

+ Minor changes to code logic in `Expression.cc` and `utilities.cc` to eliminate "unreachable code" warnings. Instead of using return statements embedded in conditionals, allow the function to reach the final `return`.
+ Eliminate `unittest.failmsg` calls that appear after explicit calls to C++ `throw`. Instead, add a bool to ensure that the C++ assertion was thrown and caught.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
