### PR TITLE
A couple of tweaks to fix build/run on Darwin ARM nodes.

### DIFF
--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -40,6 +40,9 @@ if test -n "$MODULESHOME"; then
         compflavor="gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.3.1-$cflavor openmpi/3.1.2-gcc_8.2.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-netlib trilinos/12.12.1-$mflavor-netlib"
         # ec_mf="ndi"
+        # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
+        export OMPI_MCA_btl=^openib
+        export UCX_NET_DEVICES=mlx5_0:1
       ;;
 
       x86_64)

--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -178,9 +178,12 @@ case ${-} in
      sreport -t Hours cluster AccountUtilizationByUser user=$user start=$fday end=$lday
    }
 
-   export host=`uname -n | sed -e 's/[.].*//g'`
-   case $host in
-   tt*|tr*) alias salloc='salloc --gres=craynetwork:0' ;;
+   target="`uname -n | sed -e s/[.].*//`"
+   case $target in
+     darwin-fe*)
+       alias salloc='module purge; salloc' ;;
+     tt*|tr*)
+       alias salloc='salloc --gres=craynetwork:0' ;;
    esac
    ;; # end case 'interactive'
 


### PR DESCRIPTION
### Background

We are trying to get basic builds and tests working on the ARM nodes of Darwin (at LANL).  After patching random123 to eliminate an `#error` macro the codes were building but may tests were crashing in openmpi.

We are using gcc-8.2.0 and openmpi/3.1.2.

### Description of changes

+ Howard P., Nathan H. and David R. helped me with an environment-based work around for the openmpi failures.
+ When using the Draco developer environment, we also needed to purge the module environment before sourcing `.bashrc_darwin` to remove invalid x86 paths.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
