### PR TITLE
Update regression environment to fix script-update bug.

### DIFF
--- a/regression/covclass_cmake.cfg
+++ b/regression/covclass_cmake.cfg
@@ -2,4 +2,4 @@
 
 @CTEST_SOURCE_DIRECTORY@/src/*/
 !@CTEST_SOURCE_DIRECTORY@/src/*/test/
-
+!@CTEST_SOURCE_DIRECTORY@/src/*/test_common/

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -382,9 +382,6 @@ Parsing arguments
       # Note 'DRACO_TIMING:STRING=2' will break milagro tests (python cannot
       # parse output).
     endif()
-    if( $ENV{extra_params_sort_safe} MATCHES "nr" )
-      set( RNG_NR "ENABLE_RNG_NR:BOOL=ON" )
-    endif()
     if( $ENV{extra_params_sort_safe} MATCHES "scalar" )
       set( DRACO_C4 "DRACO_C4:STRING=SCALAR" )
     elseif( $ENV{extra_params_sort_safe} MATCHES "static" )

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -21,6 +21,7 @@ timestamp=`date +%Y%m%d-%H%M`
 target="`uname -n | sed -e s/[.].*//`"
 logdir="$( cd $scriptdir/../../logs && pwd )"
 logfile=$logdir/update_regression_scripts-$target-$timestamp.log
+echo "==> Redirecting output to $logfile"
 exec > $logfile
 exec 2>&1
 
@@ -101,22 +102,42 @@ fi
 source ${scriptdir}/repository_list.sh
 
 for project in ${github_projects[@]}; do
-  namespace=`echo $p | sed -e 's%/.*%%'`
-  repo=`echo $p | sed -e 's%.*/%%'`
-  echo -e "\nUpdating $REGDIR/$repo..."
-  if test -d ${REGDIR}/$repo; then
-    run "cd ${REGDIR}/$repo; git pull"
+  namespace=`echo $project | sed -e 's%/.*%%'`
+  repo=`echo $project | sed -e 's%.*/%%'`
+  case ${repo} in
+    Draco) ldir="draco" ;;
+    *)     ldir=${repo} ;;
+  esac
+  echo -e "\nUpdating $REGDIR/$ldir..."
+  if [[ -d ${REGDIR}/$ldir ]]; then
+    run "cd ${REGDIR}/$ldir; git pull"
   else
-    case $repo in
-      draco|branson)
-        run "cd ${REGDIR}; git clone git@github.com:$project $repo"
-        ;;
-      *)
-        run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:${project}.git"
-        ;;
-    esac
+    echo "No local directory $REGDIR/${ldir}"
+    echo "  ==> To enable regressions for project ${project}, create this directory"
+    echo "      by running 'cd $REGDIR && git clone git@github.com:$project $ldir"
+#    run "cd ${REGDIR}; git clone git@github.com:$project $ldir"
   fi
 done
+
+# Gitlab repositories...
+for project in ${gitlab_projects[@]}; do
+  namespace=`echo $project | sed -e 's%/.*%%'`
+  repo=`echo $project | sed -e 's%.*/%%'`
+  case ${repo} in
+    Draco) ldir="draco" ;;
+    *)     ldir=${repo} ;;
+  esac
+  echo -e "\nUpdating $REGDIR/$ldir..."
+  if [[ -d ${REGDIR}/$ldir ]]; then
+    run "cd ${REGDIR}/$ldir; git pull"
+  else
+    echo "No local directory $REGDIR/${ldir}"
+    echo "  ==> To enable regressions for project ${project}, create this directory"
+    echo "      by running 'cd $REGDIR && git clone git@github.com:$project $ldir"
+#    run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:${project}.git"
+  fi
+done
+
 
 #------------------------------------------------------------------------------#
 # Cleanup old files and directories


### PR DESCRIPTION
### Background

* While taking a closer look at the bullseye coverage report, I realized that the run scripts in the regression directory were not being updated as expected.  A quick triage of the issue revealed some script logic errors that were fixed.

### Purpose of Pull Request

* [Fixes Redmine Issue #1335](https://rtt.lanl.gov/redmine/issues/1335)

### Description of changes

+ Rewrote portions of `update_regression_scripts.sh` that run 'git pull`.
+ Also remove some deprecated "NR" logic from the regression scripts.
+ Also update the bullseye coverage configuration file to exclude 'test_common' subdirectories that live in package directories.
+ Output looks something like this

```
Executing ./update_regression_scripts.sh ...

...

Updating /scratch/regress/draco...
==> cd /scratch/regress/draco; git pull
error: Your local changes to the following files would be overwritten by merge:
	regression/ccscs-regress.msub
Please commit your changes or stash them before you merge.
Aborting
Updating 2177e7d2..b850a7ba

Updating /scratch/regress/branson...
No local directory /scratch/regress/branson
  ==> To enable regressions for project lanl/branson, create this directory
      by running 'cd /scratch/regress && git clone git@github.com:lanl/branson branson

Updating /scratch/regress/CSK...
==> cd /scratch/regress/CSK; git pull
Already up to date.

...
```

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
