### PR TITLE
Fix a module load error

### DIFF
--- a/environment/bashrc/.bashrc_toss3
+++ b/environment/bashrc/.bashrc_toss3
@@ -56,8 +56,11 @@ intel/18.0.2 openmpi/2.1.2 mkl \
 subversion cmake/3.12.1 numdiff git totalview trilinos/12.10.1 \
 superlu-dist/5.1.3 metis parmetis random123 eospac/6.3.0"
 
-  if [[ `groups | grep -c ccsrad` != 0 ]]; then
-    dracomodules="$dracomodules csk ndi"
+  if [[ -d ${VENDOR_DIR}-ec ]]; then
+    group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`
+    if [[ `groups | grep -c $group_for_vendor_ec` != 0 ]]; then
+      dracomodules="$dracomodules csk ndi"
+    fi
   fi
 
 fi

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -75,8 +75,11 @@ export dracomodules="cmake/3.12.1 git \
 clang-format eospac/6.3.0 gsl/2.3 metis numdiff random123 \
 parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1"
 
-if [[ `groups | grep -c ccsrad` != 0 ]]; then
-  dracomodules="$dracomodules csk ndi"
+if [[ -d ${VENDOR_DIR}-ec ]]; then
+  group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`
+  if [[ `groups | grep -c $group_for_vendor_ec` != 0 ]]; then
+    dracomodules="$dracomodules csk ndi"
+  fi
 fi
 
 function dracoenv ()

--- a/src/ds++/FMA.hh
+++ b/src/ds++/FMA.hh
@@ -35,6 +35,9 @@
  *   return value;
  * }
  * \endcode
+ *
+ * \sa [What Every Computer Scientist Should Know About Floating-Point
+ * Arithmetic](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html)
  */
 //---------------------------------------------------------------------------//
 


### PR DESCRIPTION
### Background

* On machines where group 'ccsrad' doesn't exist, modules ndi and csk were not being loaded.  Update logic to do the right thing.

### Description of changes

* Don't assume that ndi and csk live in directories marked with group 'ccsrad'.  Instead, just see if the directory can be read.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
