### PR TITLE
Provide new git commit hooks that test f90 code style.

### DIFF
--- a/environment/git/f90-format.el
+++ b/environment/git/f90-format.el
@@ -1,0 +1,79 @@
+; -*- Mode: emacs -*-
+; ------------------------------------------------------------------------------
+; File:   f90-format.el
+; Date:   Wednesday, Nov 07, 2018, 11:11 am
+; Author: Kelly Thompson
+; Note:   Copyright (C) 2016-2018, Los Alamos National Security, LLC.
+;         All rights are reserved.
+; ------------------------------------------------------------------------------
+; If emacs is available, enforce f90 formatting (indentation, etc) rules.
+; ------------------------------------------------------------------------------
+
+(defun collapse-blank-lines
+  (start end)
+  (interactive "r")
+  (replace-regexp "^\n\\{2,\\}" "\n" nil start end)
+)
+
+; C-u 81 M-x goto-long-line
+; C-e
+; <space>
+; [repeat]
+(defun goto-long-line (len)
+  "Go to the first line that is at least LEN characters long.
+Use a prefix arg to provide LEN.
+Plain `C-u' (no number) uses `fill-column' as LEN."
+  (interactive "P")
+  (setq len  (if (consp len) fill-column (prefix-numeric-value len)))
+  (let ((start-line                 (line-number-at-pos))
+        (len-found                  0)
+        (found                      nil)
+        (inhibit-field-text-motion  t))
+    (while (and (not found) (not (eobp)))
+      (forward-line 1)
+      (setq found  (< len (setq len-found  (- (line-end-position) (point))))))
+    (if found
+        (when (interactive-p)
+          (message "Line %d: %d chars" (line-number-at-pos) len-found))
+      (goto-line start-line)
+      (message "Not found"))))
+
+;; (defun wrap-long-lines ()
+;;   "Find all lines > 80 columns in the current buffer and wrap them."
+;;   (interactive "p")
+;;   (set-fill-column 80)
+;;   (goto-long-line)
+;; foob
+;;   (end-of-line)
+;;   (f90-do-auto-fill)
+;; )
+
+(defun emacs-format-f90-sources ()
+   "Format the whole buffer accourding to Draco F90 rules."
+   ;; For more information about f90-mode settins in Emacs:
+   ;; 1. M-x f90-mode
+   ;; 2. C-h m
+   (set-fill-column 80)
+   (turn-on-auto-fill)
+   (setq f90-beginning-ampersand nil)
+   (setq f90-associate-indent 0)
+   ;; (setq f90-do-indent 3)
+   ;; (setq f90-if-indent 3)
+   ;; (setq f90-type-indent 3)
+   ;; (setq f90-program-indent 2)
+   ;; (setq f90-critical-indent 2)
+   ;; (setq f90-continuation-indent 5)
+   ;; (setq f90-indented-comment-re "!")
+   ;; (setq f90-break-delimiters "[-+*/><=,% \t]")
+   ;; (setq f90-break-before-delimiters t)
+   ;; (setq f90-auto-keyword-case 'downcase-word)
+   (untabify (point-min) (point-max))
+   (delete-trailing-whitespace)
+   (indent-region (point-min) (point-max) nil)
+   (collapse-blank-lines (point-min) (point-max))
+   (save-buffer)
+)
+
+; ------------------------------------------------------------------------------
+; end f90-format.el
+; ------------------------------------------------------------------------------

--- a/environment/git/install-hooks.sh
+++ b/environment/git/install-hooks.sh
@@ -15,7 +15,7 @@
 # CONFIGURATION:
 # select which pre-commit hooks are going to be installed
 #HOOKS="pre-commit pre-commit-compile pre-commit-uncrustify"
-HOOKS="pre-commit pre-commit-clang-format"
+HOOKS="pre-commit pre-commit-clang-format pre-commit-f90-format f90-format.el"
 ###########################################################
 # There should be no need to change anything below this line.
 
@@ -46,16 +46,14 @@ SCRIPTPATH="$(dirname -- "$SCRIPT")"
 # copy hooks to the directory specified as parameter
 copy_hooks() {
   echo "Copying hooks to destination directory:"
-  for hook in $HOOKS
-  do
+  for hook in $HOOKS; do
     echo "Copying $hook to $dotgitdir/hooks/."
     cp -i -- "$SCRIPTPATH/$hook" "$dotgitdir/hooks/." || true
   done
 
   echo ""
   echo "Checking if hooks are executable:"
-  for hook in $HOOKS
-  do
+  for hook in $HOOKS; do
     if [ ! -x "$dotgitdir/hooks/$hook" ] ; then
       chmod +x $dotgitdir/hooks/$hook
     else

--- a/environment/git/pre-commit
+++ b/environment/git/pre-commit
@@ -14,7 +14,7 @@
 # as this script. Hooks should return 0 if successful and nonzero to cancel the
 # commit. They are executed in the order in which they are listed.
 #HOOKS="pre-commit-compile pre-commit-uncrustify"
-HOOKS="pre-commit-clang-format"
+HOOKS="pre-commit-clang-format pre-commit-f90-format"
 ###########################################################
 # There should be no need to change anything below this line.
 

--- a/environment/git/pre-commit-f90-format
+++ b/environment/git/pre-commit-f90-format
@@ -1,38 +1,39 @@
 #!/bin/bash
 
-# git pre-commit hook that runs an clang-format stylecheck.
+# git pre-commit hook that runs a f90-format stylecheck.
 # Features:
 #  - abort commit when commit does not comply with the style guidelines
-#  - create a patch of the proposed style changes
-
-# modifications for clang-format by rene.milk@wwu.de
-# This file is part of a set of unofficial pre-commit hooks available
-# at github.
-# Link:    https://github.com/githubbrowser/Pre-commit-hooks
-# Contact: David Martin, david.martin.mailbox@googlemail.com
-
 
 ##################################################################
 # SETTINGS
-# set path to clang-format binary. If clang-format is not available, then don't
+# set path to f90-format binary. If f90-format is not available, then don't
 # run this hook. Style issues will be caught during by the pull request process.
+
+# make tmp file readable only by owner
+umask 0077
+
+debug=off
+function debugprint()
+{
+  if [[ "$debug" == "on" ]]; then
+    echo $@
+  fi
+}
 
 function version_gt()
 {
-  test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1";
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
 }
 
-CLANG_FORMAT=`which clang-format`
-if ! test -x "$CLANG_FORMAT"; then
-  exit 0
-fi
-
-cf_min_ver=6.0
-cf_ver=`"$CLANG_FORMAT" --version`
-if version_gt $cf_ver_min $cf_min; then
-  echo "ERROR: Your version of clang-format is too old. Expecting v 6.0+."
-  echo "       pre-commit-hook disabled."
-  exit 0
+# Defaults ----------------------------------------
+EMACS=`which emacs`
+if [[ $EMACS ]]; then
+  EMACSVER=`$EMACS --version | head -n 1 | sed -e 's/.*Emacs //'`
+  if [[ `version_gt "24.0.0" $EMACSVER`  ]]; then
+    echo "ERROR: Your version of emacs is too old. Expecting v 24.0+."
+    echo "       pre-commit-hook partially disabled (f90 indentation)"
+    unset EMACS
+  fi
 fi
 
 # Allow developers to opt-out
@@ -50,14 +51,14 @@ fi
 DELETE_OLD_PATCHES=true
 
 # only parse files with the extensions in FILE_EXTS. Set to true or false.
-# if false every changed file in the commit will be parsed with clang-format.
-# if true only files matching one of the extensions are parsed with clang-format.
+# if false every changed file in the commit will be parsed with f90-format.
+# if true only files matching one of the extensions are parsed with f90-format.
 # PARSE_EXTS=true
 PARSE_EXTS=true
 
 # file types to parse. Only effective when PARSE_EXTS is true.
 # FILE_EXTS=".c .h .cpp .hpp"
-FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx"
+FILE_EXTS=".f90 .F90"
 
 # file endings for files to exclude from parsing when PARSE_EXTS is true.
 FILE_ENDINGS="_f.h _f77.h _f90.h"
@@ -97,7 +98,7 @@ canonicalize_filename () {
 }
 
 # exit on error
-set -e
+# set -e
 
 # check whether the given file matches any of the set extensions
 matches_extension() {
@@ -113,6 +114,10 @@ matches_extension() {
     return 1
 }
 
+# Absolute path this script is in, thus /home/user/bin
+SCRIPT="$(canonicalize_filename "$0")"
+SCRIPTPATH="$(dirname -- "$SCRIPT")"
+
 # necessary check for initial commit
 if git rev-parse --verify HEAD >/dev/null 2>&1 ; then
     against=HEAD
@@ -121,19 +126,21 @@ else
     against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
-if [ ! -x "$CLANG_FORMAT" ] ; then
-    printf "Error: clang-format executable not found.\n"
+if [ ! -x "$EMACS" ] ; then
+    printf "Error: emacs executable not found.\n"
     printf "Set the correct path in $(canonicalize_filename "$0").\n"
     exit 1
 fi
 
 # create a random filename to store our generated patch
-prefix="pre-commit-clang-format"
+prefix="pre-commit-f90-format"
 suffix="$(date +%s)"
-patch="/tmp/$prefix-$suffix.patch"
 
-# clean up any older clang-format patches
-$DELETE_OLD_PATCHES && rm -f /tmp/$prefix*.patch
+# clean up any older f90-format patches
+$DELETE_OLD_PATCHES && rm -f /tmp/$prefix-*.patch.*
+$DELETE_OLD_PATCHES && rm -f /tmp/f90-format-*
+
+patch=$(mktemp /tmp/$prefix-$suffix.patch.XXXXXXXX)
 
 # create one patch containing all changes to the files
 git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;
@@ -144,23 +151,86 @@ do
         continue;
     fi
 
-    # clang-format our sourcefile, create a patch with diff and append it to our $patch
-    # The sed call is necessary to transform the patch from
-    #    --- $file timestamp
-    #    +++ - timestamp
-    # to both lines working on the same file and having a a/ and b/ prefix.
-    # Else it can not be applied with 'git apply'.
-    "$CLANG_FORMAT" -style=file "$file" | \
-        diff -u "$file" - | \
-        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+    file_nameonly=`basename $file`
+    tmpfile1=/tmp/f90-format-$file_nameonly
+    debugprint "cp -f $file $tmpfile1"
+    cp -f $file $tmpfile1
+    debugprint "$EMACS -batch ${tmpfile1} -l ${SCRIPTPATH}/f90-format.el -f emacs-format-f90-sources"
+    $EMACS -batch ${tmpfile1} -l ${SCRIPTPATH}/f90-format.el -f emacs-format-f90-sources
+    diff -u "${file}" "${tmpfile1}" | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patch"
+    debugprint "rm $tmpfile1"
+    rm $tmpfile1
 
 done
 
 # if no patch has been generated all is ok, clean up the file stub and exit
+found_issue=1
 if [ ! -s "$patch" ] ; then
-    printf "Files in this commit comply with the clang-format rules.\n"
+    printf "Files in this commit comply with the emacs-based f90-format rules.\n"
     rm -f "$patch"
-    exit 0
+    found_issue=0
+fi
+
+if [[ $found_issue == 0 ]]; then
+
+  # Check file lengths
+  printf "Now, checking file lengths...\n"
+
+  filelist=`git diff-index --cached --diff-filter=ACMR --name-only $against --`
+  tmpfile2=$(mktemp /tmp/pre-commit-f90-format-line-len.XXXXXXXX)
+
+  for file in $filelist; do
+
+    # ignore file if we do check for file extensions and the file does not
+    # match any of the extensions specified in $FILE_EXTS
+    if $PARSE_EXTS && ! matches_extension "$file"; then
+      continue;
+    fi
+
+    header_printed=0
+    lindeno=0
+
+    cat "$file" | while read line; do
+      let lineno++
+      # Exceptions:
+      # - Long URLs
+      exception=`echo $line | grep -i -c http`
+      if [[ ${#line} -gt 80 && ${exception} == 0 ]]; then
+        if [[ ${header_printed} == 0 ]]; then
+          echo -e "\nFile: ${file} [code line too long]\n" >> $tmpfile2
+          echo "  line   length content" >> $tmpfile2
+          echo "  ------ ------ --------------------------------------------------------------------------------" >> $tmpfile2
+          header_printed=1
+        fi
+        printf "  %-6s %-6s %s\n" "${lineno}" "${#line}" "${line}" >> $tmpfile2
+      fi
+      # reset exception flag
+      exception=0
+    done
+  done
+
+  len_issue=`cat $tmpfile2 | wc -l`
+  if [[ $len_issue -gt 0 ]]; then
+    echo -e "\nError: Found source code lines that are longer than 80 columns!"
+    cat $tmpfile2
+    echo -ne "\nPlease reformat lines listed above to fit into 80 columns and"
+    echo -e "attempt your\ncommit again.\n"
+    found_issue=$len_issue
+  fi
+
+  if [[ -f $tmpfile2 ]]; then
+    echo "remove $tmpfile2"
+    rm $tmpfile2
+  fi
+
+  if [[ $found_issue != 0 ]]; then
+    exit $found_issue
+  fi
+fi
+
+if [[ $found_issue == 0 ]]; then
+  exit 0
 fi
 
 # There are files that don't comply...
@@ -168,26 +238,27 @@ fi
 # If user wants to automatically apply these changes, then do it, otherwise,
 # print the diffs and reject the commit.
 if test $auto_apply = true; then
+  debugprint "git apply $patch"
   git apply "$patch"
-  printf "\nFiles in this commit were updated to comply with the clang-format rules.\n"
+  printf "\nFiles in this commit were updated to comply with the f90-format rules.\n"
   printf "You must check and test these changes and then stage these updates to\n"
   printf "be part of your current change set and retry the commit.\n\n"
   git status
-#  printf "The following changes were applied:\n\n"
-#  cat "$patch"
+  printf "The following changes were applied:\n\n"
+  cat "$patch"
   rm -f "$patch"
   exit 1
 fi
 
 # a patch has been created, notify the user and exit
 printf "\nThe following differences were found between the code to commit "
-printf "and the clang-format rules:\n\n"
+printf "and the f90-format rules:\n\n"
 cat "$patch"
 
 printf "\nYou can apply these changes with:\n git apply $patch\n"
 printf "(may need to be called from the root directory of your repository)\n"
 printf "Aborting commit. Apply changes and commit again or skip checking with"
 printf " --no-verify (not recommended).\n"
-printf "\nYou can also manually update format by running clang-format -i <file>. "
+printf "\nYou can also manually update format by running f90-format -i <file>.\n"
 
 exit 1

--- a/environment/git/pre-commit-f90-format
+++ b/environment/git/pre-commit-f90-format
@@ -259,6 +259,7 @@ printf "\nYou can apply these changes with:\n git apply $patch\n"
 printf "(may need to be called from the root directory of your repository)\n"
 printf "Aborting commit. Apply changes and commit again or skip checking with"
 printf " --no-verify (not recommended).\n"
-printf "\nYou can also manually update format by running f90-format -i <file>.\n"
+printf "\nYou can also manually update format by running\n"
+printf " emacs -batch <file> -l ${SCRIPTPATH}/f90-format.el -f emacs-format-f90-sources\n"
 
 exit 1


### PR DESCRIPTION
### Background

* In an attempt to make our F90 code more stylistically consistent, provide a new style check that will be run as a pre-commit hook in git.  The new script will use emacs (if available, otherwise this check will be skipped) to ensure indentation is consistent (indentation style is controlled by `f90-format.el`).  The shell script will also ensure that all code lines are shorter than 80 columns.

### Purpose of Pull Request

* Provide a style check pre-commit hook for F90 code.
* [Fixes Redmine Issue #1250](https://rtt.lanl.gov/redmine/issues/1250)

### Description of changes

+ Update the `install-hooks.sh` to provide the new scripts.
+ Provide a shell script `pre-commit-f90-format` and associated `f90-format.el` emacs lisp program.
+ When `git commit` is run, the `pre-commit-f90-format` shell script will be run.  If this script reterns a non-zero error code, the commit will be aborted.
+ Also update `pre-commit-clang-format` to sest the minimum allowed version of clang-format to 6.0.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
