### PR TITLE
More cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ install:
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} kinetictheory/draco-travis-ci /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} kinetictheory/draco-travis-ci /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/config/autodoc_macros.cmake
+++ b/config/autodoc_macros.cmake
@@ -120,7 +120,7 @@ function( set_doxygen_dot_num_threads )
       PARENT_SCOPE)
   endif()
   # Escalate doxygen warnings into errors for CI builds
-  if( DEFINED ENV{CI} AND "$ENV{TRAVIS}" )
+  if( DEFINED ENV{CI} AND DEFINED ENV{TRAVIS} )
     set( DOXYGEN_WARN_AS_ERROR "YES" PARENT_SCOPE )
   else()
     set( DOXYGEN_WARN_AS_ERROR "NO" PARENT_SCOPE )

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -139,12 +139,16 @@ macro(dbsSetupCxx)
     set( my_cxx_compiler ${CMAKE_CXX_COMPILER} )
   endif()
 
+  # These CMAKE_* variables create defaults for the entire project so that we no
+  # longer need to set 'per_target' properties using:
+  # set_target_properties( <tgt> PROPERTIES C_STANDARD 11 ... )
+
   # C11 support:
   set( CMAKE_C_STANDARD 11 )
 
   # C++14 support:
   set( CMAKE_CXX_STANDARD 14 )
-  set( CXX_STANDARD_REQUIRED ON )
+  set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
   # Do not enable extensions (e.g.: --std=gnu++11)
   # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
@@ -153,7 +157,7 @@ macro(dbsSetupCxx)
 
   # -fPIC by default
   set( CMAKE_POSITION_INDEPENDENT_CODE ON )
-  
+
   # Setup compiler flags
   get_filename_component( my_cxx_compiler "${my_cxx_compiler}" NAME )
 

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -117,6 +117,9 @@ or the target must be labeled NOEXPORT.")
     add_executable( ${ace_TARGET} ${ace_SOURCES} )
   endif()
 
+  # Some properties are set at a global scope in compilerEnv.cmake:
+  # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
+  #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
   set_target_properties( ${ace_TARGET} PROPERTIES
     OUTPUT_NAME ${ace_EXE_NAME}
     FOLDER      ${ace_FOLDER}
@@ -310,6 +313,9 @@ macro( add_component_library )
   string( REPLACE "Lib_" "" folder_name ${acl_TARGET} )
 
   add_library( ${acl_TARGET} ${DRACO_LIBRARY_TYPE} ${acl_SOURCES} )
+  # Some properties are set at a global scope in compilerEnv.cmake:
+  # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
+  #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
   set_target_properties( ${acl_TARGET} PROPERTIES
     # ${compdefs}
     # Use custom library naming
@@ -853,6 +859,9 @@ macro( add_scalar_tests test_sources )
 
     get_filename_component( testname ${file} NAME_WE )
     add_executable( Ut_${compname}_${testname}_exe ${file} )
+    # Some properties are set at a global scope in compilerEnv.cmake:
+    # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
+    #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
     set_target_properties( Ut_${compname}_${testname}_exe
       PROPERTIES
       OUTPUT_NAME ${testname}
@@ -1001,6 +1010,9 @@ macro( add_parallel_tests )
       )")
     endif()
     add_executable( Ut_${compname}_${testname}_exe ${file} )
+    # Some properties are set at a global scope in compilerEnv.cmake:
+    # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
+    #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
     set_target_properties(
       Ut_${compname}_${testname}_exe
       PROPERTIES
@@ -1199,7 +1211,7 @@ macro( process_autodoc_pages )
   if( ${num_images} GREATER 0 )
     list( APPEND DOXYGEN_IMAGE_PATH "${PROJECT_SOURCE_DIR}/autodoc" )
   endif()
-  set( DOXYGEN_IMAGE_PATH "${DOXYGEN_IMAGE_PATH}" CACHE PATH 
+  set( DOXYGEN_IMAGE_PATH "${DOXYGEN_IMAGE_PATH}" CACHE PATH
      "List of directories that contain images for doxygen pages." FORCE )
   unset( images_in )
   unset( num_images )

--- a/regression/check_style.sh
+++ b/regression/check_style.sh
@@ -128,8 +128,10 @@ patchfile_c=$(mktemp /tmp/gcf.patch.XXXXXXXX)
 cmd="${gcf} --binary ${cf} -f --diff --extensions hh,cc develop"
 run "${cmd}" &> $patchfile_c
 
-# if the patch file has the string "no modified files to format", the check passes.
-if [[ `grep -c "no modified files" ${patchfile_c}` != 0 ]]; then
+# if the patch file has the string "no modified files to format", the check
+# passes.
+if [[ `grep -c "no modified files" ${patchfile_c}` != 0 ]] || \
+   [[ `grep -c "clang-format did not modify any files" ${patchfile_c}` != 0 ]]; then
   echo -n "PASS: Changes to C++ sources conform to this project's style "
   echo "requirements."
 else

--- a/src/cdi_analytic/Analytic_Models.cc
+++ b/src/cdi_analytic/Analytic_Models.cc
@@ -268,8 +268,11 @@ Polynomial_Analytic_Opacity_Model::get_parameters() const {
 //===========================================================================//
 // STIMULATED_EMISSION_ANALYTIC_OPACITY_MODEL DEFINITIONS
 //===========================================================================//
-// Unpacking constructor.
-
+/*!
+ * \brief Unpacking constructor for Stimulated_Emission_Analytic_Opacity_Model
+ *        objects.
+ * \bug   There are no unit tests for this function.
+ */
 Stimulated_Emission_Analytic_Opacity_Model::
     Stimulated_Emission_Analytic_Opacity_Model(const sf_char &packed)
     : a(0.0), b(0.0), c(0.0), d(0.0), e(0.0), f(1.0), g(1.0), h(1.0) {
@@ -298,8 +301,11 @@ Stimulated_Emission_Analytic_Opacity_Model::
 }
 
 //---------------------------------------------------------------------------//
-// Packing function
-
+/*!
+ * \brief Packing functionfor Stimulated_Emission_Analytic_Opacity_Model
+ *        objects.
+ * \bug   There are no unit tests for this function, so commenting it out.
+ */
 Analytic_Opacity_Model::sf_char
 Stimulated_Emission_Analytic_Opacity_Model::pack() const {
   // get the registered indicator
@@ -337,8 +343,11 @@ Stimulated_Emission_Analytic_Opacity_Model::pack() const {
 }
 
 //---------------------------------------------------------------------------//
-// Return the model parameters
-
+/*!
+ * \brief Return the model parameters for a
+ *        Stimulated_Emission_Analytic_Opacity_Model
+ * \bug   There are no unit tests for this, so commenting it out.
+ */
 Analytic_Opacity_Model::sf_double
 Stimulated_Emission_Analytic_Opacity_Model::get_parameters() const {
   sf_double p(8);
@@ -350,7 +359,6 @@ Stimulated_Emission_Analytic_Opacity_Model::get_parameters() const {
   p[5] = f;
   p[6] = g;
   p[7] = h;
-
   return p;
 }
 
@@ -425,7 +433,6 @@ Polynomial_Specific_Heat_Analytic_EoS_Model::pack() const {
 
 //---------------------------------------------------------------------------//
 // Return the model parameters
-
 Analytic_EoS_Model::sf_double
 Polynomial_Specific_Heat_Analytic_EoS_Model::get_parameters() const {
   sf_double p(6);

--- a/src/cdi_analytic/Analytic_Models.hh
+++ b/src/cdi_analytic/Analytic_Models.hh
@@ -35,6 +35,7 @@ enum Opacity_Models {
   STIMULATED_EMISSION_ANALYTIC_OPACITY_MODEL,
 };
 
+//----------------------------------------------------------------------------//
 /*!
  * \brief Enumeration describing the eos  models that are available.
  *
@@ -50,16 +51,16 @@ enum EoS_Models { POLYNOMIAL_SPECIFIC_HEAT_ANALYTIC_EOS_MODEL };
  * \brief Analytic_Opacity_Model base class.
  *
  * This is a base class that defines the interface given to
- * Analytic_Gray_Opacity or Analytic_MultiGroup_Opacity constructors.  The
- * user can define any derived model class that will work with these analtyic
- * opacity generation classes as long as it contains the following function:
- * (declared pure virtual in this class).
+ * Analytic_Gray_Opacity or Analytic_MultiGroup_Opacity constructors.  The user
+ * can define any derived model class that will work with these analtyic opacity
+ * generation classes as long as it contains the following function: (declared
+ * pure virtual in this class).
  *
  * \arg double calculate_opacity(double T, double rho)
  *
  * To enable packing functionality, the class must be registered in the
- * Opacity_Models enumeration.  Also, it must contain the following pure
- * virtual function:
+ * Opacity_Models enumeration.  Also, it must contain the following pure virtual
+ * function:
  *
  * \arg vector<char> pack() const;
  *
@@ -113,7 +114,6 @@ public:
  * where the coefficient has the following units:
  *
  * \arg a = [cm^2/g]
- *
  */
 class Constant_Analytic_Opacity_Model : public Analytic_Opacity_Model {
 private:
@@ -168,14 +168,14 @@ public:
 class Polynomial_Analytic_Opacity_Model : public Analytic_Opacity_Model {
 private:
   // Coefficients
-  double a; // constant [cm^2/g * (cm^3/g)^d]
-  double b; // temperature multiplier [keV^(-c) * cm^2/g * (cm^3/g)^d]
-  double c; // temperature power
-  double d; // density power
-  double e; // frequency power
-  double f; // reference temperature
-  double g; // reference density
-  double h; // reference frequency
+  double a; //!< constant [cm^2/g * (cm^3/g)^d]
+  double b; //!< temperature multiplier [keV^(-c) * cm^2/g * (cm^3/g)^d]
+  double c; //!< temperature power
+  double d; //!< density power
+  double e; //!< frequency power
+  double f; //!< reference temperature
+  double g; //!< reference density
+  double h; //!< reference frequency
 
 public:
   /*!
@@ -258,7 +258,7 @@ public:
 /*!
  * \class Stimulated_Emission_Analytic_Opacity_Model
  * \brief Derived Analytic_Opacity_Model class that defines a polynomial
- * function for the opacity that includes stimulated emission.
+ *        function for the opacity that includes stimulated emission.
  *
  * The opacity is defined:
  *
@@ -280,23 +280,23 @@ public:
  * \arg d = constant
  * \arg e = -3
  *
- * This produces a Planck or Rosseland opacity of the form
- *         \f[ \overline{\sigma} \propto T^{-7/2} \f]
- * which is also known as Kramers' Opacity Law.
+ * This produces a Planck or Rosseland opacity of the form \f[ \overline{\sigma}
+ * \propto T^{-7/2} \f] which is also known as Kramers' Opacity Law.
+ *
  * \sa{ http://en.wikipedia.org/wiki/Kramers'_opacity_law }
  */
 class Stimulated_Emission_Analytic_Opacity_Model
     : public Analytic_Opacity_Model {
 private:
   // Coefficients
-  double a; // constant [cm^2/g * (cm^3/g)^d]
-  double b; // temperature multiplier [keV^(-c) * cm^2/g * (cm^3/g)^d]
-  double c; // temperature power
-  double d; // density power
-  double e; // frequency power
-  double f; // reference temperature
-  double g; // reference density
-  double h; // reference frequency
+  double a; //!< constant [cm^2/g * (cm^3/g)^d]
+  double b; //!< temperature multiplier [keV^(-c) * cm^2/g * (cm^3/g)^d]
+  double c; //!< temperature power
+  double d; //!< density power
+  double e; //!< frequency power
+  double f; //!< reference temperature
+  double g; //!< reference density
+  double h; //!< reference frequency
 
 public:
   /*!
@@ -309,6 +309,8 @@ public:
    * \param f_ reference temperature
    * \param g_ reference density
    * \param h_ reference frequency
+   *
+   * \bug no unit test exists.
    */
   Stimulated_Emission_Analytic_Opacity_Model(double a_, double b_, double c_,
                                              double d_, double e_ = 0,
@@ -319,6 +321,7 @@ public:
   }
 
   //! Constructor for packed state.
+  //! \bug no unit test exists.
   explicit Stimulated_Emission_Analytic_Opacity_Model(const sf_char &packed);
 
   //! Calculate the opacity in units of cm^2/g
@@ -366,9 +369,11 @@ public:
   }
 
   //! Return the model parameters.
+  //! \bug no unit test exists.
   sf_double get_parameters() const;
 
   //! Pack up the class for persistence.
+  //! \bug no unit test exists.
   sf_char pack() const;
 };
 
@@ -397,12 +402,11 @@ public:
  * \arg ion heat capacity             = kJ/g/keV
  * \arg electron thermal conductivity = /s/cm
  *
- * These units correspond to the units defined by the rtt_cdi::EoS base
- * class.
+ * These units correspond to the units defined by the rtt_cdi::EoS base class.
  *
  * To enable packing functionality, the class must be registered in the
- * EoS_Models enumeration.  Also, it must contain the following pure
- * virtual function:
+ * EoS_Models enumeration.  Also, it must contain the following pure virtual
+ * function:
  *
  * \arg vector<char> pack() const;
  *
@@ -465,8 +469,8 @@ public:
 //---------------------------------------------------------------------------//
 /*!
  * \class Polynomial_Specific_Heat_Analytic_EoS_Model
- * \brief Derived Analytic_EoS_Model class that defines polymomial functions
- *        for EoS specific heat data.
+ * \brief Derived Analytic_EoS_Model class that defines polymomial functions for
+ *        EoS specific heat data.
  *
  * The electron and ion specific heats are defined:
  *
@@ -479,8 +483,8 @@ public:
  * \arg b,e = [kJ/g/keV^(c+1,f+1)]
  *
  * The additional data that is required by the Analytic_EoS_Model base class is
- * set to zero by default. The Polynomial_Specific_Heat_Analytic_EoS_Model
- * class is intended to be used by radiation-only packages for testing and
+ * set to zero by default. The Polynomial_Specific_Heat_Analytic_EoS_Model class
+ * is intended to be used by radiation-only packages for testing and
  * verification purposes.  More complex analytic EoS models can be easily
  * defined if they are required; however, radiation-only packages (without
  * Compton scatter) only require specfic heat data.
@@ -488,12 +492,12 @@ public:
 class Polynomial_Specific_Heat_Analytic_EoS_Model : public Analytic_EoS_Model {
 private:
   // Coefficients.
-  double a; // electron Cv constant [kJ/g/keV]
-  double b; // electron Cv temperature multiplier [kJ/g/keV^(c+1)]
-  double c; // electron Cv temperature power
-  double d; // ion Cv constant [kJ/g/keV]
-  double e; // ion Cv temperature multiplier [kJ/g/keV^(c+1)]
-  double f; // ion Cv temperature power
+  double a; //!< electron Cv constant [kJ/g/keV]
+  double b; //!< electron Cv temperature multiplier [kJ/g/keV^(c+1)]
+  double c; //!< electron Cv temperature power
+  double d; //!< ion Cv constant [kJ/g/keV]
+  double e; //!< ion Cv temperature multiplier [kJ/g/keV^(c+1)]
+  double f; //!< ion Cv temperature power
 
 public:
   /*!
@@ -510,6 +514,8 @@ public:
       : a(a_), b(b_), c(c_), d(d_), e(e_), f(f_) {
     Insist(c >= 0.0, "The Cve temperature exponent must be nonnegative");
     Insist(f >= 0.0, "The Cvi temperature exponent must be nonnegative");
+
+    /*...*/
   }
 
   //! Constructor for packed state.
@@ -541,10 +547,11 @@ public:
     return Cv;
   }
 
-  /*! Calculate the electron specific internal energy.
+  /*!
+   * \brief Calculate the electron specific internal energy.
    *
-   * This is done by integrating the specific heat capacity at constant
-   * density from T=0 to the specified temperature.
+   * This is done by integrating the specific heat capacity at constant density
+   * from T=0 to the specified temperature.
    *
    * \param T Temperature (keV) for which the specific internal energy is to be
    *          evaluated.
@@ -604,13 +611,17 @@ public:
     return 0.0;
   }
 
-  //! Calculate the electron temperature given density and Electron internal
-  //! energy and initial temperature.
+  /*!
+   * \brief Calculate the electron temperature given density and Electron
+   *        internal energy and initial temperature.
+   */
   double calculate_elec_temperature(double const /*rho*/, double const Ue,
                                     double const Te0) const override;
 
-  //! Calculate the ion temperature given density and ion internal energy and
-  //! initial temperature.
+  /*!
+   * \brief Calculate the ion temperature given density and ion internal energy
+   *        and initial temperature.
+   */
   double calculate_ion_temperature(double const /*rho*/, double const Uic,
                                    double const Ti0) const override;
   //! Return the model parameters.
@@ -620,6 +631,7 @@ public:
   sf_char pack() const override;
 };
 
+//----------------------------------------------------------------------------//
 /*!
  * \brief Functor used by calculate_Te_DU.
  *
@@ -629,10 +641,10 @@ public:
  * We solve for the new T by minimizing the function \f$ f(T) \f$ :
  *
  * \f[
- * f(T) = U_e(T_i) - \int_0^{T_i}{C_{v_e}(T) dT}
+ *     f(T) = U_e(T_i) - \int_0^{T_i}{C_{v_e}(T) dT}
  * \f]
  * \f[
- * f(T) = U_e(T_i) - a T_i - \frac{b}{c+1} T_i^{c+1}
+ *     f(T) = U_e(T_i) - a T_i - \frac{b}{c+1} T_i^{c+1}
  * \f]
  *
  */

--- a/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.hh
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_MultigroupOpacity.hh
@@ -20,7 +20,7 @@ using rtt_parser::Expression;
 /*!
  * \class Pseudo_Line_Analytic_Opacity_Model
  * \brief Derived Analytic_Opacity_Model class that defines a random line
- * spectrum for the opacity.
+ *        spectrum for the opacity.
  *
  * The opacity function is a continuum on which is superimposed a number of
  * lines of the specified peak and width. The line locations are chosen at
@@ -35,11 +35,11 @@ class Pseudo_Line_Analytic_MultigroupOpacity
       public Pseudo_Line_Base {
 private:
   Averaging averaging_;
+  //! value of 0 indicates to use adaptive Romberg integration
   unsigned qpoints_;
-  // value of 0 indicates to use adaptive Romberg integration
 
-  friend class PLR_Functor; // used in calculation of Rosseland averages
-  friend class PLP_Functor; // used in calculation of Planck averages
+  friend class PLR_Functor; //!< used in calculation of Rosseland averages
+  friend class PLP_Functor; //!< used in calculation of Planck averages
 
 public:
   Pseudo_Line_Analytic_MultigroupOpacity(
@@ -52,16 +52,16 @@ public:
   //! Constructor for packed state.
   explicit Pseudo_Line_Analytic_MultigroupOpacity(const sf_char &packed);
 
-  // Get the group opacities.
+  //! Get the group opacities.
   virtual sf_double getOpacity(double, double) const;
 
-  // Get the group opacity fields given a field of temperatures.
+  //! Get the group opacity fields given a field of temperatures.
   virtual vf_double getOpacity(const sf_double &, double) const;
 
-  // Get the group opacity fields given a field of densities.
+  //! Get the group opacity fields given a field of densities.
   virtual vf_double getOpacity(double, const sf_double &) const;
 
-  // Get the data description of the opacity.
+  //! Get the data description of the opacity.
   virtual std_string getDataDescriptor() const;
 
   //! Pack up the class for persistence.

--- a/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc
@@ -232,9 +232,9 @@ Pseudo_Line_Analytic_Odfmg_Opacity::getOpacity(double targetTemperature,
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Opacity accessor that returns a vector of multigroupband
- *     opacity 2-D vectors that correspond to the provided vector of
- *     temperatures and a single density value.
+ * \brief Opacity accessor that returns a vector of multigroupband opacity 2-D
+ *        vectors that correspond to the provided vector of temperatures and a
+ *        single density value.
  */
 std::vector<std::vector<std::vector<double>>>
 Pseudo_Line_Analytic_Odfmg_Opacity::getOpacity(
@@ -250,16 +250,16 @@ Pseudo_Line_Analytic_Odfmg_Opacity::getOpacity(
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Opacity accessor that returns a vector of multigroupband
- *     opacity 2-D vectors that correspond to the provided
- *     temperature and a vector of density values.
+ * \brief Opacity accessor that returns a vector of multigroupband opacity 2-D
+ *        vectors that correspond to the provided temperature and a vector of
+ *        density values.
  */
 std::vector<std::vector<std::vector<double>>>
 Pseudo_Line_Analytic_Odfmg_Opacity::getOpacity(
     double targetTemperature, const std::vector<double> &targetDensity) const {
   std::vector<std::vector<std::vector<double>>> opacity(targetDensity.size());
 
-  //call our regular getOpacity function for every target density
+  // call our regular getOpacity function for every target density
   for (size_t i = 0; i < targetDensity.size(); ++i) {
     opacity[i] = getOpacity(targetTemperature, targetDensity[i]);
   }
@@ -287,8 +287,9 @@ Pseudo_Line_Analytic_Odfmg_Opacity::getDataDescriptor() const {
 }
 
 //---------------------------------------------------------------------------//
-// Packing function
-
+/*!
+ * \brief Packing function for Pseudo_Line_Analytic_Odfmg_Opacity
+ */
 Analytic_MultigroupOpacity::sf_char
 Pseudo_Line_Analytic_Odfmg_Opacity::pack() const {
   sf_char const pdata = Analytic_Odfmg_Opacity::pack();

--- a/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh
@@ -27,9 +27,8 @@ using std::pair;
  */
 //===========================================================================//
 
-class DLL_PUBLIC_cdi_analytic Pseudo_Line_Analytic_Odfmg_Opacity
-    : public Analytic_Odfmg_Opacity,
-      public Pseudo_Line_Base {
+class Pseudo_Line_Analytic_Odfmg_Opacity : public Analytic_Odfmg_Opacity,
+                                           public Pseudo_Line_Base {
 private:
   Averaging averaging_;
   unsigned qpoints_;
@@ -48,7 +47,12 @@ public:
       double edge_ratio, double Tref, double Tpow, double emin, double emax,
       Averaging averaging, unsigned qpoints, unsigned seed);
 
-  // Constructor.
+  /*!
+   * \brief Constructor 2
+   * \bug No doxygen documentation
+   * \bug No unit test in Draco but used by Capsaicin in
+   *      thermal_data/microphysics_parser.cc.
+   */
   Pseudo_Line_Analytic_Odfmg_Opacity(
       const sf_double &groups, const sf_double &bands,
       rtt_cdi::Reaction reaction_in, string const &cont_file,
@@ -57,7 +61,12 @@ public:
       double emin, double emax, Averaging averaging, unsigned qpoints,
       unsigned seed);
 
-  // Constructor.
+  /*!
+   * \brief Constructor 3
+   * \bug No doxygen documentation
+   * \bug No unit test in Draco but used by Capsaicin in
+   *      thermal_data/microphysics_parser.cc.
+   */
   Pseudo_Line_Analytic_Odfmg_Opacity(
       const sf_double &groups, const sf_double &bands,
       rtt_cdi::Reaction reaction_in, double nu0, double C, double Bn, double Bd,

--- a/src/cdi_analytic/Pseudo_Line_Base.cc
+++ b/src/cdi_analytic/Pseudo_Line_Base.cc
@@ -106,6 +106,12 @@ Pseudo_Line_Base::Pseudo_Line_Base(
   setup_(emin, emax);
 }
 
+//----------------------------------------------------------------------------//
+// Pseudo_Line_Base::Pseudo_Line_Base(const string &cont_file, int number_of_lines,
+//                                    double line_peak, double line_width,
+//                                    int number_of_edges, double edge_ratio,
+//                                    double Tref, double Tpow, double emin,
+//                                    double emax, unsigned seed)
 Pseudo_Line_Base::Pseudo_Line_Base(const string &cont_file, int number_of_lines,
                                    double line_peak, double line_width,
                                    int number_of_edges, double edge_ratio,
@@ -172,8 +178,7 @@ Pseudo_Line_Base::Pseudo_Line_Base(double nu0, double C, double Bn, double Bd,
 }
 
 //---------------------------------------------------------------------------//
-// Packing function
-
+//! Packing function for Pseudo_Line_Base objects.
 vector<char> Pseudo_Line_Base::pack() const {
   throw std::range_error("sorry, pack not implemented for Pseudo_Line_Base");
   // Because we haven't implemented packing functionality for Expression trees

--- a/src/cdi_analytic/Pseudo_Line_Base.hh
+++ b/src/cdi_analytic/Pseudo_Line_Base.hh
@@ -35,7 +35,7 @@ double expm1(double const &x);
  * density, which allows precalculation of the opacity structure, an important
  * time saver.
  */
-class DLL_PUBLIC_cdi_analytic Pseudo_Line_Base {
+class Pseudo_Line_Base {
 public:
   enum Averaging {
     NONE,      //!< evaluate opacity at band center
@@ -47,7 +47,7 @@ public:
 
 private:
   // Coefficients
-  std::shared_ptr<Expression const> continuum_; // continuum opacity [cm^2/g]
+  std::shared_ptr<Expression const> continuum_; //!< continuum opacity [cm^2/g]
   vector<double> continuum_table_;
   double emax_;
 
@@ -59,17 +59,17 @@ private:
 
   unsigned seed_;
   int number_of_lines_;
-  double line_peak_;  // peak line opacity [cm^2/g]
-  double line_width_; // line width as fraction of line frequency.
+  double line_peak_;  //!< peak line opacity [cm^2/g]
+  double line_width_; //!< line width as fraction of line frequency.
   int number_of_edges_;
   double edge_ratio_;
 
-  double Tref_; // reference temperature for temperature dependence
-  double Tpow_; // temperature dependence exponent
+  double Tref_; //!< reference temperature for temperature dependence
+  double Tpow_; //!< temperature dependence exponent
 
-  vector<double> center_;      // line centers for this realization
-  vector<double> edge_;        // edges for this realization
-  vector<double> edge_factor_; // opacity at threshold
+  vector<double> center_;      //!< line centers for this realization
+  vector<double> edge_;        //!< edges for this realization
+  vector<double> edge_factor_; //!< opacity at threshold
 
   void setup_(double emin, double emax);
 
@@ -79,11 +79,23 @@ public:
                    int number_of_edges, double edge_ratio, double Tref,
                    double Tpow, double emin, double emax, unsigned seed);
 
+  /*!
+   * \brief Second constructor for Pseudo_Line_Base.
+   * \bug No unit test, but needed by Capsaicin
+   *      thermal_data/microphysics_parser.cc ->
+   *      cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc -> Pseudo_Line_Base
+   */
   Pseudo_Line_Base(string const &cont_file, int number_of_lines,
                    double line_peak, double line_width, int number_of_edges,
                    double edge_ratio, double Tref, double Tpow, double emin,
                    double emax, unsigned seed);
 
+  /*!
+   * \brief Third constructor for Pseudo_Line_Base.
+   * \bug No unit test, but needed by Capsaicin
+   *      thermal_data/microphysics_parser.cc ->
+   *      cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.cc -> Pseudo_Line_Base
+   */
   Pseudo_Line_Base(double nu0, double C, double Bn, double Bd, double R,
                    int number_of_lines, double line_peak, double line_width,
                    int number_of_edges, double edge_ratio, double Tref,

--- a/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.cc
@@ -179,9 +179,9 @@ nGray_Analytic_Odfmg_Opacity::getOpacity(double targetTemperature,
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Opacity accessor that returns a vector of multigroupband
- *     opacity 2-D vectors that correspond to the provided vector of
- *     temperatures and a single density value.
+ * \brief Opacity accessor that returns a vector of multigroupband opacity 2-D
+ *        vectors that correspond to the provided vector of temperatures and a
+ *        single density value.
  */
 std::vector<std::vector<std::vector<double>>>
 nGray_Analytic_Odfmg_Opacity::getOpacity(
@@ -197,9 +197,9 @@ nGray_Analytic_Odfmg_Opacity::getOpacity(
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Opacity accessor that returns a vector of multigroupband
- *     opacity 2-D vectors that correspond to the provided
- *     temperature and a vector of density values.
+ * \brief Opacity accessor that returns a vector of multigroupband opacity 2-D
+ *        vectors that correspond to the provided temperature and a vector of
+ *        density values.
  */
 std::vector<std::vector<std::vector<double>>>
 nGray_Analytic_Odfmg_Opacity::getOpacity(
@@ -217,9 +217,9 @@ nGray_Analytic_Odfmg_Opacity::getOpacity(
 /*!
  * \brief Pack an analytic odfmg opacity.
  *
- * This function will pack up the Analytic_Mulitgroup_Opacity into a char
- * array (represented by a vector<char>).  The nGray_Analytic_Opacity_Model
- * derived class must have a pack function; this is enforced by the virtual
+ * This function will pack up the Analytic_Mulitgroup_Opacity into a char array
+ * (represented by a vector<char>).  The nGray_Analytic_Opacity_Model derived
+ * class must have a pack function; this is enforced by the virtual
  * nGray_Analytic_Opacity_Model base class.
  */
 nGray_Analytic_Odfmg_Opacity::sf_char
@@ -243,9 +243,9 @@ nGray_Analytic_Odfmg_Opacity::pack() const {
   }
 
   // now add up the total size; number of groups + 1 size_t for number of
-  // groups, number of bands + 1 size_t for number of
-  // bands, number of models + size in each model + models, 1 size_t for
-  // reaction type, 1 size_t for model type
+  // groups, number of bands + 1 size_t for number of bands, number of models +
+  // size in each model + models, 1 size_t for reaction type, 1 size_t for model
+  // type
   size_t base_size = packed.size();
   size_t size = models.size() * sizeof(int) + num_bytes_models;
 

--- a/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
@@ -66,9 +66,9 @@ public:
    *        density.
    *
    * \param targetTemperature The temperature value for which an opacity value
-   *     is being requested.
+   *             is being requested.
    * \param targetDensity The density value for which an opacity value is being
-   *     requested.
+   *             requested.
    * \return A vector of opacities.
    */
   std::vector<std::vector<double>> getOpacity(double targetTemperature,

--- a/src/cdi_analytic/test/tstAnalytic_EoS.cc
+++ b/src/cdi_analytic/test/tstAnalytic_EoS.cc
@@ -454,7 +454,6 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
 }
 
 //---------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {

--- a/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
@@ -20,7 +20,6 @@
 
 using namespace std;
 using namespace rtt_cdi_analytic;
-
 using namespace rtt_dsxx;
 using rtt_cdi::CDI;
 using rtt_cdi::OdfmgOpacity;
@@ -521,9 +520,10 @@ void pseudo_line_opacity_test(UnitTest &ut) {
 
   // Try pack
 
-  //    vector<char> data = model.pack();
   // kgbudge: Doesn't work yet, because we haven't implemented packing for
   // expression trees yet.
+
+  // vector<char> data = model.pack();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/memory/memory.cc
+++ b/src/memory/memory.cc
@@ -59,9 +59,15 @@ struct Unsigned {
   unsigned &operator++() { return ++value; }
 };
 
-// We put the following in a wrapper so we can control destruction. We want to
-// be sure is_active is forced to be false once alloc_map is destroyed.
-
+//============================================================================//
+/*!
+ * \class memory_diagnostics
+ * \brief
+ *
+ * We put the following in a wrapper so we can control destruction. We want to
+ * be sure is_active is forced to be false once alloc_map is destroyed.
+ */
+//============================================================================//
 struct memory_diagnostics {
   map<void *, alloc_t> alloc_map;
   map<size_t, Unsigned> alloc_count;
@@ -71,7 +77,7 @@ struct memory_diagnostics {
 
 #endif // DRACO_DIAGNOSTICS & 2
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 bool set_memory_checking(bool new_status) {
   bool Result = is_active;
 
@@ -87,16 +93,17 @@ bool set_memory_checking(bool new_status) {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 uint64_t total_allocation() { return total; }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 uint64_t peak_allocation() { return peak; }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 uint64_t largest_allocation() { return largest; }
 
 //---------------------------------------------------------------------------//
+//! \bug Untested
 void report_leaks(ostream &out) {
   if (is_active) {
 #if DRACO_DIAGNOSTICS & 2
@@ -120,14 +127,14 @@ void report_leaks(ostream &out) {
 using namespace rtt_memory;
 
 #if DRACO_DIAGNOSTICS & 2
-//---------------------------------------------------------------------------------------//
+
+//----------------------------------------------------------------------------//
 /*! Allocate memory with diagnostics.
  *
  * This version of operator new overrides the library default and allows us to
  * track how memory is being used while debugging. Since this introduces
  * considerable overhead, it should not be used for production builds.
  */
-
 void *operator new(std::size_t n) _GLIBCXX_THROW(std::bad_alloc) {
   void *Result = malloc(n);
 
@@ -153,23 +160,22 @@ void *operator new(std::size_t n) _GLIBCXX_THROW(std::bad_alloc) {
   if (is_active) {
     is_active = false;
     total += n;
-    // Don't use max() here; doing it with if statement allows programmers
-    // to set a breakpoint here to find high water marks of memory usage.
+    // Don't use max() here; doing it with if statement allows programmers to
+    // set a breakpoint here to find high water marks of memory usage.
     if (total > peak) {
       peak = total;
       if (peak >= check_peak) {
-        // This is where a programmer should set his breakpoint if he
-        // wishes to pause execution when total memory exceeds the
-        // check_peak value (which the programmer typically also sets
-        // in the debugger).
+        // This is where a programmer should set his breakpoint if he wishes to
+        // pause execution when total memory exceeds the check_peak value (which
+        // the programmer typically also sets in the debugger).
         cout << "Reached check peak value" << endl;
       }
     }
     if (n >= check_large) {
-      // This is where a programmer should set his breakpoint if he
-      // wishes to pause execution when a memory allocation is requested
-      // that is larger than the check_large value (which the programmer
-      // typically also sets in the debugger).
+      // This is where a programmer should set his breakpoint if he wishes to
+      // pause execution when a memory allocation is requested that is larger
+      // than the check_large value (which the programmer typically also sets in
+      // the debugger).
       cout << "Allocated check large value" << endl;
     }
     if (n > largest) {
@@ -179,14 +185,13 @@ void *operator new(std::size_t n) _GLIBCXX_THROW(std::bad_alloc) {
     unsigned count = ++st.alloc_count[n];
     st.alloc_map[Result] = alloc_t(n, count);
     if (n == check_select_size && count == check_select_count) {
-      // This is where the programmer should set his breakpoint if he
-      // wishes to pause execution on the check_select_count'th instance
-      // of requesting an allocation of size check_select_size (which
-      // the programmer typically also set in the debugger.) This is
-      // typically done to narrow in on a potential memory leak, by
-      // identifying exactly which allocation is being leaked by looking
-      // at the allocation map (st.alloc_map) to see the size and
-      // instance.
+      // This is where the programmer should set his breakpoint if he wishes to
+      // pause execution on the check_select_count'th instance of requesting an
+      // allocation of size check_select_size (which the programmer typically
+      // also set in the debugger.) This is typically done to narrow in on a
+      // potential memory leak, by identifying exactly which allocation is being
+      // leaked by looking at the allocation map (st.alloc_map) to see the size
+      // and instance.
       cout << "Reached check select allocation" << endl;
     }
     is_active = true;
@@ -194,7 +199,7 @@ void *operator new(std::size_t n) _GLIBCXX_THROW(std::bad_alloc) {
   return Result;
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Deallocate memory with diagnostics
  *
  * This is the operator delete override to go with the operator new override
@@ -207,10 +212,10 @@ void operator delete(void *ptr) throw() {
     if (i != st.alloc_map.end()) {
       total -= i->second.size;
       if (i->second.size >= check_large) {
-        // This is where the programmer should set his breakpoint if
-        // he wishes to pause execution when an allocation larger than
-        // check_large is deallocated. check_large is typically also
-        // set in the debugger by the programmer.
+        // This is where the programmer should set his breakpoint if he wishes
+        // to pause execution when an allocation larger than check_large is
+        // deallocated. check_large is typically also set in the debugger by the
+        // programmer.
         cout << "Deallocated check large value" << endl;
       }
       is_active = false;
@@ -239,8 +244,7 @@ void operator delete(void *ptr, size_t) throw() { operator delete(ptr); }
  *        encountered.
  *
  * The usual notion is that if new operator cannot allocate dynamic memory of
- * the requested size, then it should throw an exception of type
- * std::bad_alloc.
+ * the requested size, then it should throw an exception of type std::bad_alloc.
  *
  * If std::bad_alloc is about to be thrown because new is unable to allocate
  * enough memory, a user-defined function can be called to provide diagnostic
@@ -262,6 +266,7 @@ void operator delete(void *ptr, size_t) throw() { operator delete(ptr); }
  * }
  * \endcode
  *
+ * \bug untested
  */
 void rtt_memory::out_of_memory_handler(void) {
   std::cerr << "Unable to allocate requested memory.\n"

--- a/src/memory/memory.hh
+++ b/src/memory/memory.hh
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \brief  memory utilities for diagnostic purposes
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id: memory.hh 7239 2013-10-07 20:29:39Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef memory_memory_hh

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -4,18 +4,14 @@
  * \author Kent G. Budge, Kelly G. Thompson
  * \brief  memory test.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-//! \version $Id: tstProcmon.cc 5830 2011-05-05 19:43:43Z kellyt $
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "memory/memory.hh"
-#include <sstream>
-//#include <new> // std::set_new_handler
 #include <limits>
+#include <sstream>
 
 using namespace std;
 using namespace rtt_memory;

--- a/src/timestep/test/tstTimeStep.cc
+++ b/src/timestep/test/tstTimeStep.cc
@@ -121,8 +121,12 @@ void run_tests(rtt_dsxx::UnitTest &ut) {
 
     sp_dt->set_fixed_value(dt);
     if (override_flag) {
-      sp_ovr->activate();
-      sp_ovr->set_fixed_value(override_dt);
+      // This branch is never used.  The next functions are commented out.
+      // If you get here, please add a unit test and re-enable these
+      // functions.
+      ITFAILS;
+      // sp_ovr->activate();
+      // sp_ovr->set_fixed_value(override_dt);
     } else {
       sp_ovr->deactivate();
     }

--- a/src/timestep/ts_advisor.cc
+++ b/src/timestep/ts_advisor.cc
@@ -5,10 +5,7 @@
  * \date   Thu Apr  2 14:06:18 1998
  * \brief  Defines the base class time-step advisor.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ts_advisor.hh"
@@ -17,12 +14,14 @@
 
 namespace rtt_timestep {
 
+//----------------------------------------------------------------------------//
 ts_advisor::ts_advisor(const std::string &name_, const usage_flag usage_,
                        const bool active_)
     : name(name_), usage(usage_), active(active_) {
   // empty
 }
 
+//----------------------------------------------------------------------------//
 void ts_advisor::print(const ts_manager &tsm, const bool controlling) const {
   using std::cout;
   using std::endl;

--- a/src/timestep/ts_advisor.hh
+++ b/src/timestep/ts_advisor.hh
@@ -26,9 +26,9 @@ class ts_manager;
 /*!
  * \brief Defines the base class time-step advisor.
  *
- * \sa The ts_manager class provides a means to manage this advisor.
- * The \ref overview_timestep page gives a summary of the Draco time
- * step control utilities.
+ * \sa The ts_manager class provides a means to manage this advisor. The \ref 
+ *     overview_timestep page gives a summary of the Draco time step control
+ *     utilities.
  */
 //===========================================================================//
 class DLL_PUBLIC_timestep ts_advisor {
@@ -39,8 +39,8 @@ public:
   /*! 
    * \brief Flag to determine how the recommended timestep is to be used.
    *
-   * The recommended value "dt_rec" is to be used as indicated by
-   * the enumeration value selected
+   * The recommended value "dt_rec" is to be used as indicated by the
+   * enumeration value selected
    */
   enum usage_flag {
     min,       //!< use as a lower limit
@@ -79,6 +79,7 @@ public:
 
   /*!
    * \brief Constucts the advisor
+   *
    * \param name_ the name of the advisor
    * \param usage_ Specifies how the advisor is to be used
    * \param active_ turns the advisor on/off
@@ -92,7 +93,8 @@ public:
   //MANIPULATORS
 
   //! Turn the advisor on
-  void activate() { active = true; }
+  // void activate() { active = true; }
+
   //! Turn the advisor off
   void deactivate() { active = false; }
 
@@ -101,19 +103,22 @@ public:
   //! Determine if the advisor is active or not
   bool is_active() const { return active; }
 
-  /*! 
+  /*!
    * \brief Update and/or produce the time-step recommended by this advisor
    * \param tsm the timestep manager in which the advisor resides
    */
   virtual double get_dt_rec(const ts_manager &tsm) const = 0;
 
-  /*! 
+  /*!
    * \brief Determine if the advisor is fit to use in a time-step calculation
-   * 
+   * \param tsm the timestep manager in which the advisor resides
+   *
    * Derived classes will have parameter 'tsm', the timestep manager in which 
    * the advisor resides.
    */
-  virtual bool advisor_usable(const ts_manager & /*tsm*/) const {
+  virtual bool advisor_usable(const ts_manager & /*tsm*/) const
+
+  {
     return (active == true);
   }
 
@@ -126,15 +131,14 @@ public:
   //! Vomit the entire internal state of the advisor to std out
   virtual void print_state(std::ostream &out = std::cout) const = 0;
 
-  //! Invariant function
-  /*! \return True if the invariant is satisfied.
-     */
+  //! True if the invariant is satisfied.
   virtual bool invariant_satisfied() const {
     return name.length() != 0 && 0 <= usage && usage < last_usage;
   }
 
-  /*! 
+  /*!
    * \brief Print out advisor data
+   *
    * \param tsm the timestep manager in which the advisor resides
    * \param controlling flags the advisor as the controlling advisor
    */

--- a/src/timestep/ts_advisor.hh
+++ b/src/timestep/ts_advisor.hh
@@ -111,7 +111,6 @@ public:
 
   /*!
    * \brief Determine if the advisor is fit to use in a time-step calculation
-   * \param tsm the timestep manager in which the advisor resides
    *
    * Derived classes will have parameter 'tsm', the timestep manager in which 
    * the advisor resides.


### PR DESCRIPTION
### Background

* #471 and #472 contain changes to improve code coverage.  They also include more general code cleanup for portions of the code base that we rarely edit.  Because these PRs might break Capsaicin, I've marked them as WIP, but the general changes should be merged soon.  Thus, the creation of this PR.
* I also discovered that the `make autodoc` target wasn't setting the doxygen option `WARN_AS_ERROR` as designed.  

### Description of changes

* Mostly changes and additions to documentation blocks.
* Update how the Travis CI uses variables to fix this issue (export more variables to the docker image). Fixes #537.
* Add some notes to cmake files about how some build system related variables are set (language standards, PIC, etc.)
* Also fixes #538

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
