### PR TITLE
Enhance autodoc features.

### DIFF
--- a/autodoc/CMakeLists.txt
+++ b/autodoc/CMakeLists.txt
@@ -68,8 +68,12 @@ add_custom_command(
           -DDOXYGEN_IMAGE_PATH=${DOXYGEN_IMAGE_PATH}
           -DDOXYGEN_HTML_DYNAMIC_MENUS="${DOXYGEN_HTML_DYNAMIC_MENUS}"
           -DDOXYGEN_WARN_AS_ERROR="${DOXYGEN_WARN_AS_ERROR}"
+          -DDOXYGEN_ENABLED_SECTIONS="${DOXYGEN_ENABLED_SECTIONS}"
+          -DDOXYGEN_INCLUDE_PATH="${DOXYGEN_INCLUDE_PATH}"
           -P "${PROJECT_SOURCE_DIR}/config/configureFileOnMake.cmake"
   DEPENDS "${PROJECT_SOURCE_DIR}/config/doxygen_config.in"
+          "${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/header.html"
+          "${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/footer.html"
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/autodoc)
 
 # Create header.html, footer.html and doxygen.css.

--- a/config/autodoc_macros.cmake
+++ b/config/autodoc_macros.cmake
@@ -78,6 +78,13 @@ function( set_doxygen_input )
   set( DOXYGEN_EXAMPLE_PATH "${temp}" PARENT_SCOPE)
   unset( temp )
 
+  if( ${DRACO_DBC_LEVEL} GREATER 0 )
+    set(DOXYGEN_ENABLED_SECTIONS "REMEMBER_ON" PARENT_SCOPE)
+  endif()
+
+  # Tell doxygen where Draco's include files are:
+  set( DOXYGEN_INCLUDE_PATH "${CMAKE_INSTALL_PREFIX}/include" PARENT_SCOPE)
+
 endfunction()
 
 #------------------------------------------------------------------------------
@@ -115,7 +122,7 @@ function( set_doxygen_dot_num_threads )
   endif()
   # hack in a couple of other settings based on the version of doxygen
   # discovered.
-  if( ${DOXYGEN_VERSION} VERSION_GREATER_EQUAL 1.8.14 )
+  if( ${DOXYGEN_VERSION} VERSION_GREATER 1.8.14 )
     set( DOXYGEN_HTML_DYNAMIC_MENUS "HTML_DYNAMIC_MENUS = YES"
       PARENT_SCOPE)
   endif()
@@ -139,14 +146,21 @@ endfunction()
 # - DOXYGEN_HTML_OUTPUT - The project name in all lowercase.
 #------------------------------------------------------------------------------
 macro( doxygen_provide_support_files )
-  configure_file(
-    "${PROJECT_SOURCE_DIR}/autodoc/html/footer.html.in"
-    "${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/footer.html"
-    @ONLY )
-  configure_file(
-    "${PROJECT_SOURCE_DIR}/autodoc/html/header.html.in"
-    "${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/header.html"
-    @ONLY )
+
+  add_custom_command(
+    OUTPUT  "${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/footer.html"
+    COMMAND "${CMAKE_COMMAND}"
+            -DINFILE="${PROJECT_SOURCE_DIR}/autodoc/html/footer.html.in"
+            -DOUTFILE="${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/footer.html"
+            -P "${draco_config_dir}/configureFileOnMake.cmake"
+    DEPENDS "${PROJECT_SOURCE_DIR}/autodoc/html/footer.html.in" )
+  add_custom_command(
+    OUTPUT  "${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/header.html"
+    COMMAND "${CMAKE_COMMAND}"
+            -DINFILE="${PROJECT_SOURCE_DIR}/autodoc/html/header.html.in"
+            -DOUTFILE="${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/header.html"
+            -P "${draco_config_dir}/configureFileOnMake.cmake"
+    DEPENDS "${PROJECT_SOURCE_DIR}/autodoc/html/header.html.in" )
 
   if( EXISTS "${draco_config_dir}/doxygen.css" )
     # use Draco's version of the style sheet
@@ -176,7 +190,9 @@ function( set_doxygen_tagfiles )
   # Create links to Draco autodoc installation.
   unset( DRACO_TAG_FILE CACHE )
   find_file( DRACO_TAG_FILE Draco.tag
-    HINTS ${DOXYGEN_OUTPUT_DIR} )
+    HINTS
+      ${DOXYGEN_OUTPUT_DIR}
+      ${DOXYGEN_OUTPUT_DIR}/.. )
   get_filename_component( DRACO_AUTODOC_DIR ${DRACO_TAG_FILE} PATH )
   file( RELATIVE_PATH DRACO_AUTODOC_HTML_DIR
     ${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}

--- a/config/doxygen_config.in
+++ b/config/doxygen_config.in
@@ -649,7 +649,7 @@ GENERATE_DEPRECATEDLIST= YES
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
 
-ENABLED_SECTIONS       =
+ENABLED_SECTIONS       = @DOXYGEN_ENABLED_SECTIONS@
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines that the
 # initial value of a variable or macro / define can have for it to appear in the
@@ -2055,7 +2055,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2077,7 +2077,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           =
+INCLUDE_PATH           = @DOXYGEN_INCLUDE_PATH@
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2133,7 +2133,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-# TAGFILES               = @TAGFILES@
+TAGFILES               = @TAGFILES@
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/src/ds++/Safe_Divide.hh
+++ b/src/ds++/Safe_Divide.hh
@@ -5,10 +5,7 @@
  * \date   Tue Jun 21 15:35:05 2005
  * \brief  Provide protected division functions.
  * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef dsxx_Save_Divide_hh


### PR DESCRIPTION
### Background

* I'm trying to stand up a Jayenne gitlab runner CI that builds the autodoc target (Jayenne uses the Draco build system and links to Draco libraries). While working this feature, I needed to enhance the Draco build system's autodoc capabilities.

### Purpose of Pull Request

* [Related to Redmine Issue #1315](https://rtt.lanl.gov/redmine/issues/1315) and linked issues.
* [Related to Redmine Issue #1330](https://rtt.lanl.gov/redmine/issues/1330)

### Description of changes

* Teach DBS how to set doxygen options `ENABLED_SECTIONS` and `INCLUDE_PATH` when configuring `doxygen_config`. Also re-enable the `TAGFILES` entry and set doxygen option `MACRO_EXPANSION=YES`.
  - `ENABLED_SECTIONS` allows the use of the doxygen `\cond` command.
  - `MACRO_EXPANSION=YES` allows Draco Design-by-Contract CPP macros to be understood by doxygen.  However, the `INCLUDE_PATH` must also be set to a file location where `ds++/Assert.hh` is located.
* Update `autodoc/CMakeLists.txt` to provide an example of how to specify `ENABLED_SECTIONS` and `INCLUDE_PATH` when configuring `doxygen_config`.
* Update `autodoc_macros.cmake` to automatically set
  * `DOXYGEN_ENABLED_SECTIONS="REMEMBER_ON", when `DbC>0`.
  * `DOXYGEN_INCLUDE_PATH` (should work for CI, but might not work in all cases).
* Update the build system rules that install `header.html` and `footer.html` so that they are installed during the build instead of during the configure step.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
