### PR TITLE
Order nodes counterclockwise for each face in `Draco_Mesh::Layout`.

### DIFF
--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -156,8 +156,8 @@ private:
   std::vector<std::vector<double>>
   compute_node_coord_vec(const std::vector<double> &coordinates) const;
 
-  //! Calculate the cell-to-cell linkage (layout)
   // \todo: add layout class and complete temporary version of this function.
+  //! Calculate the cell-to-cell linkage (layout)
   void compute_cell_to_cell_linkage(
       const std::vector<unsigned> &cell_type,
       const std::vector<unsigned> &cell_to_node_linkage,

--- a/src/mesh/X3D_Draco_Mesh_Reader.i.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.i.hh
@@ -19,7 +19,7 @@ namespace rtt_mesh {
  * \brief Generate a map from a block in an x3d file
  *
  * \param[in] block_name name of parsed x3d block
- * \param[in] dist help me
+ * \param[in] dist number of string-pairs to skip when looking for an x3d block
  *
  * \return map of mesh data with key of type KT and value of type VT
  */


### PR DESCRIPTION
### Background

* In 2D, it is simpler to assume rotation-ordered face-node pairing in `Draco_Mesh::Layout`.
  * For instance, it is easier to determine orientation of a normal vector to a face.
* Since the `X3D` and `RTT` mesh file parsers preserve counterclockwise node ordering in 2D, the generation of the connectivity data (for instance, cell-to-cell linkage) can be made somewhat less computationally complex.  

### Purpose of Pull Request

* Keep node ordering in generation of [cell, side, ghost cell]-node vector pairs, where vector is subscripted by cell-local face index (which simplifies generation of mesh connectivity data in 2D).
* Add some missing comment documentation for functions arguments in `Draco_Mesh.cc` and `X3D_Draco_Mesh_Reader.i.hh` 
* Fixes Issue #524

### Description of changes

+ Generate Draco_Mesh Layouts assuming rotation-ordered node pairs.
+ Add missing parameter descriptions needed by autodoc (issue 524).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
