### PR TITLE
Add boilerplate base for Class_Parse_Table 

### DIFF
--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -244,7 +244,7 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
  *
  * Class__parser.cc:
  *
- * #include "Class__parser.hh"
+ * include "Class__parser.hh"
  *
  * void Class_Parse_Table<Class>::parse_flag(Token_Stream &tokens, int)
  * {

--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -210,6 +210,137 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
   return Result;
 }
 
+//----------------------------------------------------------------------------------------//
+/*! Template for base class for class parser
+ *
+ * This is to simplify writing a class parser. A specializaton of Class_Parse_Table for a
+ * class Class uses this as a base class, as follows:
+ *
+ * Class__parser.hh:
+ *
+ * template<>
+ * class Class_Parse_Table<Class> : public Class_Parse_Table_Base<Class>
+ * {
+ *    public:
+ *      explicit Class_Parse_Table(Context_Type debug_context);
+ *
+ *      void check_completeness(Token_Stream &tokens);
+ *
+ *      shared_ptr<Sweeper_Creator> create_object();
+ *
+ *    protected:
+ *      // Data to be parsed which will be used to construct the class, for example:
+ *
+ *      Context_Type debug_context;
+ *      bool flag;
+ *      double constant;
+ *
+ *    private:
+ *      // Parse functions
+ *
+ *      static void parse_flag(Token_Stream &, int);
+ *      static void parse_constant(Token_Stream &, double);
+ * };
+ *
+ * Class__parser.cc:
+ *
+ * #include "Class__parser.hh"
+ *
+ * void Class_Parse_Table<Class>::parse_flag(Token_Stream &tokens, int)
+ * {
+ *    ...
+ * }
+ *
+ * void Class_Parse_Table<Class>::parse_constant(Token_Stream &tokens, int)
+ * {
+ *    ...
+ * }
+ *
+ * Class_Parse_Table<Class>::Class_Parse_Table(Context_Type debug_word)
+ * : debug_context(debug_word), flag(false), constant(0.0)
+ * {
+ *   const Keyword keywords[] = {
+ *     {"block", parse_block, 0, ""},
+ *     {"solver", parse_solver, 0, ""},
+ *   };
+ *   initialize(keywords, sizeof(keywords));
+ * }
+ *
+ * void Class_Parse_Table<Class>::check_completeness(Token_Stream &tokens)
+ * {
+ *   ... check the parsed data ...
+ * }
+ *
+ * shared_ptr<Sweeper_Creator> Class_Parse_Table<Class>::create_object()
+ * {
+ *   return make_shared<Class>(debug_context, flag, constant);
+ * }
+ *
+ * template <>
+ * shared_ptr<Class>
+ * parse_class<Class>(Token_Stream &tokens,
+ *                    Debug_Context debug_context)
+ * {
+ *    return parse_class_from_table<Class_Parse_Table<Class>>(
+ *        tokens, debug_context);
+ * }
+ *
+ * This introduces all the "boilerplate" and lets the developer focus on the data required
+ * for the constructor for Class, the parse functions needed to parse this data, and the
+ * check and construct functions.
+ */
+
+template <class Class, bool allow_an_exit = false>
+class Class_Parse_Table_Base {
+public:
+  // TYPEDEFS
+
+  typedef Class Return_Class;
+  typedef unsigned Context_Type;
+
+  // MANAGEMENT
+
+  // SERVICES
+
+  bool allow_exit() const { return allow_an_exit; }
+
+  // STATIC
+
+  static Parse_Table &parse_table() { return parse_table_; }
+
+protected:
+  // DATA
+
+  // STATIC
+
+private:
+  // IMPLEMENTATION
+
+  // STATIC
+
+  friend class Class_Parse_Table<Class>;
+
+  void initialize(Keyword const keywords[], unsigned count) {
+    static bool first_time = true;
+    if (first_time) {
+      count /= sizeof(Keyword);
+      parse_table_.add(keywords, count);
+      first_time = false;
+    }
+    current_ = (Class_Parse_Table<Class> *)this;
+  }
+
+  static Class_Parse_Table<Class> *current_;
+  static Parse_Table parse_table_;
+};
+
+template <class Class, bool allow_exit>
+/*static*/ Class_Parse_Table<Class>
+    *Class_Parse_Table_Base<Class, allow_exit>::current_;
+
+template <class Class, bool allow_exit>
+/*static*/ Parse_Table Class_Parse_Table_Base<Class, allow_exit>::parse_table_;
+
 } // end namespace rtt_parser
 
 #endif // parser_Class_Parse_Table_hh

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -32,7 +32,7 @@ namespace rtt_parser {
 //---------------------------------------------------------------------------//
 template <>
 class Class_Parse_Table<DummyClass>
-    : public Class_Parse_Table_Base<DummyClass> {
+    : public Class_Parse_Table_Base<DummyClass, false> {
 public:
   // TYPEDEFS
 

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -30,21 +30,17 @@ private:
 
 namespace rtt_parser {
 //---------------------------------------------------------------------------//
-template <> class Class_Parse_Table<DummyClass> {
+template <>
+class Class_Parse_Table<DummyClass>
+    : public Class_Parse_Table_Base<DummyClass> {
 public:
   // TYPEDEFS
 
-  typedef DummyClass Return_Class;
-
   // MANAGEMENT
 
-  Class_Parse_Table(bool is_indolent = false);
+  Class_Parse_Table(bool context = false);
 
   // SERVICES
-
-  Parse_Table const &parse_table() const { return parse_table_; }
-
-  bool allow_exit() const { return false; }
 
   void check_completeness(Token_Stream &tokens);
 
@@ -54,8 +50,7 @@ protected:
   // DATA
 
   double parsed_insouciance;
-
-  bool is_indolent;
+  bool context;
 
 private:
   // IMPLEMENTATION
@@ -63,29 +58,19 @@ private:
   static void parse_insouciance_(Token_Stream &tokens, int);
 
   // STATIC
-
-  static Class_Parse_Table *current_;
-  static Parse_Table parse_table_;
-  static bool parse_table_is_initialized_;
 };
-
-//---------------------------------------------------------------------------//
-Class_Parse_Table<DummyClass> *Class_Parse_Table<DummyClass>::current_;
-Parse_Table Class_Parse_Table<DummyClass>::parse_table_;
-bool Class_Parse_Table<DummyClass>::parse_table_is_initialized_ = false;
-
-//---------------------------------------------------------------------------//
-template <>
-std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
-  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens);
-}
 
 //---------------------------------------------------------------------------//
 template <>
 std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
-                                                    bool const &is_indolent) {
-  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens,
-                                                               is_indolent);
+                                                    bool const &context) {
+  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens, context);
+}
+
+//---------------------------------------------------------------------------//
+template <>
+std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
+  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens, false);
 }
 
 //---------------------------------------------------------------------------//
@@ -100,34 +85,24 @@ void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
     current_->parsed_insouciance = 1;
   }
 
-  if (current_->is_indolent) {
+  if (current_->context) {
     current_->parsed_insouciance = -current_->parsed_insouciance;
   }
 }
 
 //---------------------------------------------------------------------------//
-Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const is_indolent)
-    : parsed_insouciance(-1.0) // sentinel value
+Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const context)
+    : parsed_insouciance(-1.0), context(context) // sentinel value
 {
-  if (!parse_table_is_initialized_) {
-    Keyword const keywords[] = {
-        {"insouciance", parse_insouciance_, 0, ""},
-    };
-    unsigned const number_of_keywords = sizeof(keywords) / sizeof(Keyword);
-
-    parse_table_.add(keywords, number_of_keywords);
-
-    parse_table_is_initialized_ = true;
-  }
-
-  this->is_indolent = is_indolent;
-
-  current_ = this;
+  Keyword const keywords[] = {
+      {"insouciance", parse_insouciance_, 0, ""},
+  };
+  initialize(keywords, sizeof(keywords));
 }
 
 //---------------------------------------------------------------------------//
 void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
-  tokens.check_semantics(is_indolent || parsed_insouciance >= 0,
+  tokens.check_semantics(context || parsed_insouciance >= 0,
                          "insouciance was not specified");
 }
 

--- a/src/parser/utilities.hh
+++ b/src/parser/utilities.hh
@@ -84,36 +84,24 @@ parse_temperature(Token_Stream &, unsigned number_of_variables,
  * Token_Stream, so that the common code idiom for parsing an object of MyClass
  * is:
  * \code
- *   std::shared_ptr<MyClass> spMyClass = parse_class<MyClass>(tokens);
+ *   auto spMyClass = parse_class<MyClass>(tokens);
  * \endcode
  * Developers may specialize this function as needed. A particular
  * implementation is suggested in Class_Parse_Table.hh.
  *
- * The template parameter names the type of the object for which a smart pointer
+ * \tparam class The type of the object for which a smart pointer
  * is returned.
  *
- * \param tokens Token stream from which to parse the user input.
- *
- * \return A pointer to an object matching the user specification, or NULL if
- * the specification is not valid.
- */
-template <typename Class>
-std::shared_ptr<Class> parse_class(Token_Stream &tokens);
-
-//----------------------------------------------------------------------------//
-/*! Template for parse function that produces a class object.
- *
- * This function resembles the previous one, but takes a second argument supply
- * a context that may alter the parser behavior..
+ * \tparam Context Parameter pack giving parsing context, if any.
  *
  * \param tokens Token stream from which to parse the user input.
  * \param context Context for the parse.
  * \return A pointer to an object matching the user specification, or NULL if
  * the specification is not valid.
  */
-template <typename Class, typename Context>
+template <typename Class, typename... Context>
 std::shared_ptr<Class> parse_class(Token_Stream &tokens,
-                                   Context const &context);
+                                   Context const &... context);
 
 } // namespace rtt_parser
 


### PR DESCRIPTION
### Background

The Class_Parse_Table template is a useful idiom for writing parsers for class objects, but as presently formulated, it requires the developer to copy some tedious boilerplate. There is also presently  no way to propagate improvements to the boilerplate automatically. This is because the develop must explicitly specialize the template for every class for which a parser is needed, but the boilerplate must be included in the specialization to conform with the parse_class_from_table template function.

### Purpose of Pull Request

Simplify development and maintenance of Class_Parse_Table specializations.

### Description of changes

Add a boilerplate base class template, Class_Parse_Table_Base, which automatically adds the boilerplate to the Class_Parse_Table which inherits it. 

Also, the current model of having separate parse_class templates with and without context has been simplified by treating any context parameters as a parameter pack. 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
