### PR TITLE
Upgrade Require to Insist to avoid unused variable warning (found in Clang Release build).

### DIFF
--- a/src/rng/Halton_Sequence.cc
+++ b/src/rng/Halton_Sequence.cc
@@ -997,7 +997,8 @@ Halton_Sequence::Halton_Sequence(unsigned const base_index,
     : base_(prime[base_index]), count_(initial_count - 1),
       value_(0.5), // to ensure good behavior on first, unused, call to shift().
       n_() {
-  Require(base_index < NUMBER_OF_KNOWN_PRIMES);
+  Insist(base_index < NUMBER_OF_KNOWN_PRIMES,
+         "base_index > NUMBER_OF_KNOWN_PRIMES");
   Require(initial_count > 0);
 
   // Decompose the count into the selected base.


### PR DESCRIPTION
### Purpose of Pull Request

* Make 1-line change to remove warning for an unused variable in Release, caught by Clang 6

### Description of changes

* Upgrade assertion from `Require` to `Insist` when checking against `NUMBER_OF_KNOWN_PRIMES` in `Halton_Sequence` ctor.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
