### PR TITLE
Enable xthi and ythi builds/tests for Visual Studio.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
-  SplitEmptyFunction: true
+#  SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None

--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories( Lib_c4
   PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
 # xthi binary
-if( NOT WIN32 AND NOT APPLE )
+if( NOT APPLE )
   add_subdirectory( bin )
 endif()
 

--- a/src/c4/bin/CMakeLists.txt
+++ b/src/c4/bin/CMakeLists.txt
@@ -26,21 +26,20 @@ add_component_executable(
   TARGET      Exe_xthi
   TARGET_DEPS Lib_c4
   SOURCES     ${PROJECT_SOURCE_DIR}/xthi.cc
-  PREFIX       Draco
-  )
+  PREFIX       Draco )
 
 add_component_executable(
   TARGET      Exe_ythi
   TARGET_DEPS Lib_c4
   SOURCES     ${PROJECT_SOURCE_DIR}/ythi.cc
-  PREFIX       Draco
-  )
-
+  PREFIX       Draco )
+  
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 
 install( TARGETS Exe_xthi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
+install( TARGETS Exe_ythi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 
 # ---------------------------------------------------------------------------- #
 # End cdi_eospac/CMakeLists.txt

--- a/src/c4/bin/xthi.hh
+++ b/src/c4/bin/xthi.hh
@@ -1,0 +1,122 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   c4/bin/xthi.hh
+ * \author Mike Berry <mrberry@lanl.gov>, Kelly Thompson <kgt@lanl.gov>
+ * \date   Wednesday, Aug 09, 2017, 11:45 am
+ * \brief  Helper functions to generate string for core affinity.
+ * \note   Copyright (C) 2017-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "c4_omp.h"
+#include "ds++/Assert.hh"
+#include "ds++/SystemCall.hh"
+#include <bitset>
+#include <sstream>
+
+#ifdef WIN32
+#include <processthreadsapi.h> // requries SystemCall.hh to be loaded first.
+#endif
+
+namespace rtt_c4 {
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief query the OS for an affinity bitmask and translate it to a human
+ *        readable form.
+ *
+ * For Linux-like systems, borrow code from
+ * util-linux-2.13-pre7/schedutils/taskset.c.
+ *
+ * For Windows systems, make use of GetProcessAffinityMask
+ * (processthreadsapi.h). Refs:
+ *
+ * - https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-getprocessaffinitymask
+ * - https://stackoverflow.com/questions/10877182/getprocessaffinitymask-returns-processaffinty-and-systemaffinity-as-1-overflow
+ * - https://stackoverflow.com/questions/2215063/how-can-you-find-the-processor-number-a-thread-is-running-on
+ * .
+ *
+ * In both cases, the affinity bitmask is restricted to 64 cores.  If a node has
+ * more than 64 cores, extra logic will be needed to make this function work.
+ *
+ * \return A string of the form "0-8;16-32;" or "0-63"
+ */
+#ifdef WIN32
+
+//! \param[in] num_cpu Number of CPU's per node.
+std::string cpuset_to_string(unsigned const num_cpu) {
+
+  // return value;
+  std::ostringstream cpuset;
+  // The thread affinity bitmask functions used below are limited to 64.
+  Insist(
+      num_cpu <= 64,
+      "Might need to use alternate cpu-groups information with this fuction!");
+
+  DWORD_PTR dwProcessAffinity;
+  DWORD_PTR dwSystemAffinity;
+  bool ok = GetProcessAffinityMask(GetCurrentProcess(), &dwProcessAffinity,
+                                   &dwSystemAffinity);
+  Insist(ok, "GetProcessAffinityMask() failed!");
+
+  // Convert the bitmask to an array of bools and then to a string to represent
+  // a CPU range
+  std::bitset<64> const affmask(dwProcessAffinity);
+  size_t begin(0);
+  bool enabled(false);
+  for (size_t i = 0; i < affmask.size(); ++i) {
+    if (enabled) {
+      if (!affmask[i]) {
+        enabled = false;
+        cpuset << begin << "-" << i - 1 << "; ";
+      }
+    } else {
+      // looking for next core that can be used
+      if (affmask[i]) {
+        enabled = true;
+        begin = i;
+      }
+    }
+  }
+  return cpuset.str();
+}
+
+#else
+
+std::string cpuset_to_string(unsigned const /*num_cpu*/) {
+
+  // return value;
+  std::ostringstream cpuset;
+  // local storage; retrieve the thread affinity bitmask
+  cpu_set_t coremask;
+  (void)sched_getaffinity(0, sizeof(coremask), &coremask);
+
+  // Convert the bitmask into something that is human readable.
+  size_t entry_made = 0;
+  for (int i = 0; i < CPU_SETSIZE; i++) {
+    if (CPU_ISSET(i, &coremask)) {
+      int run = 0;
+      entry_made = 1;
+      for (int j = i + 1; j < CPU_SETSIZE; j++) {
+        if (CPU_ISSET(j, &coremask))
+          run++;
+        else
+          break;
+      }
+      if (run == 0)
+        cpuset << i << ",";
+      else
+        cpuset << i << "" << i + run << ",";
+      i += run;
+    }
+  }
+  return cpuset.str().substr(0, cpuset.str().length() - entry_made);
+}
+
+#endif
+
+} // end namespace rtt_c4
+
+//----------------------------------------------------------------------------//
+// End c4/bin/xthi.hh
+//----------------------------------------------------------------------------//

--- a/src/ds++/SystemCall.cc
+++ b/src/ds++/SystemCall.cc
@@ -14,7 +14,7 @@
 #include <cstdio>  // remove()
 #include <cstdlib> // _fullpath
 #include <cstring> // strncpy()
-#ifdef UNIX
+#if defined UNIX || defined MINGW
 #include <sys/param.h> // MAXPATHLEN
 #include <unistd.h>    // gethostname
 #endif

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -50,6 +50,9 @@
 #cmakedefine MSVC @MSVC@
 #cmakedefine MSVC_IDE @MSVC_IDE@
 #cmakedefine MSVC_VERSION @MSVC_VERSION@
+#cmakedefine MINGW @MINGW@
+#cmakedefine XCODE @XCODE@
+#cmakedefine XCODE_VERSION @XCODE_VERSION@
 #cmakedefine CMAKE_SYSTEM_NAME @CMAKE_SYSTEM_NAME@
 #ifdef CMAKE_SYSTEM_NAME
 #define CMAKE_SYSTEM_NAME_STRING "@CMAKE_SYSTEM_NAME@"

--- a/src/ds++/path.hh
+++ b/src/ds++/path.hh
@@ -15,7 +15,7 @@
 #include "Assert.hh"
 #include "SystemCall.hh"
 #include <iostream>
-#ifdef UNIX
+#if defined UNIX || defined MINGW
 #include <dirent.h>   // struct DIR
 #include <sys/stat.h> // struct stat; S_ISDIR
 #endif


### PR DESCRIPTION
### Background

* These applications were excluded from the Visual Studio build because they used Linux kernel specific calls to obtain the affinity bitmask.

### Description of changes

* I have added a Windows kernel equivalent of the non-portable code and moved these two code blocks into a new file, `xthi.hh`.
* I also updated some of the CPP macro logic used to select Windows vs. Linux kernel commands to deal with the half-Linux, half-Windows MinGW environment.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
