### PR TITLE
Add delete with size to complement unsized delete. 

### DIFF
--- a/src/memory/memory.cc
+++ b/src/memory/memory.cc
@@ -222,12 +222,24 @@ void operator delete(void *ptr) throw() {
     }
   }
 }
+
+//---------------------------------------------------------------------------//
+/*! Deallocate memory with diagnostics
+ *
+ * C++14 introduces operator delete with a size_t argument, used in place of
+ * the unsized operator delete when the size of the allocation can be deduced
+ * as a hint to the memory manager. For now, we ignore the hint.
+ *
+ * Since C++14 does not mandate when the compiler calls this version, it is
+ * not possible to guarantee coverage on all platforms.
+ */
+void operator delete(void *ptr, size_t) throw() { operator delete(ptr); }
 #endif
 
 //---------------------------------------------------------------------------//
-/*! 
- * \brief 
- * 
+/*!
+ * \brief
+ *
  * \param name description
  * \return description
  *
@@ -240,7 +252,7 @@ void operator delete(void *ptr) throw() {
  * information.  This function must be registered in the program.
  *
  * Example:
- * 
+ *
  * \code
  * #include <cstdlib>
  * int main()

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -88,6 +88,47 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
   } else {
     FAILMSG("NOT correct largest allocation");
   }
+#endif
+
+  // Just to try to exercise the sized delete version.
+  int *scalar = new int;
+
+#if DRACO_DIAGNOSTICS & 2
+  if (total_allocation() == sizeof(int)) {
+    PASSMSG("correct total allocation");
+  } else {
+    FAILMSG("NOT correct total allocation");
+  }
+  if (peak_allocation() >= 50 * sizeof(double) + sizeof(int)) {
+    PASSMSG("correct peak allocation");
+  } else {
+    FAILMSG("NOT correct peak allocation");
+  }
+  if (largest_allocation() >= 30 * sizeof(double)) {
+    PASSMSG("correct largest allocation");
+  } else {
+    FAILMSG("NOT correct largest allocation");
+  }
+#endif
+
+  delete scalar;
+
+#if DRACO_DIAGNOSTICS & 2
+  if (total_allocation() == 0) {
+    PASSMSG("correct total allocation");
+  } else {
+    FAILMSG("NOT correct total allocation");
+  }
+  if (peak_allocation() >= 50 * sizeof(double) + sizeof(int)) {
+    PASSMSG("correct peak allocation");
+  } else {
+    FAILMSG("NOT correct peak allocation");
+  }
+  if (largest_allocation() >= 30 * sizeof(double)) {
+    PASSMSG("correct largest allocation");
+  } else {
+    FAILMSG("NOT correct largest allocation");
+  }
   report_leaks(cerr);
 #endif
 }


### PR DESCRIPTION
Add delete with size to complement unsized delete. The former is a ne… C++14 feature that rightly generates a warning.

### Background

The memory package replaces new and delete with versions that are internally tracked to give superior diagnosis of memory usage when debugging code. This is done by replacing the system global operator new(size_t) and operator delete(void *) with versions that intercept memory allocation calls before passing on the requests to C malloc and free. The intercepting code keeps track of active allocations and the maximum total allocation and helps developers identify memory high water marks.

C++14 introduced operator delete(void *, size_t) for cases where the compiler can deduce the size of the original allocation  and pass this information on as a hint to the memory manager. We get a warning about this version not being defined when building with C++14 platforms with the memory package active (DRACO_DIAGNOSTICS & 2).

### Purpose of Pull Request

Add the operator delete(void *, size_t) which simply passes the call on to operator delete(void *); we take no advantage of the optimization hint.

This resolves issue #512 . 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
