### PR TITLE
Misc updates to prepare for next release

### DIFF
--- a/config/autodoc_macros.cmake
+++ b/config/autodoc_macros.cmake
@@ -16,15 +16,17 @@ set(draco_config_dir ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
 function( set_autodocdir )
   # if AUTODOCDIR is set in environment (or make command line), create a CMake
   # variable with this value.
-  if( ENV{AUTODOCDIR} )
+  if( DEFINED ENV{AUTODOCDIR} )
     set( AUTODOCDIR "$ENV{AUTODOCDIR}" )
   endif()
   # if AUTODOCDIR is set, use it, otherwise, default to CMAKE_INSTALL_PREFIX.
-  if( AUTODOCDIR )
+  if( DEFINED AUTODOCDIR )
     set( DOXYGEN_OUTPUT_DIR "${AUTODOCDIR}" PARENT_SCOPE)
   else()
     set( DOXYGEN_OUTPUT_DIR ${CMAKE_INSTALL_PREFIX}/autodoc PARENT_SCOPE)
   endif()
+
+  message(STATUS "Using autodoc directory ${AUTODOCDIR}")
 
 endfunction()
 

--- a/config/doxygen_config.in
+++ b/config/doxygen_config.in
@@ -2370,7 +2370,7 @@ DIRECTORY_GRAPH        = YES
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = svg
+DOT_IMAGE_FORMAT       = png
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -71,7 +71,7 @@ if [[ ${SLURM_JOB_PARTITION} == "knl" ]]; then
   module swap craype-haswell craype-mic-knl
 fi
 
-export dracomodules="cmake/3.12.1 git subversion \
+export dracomodules="cmake/3.12.1 git \
 clang-format eospac/6.3.0 gsl/2.3 metis numdiff random123 \
 parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1"
 

--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -480,7 +480,15 @@ auto-mode-alist."
     (defvar crypt-freeze-vs-fortran nil)
     (add-hook 'f90-mode-hook 'draco-f90-mode-hook)
     (add-hook 'f90-mode-hook 'turn-on-draco-mode)
-    (add-hook 'f90-mode-hook 'turn-on-auto-fill)))
+    (add-hook 'f90-mode-hook 'turn-on-auto-fill)
+    ; should add this sometime
+    ; (add-hook 'font-lock-mode-hook
+    ;          '(lambda ()
+    ;             (if (major-mode 'f90-mode)
+    ;                 (draco-f90-font-lock)))) ; create this function
+                                        ; based on draco-font-lock but
+                                        ; for f90
+    ))
 
 ;; ========================================
 ;; FORTRAN
@@ -524,7 +532,8 @@ auto-mode-alist."
       (draco-mode-update-menu (draco-menu-insert-comments-f77)))
     (add-hook 'fortran-mode-hook 'draco-fortran-mode-hook)
     (add-hook 'fortran-mode-hook 'turn-on-draco-mode)
-    (add-hook 'fortran-mode-hook 'turn-on-auto-fill)))
+    (add-hook 'fortran-mode-hook 'turn-on-auto-fill)
+    ))
 
 ;; ========================================
 ;; ChangeLog

--- a/regression/ccscs2-crontab
+++ b/regression/ccscs2-crontab
@@ -33,9 +33,9 @@
 # gcc-8.2.0, openmpi-3.1.0
 #------------------------------------------------------------------------------#
 
-05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p \"draco jayenne capsaicin core\"
+05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"draco jayenne capsaicin core\"
 
-00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e coverage
+00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e coverage
 
 30 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e valgrind
 

--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -221,6 +221,7 @@ for ep in $extra_params; do
   esac
 done
 run "module list"
+unset MPI_ROOT
 
 # Use a unique regression folder for each github branch
 if [[ $extra_params_sort_safe ]]; then

--- a/src/c4/ParallelUnitTest.hh
+++ b/src/c4/ParallelUnitTest.hh
@@ -17,7 +17,7 @@
 #define c4_ParallelUnitTest_hh
 
 #include "C4_Functions.hh"
-#include "ds++/UnitTest.hh"
+#include "ds++/ScalarUnitTest.hh"
 
 namespace rtt_c4 {
 
@@ -106,7 +106,6 @@ public:
  * \param[in] lambda Lambda function defining the test.
  * \return EXIT_SUCCESS or EXIT_FAILURE as appropriate.
  */
-
 template <typename... Lambda, typename Release>
 int do_parallel_unit_test(int argc, char *argv[], Release release,
                           Lambda const &... lambda);

--- a/src/c4/ParallelUnitTest.i.hh
+++ b/src/c4/ParallelUnitTest.i.hh
@@ -10,10 +10,6 @@
 #ifndef dsxx_parallel_unit_test_i_hh
 #define dsxx_parallel_unit_test_i_hh
 
-#include "c4/ParallelUnitTest.hh"
-
-#include "ds++/ScalarUnitTest.i.hh"
-
 namespace rtt_c4 {
 
 template <typename... Lambda, typename Release>

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -249,7 +249,8 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
  0      Require
  1      Check
  2      Ensure, Remember
- 3      (nothrow option)
+ 3      (nothrow versions of above macros) [8-15]
+ 4      (deferred exception throwing versions of above macros)
  \endverbatim
  *
  * So for instance, \c -DDBC=7 turns them all on, \c -DDBC=0 turns them all off,
@@ -315,7 +316,7 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
 // clang-format off
 
 //---------------------------------------------------------------------------//
-// No-throw versions of DBC
+// No-throw versions of DBC [8-15]
 //---------------------------------------------------------------------------//
 #if DBC & 8
 
@@ -489,7 +490,35 @@ DLL_PUBLIC_dsxx std::string verbose_error(std::string const &message);
 #endif
 
 //----------------------------------------------------------------------------//
+/*! Ensure all possible Draco DbC macros are defined.  If not already defined,
+ * then define them as no-op. */
+//----------------------------------------------------------------------------//
+#ifndef Require
+#define Require(c)
+#endif
+#ifndef Check
+#define Check(c)
+#endif
+#ifndef Assert
+#define Assert(c)
+#endif
+#ifndef Ensure
+#define Ensure(c)
+#endif
+#ifndef Insist
+#define Insist(c,m)
+#endif
+#ifndef Insist_ptr
+#define Insist_ptr(c,m)
+#endif
+#ifndef Bad_Case
+#define Bad_Case(m)
+#endif
+#ifndef Remember
+#define Remember(c)
+#endif
 
+//----------------------------------------------------------------------------//
 #if defined(MSVC)
 #pragma warning(pop)
 #endif

--- a/src/ds++/ScalarUnitTest.i.hh
+++ b/src/ds++/ScalarUnitTest.i.hh
@@ -10,8 +10,6 @@
 #ifndef dsxx_ScalarUnitTest_i_hh
 #define dsxx_ScalarUnitTest_i_hh
 
-#include "ds++/ScalarUnitTest.hh"
-
 namespace rtt_dsxx {
 
 template <typename Lambda>


### PR DESCRIPTION

### Background

* This change set includes a handful over very small changes to address minor issues and to adapt to changing environments.

### Purpose of Pull Request

* [Fixes Redmine Issue #1354](https://rtt.lanl.gov/redmine/issues/1354) (cyclic file deps)

### Description of changes

+ Update the cmake `set_autodocdir` macro to do a better job of importing settings found in the developer's environment.
+ Modify the doxygen configuration file so that dot produces `png` image files instead of `svg` image files.  The `svg` files where causing link issues in published documents.
+ Eliminate two cyclic file dependencies:
  - ScalarUnitTest.hh <--> ScalarUnitTest.i.hh
  - ParallelUnitTest.hh <--> ParallelUnitTest.i.hh
+ In `Assert.hh`, add some logic that ensures that all Design-by-Contract CPP macros are defined for the current `DBC_LEVEL`.  Previously, if `DBC_LEVEL>7`, the  macro `Bad_Case` wasn't defined.
+ Draco developer environment:
  - trinitite: no longer load the subversion module by default.
  - Add some notes to the elisp scripts about possible future modifications.
  - On CTS machines, unset `MPI_ROOT` after loading modules to avoid some cmake  generated warnings.
+ Regressions:
  - Modify the ccscs2 crontab so that autodoc is built from a Debug build where  more function parameters are defined (i.e.. `Remember` won't remove  variables).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
