### PR TITLE
Add compton to VS2017 regressions.

### DIFF
--- a/config/FindCOMPTON.cmake
+++ b/config/FindCOMPTON.cmake
@@ -87,7 +87,7 @@ find_path( COMPTON_INCLUDE_DIR
   PATH_SUFFIXES Release Debug
 )
 
-set( COMPTON_LIBRARY_NAME Lib_compton_omp;Lib_compton)
+set( COMPTON_LIBRARY_NAME Lib_compton_omp;Lib_compton;compton)
 find_library( COMPTON_LIBRARY
   NAMES ${COMPTON_LIBRARY_NAME}
   HINTS ${COMPTON_ROOT_DIR}/lib ${COMPTON_LIBDIR}

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -681,6 +681,7 @@ macro( SetupVendorLibrariesWindows )
   setupGSL()
   setupParMETIS()
   setupRandom123()
+  setupCOMPTON()
   setupPython()
   setupQt()
 

--- a/src/compton/test/tCompton.cc
+++ b/src/compton/test/tCompton.cc
@@ -40,7 +40,7 @@ void compton_file_test(rtt_dsxx::UnitTest &ut) {
 
   try {
     compton_test.reset(new rtt_compton::Compton(filename));
-  } catch (int asrt) {
+  } catch (int /*asrt*/) {
     FAILMSG("Failed to construct a Compton object!");
     // if construction fails, there is no reason to continue testing...
     return;
@@ -268,7 +268,7 @@ void compton_build_test(rtt_dsxx::UnitTest &ut) {
     compton_test.reset(new rtt_compton::Compton(
         filename, test_groups, opac_type, wt_func, induced, det_bal, nxi));
     std::cout << "\n\n";
-  } catch (rtt_dsxx::assertion &asrt) {
+  } catch (rtt_dsxx::assertion & /*asrt*/) {
     FAILMSG("Failed to construct a Compton object!");
     // if construction fails, there is no reason to continue testing...
     return;


### PR DESCRIPTION
### Background

* Previously, we had not attempted to build the compton package when building on Win32/VS2017.
* With a few tweaks, CSK was successfully and installed built under VS2017.

### Description of changes

* This minor update enables finding, linking-to and running the compton tests.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
