### PR TITLE
Add F90 style and line-length checks to check_style.sh

### DIFF
--- a/regression/check_style.sh
+++ b/regression/check_style.sh
@@ -11,19 +11,36 @@
 # Enable job control
 set -m
 
+# protect temp files
+umask 0077
+
+# load some common bash functions
+export rscriptdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" )
+if ! [[ -d $rscriptdir ]]; then
+  export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
+if [[ -f $rscriptdir/scripts/common.sh ]]; then
+  source $rscriptdir/scripts/common.sh
+else
+  echo " "
+  echo "FATAL ERROR: Unable to locate Draco's bash functions: "
+  echo "   looking for .../regression/scripts/common.sh"
+  echo "   searched rscriptdir = $rscriptdir"
+  exit 1
+fi
+
 ##---------------------------------------------------------------------------##
 ## Support functions
 ##---------------------------------------------------------------------------##
 print_use()
 {
     echo " "
-    echo "Usage: ${0##*/} -d -n -t"
+    echo "Usage: ${0##*/} -f -t"
     echo " "
     echo "All arguments are optional."
-    echo "  -d Diff mode only. Do not modify files."
-    echo "  -n Alias for -d."
+    echo "  -f Show diff and fix files (when possible)."
     echo "  -t Run as a pre-commit check, print list of non-conformant files and return"
-    echo "     with exit code = 1."
+    echo "     with exit code = 1 (implies -d)."
     echo " "
 }
 
@@ -55,8 +72,8 @@ if [[ ! ${gcf} ]]; then
    echo "which git-clang-format${cfver}"
    echo $gcf
    exit 1
-else
-  echo "Using $gcf --binary $cf"
+#else
+#  echo "Using $gcf --binary $cf"
 fi
 if [[ ! ${cf} ]]; then
    echo "ERROR: clang-format${cfver} was not found in your PATH."
@@ -69,90 +86,193 @@ if [[ ! ${cf} ]]; then
    exit 1
 fi
 
-ver=`${cf} --version`
-echo " "
-echo "--------------------------------------------------------------------------------"
-echo "Checking modified code for style conformance..."
-echo "  - using clang-format version $ver"
-echo "  - using settings from this project's .clang_format configuration file."
-echo " "
-
 ##---------------------------------------------------------------------------##
 ## Default values
 ##---------------------------------------------------------------------------##
-pct_mode=0
-diff_mode=0
-allok=0
+pct_mode=0     # pre-commit test mode.
+fix_mode=0     # show diffs AND modify code
+foundissues=0  # 0 == ok
 
 ##---------------------------------------------------------------------------##
 ## Command options
 ##---------------------------------------------------------------------------##
 
-while getopts ":dhnt" opt; do
+while getopts ":fht" opt; do
 case $opt in
-d) diff_mode=1 ;;
+f) fix_mode=1 ;; # also modify code (as possible)
 h) print_use; exit 0 ;;
-n) diff_mode=1 ;;
-t) pct_mode=1 ;;
+t) pct_mode=1    # pre-commit test
+   fix_mode=0
+   ;;
 \?) echo "" ;echo "invalid option: -$OPTARG"; print_use; exit 1 ;;
 :)  echo "" ;echo "option -$OPTARG requires an argument."; print_use; exit 1 ;;
 esac
 done
 
 ##---------------------------------------------------------------------------##
-## Check mode
+## Check mode (Test C++ code with git-clang-format)
 ##---------------------------------------------------------------------------##
 
-if test "${pct_mode}" = "1"; then
+ver=`${cf} --version`
+echo -e "\n--------------------------------------------------------------------------------"
+echo "Checking modified C/C++ code for style conformance..."
+#echo "  - using clang-format version $ver"
+#echo "  - using settings from this project's .clang_format configuration file."
+echo " "
 
-  # don't actually modify the files (compare to branch 'develop')
-  cmd='${gcf} --binary ${cf} -f --diff --extensions hh,cc develop'
-  echo "Running..."
-  echo "   ${gcf} --binary ${cf} -f --diff --extensions hh,cc develop"
-  echo " "
-  result=`eval $cmd`
-  allok=`echo $result | grep -c "did not modify"`
-  # 2nd chance (maybe there are no files to check)
-  if test $allok = 0; then
-    allok=`echo $result | grep -c "no modified files"`
-  fi
+patchfile_c=$(mktemp /tmp/gcf.patch.XXXXXXXX)
 
-  if test $allok = 1; then
-    echo "PASS: Changes conform to this project's style requirements."
-  else
-    echo "FAIL: some files do not conform to this project's style requirements:"
-    echo " "
-    # rerun the command to capture color output.
-    eval $cmd
-    exit 1
-  fi
+# don't actually modify the files (compare to branch 'develop')
+cmd="${gcf} --binary ${cf} -f --diff --extensions hh,cc develop"
+run "${cmd}" &> $patchfile_c
 
-##---------------------------------------------------------------------------##
-## Fix mode
-##   no options --> fix the files by running clang-format
-##   -d | -n    --> print diff of required changes.
-##---------------------------------------------------------------------------##
-
+# if the patch file has the string "no modified files to format", the check passes.
+if [[ `grep -c "no modified files" ${patchfile_c}` != 0 ]]; then
+  echo "PASS: Changes to C++ sources conform to this project's style requirements."
 else
-
-  if test ${diff_mode} = 1; then
-    cmd='${gcf} --binary ${cf} -f --diff --extensions hh,cc develop'
-    result=`eval $cmd`
-    echo "The following non-conformances were discovered. Rerun without -d|-n to"
-    echo "automatically apply these changes:"
-    echo " "
-    # rerun command to capture color output.
-    eval $cmd
+  foundissues=1
+  echo    "FAIL: some C++ files do not conform to this project's style requirements:"
+  # Modify files, if requested
+  if [[ ${fix_mode} == 1 ]]; then
+    echo -e "      The following patch has been applied to your file.\n"
+    run "git apply $patchfile_c"
+    cat $patchfile_c
   else
-    result=`${gcf} --binary ${cf} -f --extensions hh,cc develop`
-    nonconformantfilesfound=`echo $result | grep -c "changed files"`
-    echo "The following files in your working directory were modified to meet the"
-    echo "this project's style requirement:"
-    echo " "
-    echo $result
+    echo -e "      run ${0##*/} with option -f to automatically apply this patch.\n"
+    cat $patchfile_c
   fi
+fi
+rm -f $patchfile_c
+
+##---------------------------------------------------------------------------##
+## Check mode (Test F90 code indentation with emacs and bash)
+##---------------------------------------------------------------------------##
+
+# Defaults ----------------------------------------
+EMACS=`which emacs`
+if [[ $EMACS ]]; then
+  EMACSVER=`$EMACS --version | head -n 1 | sed -e 's/.*Emacs //'`
+  if [[ `version_gt "24.0.0" $EMACSVER`  ]]; then
+    echo "WARNING: Your version of emacs is too old. Expecting v 24.0+."
+    echo "         pre-commit-hook partially disabled (f90 indentation)"
+    unset EMACS
+  fi
+fi
+
+# staged files
+modifiedfiles=`git diff --name-only --cached`
+# unstaged files
+modifiedfiles="${modifiedfiles} `git diff --name-only`"
+# all files
+modifiedfiles=`echo ${modifiedfiles} | sort -u`
+
+# file types to parse. Only effective when PARSE_EXTS is true.
+FILE_EXTS=".f90 .F90"
+
+# file endings for files to exclude from parsing when PARSE_EXTS is true.
+FILE_ENDINGS="_f.h _f77.h _f90.h"
+
+if [[ -x $EMACS ]]; then
+
+  echo -e "\n--------------------------------------------------------------------------------"
+  echo -e "Checking modified F90 code for style conformance (indentation)..\n"
+
+  patchfile_f90=$(mktemp /tmp/emf90.patch.XXXXXXXX)
+
+  # Loop over all modified F90 files.  Create one patch containing all changes
+  # to these files
+  for file in $modifiedfiles; do
+
+    # ignore file if we do check for file extensions and the file does not match
+    # any of the extensions specified in $FILE_EXTS
+    if ! matches_extension "$file"; then continue; fi
+
+    file_nameonly=`basename $file`
+    tmpfile1=/tmp/f90-format-$file_nameonly
+    cp -f $file $tmpfile1
+    $EMACS -batch ${tmpfile1} -l ${rscriptdir}/../environment/git/f90-format.el \
+      -f emacs-format-f90-sources &> /dev/null
+    # color output is possible if diff -version >= 3.4 with option `--color`
+    diff -u "${file}" "${tmpfile1}" | \
+      sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patchfile_f90"
+    rm $tmpfile1
+
+  done
+
+  # If the patch file is size 0, then no changes are needed.
+  if [[ -s "$patchfile_f90" ]]; then
+    foundissues=1
+    echo "FAIL: some F90 files do not conform to this project's style requirements:"
+    # Modify files, if requested
+    if [[ ${fix_mode} == 1 ]]; then
+      echo -e "      The following patch has been applied to your file.\n"
+      run "git apply $patchfile_f90"
+      cat $patchfile_f90
+    else
+      echo -e "      run ${0##*/} with option -f to automatically apply this patch.\n"
+      cat $patchfile_f90
+    fi
+  else
+    echo "PASS: Changes to F90 sources conform to this project's style requirements."
+  fi
+  rm -f $patchfile_f90
 
 fi
+
+##---------------------------------------------------------------------------##
+## Check mode (Test F90 code line length with bash)
+##---------------------------------------------------------------------------##
+
+echo -e "\n--------------------------------------------------------------------------------"
+echo -e "Checking modified F90 code for style conformance (line length)..\n"
+
+tmpfile2=$(mktemp /tmp/f90-format-line-len.XXXXXXXX)
+# Loop over all modified F90 files.  Create one patch containing all changes
+# to these files
+for file in $modifiedfiles; do
+
+  # ignore file if we do check for file extensions and the file does not match
+  # any of the extensions specified in $FILE_EXTS
+  if ! matches_extension "$file"; then continue; fi
+
+  header_printed=0
+  lindeno=0
+
+  cat "$file" | while read line; do
+    let lineno++
+    # Exceptions:
+    # - Long URLs
+    exception=`echo $line | grep -i -c http`
+    if [[ ${#line} -gt 80 && ${exception} == 0 ]]; then
+      if [[ ${header_printed} == 0 ]]; then
+        echo -e "\nFile: ${file} [code line too long]\n" >> $tmpfile2
+        echo "  line   length content" >> $tmpfile2
+        echo "  ------ ------ --------------------------------------------------------------------------------" >> $tmpfile2
+        header_printed=1
+      fi
+      printf "  %-6s %-6s %s\n" "${lineno}" "${#line}" "${line}" >> $tmpfile2
+    fi
+    # reset exception flag
+    exception=0
+  done
+done
+
+# If there are issues, report them
+if [[ `cat $tmpfile2 | wc -l` -gt 0 ]]; then
+    foundissues=1
+    echo -e "FAIL: some F90 files do not conform to this project's style requirements:\n"
+    cat $tmpfile2
+    echo -ne "\nPlease reformat lines listed above to fit into 80 columns and "
+    echo -ne "attempt running\n${0##*/} again. These issues cannot be fixed "
+    echo "with the -f option."
+fi
+
+#------------------------------------------------------------------------------#
+# Done
+#------------------------------------------------------------------------------#
+
+# Return code: 0==ok,1==bad
+exit $foundissues
 
 ##---------------------------------------------------------------------------##
 ## End check_style.sh

--- a/regression/check_style.sh
+++ b/regression/check_style.sh
@@ -39,7 +39,8 @@ print_use()
     echo " "
     echo "All arguments are optional."
     echo "  -f Show diff and fix files (when possible)."
-    echo "  -t Run as a pre-commit check, print list of non-conformant files and return"
+    echo -n "  -t Run as a pre-commit check, print list of non-conformant "
+    echo "files and return"
     echo "     with exit code = 1 (implies -d)."
     echo " "
 }
@@ -114,7 +115,8 @@ done
 ##---------------------------------------------------------------------------##
 
 ver=`${cf} --version`
-echo -e "\n--------------------------------------------------------------------------------"
+echo -ne "\n------------------------------------------------------------"
+echo "--------------------"
 echo "Checking modified C/C++ code for style conformance..."
 #echo "  - using clang-format version $ver"
 #echo "  - using settings from this project's .clang_format configuration file."
@@ -128,17 +130,20 @@ run "${cmd}" &> $patchfile_c
 
 # if the patch file has the string "no modified files to format", the check passes.
 if [[ `grep -c "no modified files" ${patchfile_c}` != 0 ]]; then
-  echo "PASS: Changes to C++ sources conform to this project's style requirements."
+  echo -n "PASS: Changes to C++ sources conform to this project's style "
+  echo "requirements."
 else
   foundissues=1
-  echo    "FAIL: some C++ files do not conform to this project's style requirements:"
+  echo -n "FAIL: some C++ files do not conform to this project's style "
+  echo "requirements:"
   # Modify files, if requested
   if [[ ${fix_mode} == 1 ]]; then
     echo -e "      The following patch has been applied to your file.\n"
     run "git apply $patchfile_c"
     cat $patchfile_c
   else
-    echo -e "      run ${0##*/} with option -f to automatically apply this patch.\n"
+    echo -ne "      run ${0##*/} with option -f to automatically apply this "
+    echo -e "patch.\n"
     cat $patchfile_c
   fi
 fi
@@ -152,7 +157,7 @@ rm -f $patchfile_c
 EMACS=`which emacs`
 if [[ $EMACS ]]; then
   EMACSVER=`$EMACS --version | head -n 1 | sed -e 's/.*Emacs //'`
-  if [[ `version_gt "24.0.0" $EMACSVER`  ]]; then
+  if `version_gt "24.0.0" $EMACSVER` ; then
     echo "WARNING: Your version of emacs is too old. Expecting v 24.0+."
     echo "         pre-commit-hook partially disabled (f90 indentation)"
     unset EMACS
@@ -174,7 +179,8 @@ FILE_ENDINGS="_f.h _f77.h _f90.h"
 
 if [[ -x $EMACS ]]; then
 
-  echo -e "\n--------------------------------------------------------------------------------"
+  echo -ne "\n----------------------------------------------------------------"
+  echo "----------------"
   echo -e "Checking modified F90 code for style conformance (indentation)..\n"
 
   patchfile_f90=$(mktemp /tmp/emf90.patch.XXXXXXXX)
@@ -194,7 +200,8 @@ if [[ -x $EMACS ]]; then
       -f emacs-format-f90-sources &> /dev/null
     # color output is possible if diff -version >= 3.4 with option `--color`
     diff -u "${file}" "${tmpfile1}" | \
-      sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patchfile_f90"
+      sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" \
+          >> "$patchfile_f90"
     rm $tmpfile1
 
   done
@@ -202,18 +209,21 @@ if [[ -x $EMACS ]]; then
   # If the patch file is size 0, then no changes are needed.
   if [[ -s "$patchfile_f90" ]]; then
     foundissues=1
-    echo "FAIL: some F90 files do not conform to this project's style requirements:"
+    echo -n "FAIL: some F90 files do not conform to this project's style "
+    echo "requirements:"
     # Modify files, if requested
     if [[ ${fix_mode} == 1 ]]; then
       echo -e "      The following patch has been applied to your file.\n"
       run "git apply $patchfile_f90"
       cat $patchfile_f90
     else
-      echo -e "      run ${0##*/} with option -f to automatically apply this patch.\n"
+      echo -ne "      run ${0##*/} with option -f to automatically apply this "
+      ehco -e "patch.\n"
       cat $patchfile_f90
     fi
   else
-    echo "PASS: Changes to F90 sources conform to this project's style requirements."
+    echo -n "PASS: Changes to F90 sources conform to this project's style "
+    echo "requirements."
   fi
   rm -f $patchfile_f90
 
@@ -223,7 +233,8 @@ fi
 ## Check mode (Test F90 code line length with bash)
 ##---------------------------------------------------------------------------##
 
-echo -e "\n--------------------------------------------------------------------------------"
+echo -ne "\n----------------------------------------------------------------"
+echo "----------------"
 echo -e "Checking modified F90 code for style conformance (line length)..\n"
 
 tmpfile2=$(mktemp /tmp/f90-format-line-len.XXXXXXXX)
@@ -247,7 +258,8 @@ for file in $modifiedfiles; do
       if [[ ${header_printed} == 0 ]]; then
         echo -e "\nFile: ${file} [code line too long]\n" >> $tmpfile2
         echo "  line   length content" >> $tmpfile2
-        echo "  ------ ------ --------------------------------------------------------------------------------" >> $tmpfile2
+        echo -n "  ------ ------ -------------------------------" >> $tmpfile2
+        echo "-------------------------------------------------" >> $tmpfile2
         header_printed=1
       fi
       printf "  %-6s %-6s %s\n" "${lineno}" "${#line}" "${line}" >> $tmpfile2
@@ -260,7 +272,8 @@ done
 # If there are issues, report them
 if [[ `cat $tmpfile2 | wc -l` -gt 0 ]]; then
     foundissues=1
-    echo -e "FAIL: some F90 files do not conform to this project's style requirements:\n"
+    echo -ne "FAIL: some F90 files do not conform to this project's style "
+    echo "requirements:\n"
     cat $tmpfile2
     echo -ne "\nPlease reformat lines listed above to fit into 80 columns and "
     echo -ne "attempt running\n${0##*/} again. These issues cannot be fixed "

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -699,7 +699,7 @@ canonicalize_filename () {
 # Example:
 #
 # EMACSVER=`emacs --version | head -n 1 | sed -e 's/.*Emacs //'`
-# if [[ `version_gt "24.0.0" $EMACSVER`  ]]; then echo yes; fi
+# if `version_gt "24.0.0" $EMACSVER` ; then echo yes; fi
 ##----------------------------------------------------------------------------##
 function version_gt()
 {

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -9,24 +9,6 @@
 ##---------------------------------------------------------------------------##
 ##
 ## Summary: Misc bash functions useful during development of code.
-##
-## Functions
-## ---------
-## die           - exit with a message
-## run           - echo a command and then run it.
-## fn_exists     - return true if named bash function is defined
-## establish_permissions - Change group to othello, dacodes or draco and change
-##                 permissions to g+rwX,o-rwX
-## machineName   - return a string to represent the current machine.
-## osName        - return a string to represent the current machine's OS.
-## flavor        - build a string that looks like fire-openmpi-2.0.2-intel-17.0.1
-## selectscratchdir - find a scratch drive
-## lookupppn     - return PE's per node.
-## npes_build    - return PE's to be used for compiling.
-## npes_test     - return PE's to be used for testing.
-## install_verions - helper for doing releases (see release_toss2.sh)
-## publish_release - helper for doing releases (see release_toss2.sh)
-## allow_file_to_age - pause a program until a file is 'old'
 
 ##---------------------------------------------------------------------------##
 ## Helpful functions
@@ -37,6 +19,7 @@ function dracohelp()
 echo -e "Bash functions defined by Draco:\n\n"
 echo -e "Also try 'slurmhelp'\n"
 echo "allow_file_to_age - pause a program until a file is 'old'"
+echo "canonicalize_filename - standardize paths to files"
 echo "cleanemacs    - remove ~ and .elc files."
 echo "die           - exit with a message"
 echo "dracoenv/rmdracoenv - load/unload the draco environment"
@@ -46,6 +29,7 @@ echo "fn_exists     - return true if named bash function is defined"
 echo "install_verions - helper for doing releases (see release_toss2.sh)"
 echo "lookupppn     - return PE's per node."
 echo "machineName   - return a string to represent the current machine."
+echo "matches_extension - Does the provided filename have a matching extension?"
 echo "npes_build    - return PE's to be used for compiling."
 echo "npes_test     - return PE's to be used for testing."
 echo "osName        - return a string to represent the current machine's OS."
@@ -55,13 +39,14 @@ echo "qrm           - quick rm for directories located in lustre scratch spaces.
 echo "rdde          - more agressive reset of the draco environment."
 echo "run           - echo a command and then run it."
 echo "selectscratchdir - find a scratch drive"
+echo "version_gt    - compare versions"
 echo "whichall      - Find all matchs."
 echo "xfstatus      - print status 'transfered' files."
 echo -e "\nUse 'type <function>' to print the full content of any function.\n"
 }
 
 #------------------------------------------------------------------------------#
-#
+# Function Definitions
 #------------------------------------------------------------------------------#
 
 # Print an error message and exit.
@@ -675,6 +660,77 @@ echo " "
 }
 
 ##----------------------------------------------------------------------------##
+# Canonicalize_filename:
+# See http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+##----------------------------------------------------------------------------##
+canonicalize_filename () {
+    local target_file=$1
+    local physical_directory=""
+    local result=""
+
+    # Need to restore the working directory after work.
+    pushd `pwd` > /dev/null
+
+    cd "$(dirname "$target_file")"
+    target_file=`basename $target_file`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$target_file" ]
+    do
+        target_file=$(readlink "$target_file")
+        cd "$(dirname "$target_file")"
+        target_file=$(basename "$target_file")
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    physical_directory=`pwd -P`
+    result="$physical_directory"/"$target_file"
+
+    # restore the working directory after work.
+    popd > /dev/null
+
+    echo "$result"
+}
+
+##----------------------------------------------------------------------------##
+# Compare versions
+#
+# Example:
+#
+# EMACSVER=`emacs --version | head -n 1 | sed -e 's/.*Emacs //'`
+# if [[ `version_gt "24.0.0" $EMACSVER`  ]]; then echo yes; fi
+##----------------------------------------------------------------------------##
+function version_gt()
+{
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+}
+
+##----------------------------------------------------------------------------##
+# check whether the given file matches any of the set extensions
+#
+# Example:
+#
+# FILE_EXTS=".f90 .F90"
+# FILE_ENDINGS="_f.h _f77.h _f90.h"
+# for file in $modified_files; do
+#   if ! matches_extension $file; then
+#      continue;
+#   fi
+#   <do stuff>
+# done
+##----------------------------------------------------------------------------##
+matches_extension() {
+    local filename=$(basename "$1")
+    local extension=".${filename##*.}"
+    local end
+    local ext
+    for end in $FILE_ENDINGS; do [[ "$filename" == *"$end" ]] && return 1; done
+    for ext in $FILE_EXTS; do [[ "$ext" == "$extension" ]] && return 0; done
+    return 1
+}
+
+##----------------------------------------------------------------------------##
 export die
 export run
 export establish_permissions
@@ -686,6 +742,9 @@ export npes_build
 export npes_test
 export install_versions
 export job_launch_sanity_checks
+export version_gt
+export canonicalize_filename
+export matches_extension
 
 ##----------------------------------------------------------------------------##
 ## End common.sh

--- a/src/FortranChecks/f90sub/Draco_MPI.F90
+++ b/src/FortranChecks/f90sub/Draco_MPI.F90
@@ -9,8 +9,6 @@
 !
 ! This is a modified version of jayenne/src/wedgehog/ftest/Wedgehog_MPI.F90
 !---------------------------------------------------------------------------
-! $Id$
-!---------------------------------------------------------------------------
 
 module draco_mpi
   use iso_c_binding, only : c_double, c_intptr_t
@@ -98,3 +96,7 @@ contains
   end subroutine f90_mpi_barrier
 
 end module draco_mpi
+
+!-----------------------------------------------------------------------------!
+! End Draco_MPI.F90
+!-----------------------------------------------------------------------------!

--- a/src/FortranChecks/f90sub/derived_types.f90
+++ b/src/FortranChecks/f90sub/derived_types.f90
@@ -33,7 +33,7 @@ module rtt_test_derived_types
   ! Now create an interface to the C routine that accepts that type
   interface
      subroutine rtt_test_derived_type(dt_in, err_code) bind(C, &
-          & name="rtt_test_derived_type")
+          name="rtt_test_derived_type")
        use iso_c_binding, only : c_int
        import my_informative_type  ! F2003 standard, brings in host scope
        implicit none
@@ -74,7 +74,8 @@ subroutine test_derived_types() bind(c)
 
   error_code = -1
 
-  print '(a,f7.5)', "On Fortran side, derived type contains double = ", mit%some_double
+  print '(a,f7.5)', "On Fortran side, derived type contains double = ", &
+       mit%some_double
   print '(a,i3)', "integer = ", mit%some_int
   print '(a,i11)', "large integer = ", mit%some_large_int
   print '(a,i4)', "int_array(1) = ", int_array(1)


### PR DESCRIPTION
### Background

* The `check_style.sh` script is used by the Travis CI style check.  Currently, only C/C++ code is checked.  This PR extends style checks to include F90.  We will be adding flake8 based formatting checks for python soon, so this is a good opportunity to make ths script more extensible.

### Purpose of Pull Request

* Provide an interactive style check (`style_check.sh`) to report style issues in F90 files.  This script can be run be developers and will be run by Travis CI.
* [Fixes Redmine Issue #1250](https://rtt.lanl.gov/redmine/issues/1250)

### Description of changes

+ Rework the `check_style.sh` script so that it has the following behavior.
  - Normal mode:
    1. Loop over all touched files, Print a fail message and a diff on failure.
    2. Test each modified C/C++ file for clang-format conformance (no changes here). Print the patch file upon failure.
    3. Test each modified F90 file for indentation conformance (if emacs is available). Print the patch file upon failure.
    4. Test each modified F90 file for line-length issues.  Print a summary upon failure.
  - Fix mode: same as above but automatically fix diffs reported by (b) or (c). Issues reported by (d) must be fixed manually.
+ Deprecate the old `-d` option (diff-mode).  This is now the default.  The newly added `-f` option (fix-mode) is a new behavior.
+ The `check_style.sh` will return error code `0` if all files meet style requirements, otherwise `1` is returned.
+ Ensure that tmp files are created as read-only by the owner to avoid exposing information.
+ Update the script to pull in bash functions defined in `common.sh`
+ Add three new bash functions to `common.sh`
  - `canonicalize_filename()` - Return the actual, full file path.
  - `matches_extension()` - Return true if a file's extension matches any string provided by `ENV{FILE_EXTS}` and doesn't match a string provided by `ENV{FILE_ENDINGS}`.
  - `version_gt()` - a bash function that correctly compares version strings of the form `XX.YY.ZZ`
+ Fix style issues and comments in two F90 files.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
