### PR TITLE
Fix a bug related to setting version numbers.

### DIFF
--- a/config/dracoVersion.cmake
+++ b/config/dracoVersion.cmake
@@ -9,11 +9,11 @@
 
 macro( set_ccs2_software_version PROJNAME )
 
-  if( NOT ${PROJNAME}_VERSION_MAJOR )
+  if( NOT DEFINED ${PROJNAME}_VERSION_MAJOR )
     message( WARNING "${PROJNAME}_VERSION_MAJOR should already be set!" )
     set(${PROJNAME}_VERSION_MAJOR 0)
   endif()
-  if( NOT ${PROJNAME}_VERSION_MINOR )
+  if( NOT DEFINED ${PROJNAME}_VERSION_MINOR )
     message( WARNING "${PROJNAME}_VERSION_MINOR should already be set!" )
     set(${PROJNAME}_VERSION_MINOR 0)
   endif()

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -53,6 +53,9 @@ if( ${DBS_CXX_IS_BULLSEYE} MATCHES BullseyeCoverage )
   mark_as_advanced( DBS_CXX_IS_BULLSEYE )
 endif()
 
+# LTO (option '-flto') is controlled via the cmake variable
+# CMAKE_INTERPROCEDURAL_OPTIMIZATION, see config/compilerEnv.cmake.
+
 #
 # Compiler Flags
 #
@@ -88,9 +91,6 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -gdwarf-3 -fno-eliminate-unused-debug-types -Wextra -Wno-expansion-to-defined -funroll-loops" )
 
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
-    # LTO appears to be broken (at least for Jayenne with gcc 4 and 5 series).
-    # string( APPEND CMAKE_C_FLAGS_RELEASE " -flto" )
-
     # See https://gcc.gnu.org/gcc-5/changes.html
     # UndefinedBehaviorSanitizer gained a few new sanitization options:
     #  -fsanitize=float-divide-by-zero: detect floating-point division by 0

--- a/regression/ccsnet3-crontab
+++ b/regression/ccsnet3-crontab
@@ -1,0 +1,13 @@
+# crontab for ccsnet3
+5 4 * * sun	/var/www/bin/rsync-rtt > /dev/null 2>&1
+
+*/30  6-18 * * * /home/kellyt/bin/sync_autodoc.sh &> /home/kellyt/logs/sync_autodoc.log
+
+# |    |    |    |    |   |
+# |    |    |    |    |   +- command
+# |    |    |    |    +----- day of week (0 - 6) (Sunday=0)
+# |    |    |    +---------- month (1 - 12)
+# |    |    +--------------- day of month (1 - 31)
+# |    +-------------------- hour (0 - 23)
+# +------------------------- min (0 - 59)
+#


### PR DESCRIPTION
### Description of changes

+ The current cmake code thinks the minor version is not set if it is zero. Used  `DEFINED` in the check to fix this issue.
+ Sneak in two other minor changes.
  - Update a comment about setting `-flto` when using g++.
  - Archive the crontab used on ccsnet3.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
