### PR TITLE
Modify/Upgrade how the FMA CPP macro works.

### DIFF
--- a/config/autodoc_macros.cmake
+++ b/config/autodoc_macros.cmake
@@ -25,9 +25,6 @@ function( set_autodocdir )
   else()
     set( DOXYGEN_OUTPUT_DIR ${CMAKE_INSTALL_PREFIX}/autodoc PARENT_SCOPE)
   endif()
-
-  message(STATUS "Using autodoc directory ${AUTODOCDIR}")
-
 endfunction()
 
 #------------------------------------------------------------------------------

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -145,7 +145,7 @@ inline double fma_with_diagnostics(double const a, double const b,
 #define FMA_ACCURATE(a, b, c) fma((a), (b), (c))
 #else
 #define FMA(a, b, c) ((a) * (b) + c)
-#define FMA_ACURATE(a, b, c) ((a) * (b) + c)
+#define FMA_ACCURATE(a, b, c) ((a) * (b) + c)
 #endif
 
 #else /* HAVE_HARDWARE_FMA is false */

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -4,7 +4,7 @@
  * \author  Kelly Thompson
  * \date    Thursday, Feb 09, 2017, 11:22 am
  * \brief   Provide extra control for FMA operations.
- * \note    Copyright (C) 2017-2018 Los Alamos National Security, LLC.
+ * \note    Copyright (C) 2017-2019 Los Alamos National Security, LLC.
  *          All rights reserved.
  *
  * Intel Haswell and later (and also modern AMD cpus) have hardware FMA
@@ -19,7 +19,7 @@
  * https://software.intel.com/en-us/node/405250?language=es&wapkw=avx2+cpuid
  *
  * \note The Intel compiler doesn't seem to set \c FP_FAST_FMA. If you know that
- * your algorithm is sensitive to roundoff, you might to locally disable
+ * your algorithm is sensitive to roundoff, you might need to locally disable
  * '-fp-model fast' by inserting this bit of code at the start of each function
  * that is sensitive:
  *
@@ -137,8 +137,8 @@ inline double fma_with_diagnostics(double const a, double const b,
  * compiler, so Intel will always pick the 2nd option.
  *
  * The intent of the \c FMA_ACCURATE version is to pick the more accurate
- * multiply-plus-add operation. When hardware FMA is available, we just just the
- * normal 'fast' version.
+ * multiply-plus-add operation. When hardware FMA is available, we just choose
+ * the normal 'fast' version.
  */
 #ifdef FP_FAST_FMA
 #define FMA(a, b, c) fma((a), (b), (c))

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -144,7 +144,7 @@ inline double fma_with_diagnostics(double const a, double const b,
 #define FMA(a, b, c) fma((a), (b), (c))
 #define FMA_ACCURATE(a, b, c) fma((a), (b), (c))
 #else
-#define FMA(a, b, c) fma((a), (b), (c))
+#define FMA(a, b, c) ((a) * (b) + c)
 #define FMA_ACURATE(a, b, c) ((a) * (b) + c)
 #endif
 

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -7,16 +7,34 @@
  * \note    Copyright (C) 2017-2018 Los Alamos National Security, LLC.
  *          All rights reserved.
  *
- * Intel Haswell and later (and also modern AMD cpus), have hardware FMA
- * features. Using \c fma(c,b,a) is more accurate than \c a*b+c because there is
- * less roundoff error. This difference in accuracy causes issues for IMC
- * because solutions are not consistent between older and newer hardware.
+ * Intel Haswell and later (and also modern AMD cpus) have hardware FMA
+ * features. On machines without hardware FMA, the use of \c fma(c,b,a) provides
+ * a accurate value than \c a*b+c because roundoff error is accounted for.
+ * However, \c fma can be slow (maybe 3x slower).
  *
  * To improve solution consistency across platforms, we can choose to use a
  * software-based infinite precision fma call.
  *
  * \note Intel's code for detecting FMA availability on hardware.
  * https://software.intel.com/en-us/node/405250?language=es&wapkw=avx2+cpuid
+ *
+ * \note The Intel compiler doesn't seem to set \c FP_FAST_FMA. If you know that
+ * your algorithm is sensitive to roundoff, you might to locally disable
+ * '-fp-model fast' by inserting this bit of code at the start of each function
+ * that is sensitive:
+ *
+ * \code
+ * int foo(int b) {
+ *
+ * #if defined __INTEL_COMPILER
+ * #  pragma float_control(precise, on, push)
+ * #endif
+ *
+ *   // code goes here
+ *
+ *   return value;
+ * }
+ * \endcode
  */
 //---------------------------------------------------------------------------//
 
@@ -26,40 +44,128 @@
 #include "ds++/config.h"
 #include <cmath>
 
-//---------------------------------------------------------------------------//
-// HAVE_HARDWARE_FMA is set by config/platform_checks.cmake.
+/*!
+ * Normally \c FMA_FIND_DIFFS is \b NOT defined.  If defined then all FMA calls
+ * will be processed by fma_with_diagnostics and will throw an exception if
+ * roundoff between the two computations is significant.
+ */
+// #define FMA_FIND_DIFFS 1
 
+#ifdef FMA_FIND_DIFFS
+
+#include "ds++/Soft_Equivalence.hh"
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+
+namespace rtt_dsxx {
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief fma_with_diagnostics
+ *
+ * \param[in] a Used when computing a*b + c
+ * \param[in] b Used when computing a*b + c
+ * \param[in] c Used when computing a*b + c
+ * \param[in] file Filename where calculation occurs
+ * \param[in] line Line number where calculation occurs
+ * \param[in] abort_on_fail  Is failure fatal?
+ * \return (a*b + c) if roundoff is small, otherwise throw an exception
+ *
+ * If \c abort_on_fail is \c true:
+ * - Throw a C++ exception if the two values are sufficiently different
+ * - Otherwise return the 'fast' result.
+ *
+ * If \c abort_on_fail is \c false:
+ * - Print a message with details (don't throw) if the two values are
+ *   sufficiently different.
+ * - Return the 'accurate' result.
+ */
+inline double fma_with_diagnostics(double const a, double const b,
+                                   double const c, std::string const &file,
+                                   uint32_t const line,
+                                   bool const abort_on_fail) {
+  double const accurate = fma(a, b, c);
+  double const fast = ((a) * (b) + c);
+  double const tol = 1.e-13;
+  std::ostringstream msg;
+  msg << "FMA accuracy error in " << file << " (" << line << ") "
+      << std::setprecision(std::numeric_limits<double>::max_digits10)
+      << "\n  accurate = " << accurate << "\n  fast = " << fast
+      << "\n  diff = " << fabs(accurate - fast)
+      << "\n  rdiff = " << 2.0 * fabs(accurate - fast) / fabs(accurate + fast)
+      << "\n  a = " << a << "\n  b = " << b << "\n  c = " << c << std::endl;
+  if (abort_on_fail) {
+    Insist(rtt_dsxx::soft_equiv(accurate, fast, tol), msg.str().c_str());
+  } else {
+    if (!rtt_dsxx::soft_equiv(accurate, fast, tol)) {
+      std::cout << msg.str();
+    }
+  }
+
+  return abort_on_fail ? fast : accurate;
+}
+} // namespace rtt_dsxx
+
+//----------------------------------------------------------------------------//
+/*!
+ * If \c FMA_FIND_DIFFS is defined, then hijack the whole FMA operation.
+ * Instead, perform the operation both ways and compare the result.  If the
+ * result is significantly different, throw an exception.  This is useful for
+ * finding operations that are sensitive to roundoff.
+ */
+#define FMA(a, b, c)                                                           \
+  rtt_dsxx::fma_with_diagnostics((a), (b), (c), __FILE__, __LINE__, true)
+#define FMA_ACCURATE(a, b, c)                                                  \
+  rtt_dsxx::fma_with_diagnostics((a), (b), (c), __FILE__, __LINE__, false)
+#else
+
+//----------------------------------------------------------------------------//
+//! HAVE_HARDWARE_FMA is set by config/platform_checks.cmake.
 #ifdef HAVE_HARDWARE_FMA
 
-/* This will be the default for new machines. Both versions should be equally
- * accurate, choose whatever is faster. FP_FAST_FMA is set by the compiler
+//----------------------------------------------------------------------------//
+/*!
+ * This will be the default for new machines. Both versions should be equally
+ * accurate, choose whatever is faster. \c FP_FAST_FMA is set by the compiler
  *
  * \ref http://en.cppreference.com/w/c/numeric/math/fma
+ *
+ * Working on LANL systems, it seems that \c FP_FAST_FMA is not set by the Intel
+ * compiler, so Intel will always pick the 2nd option.
+ *
+ * The intent of the \c FMA_ACCURATE version is to pick the more accurate
+ * multiply-plus-add operation. When hardware FMA is available, we just just the
+ * normal 'fast' version.
  */
 #ifdef FP_FAST_FMA
-#define FMA(a, b, c) fma(a, b, c)
+#define FMA(a, b, c) fma((a), (b), (c))
+#define FMA_ACCURATE(a, b, c) fma((a), (b), (c))
 #else
-#define FMA(a, b, c) ((a) * (b) + c)
+#define FMA(a, b, c) fma((a), (b), (c))
+#define FMA_ACURATE(a, b, c) ((a) * (b) + c)
 #endif
 
 #else /* HAVE_HARDWARE_FMA is false */
 
-/*! For older hardware that does not support FMA natively, provide a macro that
- *  will call an infinite precision fma function so that numerical
- *  reproducibility is enhanced (if FP_ACCURATE_FMA is defined). This allows
- *  solutions generated on older machines to match solutions generated on newer
- *  machines. */
-#ifndef FP_ACCURATE_FMA
-#error "Must set FP_ACCURATE_FMA to 0 or 1."
-#endif
-
-#if FP_ACCURATE_FMA > 0
-#define FMA(a, b, c) fma(a, b, c)
-#else
+//----------------------------------------------------------------------------//
+/*!
+ * For older hardware that does \b not support FMA natively, provide a macro
+ * that will call an infinite precision fma function so that numerical
+ * reproducibility is enhanced This allows solutions generated on older machines
+ * to match solutions generated on newer machines.
+ *
+ * Operations that are known to be very sensitive to round-off error should use
+ * \c FMA_ACCURATE even though it is much slower (2-3x slower).
+ */
 #define FMA(a, b, c) ((a) * (b) + c)
-#endif
+#define FMA_ACCURATE(a, b, c) fma((a), (b), (c))
 
 #endif /* HAVE_HARDWARE_FMA */
+
+#endif /* FMA_FIND_DIFFS */
 
 #endif // rtt_dsxx_FMA_hh
 


### PR DESCRIPTION
### Background

* Jayenne uses the FMA macro to select accurate vs fast fused-multiply-add operations.  This allows us to use a high precision software version when hardware FMA are not available.

### Purpose of Pull Request

* [Related to Redmine Issue #1363](https://rtt.lanl.gov/redmine/issues/1363)
* [Related to Redmine Issue #1364](https://rtt.lanl.gov/redmine/issues/1364)

### Description of changes

* Eliminate the `FP_ACCURATE_FMA` mode for machines w/o hardware FMA.  Replace this with the CPP macro `FMA_ACCURATE`.
* For machines with hardware FMA, use the software call if it is faster, otherwise send `a*b+c` to the compiler
* For machines w/o hardware FMA, only use the very slow software call when `FMA_ACCURATE` is requested.
* Provide a special developer toggle `FMA_FIND_DIFFS` that can be set to have every call to FMA compute values using the software call and by direct evaluation of `a*b+c`.  When this mode is active, a report will be printed if the two calculations have a relative difference greater than 1.0e-13.  This is very useful for finding code that is sensitive to round-off errors.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
