### PR TITLE
Add single-call test functions to Draco.

### DIFF
--- a/src/c4/parallel_unit_test.hh
+++ b/src/c4/parallel_unit_test.hh
@@ -1,0 +1,37 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   c4/parallel_unit_test.hh
+ * \author Kent Grimmett Budge
+ * \brief  Define uniform test function for unit testing
+ * \note   Copyright (C) 2018 TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef dsxx_parallel_unit_test_hh
+#define dsxx_parallel_unit_test_hh
+
+namespace rtt_dsxx {
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Run a parallel unit test.
+ *
+ * \param[in] argc Number of command line arguments
+ * \param[in] argv Command line arguments
+ * \param[in] release Release string
+ * \param[in] lambda Lambda function defining the test.
+ * \return EXIT_SUCCESS or EXIT_FAILURE as appropriate.
+ */
+
+template<typename Lambda, typename Release>
+int do_parallel_unit_test(int argc, char *argv[], Release release,
+                          Lambda const &lambda);
+
+} // end namespace rtt_dsxx
+
+#include "parallel_unit_test.i.hh"
+
+#endif // dsxx_test_hh
+
+//----------------------------------------------------------------------------//
+// end of ds++/parallel_unit_test.hh
+//----------------------------------------------------------------------------//

--- a/src/c4/parallel_unit_test.i.hh
+++ b/src/c4/parallel_unit_test.i.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   c4/parallel_unit_test.i.hh
+ * \author Kent Grimmett Budge
+ * \date   Tue Nov  6 13:12:37 2018
+ * \brief  Member definitions of class test
+ * \note   Copyright (C) TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef dsxx_parallel_unit_test_i_hh
+#define dsxx_parallel_unit_test_i_hh
+
+#include "c4/ParallelUnitTest.hh"
+
+namespace rtt_dsxx {
+
+template<typename Lambda, typename Release>
+int do_parallel_unit_test(int argc, char *argv[], Release release,
+                 Lambda const &lambda)
+{
+  rtt_c4::ParallelUnitTest ut(argc, argv, release);
+  try
+  {
+    lambda(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+} // end namespace rtt_dsxx
+
+#endif // dsxx_test_i_hh
+
+//----------------------------------------------------------------------------//
+// end of ds++/parallel_unit_test.i.hh
+//----------------------------------------------------------------------------//

--- a/src/c4/test/tstparallel_unit_test.cc
+++ b/src/c4/test/tstparallel_unit_test.cc
@@ -1,0 +1,28 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   c4/test/tstparallel_unit_test.cc
+ * \author Kent Grimmett Budge
+ * \date   Tue Nov  6 13:19:40 2018
+ * \brief  Test the test function for parallel case.
+ * \note   Copyright (C) 2018 TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "c4/parallel_unit_test.hh"
+
+using namespace rtt_dsxx;
+using namespace rtt_c4;
+
+//----------------------------------------------------------------------------//
+// TESTS
+//----------------------------------------------------------------------------//
+
+//----------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  return do_parallel_unit_test(argc, argv, release,
+                               [](UnitTest &ut) { ut.passes("basic run"); });
+}
+
+//----------------------------------------------------------------------------//
+// end of tstparallel_unit_test.cc
+//----------------------------------------------------------------------------//

--- a/src/ds++/scalar_unit_test.hh
+++ b/src/ds++/scalar_unit_test.hh
@@ -1,0 +1,37 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   ds++/scalar_unit_test.hh
+ * \author Kent Grimmett Budge
+ * \brief  Define uniform test function for unit testing
+ * \note   Copyright (C) 2018 TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef dsxx_scalar_unit_test_hh
+#define dsxx_scalar_unit_test_hh
+
+namespace rtt_dsxx {
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Run a scalar unit test.
+ *
+ * \param[in] argc Number of command line arguments
+ * \param[in] argv Command line arguments
+ * \param[in] release Release string
+ * \param[in] lambda Lambda function defining the test.
+ * \return EXIT_SUCCESS or EXIT_FAILURE as appropriate.
+ */
+
+template<typename Lambda, typename Release>
+int do_scalar_unit_test(int argc, char *argv[], Release release,
+                 Lambda const &lambda);
+
+} // end namespace rtt_dsxx
+
+#include "scalar_unit_test.i.hh"
+
+#endif // dsxx_test_hh
+
+//----------------------------------------------------------------------------//
+// end of ds++/scalar_unit_test.hh
+//----------------------------------------------------------------------------//

--- a/src/ds++/scalar_unit_test.i.hh
+++ b/src/ds++/scalar_unit_test.i.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   ds++/scalar_unit_test.i.hh
+ * \author Kent Grimmett Budge
+ * \date   Tue Nov  6 13:12:37 2018
+ * \brief  Member definitions of class test
+ * \note   Copyright (C) TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef dsxx_scalar_unit_test_i_hh
+#define dsxx_scalar_unit_test_i_hh
+
+#include "ds++/ScalarUnitTest.hh"
+
+namespace rtt_dsxx {
+
+template<typename Lambda, typename Release>
+int do_scalar_unit_test(int argc, char *argv[], Release release,
+                 Lambda const &lambda)
+{
+  ScalarUnitTest ut(argc, argv, release);
+  try
+  {
+    lambda(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+} // end namespace rtt_dsxx
+
+#endif // dsxx_test_i_hh
+
+//----------------------------------------------------------------------------//
+// end of ds++/scalar_unit_test.i.hh
+//----------------------------------------------------------------------------//

--- a/src/ds++/test/tstscalar_unit_test.cc
+++ b/src/ds++/test/tstscalar_unit_test.cc
@@ -1,0 +1,27 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   ds++/test/tstscalar_unit_test.cc
+ * \author Kent Grimmett Budge
+ * \date   Tue Nov  6 13:19:40 2018
+ * \brief  Test the test function for scalar case.
+ * \note   Copyright (C) 2018 TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "ds++/scalar_unit_test.hh"
+
+using namespace rtt_dsxx;
+
+//----------------------------------------------------------------------------//
+// TESTS
+//----------------------------------------------------------------------------//
+
+//----------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  return do_scalar_unit_test(argc, argv, release,
+                               [](UnitTest &ut) { ut.passes("basic run"); });
+}
+
+//----------------------------------------------------------------------------//
+// end of tstscalar_unit_test.cc
+//----------------------------------------------------------------------------//


### PR DESCRIPTION
These carry out the entire unit testing sequence as a single function call, using lambdas, and eliminating the need for preprocessor macros like UT_EPILOG.

### Background

The great majority of unit test programs uses a common idiom of constructing a UnitTest child (ScalarUnitTest or ParallelUnitTest); passing this to one or more unit test functions within a try-block; and appending the preprocessor macro UT_EPILOG(ut) to the end of the try-block.  This is not bad, but one of the guiding principles of C++ has been "the preprocessor is (mostly) evil." By using a lambda to represent the try-block, we can do the entire idiom as a single function call with the lambda as one of the arguments, and eventually eliminate the preprocessor code.

### Purpose of Pull Request

Add two function templates, rtt_dsxx::do_scalar_unit_test and rtt_c4::do_parallel_unit_test. Each takes argc, argv, release, and a lambda taking a reference to UnitTest as its argument, and returns the success or failure status of the tests within the lambda.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
