### PR TITLE
Fix a cmake logic error related to XCode.

### DIFF
--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -79,8 +79,14 @@ list( APPEND headers
    ${PROJECT_BINARY_DIR}/ds++/dll_declspec.h )
 list( REMOVE_ITEM headers ${template_implementations} )
 
-set_source_files_properties( Release.cc PROPERTIES 
-  COMPILE_DEFINITIONS BUILD_TYPE="$<CONFIG>" )
+if( ${CMAKE_GENERATOR} MATCHES "Xcode" )
+  # Xcode does not support per file, per configuration compile definitions, so
+  # we add this compile definition for all files
+  add_compile_definitions( BUILD_TYPE="$<CONFIG>" )
+else()
+  set_source_files_properties( Release.cc PROPERTIES
+    COMPILE_DEFINITIONS BUILD_TYPE="$<CONFIG>" )
+endif()
 
 # ---------------------------------------------------------------------------- #
 # Build package library


### PR DESCRIPTION
### Background

* @clevelam reported that Xcode failed to configure draco due to a per file per configuration CPP define instruction. 

### Purpose of Pull Request

* Fixes #532

### Description of changes

* Add special logic for Xcode in `ds++/CMakeLists.txt`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
