### PR TITLE
Teach the PR regression system to also build autodoc.

### DIFF
--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -53,6 +53,8 @@ case ${-} in
      echo "jobpriorities  - List of all jobs and their priorities."
      echo "backfill       - Maximum job size to allow immediate start?"
      echo "usercpuhrs [moniker] [start date (mm/dd/yy)] [end date (mm/dd/yy)] - Print total cpu-hr usage by account."
+     if [[ -f /usr/projects/consult/public/SLURM/aliases/slurm_bash_alias ]]; then
+     echo -e "\nMore slurm related aliases can be found at /usr/projects/consult/public/SLURM/aliases/slurm_bash_alias."
    }
 
    alias hluser="egrep --color -E '.*${USER}.*|$'"

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -257,8 +257,12 @@ if [[ "${regress_mode}" = "off" ]]; then
   export AUTODOCDIR=$work_dir/autodoc
 else
   export work_dir=${base_dir}/${subproj}/${dashboard_type}_${comp}/${build_type}
-  if test -d /ccs/codes/radtran/autodoc; then
-    export AUTODOCDIR=/ccs/codes/radtran/autodoc
+  if [[ -d /ccs/codes/radtran/autodoc ]]; then
+    if [[ $featurebranch == develop ]]; then
+      export AUTODOCDIR=/ccs/codes/radtran/autodoc
+    else
+      export AUTODOCDIR=/ccs/codes/radtran/autodoc/${featurebranch}
+    fi
   fi
 fi
 

--- a/regression/checkpr.sh
+++ b/regression/checkpr.sh
@@ -163,6 +163,11 @@ function startCI()
     extra=""
     edash=""
     eflag=""
+  elif [[ ${extra} == 'autodoc' ]]; then
+    extra=""
+    edash=""
+    eflag=""
+    autodoc='-a'
   else
     extrastring="(${extra}) "
     edash="-"
@@ -179,7 +184,7 @@ function startCI()
   echo "  Log: $logdir/${machine_name_short}-${build_type}-master-YYYYMMDD-hhmm.log"
   echo " "
   cmd="$rscriptdir/regression-master.sh ${rflag} -b ${build_type}"
-  cmd="$cmd ${eflag} ${extra} -p ${project} -f ${pr}"
+  cmd="$cmd ${autodoc} ${eflag} ${extra} -p ${project} -f ${pr}"
   case $target in
     ccscs* )  # build one at a time.
       ;;
@@ -254,7 +259,7 @@ case $target in
 
   # CCS-NET: Release, vtest, coverage
   ccscs2*)
-    startCI ${project} Release na $pr
+    startCI ${project} Release autodoc $pr
     startCI ${project} Debug coverage $pr
     ;;
 
@@ -296,7 +301,7 @@ case $target in
 
   # These cases are not automated checks of PRs.  However, these machines are
   # supported if this script is started by a developer:
-  ccscs[134]*)
+  ccscs[14]*)
     startCI ${project} Release na $pr
     startCI ${project} Debug na $pr ;;
   ccscs[589]*)

--- a/regression/sync_autodoc.sh
+++ b/regression/sync_autodoc.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#!/bin/bash
+##---------------------------------------------------------------------------##
+## File  : sync_autodoc.sh
+## Date  : Wednesday, Oct 17, 2018, 12:06 pm
+## Author: Kelly Thompson <kgt@lanl.gov>
+## Note  : Copyright (C) 2018, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+## Look for files at /ccs/codes/radtran/autodoc and rsync (publish) them to the
+## https://rtt.lanl.gov/autodoc web server.
+##---------------------------------------------------------------------------##
+
+umask 0002
+function run ()
+{
+    echo $1;
+    if ! [ $dry_run ]; then
+        eval $1;
+    fi
+}
+
+# Sanity checks:
+mach=`uname -n`
+if test "${mach}" != "ccsnet3.lanl.gov"; then
+   echo "FATAL ERROR: This script must be run from rtt.lanl.gov."
+   exit 1
+fi
+
+# Locations
+sourcedir=/ccs/codes/radtran/autodoc
+destdir=/var/www/virtual/rtt.lanl.gov/html/autodoc
+
+if ! test -d $sourcedir; then
+   echo "FATAL ERROR: Cannot find sourcedir = $sourcedir"
+   exit 1
+fi
+if ! test -d $destdir; then
+   echo "FATAL ERROR: Cannot find destdir = $destdir"
+   exit 1
+fi
+
+# Remove old files and directories.
+current_dir=`pwd`
+
+echo -e "\nCleaning up old builds."
+run "cd $sourcedir"
+# run "find . -mtime +5 -type f"
+# run "find . -mtime +5 -type f -delete"
+run "find . -maxdepth 1 -mtime +3 -name 'pr*' -type d"
+run "find . -maxdepth 1 -mtime +3 -name 'pr*' -type d -exec rm -rf {} \;"
+echo " "
+run "cd $destdir"
+# run "find . -mtime +5 -type f"
+# run "find . -mtime +5 -type f -delete"
+run "find . -maxdepth 1 -mtime +3 -name 'pr*' -type d"
+run "find . -maxdepth 1 -mtime +3 -name 'pr*' -type d -exec rm -rf {} \;"
+
+# Copy new files and directory to the published location
+run "cd $current_dir"
+run "rsync --delete -vaum ${sourcedir}/ ${destdir}"
+run "chgrp -R draco ${destdir}"
+run "chmod -R g+rwX,o=g-w ${destdir}"
+
+#------------------------------------------------------------------------------#
+# End sync_autodoc.sh
+#------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

* Capsaicin team members have requested that the regressions that are run to check a pull request also generate and publish doxygen-based autodoc html.

### Purpose of Pull Request

* [Fixes Redmine Issue #1284](https://rtt.lanl.gov/redmine/issues/1284)

### Description of changes

+ Teach the 'Release' PR regression to attempt to build autodoc (ccscs2 only).
+ Autodoc for PR will be created at /ccs/codes/radtran/autodoc/pr999 and will be published at https://rtt.lanl.gov/autodoc/pr999.
+ Autodoc directories will be removed after 3 days.
+ Add the `sync_autodoc.sh` script that rsyncs /ccs/codes/radtran to rtt.lanl.gov via crontab.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
