### PR TITLE
Remove csk-0.4.0 version specification from regression scripts so 0.4.1 can be loaded

### DIFF
--- a/regression/scripts/cray-env.sh
+++ b/regression/scripts/cray-env.sh
@@ -37,7 +37,7 @@ case $ddir in
       run "module load gsl random123 eospac/6.3.0 ndi"
       run "module load trilinos/12.10.1 metis parmetis/4.0.3 superlu-dist"
       run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk/0.4.0"
+      run "module load csk"
       run "module list"
       CC=`which cc`
       CXX=`which CC`
@@ -69,7 +69,7 @@ case $ddir in
       run "module load gsl random123 eospac/6.3.0 ndi"
       run "module load trilinos/12.10.1 metis parmetis/4.0.3 superlu-dist"
       run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk/0.4.0"
+      run "module load csk"
       run "module swap craype-haswell craype-mic-knl"
       run "module list"
       run "module list"

--- a/regression/scripts/cts-env.sh
+++ b/regression/scripts/cts-env.sh
@@ -16,7 +16,7 @@ case $ddir in
       run "module load cmake git numdiff python/3.6-anaconda-5.0.1"
       run "module load intel/18.0.2 openmpi/2.1.2"
       run "module load random123 eospac/6.3.0 gsl"
-      run "module load mkl metis ndi csk/0.4.0"
+      run "module load mkl metis ndi csk"
       run "module load parmetis superlu-dist trilinos"
       run "module list"
     }
@@ -74,7 +74,7 @@ case $ddir in
       run "module load cmake git numdiff"
       run "module load intel/17.0.4 openmpi/2.1.2"
       run "module load random123 eospac/6.2.4 gsl"
-      run "module load mkl metis ndi csk/0.4.0"
+      run "module load mkl metis ndi csk"
       run "module load parmetis superlu-dist trilinos"
       run "module list"
     }


### PR DESCRIPTION
### Background

* I forgot to do this in the last PR, when I removed the version specification for csk in other locations

### Purpose of Pull Request

* remove 0.4.0 version spec from regression environments

### Description of changes

* see above :)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
