### PR TITLE
Experimental simplified class parser templates.

### DIFF
--- a/regression/ccscs-job-launch.sh
+++ b/regression/ccscs-job-launch.sh
@@ -58,8 +58,7 @@ done
 if ! test -d $logdir; then
   mkdir -p $logdir
   chgrp ccsrad $logdir
-  chmod g+rwX $logdir
-  chmod g+s $logdir
+  chmod g+rsX $logdir
 fi
 
 # Configure, Build, Test and Submit (no Torque batch system here).

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -235,21 +235,24 @@ if test "${subproj}" == draco; then
 elif test "${subproj}" == jayenne; then
   script_dir=`echo ${rscriptdir} | sed -e 's/draco/jayenne/'`
   script_name=Jayenne_Linux64.cmake
-elif test "${subproj}" == capsaicin; then
-  # For now force Capsaicin to only 1 OMP thread per MPI rank to avoid
-  # oversubscribing the system.
-  export OMP_NUM_THREADS=1
-  script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%capsaicin/scripts%'`
-  script_name=Capsaicin_Linux64.cmake
 elif test "${subproj}" == core; then
   # For now force core to only 1 OMP thread per MPI rank to avoid
   # oversubscribing the system.
   export OMP_NUM_THREADS=1
   script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%core/scripts%'`
   script_name=Core_Linux64.cmake
-elif test "${subproj}" == asterisk; then
-  script_dir=`echo ${rscriptdir} | sed -e 's/draco/asterisk/'`
-  script_name=Asterisk_Linux64.cmake
+elif test "${subproj}" == trt; then
+  # For now force core to only 1 OMP thread per MPI rank to avoid
+  # oversubscribing the system.
+  export OMP_NUM_THREADS=1
+  script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%trt/scripts%'`
+  script_name=Trt_Linux64.cmake
+elif test "${subproj}" == npt; then
+  # For now force core to only 1 OMP thread per MPI rank to avoid
+  # oversubscribing the system.
+  export OMP_NUM_THREADS=1
+  script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%npt/scripts%'`
+  script_name=Npt_Linux64.cmake
 fi
 
 # Append the username to the build name unless option '-r' is specified.

--- a/regression/ccscs2-crontab
+++ b/regression/ccscs2-crontab
@@ -33,11 +33,11 @@
 # gcc-8.2.0, openmpi-3.1.0
 #------------------------------------------------------------------------------#
 
-05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"draco jayenne capsaicin core\"
+05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"draco jayenne core trt npt\"
 
-00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e coverage
+00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Debug -d Nightly -p \"draco jayenne core trt npt\" -e coverage
 
-30 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e valgrind
+30 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne core trt npt\" -e valgrind
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs3-crontab
+++ b/regression/ccscs3-crontab
@@ -26,9 +26,9 @@
 # gcc-8.1.0, openmpi-3.1.0
 #------------------------------------------------------------------------------#
 
-01 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p \"draco\"
+01 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"draco\"
 
-15 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"jayenne capsaicin core\" -e vtest
+15 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Nightly -p \"jayenne core trt npt\" -e vtest
 
 00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne\" -e scalar
 
@@ -38,7 +38,7 @@
 # Clang-6.0.0, openmpi-3.1.0
 #------------------------------------------------------------------------------#
 
-00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e clang
+00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne core trt npt\" -e clang
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs6-crontab
+++ b/regression/ccscs6-crontab
@@ -19,7 +19,7 @@
 #    valgrind
 #------------------------------------------------------------------------------#
 
-# 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne capsaicin core\" -e valgrind
+# 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p \"draco jayenne core trt npt\" -e valgrind
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -288,12 +288,15 @@ if test "${subproj}" == draco; then
 elif test "${subproj}" == jayenne; then
     script_dir=`echo ${rscriptdir} | sed -e 's/draco/jayenne/'`
     script_name=Jayenne_Linux64.cmake
-elif test "${subproj}" == capsaicin; then
-    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%capsaicin/scripts%'`
-    script_name=Capsaicin_Linux64.cmake
 elif test "${subproj}" == core; then
     script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%core/scripts%'`
     script_name=Core_Linux64.cmake
+elif test "${subproj}" == trt; then
+    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%trt/scripts%'`
+    script_name=Trt_Linux64.cmake
+elif test "${subproj}" == npt; then
+    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%npt/scripts%'`
+    script_name=Npt_Linux64.cmake
 fi
 
 if ! [[ "${regress_mode}" == "on" ]]; then

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -794,7 +794,7 @@ endmacro(process_cc_or_da)
 # ------------------------------------------------------------
 # Special default settings for a couple of platforms
 #
-# Sets DRACO_DIR
+# Sets ${dep_pkg}_DIR (e.g.: DRACO_DIR, or CORE_DIR)
 # ------------------------------------------------------------
 macro(set_pkg_work_dir this_pkg dep_pkg)
 
@@ -802,7 +802,8 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   # Assume that draco_work_dir is parallel to our current location, but only
   # replace the directory name preceeding the dashboard name.
   file( TO_CMAKE_PATH "$ENV{work_dir}" work_dir )
-  file( TO_CMAKE_PATH "$ENV{DRACO_DIR}" DRACO_DIR )
+  # ${dep_pkg_caps}_DIR == {DRACO_DIR, CORE_DIR}
+  file( TO_CMAKE_PATH "$ENV{${dep_pkg_caps}_DIR}" ${dep_pkg_caps}_DIR )
   string( REGEX REPLACE "${this_pkg}[/\\](Nightly|Experimental|Continuous)"
     "${dep_pkg}/\\1" ${dep_pkg}_work_dir ${work_dir} )
 
@@ -822,7 +823,9 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
       string( REGEX REPLACE "[-_]${extraparam}[-_]" "-" ${dep_pkg}_work_dir
         ${${dep_pkg}_work_dir} )
     endforeach()
-    if( "${this_pkg}" MATCHES "jayenne" OR "${this_pkg}" MATCHES "capsaicin" OR "${this_pkg}" MATCHES "core")
+    if( "${this_pkg}" MATCHES "jayenne"   OR
+        "${this_pkg}" MATCHES "capsaicin" OR
+        "${this_pkg}" MATCHES "core")
       # If this is jayenne, we might be building a pull request. Replace the PR
       # number in the path with '-develop' before looking for draco.
       string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/"
@@ -833,8 +836,8 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   find_file( ${dep_pkg}_target_dir
     NAMES README.${dep_pkg} README.md
     HINTS
-      # if DRACO_DIR is defined, use it.
-      ${DRACO_DIR}
+      # if DRACO_DIR or CORE_DIR is defined, use it.
+      ${${dep_pkg_caps}_DIR}
       # Try a path parallel to the work_dir
       ${${dep_pkg}_work_dir}/target
     NO_DEFAULT_PATH

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -165,7 +165,7 @@ esac
 
 for proj in ${projects}; do
    case $proj in
-   draco | jayenne | capsaicin | core ) # known projects, continue
+   draco | jayenne | core | trt | npt ) # known projects, continue
       ;;
    *)  echo "" ;echo "FATAL ERROR: unknown project name (-p) = ${proj}"
        print_use; exit 1 ;;
@@ -323,27 +323,6 @@ if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   ((ifb++))
 fi
 
-export subproj=capsaicin
-if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
-  export featurebranch=${fb[$ifb]}
-  cmd="${rscriptdir}/${machine_class}-job-launch.sh"
-  # Wait for draco regressions to finish
-  case $extra_params_sort_safe in
-  *coverage*)
-     # We can only run one instance of bullseye at a time - so wait
-     # for jayenne to finish before starting capsaicin.
-     cmd+=" ${draco_jobid} ${jayenne_jobid}" ;;
-  *)
-     cmd+=" ${draco_jobid}" ;;
-  esac
-  cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-joblaunch.log"
-  echo "${subproj}: $cmd"
-  eval "${cmd} &"
-  sleep 1s
-  capsaicin_jobid=`jobs -p | sort -gr | head -n 1`
-  ((ifb++))
-fi
-
 export subproj=core
 if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
   export featurebranch=${fb[$ifb]}
@@ -356,6 +335,48 @@ if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
      cmd+=" ${draco_jobid} ${capsaicin_jobid}" ;;
   *)
      cmd+=" ${draco_jobid}" ;;
+  esac
+  cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-joblaunch.log"
+  echo "${subproj}: $cmd"
+  eval "${cmd} &"
+  sleep 1s
+  core_jobid=`jobs -p | sort -gr | head -n 1`
+  ((ifb++))
+fi
+
+export subproj=trt
+if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
+  export featurebranch=${fb[$ifb]}
+  cmd="${rscriptdir}/${machine_class}-job-launch.sh"
+  # Wait for draco regressions to finish
+  case $extra_params_sort_safe in
+  *coverage*)
+     # We can only run one instance of bullseye at a time - so wait
+     # for capsaicin to finish before starting core.
+     cmd+=" ${draco_jobid} ${core_jobid}" ;;
+  *)
+     cmd+=" ${draco_jobid} ${core_jobid}" ;;  ## trt --> core --> draco
+  esac
+  cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-joblaunch.log"
+  echo "${subproj}: $cmd"
+  eval "${cmd} &"
+  sleep 1s
+  core_jobid=`jobs -p | sort -gr | head -n 1`
+  ((ifb++))
+fi
+
+export subproj=npt
+if [[ `echo $projects | grep -c $subproj` -gt 0 ]]; then
+  export featurebranch=${fb[$ifb]}
+  cmd="${rscriptdir}/${machine_class}-job-launch.sh"
+  # Wait for draco regressions to finish
+  case $extra_params_sort_safe in
+  *coverage*)
+     # We can only run one instance of bullseye at a time - so wait
+     # for capsaicin to finish before starting core.
+     cmd+=" ${draco_jobid} ${core_jobid} ${trt_jobid}" ;;
+  *)
+     cmd+=" ${draco_jobid} ${core_jobid}" ;;  ## npt --> core --> draco
   esac
   cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params_sort_safe}${prdash}${featurebranch}-joblaunch.log"
   echo "${subproj}: $cmd"

--- a/regression/sn-crontab
+++ b/regression/sn-crontab
@@ -25,30 +25,30 @@
 # Intel/18.0.2 and OpenMPI/2.1.2
 #------------------------------------------------------------------------------#
 
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin core\"
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne core trt npt\"
 
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin core\"
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne core trt npt\"
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \" jayenne capsaicin core\" -e vtest
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \" jayenne core trt npt\" -e vtest
 
 #------------------------------------------------------------------------------#
 # Special: NR, PerfBench and FullDiagnostics regressions.
 #------------------------------------------------------------------------------#
 
 # intel-18.0.2 + openmpi-2.1.2
-# 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin core\" -e newtools
+# 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne core trt npt\" -e newtools
 
 # gcc-6.4.0 + openmpi-2.1.2
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin core\" -e gcc640
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne core trt npt\" -e gcc640
 
 # Floating point traps, etc.
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e fulldiagnostics -p \"draco jayenne capsaicin core\"
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e fulldiagnostics -p \"draco jayenne core trt npt\"
 
 # non-reproducible flavor (IMC)
 01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e nr -p \"jayenne\"
 
 # performance over time
-01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p \"jayenne capsaicin core\"
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p \"jayenne core trt npt\"
 
 #------------------------------------------------------------------------------#
 # Periodic usage reports

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -22,25 +22,25 @@
 # Haswell
 # --------------------
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne capsaicin core\"
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p \"draco jayenne core trt npt\"
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin core\"
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne core trt npt\"
 
-01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne capsaicin core\" -e vtest
+01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne core trt npt\" -e vtest
 
 # performance over time
-01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p \"jayenne capsaicin core\"
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p \"jayenne core trt npt\"
 
 # --------------------
 # KNL
 # --------------------
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne capsaicin core\" -e knl
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"draco jayenne core trt npt\" -e knl
 
-01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne capsaicin core\" -e \"knl vtest\"
+01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p \"jayenne core trt npt\" -e \"knl vtest\"
 
 # performance over time
-01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e \"knl perfbench\" -p \"capsaicin core\"
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e \"knl perfbench\" -p \"core trt npt\"
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -239,12 +239,15 @@ if test "${subproj}" == draco; then
 elif test "${subproj}" == jayenne; then
     script_dir=`echo ${rscriptdir} | sed -e 's/draco/jayenne/'`
     script_name=Jayenne_Linux64.cmake
-elif test "${subproj}" == capsaicin; then
-    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%capsaicin/scripts%'`
-    script_name=Capsaicin_Linux64.cmake
 elif test "${subproj}" == core; then
     script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%core/scripts%'`
     script_name=Core_Linux64.cmake
+elif test "${subproj}" == trt; then
+    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%trt/scripts%'`
+    script_name=Trt_Linux64.cmake
+elif test "${subproj}" == npt; then
+    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%npt/scripts%'`
+    script_name=Npt_Linux64.cmake
 fi
 
 if ! [[ "${regress_mode}" == "on" ]]; then

--- a/src/parser/Class_Parser.hh
+++ b/src/parser/Class_Parser.hh
@@ -1,0 +1,411 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   parser/Class_Parser.hh
+ * \brief  Definition of Class_Parser_Keyword and Class_Parser.
+ * \note   Copyright (C) 2016-2019 TRIAD, LLC. All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef rtt_Class_Parser_HH
+#define rtt_Class_Parser_HH
+
+#include "Token_Stream.hh"
+#include <cstring> // strcmp
+#include <memory>
+#include <vector>
+
+namespace rtt_parser {
+
+//----------------------------------------------------------------------------//
+/*! Template for parser table classes
+ *
+ * A Class_Parser is conceptually a table of keywords and associated parsing
+ * functions. When invoked (via a call to the Class_Parser::parse() member
+ * function), it pulls tokens from a Token_Stream, and attempts to match the
+ * tokens against a table of keywords.  Each keyword has a parsing function and
+ * integer flag associate with it, and when a keyword matches an input token,
+ * the parsing function is called with the original Token_Stream and the integer
+ * flag as arguments. The parsing functions can pull additional tokens from the
+ * Token_Stream, such as parameter values, prior to returning control to the
+ * Class_Parser. The machinery to do all this is normally provided by deriving
+ * the Class_Parser from Class_Parser_Base.
+ *
+ * Each parse function is a member function of the Class_Parser, and the
+ * values it parses are normally stored in the Class_Parser for later use
+ * to construct an object of the class for which the Class_Parser is
+ * specialized. A pointer to this object is returned by parse().
+ *
+ * When the Class_Parse_Table_Base fails to match an input keyword to its
+ * keyword table, or when the input token is not a keyword, END, EXIT,
+ * or ERROR, the parse table reports an error, then attempts recovery
+ * by reading additional tokens until it encounters either a keyword
+ * it recognizes or an END, EXIT, or ERROR.  During this recovery, no
+ * additional errors are reported, to avoid swamping the user with
+ * additional messages that are unlikely to be helpful.  If recovery
+ * is successful (a keyword is recognized in the token stream) parsing
+ * resumes to diagnose any additional errors.
+ *
+ * Keyword parse routines may also encounter errors.  These may be reported
+ * to the Token_Stream through either the report_syntax_error or
+ * report_semantic_error functions.  The former is used when there is
+ * an error in the input syntax, as when a keyword is encountered when
+ * a numerical value is expected.  In this case, an exception is thrown
+ * that is caught by the Class_Parser_Base, which then attempts error
+ * recovery as described above.  The report_semantic_error indicates
+ * syntactically correct input that is nonetheless unacceptable, as when a
+ * numerical value appears where it is expected but violates some constraint,
+ * such as positivity.  The error is reported but input processing is not
+ * interrupted. In effect, this is an error with immediate recovery.
+ *
+ * No general implementation is provided. The developer wishing to make his
+ * class parsable must specialize this template for his class. This should
+ * almost always be derived from the Class_Parser_Base template, which
+ * provides the necessary boilerplate. The final specialization must define
+ * the following members:
+ *
+ *   Class_Parser()
+ *
+ * Default constructor. The constructor should set all data members to sentinel
+ * values indicating that the corresponding parameters have not been parsed yet.
+ * Where possible, the sentinel value should be one that doesn't make
+ * sense for the parameter in question, such as 0 for a dimension that
+ * must be nonzero, or a negative value for a parameter that must be
+ * positive.  This ensures that the sentinel value can be distinguished
+ * from any value a user might specify in an input "deck." If the parameter can
+ * plausibly have any value, then a bool sentinel flag should accompany the
+ * parameter and be initialized in the constructor to false (for not yet
+ * parsed).
+ *
+ * The constructor should also carry out any other preparations that are
+ * necessary before parsing.  The constructor may optionally have a context
+ * argument to provide any contextual information required to know how to parse
+ * the "deck".
+ *
+ *   void check_completeness(Token_Stream &);
+ *
+ * This function is called to check that all required specifications were
+ * found in the parsed token stream.  This function must call \c
+ * Token_Stream::report_semantic_error at least once if a required
+ * specification is missing.
+ *
+ * If default values are permitted for some parameters (which is not
+ * recommended), then they should be applied here.
+ *
+ *   Class *create_object();
+ *
+ * Create the object from the parsed fields.  This function should have no
+ * preconditions that are not guaranteed by a preceding successful call to
+ * check_completeness. create_object will be called only if no errors
+ * were detected in the input token stream.
+ *
+ * In addition to these mandatory members, any nontrivial Class_Parser
+ * will also define data members to hold the parsed specifications, and parse
+ * functions of the form
+ *
+ * void parse_parameter(Token_Stream &, int);
+ *
+ * A nontrivial Class_Parser should define a member
+ *
+ * static Class_Parser_Keyword<Class> const raw_table[];
+ *
+ * to hold a raw table of keywords that is passed to the constructor for
+ * Class_Parser_Base in the constructor for Class_Parser. The Class_Parser_Base
+ * will inspect this table for errors and make a sorted copy for fast token
+ * matching.
+ *
+ * The specialization will thus look something like
+ *
+ * Class__parser.hh:
+ *
+ * template<>
+ * class Class_Parser<Class> : public Class_Parser_Base<Class>
+ * {
+ *    public:
+ *      explicit Class_Parser(Context_Type debug_context);
+ *           // context argument is optional
+ *
+ *      void check_completeness(Token_Stream &tokens);
+ *
+ *      Class *create_object();
+ *
+ *    protected:
+ *      // Data to be parsed which will be used to construct the class, for
+ *      // example:
+ *
+ *      bool flag;
+ *      double constant;
+ *
+ *      // Optional context information
+ *      Context_Type debug_context;
+ *
+ *    private:
+ *      // Parse functions
+ *      friend Class_Parser_Base<Class>;
+ *      void parse_flag(Token_Stream &, int);
+ *      void parse_constant(Token_Stream &, int);
+ *
+ *      // The raw keyword table.
+ *      Class_Parser_Keyword<Class> const raw_table[];
+ * };
+ *
+ *
+ * Class__parser.cc:
+ *
+ * include "Class__parser.hh"
+ *
+ * void Class_Parser<Class>::parse_flag(Token_Stream &tokens, int)
+ * {
+ *    flag = parse_bool(tokens);
+ * }
+ *
+ * void Class_Parser<Class>::parse_constant(Token_Stream &tokens, int)
+ * {
+ *    constant = parse_real(tokens);
+ * }
+ *
+ * template<>
+ * Class_Parser_Keyword<Class> const Class_Parser_Base<Class>::raw_table[] = {
+ *     {"block", &Class_Parser<Class>::parse_block, 0, ""},
+ *     {"solver", &Class_Parser<Class>::parse_solver, 0, ""},
+ *   };
+ * // Note that this must be visible before the constructor so that the
+ * // constructor can compute its length correctly.
+ *
+ * Class_Parser<Class>::Class_Parser(Context_Type debug_word)
+ * : Class_Parser_Base<Class>(raw_table, sizeof(raw_table)/sizeof(raw_table[0]),
+ *   debug_context(debug_word), flag(false), constant(0.0)
+ * {
+ * }
+ *
+ * void Class_Parse_Table<Class>::check_completeness(Token_Stream &tokens)
+ * {
+ *   ... check the parsed data ...
+ * }
+ *
+ * Class *Class_Parse_Table<Class>::create_object()
+ * {
+ *   return make_shared<Class>(debug_context, flag, constant);
+ * }
+ *
+ * template <>
+ * shared_ptr<Class>
+ * parse_class<Class>(Token_Stream &tokens,
+ *                    Debug_Context debug_context)
+ * {
+ *    Class_Parser<Class> parser(debug_context);
+ *
+ *    return parser.parse(tokens);
+ * }
+ *
+ * This introduces all the "boilerplate" and lets the developer focus on the
+ * data required for the constructor for Class, the parse functions needed to
+ * parse this data, and the check and construct functions.
+ *
+ * Inheritance is supported, except for diamond inheritance (virtual base
+ * classes).
+ */
+
+template <class Class> class Class_Parser;
+
+//-------------------------------------------------------------------------//
+/*!
+ * \brief Structure to describe a parser keyword.
+ *
+ * A Class_Parser_Keyword describes a keyword in a Class_Parser.  It is
+ * a POD struct so that it can be initialized using the low-level C++
+ * initialization construct, e.g.,
+ *
+ * \code
+ *   Class_Parser_Keyword<My_Class> my_table[] = {
+ *      {"FIRST",  Parse_First,  0, "TestModule"},
+ *      {"SECOND", Parse_Second, 0, "TestModule"}
+ *   };
+ * \endcode
+ *
+ * As a POD struct, Class_Parser_Keyword can have no invariants.  However,
+ * Class_Parser imposes constraints on the keywords it will accept for
+ * its keyword list.
+ */
+template <class Class> struct Class_Parser_Keyword {
+  /*! \brief The keyword moniker.
+     *
+     * The moniker should be a sequence of valid C++ identifiers separated by
+     * a single space.  For example, <CODE>"WORD"</CODE>, <CODE>"First_Word
+     * Second_Word"</CODE>, and <CODE>"B1 T2 T3"</CODE> are all valid Keyword
+     * monikers.  Identifiers beginning with an underscore are permitted but
+     * may be reserved for internal use by frameworks that uses the
+     * Class_Parser services. A Class_Parser attempts to match
+     * input to the monikers in its Class_Parser_Keyword table according to a
+     * set of rules stored in the Class_Parser (q.v.)
+     */
+  char const *moniker;
+
+  /*! \brief The keyword parsing function.
+     *
+     * When a Class_Parser finds a match to a moniker in its keyword
+     * table, the corresponding parse function is called. The parse function
+     * may read additional tokens from the input Token_Stream, such as a
+     * parameter value or an entire keyword block, before returning control
+     * to the Class_Parser.
+     *
+     * \param stream
+     * The token stream currently being parsed.
+     *
+     * \param index
+     * An integer argument that optionally allows a single parse function to
+     * handle a set of related keywords. The
+     */
+  void (Class_Parser<Class>::*func)(Token_Stream &stream, int index);
+
+  /*! \brief The index argument to the parse function.
+     *
+     * This is the index value that is passed to the parse function when the
+     * Parse_Table finds a match to the keyword moniker. The parse function is
+     * not required to make any use of this argument, but it can be convenient
+     * at times to use the same parse function for closely related keywords
+     * and use the index argument to make the distinction.  For example, an
+     * enumerated or Boolean option may be set using a single parse function
+     * that simply copies the index argument to the option variable.
+     */
+  int index;
+
+  /*! Name of the module that supplied the keyword.
+     *
+     * This member supports diagnostics for inherited Class_Parsers.
+     * It identifies which class in the inheritance hierarchy is associated
+     * with a particular keyword.
+     */
+  char const *module;
+
+  /*! Explanation of keyword.
+   *
+   * This optional member is a brief description of the keyword. If the
+   * parser sees a keyword in the Token_Stream that it does not recognize,
+   * it will list likely matches ("Did you mean ..."). If a keyword has a
+   * non-null description, it will print that description.
+   */
+  char const *description;
+
+  Class_Parser_Keyword(char const *moniker,
+                       void (Class_Parser<Class>::*func)(Token_Stream &, int),
+                       int const index, char const *module,
+                       char const *description = nullptr)
+      : moniker(moniker), func(func), index(index), module(module),
+        description(description) {}
+};
+
+//-------------------------------------------------------------------------//
+/*!
+ * \brief Boilerplate base for Class_Parser specializations
+ *
+ * Class_Parse_Base provides the boilerplate underlying almost every
+ * Class_Parser specialization.
+ */
+
+template <class Class, bool once = false, bool allow_exit = false>
+class Class_Parser_Base {
+public:
+  // TYPEDEFS AND ENUMERATIONS
+
+  typedef Class_Parser<Class> Child;
+  typedef Class_Parser_Keyword<Class> Keyword;
+  typedef void (Child::*Parse_Function)(Token_Stream &, int);
+
+  // CREATORS
+
+  //! Constrauct a parse table with no keywords. Useful as a placeholder.
+  Class_Parser_Base(Child &child) : child_(child) {}
+
+  //! Construct a parse table with the specified keywords.
+  Class_Parser_Base(Child &child,
+                    Class_Parser_Keyword<Class> const *raw_table,
+                    unsigned const count);
+
+  //! This class is meant to be heritable.
+  virtual ~Class_Parser_Base(void) = default;
+
+  // MANIPULATORS
+
+  //! Add keywords to the parser.
+  void add(Keyword const *table, size_t count) noexcept(false);
+
+  //! Add keywords to the parser. Used for derived parsers.
+  template<class Base>
+  void add(std::vector<Class_Parser_Keyword<Base>> const &) noexcept(false);
+
+  //! Remove a keyword from the table.
+  void remove(char const *);
+
+  //! Request a change in capacity.
+  void reserve(typename std::vector<Keyword>::size_type n) { table_.reserve(n); }
+
+  // ACCESSORS
+
+  //! Return the number of elements in the vector
+  // using std::vector<Keyword>::size;
+  typename std::vector<Keyword>::size_type size() const { return table_.size(); }
+
+  // SERVICES
+
+  //! Parse a token stream.
+  std::shared_ptr<Class> parse(Token_Stream &tokens);
+
+  //! Check the class invariants
+  bool check_class_invariants() const;
+
+  // STATIC
+
+  static std::vector<Keyword> const &table() noexcept { return table_; }
+
+protected:
+  // IMPLEMENTATION
+
+  virtual void check_completeness(Token_Stream &) = 0;
+  virtual Class *create_object() = 0;
+
+private:
+  // TYPEDEFS AND ENUMERATIONS
+
+  //-----------------------------------------------------------------------//
+  /*!
+     * \brief Ordering predicate for Keyword
+     *
+     * Defines a total ordering for Keyword compatible with STL sort
+     * and search routines.
+     */
+
+  class Keyword_Compare_ {
+  public:
+    bool operator()(Keyword const &k1, Keyword const &k2) const;
+    bool operator()(Keyword const &keyword, Token const &token) const noexcept;
+  };
+
+  // IMPLEMENTATION
+
+  //! Sort and check the table following the addition of new keywords
+  void sort_table_() noexcept(false);
+
+  // DATA
+
+  Child &child_;
+
+  // STATIC
+
+  static std::vector<Keyword> table_;
+};
+
+//---------------------------------------------------------------------------//
+//! Check whether a keyword is well-formed.
+
+template <class Class>
+DLL_PUBLIC_parser bool
+Is_Well_Formed_Keyword(Class_Parser_Keyword<Class> const &key);
+
+} // namespace rtt_parser
+
+#include "Class_Parser.ii"
+
+#endif // rtt_Parse_Table_HH
+
+//---------------------------------------------------------------------------//
+// end of Parse_Table.hh
+//---------------------------------------------------------------------------//

--- a/src/parser/Class_Parser.ii
+++ b/src/parser/Class_Parser.ii
@@ -1,0 +1,658 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   Class_Parser.ii
+ * \brief  Definitions of member functions of template Class_Parser
+ * \note   Copyright (C) 2016-2019 TRIAD, LLC. All rights reserved */
+//----------------------------------------------------------------------------//
+
+#ifndef rtt_Class_Parser_II
+#define rtt_Class_Parser_II
+
+#include <sstream>
+
+namespace rtt_parser {
+
+//----------------------------------------------------------------------------//
+/*!
+ * \param raw_table Pointer to an array of keywords.
+ *
+ * \param count Length of the array of keywords pointed to by \c table.
+ *
+ * \throw invalid_argument If the keyword table is ill-formed or ambiguous.
+ *
+ * \note See documentation for \c Parse_Table::add for an explanation of the
+ *       low-level argument list.
+ */
+template <class Class, bool once, bool allow_exit>
+Class_Parser_Base<Class, once, allow_exit>::Class_Parser_Base(
+    Child &child, Class_Parser_Keyword<Class> const *raw_table,
+    unsigned const count)
+    : child_(child) {
+  Require(count == 0 || std::find_if(raw_table, raw_table + count,
+                                     Is_Well_Formed_Keyword<Class>));
+
+  static bool first_time = true;
+  if (first_time) {
+    add(raw_table, count);
+    first_time = false;
+  }
+
+  Ensure(check_class_invariants());
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * \param table Array of keywords to be added to the table.
+ * \param count Number of valid elements in the array of keywords.
+ *
+ * \throw invalid_argument If the keyword table is ill-formed or
+ * ambiguous.
+ *
+ * \note The argument list reflects the convenience of defining raw keyword
+ * tables as static C arrays.  This justifies a low-level interface in place
+ * of, say, vector<Keyword>.
+ */
+template <class Class, bool once, bool allow_exit>
+void Class_Parser_Base<Class, once, allow_exit>::add(
+    Keyword const *const table, size_t const count) noexcept(false) {
+  Require(count == 0 || table != nullptr);
+  // Additional precondition checked in loop below
+
+  if (count > 0) {
+    // Preallocate storage.
+    reserve(size() + count);
+
+    // Add the new keywords.
+
+    for (unsigned i = 0; i < count; i++) {
+      Require(Is_Well_Formed_Keyword(table[i]));
+
+      table_.push_back(table[i]);
+    }
+
+    sort_table_();
+  }
+
+  Ensure(check_class_invariants());
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * This function is provided to support inheritance of class parsers.
+ *
+ * \param table Vector of keywords to be added to the table.
+ *
+ * \throw invalid_argument If the keyword table is ill-formed or
+ * ambiguous.
+  */
+template <class Class, bool once, bool allow_exit>
+template <class Base>
+void Class_Parser_Base<Class, once, allow_exit>::add(
+    std::vector<Class_Parser_Keyword<Base>> const &table) noexcept(false) {
+  unsigned const count = table.size();
+  // Additional precondition checked in loop below
+
+  if (count > 0) {
+    // Preallocate storage.
+    reserve(size() + count);
+
+    // Add the new keywords.
+
+    for (unsigned i = 0; i < count; i++) {
+      auto const &b = table[i];
+      Keyword d(b.moniker, b.func, b.index, b.module, b.description);
+      Require(Is_Well_Formed_Keyword(d));
+      table_.push_back(d);
+    }
+
+    sort_table_();
+  }
+
+  Ensure(check_class_invariants());
+}
+
+#if 0
+//----------------------------------------------------------------------------//
+/*!
+ * \param moniker Keyword to remove from the table.
+ *
+ * \throw invalid_argument If the keyword is not in the table.
+ */
+template <class Class, bool once, bool allow_exit>
+void Class_Parser_Base<Class, once, allow_exit>::remove(char const *moniker) {
+  // This is an order N operation as presently coded. N is never very large.
+  for (auto i = table_.begin(); i != table_.end(); ++i) {
+    if (!strcmp(i->moniker, moniker)) {
+      table_.erase(i);
+      Ensure(check_class_invariants());
+      return;
+    }
+  }
+
+  throw invalid_argument("keyword not found in Class_Parser_Base<Class, once, allow_exit>::remove");
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * \param source Parse_Table whose keywords are to be added to this
+ * Parse_Table.
+ *
+ * \throw invalid_argument If the keyword table is ill-formed or
+ * ambiguous.
+ */
+template <class Class, bool once, bool allow_exit>
+void Class_Parser_Base<Class, once, allow_exit>::add(Parse_Table const &source) noexcept(false) {
+  // Preallocate storage.
+  table_.reserve(table_.size() + source.table_.size());
+
+  // Add the new keywords.
+
+  for (auto i = source.table_.begin(); i != source.table_.end(); ++i) {
+    table_.push_back(*i);
+  }
+
+  sort_table_();
+
+  Ensure(check_class_invariants());
+}
+#endif
+
+//----------------------------------------------------------------------------//
+/* private */
+template <class Class, bool once, bool allow_exit>
+void Class_Parser_Base<Class, once, allow_exit>::sort_table_() noexcept(
+    false) // apparently std::sort can throw
+{
+  Require(table_.size() > 0);
+
+  // Sort the parse table, using a comparator predicate appropriate for the
+  // selected parser flags.
+
+  Keyword_Compare_ const comp;
+  std::sort(table_.begin(), table_.end(), comp);
+
+  // Look for ambiguous keywords, and resolve the ambiguity, if possible.
+
+  auto i = table_.begin();
+  while (i + 1 != table_.end()) {
+    Check(i->moniker != nullptr && (i + 1)->moniker != nullptr);
+    if (!comp(i[0], i[1]))
+    // kptr[i] and kptr[i+1] have the same moniker.
+    {
+      using std::endl;
+      using std::ostringstream;
+      ostringstream err;
+      err << "An ambiguous keyword was detected in a "
+          << "Parse_Table:  " << i->moniker << endl
+          << "Modules: ";
+      if (i->module)
+        err << i->module;
+      else
+        err << "<null>";
+      err << ' ';
+      if ((i + 1)->module)
+        err << (i + 1)->module;
+      else
+        err << "<null>";
+      err << endl;
+      throw std::invalid_argument(err.str().c_str());
+    } else
+    // kptr[i] and kptr[i+1] have different monikers. No ambiguity.
+    {
+      i++;
+    }
+  }
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * Parse the stream of tokens until an END, EXIT, or ERROR token is
+ * reached.
+ *
+ * \param tokens
+ * The Token Stream from which to obtain the stream of tokens.
+ *
+ * \return The terminating token: either END, EXIT, or ERROR.
+ *
+ * \throw rtt_dsxx::assertion If the keyword table is ambiguous.
+ */
+template <class Class, bool once, bool allow_exit>
+std::shared_ptr<Class>
+Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
+
+  using std::vector;
+
+  // Save the old error count, so we can distinguish fresh errors within
+  // this class keyword block from previous errors.
+  unsigned const old_error_count = tokens.error_count();
+
+  // The is_recovering flag is used during error recovery to suppress
+  // additional error messages.  This reduces the likelihood that a single
+  // error in a token stream will generate a large number of error
+  // messages.
+
+  bool is_recovering = false;
+
+  // Create a comparator object that will be used to attempt to match
+  // keywords in the Token_Stream to keywords in the Parse_Table.
+
+  Keyword_Compare_ const comp;
+
+  // Now begin the process of pulling keywords off the input token stream,
+  // and attempting to match these to the keyword table.
+
+  for (;;) {
+    Token const token = tokens.shift();
+
+    // The END, EXIT, and ERROR tokens are terminating tokens.  EXIT
+    // means the end of the token stream has been reached.  END is used
+    // to flag the end of a nested parse, where the result of matching a
+    // keyword in one parse table is to begin parsing keywords in a
+    // second parse table.  An END indicates that the second parse table
+    // should return control to the first parse table.  ERROR means that
+    // something went very wrong and we're probably hosed, but it allows
+    // some error recovery from within a nested parse table.
+
+    if (token.type() == END || token.type() == EXIT ||
+        token.type() == rtt_parser::ERROR) {
+      if (token.type() == END || (allow_exit && token.type() == EXIT))
+      // A class keyword block is expected to end with an END or (if
+      // allow_exit is true) an EXIT.
+      {
+        check_completeness(tokens);
+
+        if (tokens.error_count() == old_error_count) {
+          // No fresh errors in the class keyword block.  Create the object.
+          return std::shared_ptr<Class>(create_object());
+        } else {
+          // there were errors in the keyword block. Don't try to
+          // create a class object.  Return the null pointer.
+          return nullptr;
+        }
+      } else {
+        tokens.report_syntax_error("missing 'end'?");
+        // never returns
+      }
+    }
+
+    // A Parse_Table assumes that every construct begins with a keyword.
+    // This keyword is matched to the keyword table, and if a match is
+    // found, control is directed to the associated parse function, which
+    // can be written to accept just about any construct you wish.
+    // However, by the time return controls from a parse function, the
+    // token stream should be pointing either at a terminating token or
+    // the next keyword.
+
+    if (token.type() == KEYWORD) {
+      // Attempt to match the keyword to the keyword table.  The
+      // following call returns an iterator pointing to the first
+      // keyword in the table whose lexical ordering is greater than or
+      // equal to the keyword token.  The lexical ordering is supplied
+      // by the comp object.
+
+      auto const match = lower_bound(table_.begin(), table_.end(), token, comp);
+
+      if (match == table_.end() ||
+          strcmp(match->moniker, token.text().c_str()) != 0) {
+        // The token was not lexically equal to anything in the
+        // keyword table.  In other words, the keyword is
+        // unrecognized by the Parse_Table.  The error recovery
+        // procedure is to generate a diagnostic, then pull
+        // additional tokens off the token stream (without generating
+        // further diagnostics) until one is recognized as either a
+        // keyword or a terminating token.  We implement this
+        // behavior by setting the is_recovering flag when the first
+        // invalid token is encountered, and resetting this flag as
+        // soon as a valid token is encountered.
+
+        if (!is_recovering) {
+          // We are not recovering from a previous error.  Generate
+          // a diagnostic, and flag that we are now in error
+          // recovery mode.
+
+          tokens.report_semantic_error(token, ": unrecognized keyword: " +
+                                                  token.text());
+
+          // Give the user the possibilities.
+          tokens.comment("Perhaps you meant one of:");
+          for (auto const &i : table_) {
+            tokens.comment(string("  ") + i.moniker);
+            if (i.description != nullptr) {
+              tokens.comment(string("    ") + i.description);
+            }
+          }
+
+          is_recovering = true;
+        }
+        // else we are in recovery mode, and additional diagnostics
+        // are disabled until we see a valid construct.
+      } else {
+        // We have a valid match.
+
+        is_recovering = false;
+        // We successfully processed something, so we are no
+        // longer in recovery mode.
+
+        try {
+          // Call the parse function associated with the
+          // keyword.
+          (child_.*(match->func))(tokens, match->index);
+
+          if (once)
+          // Quit after parsing a single keyword. This is
+          // useful for parse tables for selecting one of a
+          // set of short options.
+          {
+            check_completeness(tokens);
+
+            if (tokens.error_count() == old_error_count) {
+              // No fresh errors in the class keyword block.  Create the object.
+              return std::shared_ptr<Class>(create_object());
+            } else {
+              // there were errors in the keyword block. Don't try to
+              // create a class object.  Return the null pointer.
+              return nullptr;
+            }
+          }
+        } catch (const Syntax_Error &) {
+          // If the parse function detects a syntax error, and
+          // if it does not have its own error recovery policy
+          // (or is unable to recover), it should call
+          // tokens.Report_Syntax_Error which generates a
+          // diagnostic and throws a Syntax_Error
+          // exception. This puts the main parser into recovery
+          // mode.
+
+          is_recovering = true;
+        }
+      }
+    } else if (token.type() == OTHER && token.text() == ";") {
+      // Treat a semicolon token as an empty keyword.  We are no longer
+      // in recovery mode, but we don't actually do anything.
+
+      is_recovering = false;
+    } else {
+      // The next token in the token stream is not a keyword,
+      // indicating a syntax error. Error recovery consists of
+      // generating a diagnostic message, then continuing to pull
+      // tokens off the token stream (without generating any further
+      // diagnostics) until one is recognized as either a keyword or a
+      // terminating token.  We implement this behavior by setting the
+      // is_recovering flag when the first invalid token is
+      // encountered, and resetting this flag as soon as a valid token
+      // is encountered.
+
+      if (!is_recovering) {
+        // We are not recovering from a previous error.  Generate a
+        // diagnostic, and flag that we are now in error recovery
+        // mode.
+
+        std::ostringstream msg;
+        msg << "expected a keyword, but saw " << token.text();
+        tokens.report_semantic_error(token, msg.str());
+        is_recovering = true;
+      }
+      // else we are in recovery mode, and additional diagnostics are
+      // disabled until we see a valid construct.
+    }
+  }
+}
+
+#if 0
+//----------------------------------------------------------------------------//
+/*!
+ * Parse the stream of tokens until a keyword is found or an END, EXIT, or
+ * ERROR token is reached.
+ *
+ * \param tokens The Token Stream from which to obtain the stream of tokens.
+ *
+ * \return The terminating token: either END, EXIT, or ERROR.
+ *
+ * \throw rtt_dsxx::assertion If the keyword table is ambiguous.
+ */
+template <class Class, bool once, bool allow_exit>
+Token Class_Parser_Base<Class, once, allow_exit>::parseforkeyword(Token_Stream &tokens) const {
+  // Create a comparator object that will be used to attempt to match
+  // keywords in the Token_Stream to keywords in the Parse_Table.  This
+  // comparator object incorporates the current settings of the
+  // Parse_Table, such as case sensitivity and partial matching options.
+
+  Keyword_Compare_ const comp(flags_);
+
+  // Now begin the process of pulling keywords off the input token stream,
+  // and attempting to match these to the keyword table.
+
+  for (;;) {
+    Token const token = tokens.shift();
+
+    // The END, EXIT, and ERROR tokens are terminating tokens.  EXIT
+    // means the end of the token stream has been reached.  END is used
+    // to flag the end of a nested parse, where the result of matching a
+    // keyword in one parse table is to begin parsing keywords in a
+    // second parse table.  An END indicates that the second parse table
+    // should return control to the first parse table.  ERROR means that
+    // something went very wrong and we're probably hosed, but it allows
+    // some error recovery from within a nested parse table.
+
+    if (token.type() == END || token.type() == EXIT ||
+        token.type() == rtt_parser::ERROR) {
+      return token;
+    }
+
+    // A Parse_Table assumes that every construct begins with a keyword.
+    // This keyword is matched to the keyword table, and if a match is
+    // found, control is directed to the associated parse function, which
+    // can be written to accept just about any construct you wish.
+    // However, by the time return controls from a parse function, the
+    // token stream should be pointing either at a terminating token or
+    // the next keyword.
+
+    if (token.type() == KEYWORD) {
+      // Attempt to match the keyword to the keyword table.  The
+      // following call returns an iterator pointing to the first
+      // keyword in the table whose lexical ordering is greater than or
+      // equal to the keyword token.  The lexical ordering is supplied
+      // by the comp object.
+
+      vector<Keyword>::const_iterator const match =
+          lower_bound(table_.begin(), table_.end(), token, comp);
+
+      if (match == table_.end() ||
+          comp.kt_comparison(match->moniker, token.text().c_str()) != 0) {
+        // The token was not lexically equal to anything in the
+        // keyword table.  In other words, the keyword is
+        // unrecognized by the Parse_Table.  The error recovery
+        // procedure is to generate a diagnostic, then pull
+        // additional tokens off the token stream (without generating
+        // further diagnostics) until one is recognized as either a
+        // keyword or a terminating token.  We implement this
+        // behavior by setting the is_recovering flag when the first
+        // invalid token is encountered, and resetting this flag as
+        // soon as a valid token is encountered.
+      } else {
+        // We have a valid match.  However, depending on Parse_Table
+        // options, the match might be ambiguous.  For example if the
+        // Parse_Table option to allow partial matches is active, the
+        // keyword token may partially match more than one keyword in
+        // the keyword table.  Check for an ambiguous match:
+
+        if (match + 1 != table_.end() &&
+            comp.kt_comparison(match[1].moniker, token.text().c_str()) == 0) {
+          // The match is ambiguous.  This is diagnosed whether or
+          // not we are already in recovery mode, but it does put
+          // us into recovery mode.
+
+          tokens.report_semantic_error(token,
+                                       "ambiguous keyword: " + token.text());
+        } else {
+          // We successfully processed something, so we are no
+          // longer in recovery mode.
+
+          try {
+            // Call the parse function associated with the
+            // keyword.
+            match->func(tokens, match->index);
+
+            if (flags_ & ONCE)
+            // Quit after parsing a single keyword. This is
+            // useful for parse tables for selecting one of a
+            // set of short options.
+            {
+              return Token(END, "");
+            }
+          } catch (const Syntax_Error &) {
+            // If the parse function detects a syntax error, and
+            // if it does not have its own error recovery policy
+            // (or is unable to recover), it should call
+            // tokens.Report_Syntax_Error which generates a
+            // diagnostic and throws a Syntax_Error
+            // exception. This puts the main parser into recovery
+            // mode.
+            tokens.report_semantic_error(token,
+                                         "syntax error: " + token.text());
+          }
+        }
+      }
+    }
+  }
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * \param f Flags to be set, ORed together.
+ */
+template <class Class, bool once, bool allow_exit>
+void Class_Parser_Base<Class, once, allow_exit>::set_flags(unsigned char const f) {
+  flags_ = f;
+
+  add(nullptr, 0U);
+  // The keyword list needs to be sorted and checked.  For example, if the
+  // options are changed so that a previously case-sensitive Parse_Table is
+  // no longer case-sensitive, then the ordering changes, and previously
+  // unambiguous keywords may become ambiguous.
+
+  Ensure(check_class_invariants());
+  Ensure(get_flags() == f);
+}
+#endif
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Comparison function for sorting keyword tables.
+ *
+ * This function is used by a Parse_Table to sort its keyword list using
+ * std::sort.
+ *
+ * A valid Parse_Table may not contain any keywords that test equal.
+ *
+ * \param k1 The first Keyword to be compared.
+ *
+ * \param k2 The second Keyword to be compared.
+ *
+ * \return <CODE>strcmp(k1.moniker, k2.moniker)<0 </CODE>
+ */
+template <class Class, bool once, bool allow_exit>
+bool Class_Parser_Base<Class, once, allow_exit>::Keyword_Compare_::
+operator()(Keyword const &k1, Keyword const &k2) const {
+  Require(k1.moniker != nullptr);
+  Require(k2.moniker != nullptr);
+
+  return strcmp(k1.moniker, k2.moniker) < 0;
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Comparison function for finding token match in keyword table.
+ *
+ * This function is used by a Parse_Table to match keywords to identifier
+ * tokens using std::lower_bound.
+ *
+ * \param k1 The Keyword to be compared.
+ * \param k2 The token to be compared.
+ *
+ * \return <CODE>strcmp(keyword.moniker,
+ *                          token.text().c_str())<0 </CODE>
+ */
+template <class Class, bool once, bool allow_exit>
+bool Class_Parser_Base<Class, once, allow_exit>::Keyword_Compare_::
+operator()(Keyword const &k1, Token const &k2) const noexcept {
+  Require(k1.moniker != nullptr);
+
+  return strcmp(k1.moniker, k2.text().c_str()) < 0;
+}
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Check whether a keyword satisfies the requirements for use in
+ * a Parse_Table.
+ *
+ * \param key Keyword to be checked.
+ *
+ * \return \c false unless all the following conditions are met:
+ * <ul><li>\c key.moniker must point to a null-terminated string consisting
+ * of one or more valid C++ identifiers separated by single spaces.</li>
+ * <li>\c key.func must point to a parsing function.</li></ul>
+ */
+template <class Class>
+bool Is_Well_Formed_Keyword(Class_Parser_Keyword<Class> const &key) {
+  using namespace std;
+
+  if (key.moniker == nullptr || key.func == nullptr)
+    return false;
+  char const *cptr = key.moniker;
+  for (;;) {
+    // Must be at the start of a C identifier, which begins with an
+    // alphabetic character or an underscore.
+    if (*cptr != '_' && !isalpha(*cptr))
+      return false;
+
+    // The subsequent characters in a C identifier must be alphanumeric
+    // characters or underscores.
+    while (*cptr == '_' || isalnum(*cptr))
+      cptr++;
+
+    // If the identifier is followed by a null, we're finished scanning a
+    // valid keyword.
+    if (*cptr == '\0')
+      return true;
+
+    // Otherwise, if the next character is not a space, it's not a valid
+    // keyword.
+    if (*cptr != ' ')
+      return false;
+
+    // Skip over the space. cptr should now point to the start of the
+    // next C identifier, if this is a valid keyword.
+    cptr++;
+  }
+}
+
+//----------------------------------------------------------------------------//
+template <class Class, bool once, bool allow_exit>
+bool Class_Parser_Base<Class, once, allow_exit>::check_class_invariants()
+    const {
+  // The keyword table must be well-formed, sorted, and unambiguous.
+
+  for (auto i = table_.begin(); i != table_.end(); ++i) {
+    if (!Is_Well_Formed_Keyword(i[0]))
+      return false;
+    if (i + 1 != table_.end()) {
+      if (strcmp(i[0].moniker, i[1].moniker) >= 0)
+        return false;
+    }
+  }
+  return true;
+}
+
+//----------------------------------------------------------------------------//
+template <class Class, bool once, bool allow_exit>
+std::vector<typename Class_Parser_Base<Class, once, allow_exit>::Keyword>
+    Class_Parser_Base<Class, once, allow_exit>::table_;
+
+} // namespace rtt_parser
+
+#endif // rtt_Class_Parser_II
+
+//----------------------------------------------------------------------------//
+// end of Class_Parser.ii
+//----------------------------------------------------------------------------//

--- a/src/parser/test/CMakeLists.txt
+++ b/src/parser/test/CMakeLists.txt
@@ -34,7 +34,8 @@ set( scalar_test_sources
    ${PROJECT_SOURCE_DIR}/tstutilities.cc
    ${PROJECT_SOURCE_DIR}/tstUnit.cc
    ${PROJECT_SOURCE_DIR}/tstString_Token_Stream.cc
-   ${PROJECT_SOURCE_DIR}/tstParse_Table.cc )
+   ${PROJECT_SOURCE_DIR}/tstParse_Table.cc
+   ${PROJECT_SOURCE_DIR}/tstClass_Parser.cc )
 list( REMOVE_ITEM test_sources ${scalar_test_sources} )
 add_scalar_tests(
    SOURCES "${scalar_test_sources}"

--- a/src/parser/test/tstClass_Parse_Table.cc
+++ b/src/parser/test/tstClass_Parse_Table.cc
@@ -1,0 +1,174 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   parser/test/tstClass_Parser.cc
+ * \author Kent Budge
+ * \date   Mon Aug 28 07:36:50 2006
+ * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include "parser/Class_Parse_Table.hh"
+#include "parser/String_Token_Stream.hh"
+#include "parser/utilities.hh"
+
+using namespace std;
+using namespace rtt_dsxx;
+using namespace rtt_parser;
+
+//---------------------------------------------------------------------------//
+class DummyClass {
+public:
+  DummyClass(double const insouciance) : insouciance(insouciance) {}
+
+  double Get_Insouciance() const { return insouciance; }
+
+private:
+  double insouciance;
+};
+
+namespace rtt_parser {
+//---------------------------------------------------------------------------//
+template <>
+class Class_Parse_Table<DummyClass>
+    : public Class_Parse_Table_Base<DummyClass, false> {
+public:
+  // TYPEDEFS
+
+  // MANAGEMENT
+
+  Class_Parse_Table(bool context = false);
+
+  // SERVICES
+
+  void check_completeness(Token_Stream &tokens);
+
+  std::shared_ptr<DummyClass> create_object();
+
+protected:
+  // DATA
+
+  double parsed_insouciance;
+  bool context;
+
+private:
+  // IMPLEMENTATION
+
+  static void parse_insouciance_(Token_Stream &tokens, int);
+
+  // STATIC
+};
+
+//---------------------------------------------------------------------------//
+template <>
+std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
+                                                    bool const &context) {
+  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens, context);
+}
+
+//---------------------------------------------------------------------------//
+template <>
+std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
+  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens, false);
+}
+
+//---------------------------------------------------------------------------//
+void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
+                                                       int) {
+  tokens.check_semantics(current_->parsed_insouciance < 0.0,
+                         "duplicate specification of insouciance");
+
+  current_->parsed_insouciance = parse_real(tokens);
+  if (current_->parsed_insouciance < 0) {
+    tokens.report_semantic_error("insouciance must be nonnegative");
+    current_->parsed_insouciance = 1;
+  }
+
+  if (current_->context) {
+    current_->parsed_insouciance = -current_->parsed_insouciance;
+  }
+}
+
+//---------------------------------------------------------------------------//
+Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const context)
+    : parsed_insouciance(-1.0), context(context) // sentinel value
+{
+  Keyword const keywords[] = {
+      {"insouciance", parse_insouciance_, 0, ""},
+  };
+  initialize(keywords, sizeof(keywords));
+}
+
+//---------------------------------------------------------------------------//
+void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
+  tokens.check_semantics(context || parsed_insouciance >= 0,
+                         "insouciance was not specified");
+}
+
+//---------------------------------------------------------------------------//
+std::shared_ptr<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
+  std::shared_ptr<DummyClass> Result =
+      std::shared_ptr<DummyClass>(new DummyClass(parsed_insouciance));
+  return Result;
+}
+
+} // namespace rtt_parser
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+void tstClass_Parser(UnitTest &ut) {
+  double const eps = std::numeric_limits<double>::epsilon();
+  string text = "insouciance = 3.3\nend\n";
+  String_Token_Stream tokens(text);
+
+  std::shared_ptr<DummyClass> dummy = parse_class<DummyClass>(tokens);
+
+  ut.check(dummy != nullptr, "parsed the class object", true);
+  ut.check(rtt_dsxx::soft_equiv(dummy->Get_Insouciance(), 3.3, eps),
+           "parsed the insouciance correctly");
+
+  tokens.rewind();
+  dummy = parse_class<DummyClass>(tokens, true);
+
+  ut.check(dummy != nullptr, "parsed the indolent class object", true);
+  ut.check(rtt_dsxx::soft_equiv(dummy->Get_Insouciance(), -3.3, eps),
+           "parsed the indolent insouciance correctly");
+
+  // Test that missing end is caught.
+
+  text = "insouciance = 3.3\n";
+  String_Token_Stream etokens(text);
+
+  bool good = false;
+  try {
+    std::shared_ptr<DummyClass> dum = parse_class<DummyClass>(etokens);
+  } catch (Syntax_Error &) {
+    good = true;
+  }
+  ut.check(good, "catches missing end");
+
+  tokens.rewind();
+  good = false;
+  try {
+    std::shared_ptr<DummyClass> dum = parse_class<DummyClass>(etokens, true);
+  } catch (Syntax_Error &) {
+    good = true;
+  }
+  ut.check(good, "indolent catches missing end");
+}
+
+//---------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  ScalarUnitTest ut(argc, argv, release);
+  try {
+    tstClass_Parser(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of tstClass_Parser.cc
+//---------------------------------------------------------------------------//

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -1,174 +1,556 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   parser/test/tstClass_Parser.cc
- * \author Kent Budge
- * \date   Mon Aug 28 07:36:50 2006
- * \note   Copyright (C) 2016-2018 Los Alamos National Security, LLC.
- *         All rights reserved. */
+ * \file   parser/test/tstClass_Parse_Table.cc
+ * \brief  Unit tests for the Class_Parse_Table template.
+ * \note   Copyright (C) 2016-2018 TRIAD, LLC. All rights reserved.
+  */
 //---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
-#include "parser/Class_Parse_Table.hh"
+#include "parser/Class_Parser.hh"
+#include "parser/File_Token_Stream.hh"
 #include "parser/String_Token_Stream.hh"
 #include "parser/utilities.hh"
+#include <string.h>
+
+#ifdef _MSC_VER
+#undef ERROR
+#endif
 
 using namespace std;
-using namespace rtt_dsxx;
 using namespace rtt_parser;
-
-//---------------------------------------------------------------------------//
-class DummyClass {
-public:
-  DummyClass(double const insouciance) : insouciance(insouciance) {}
-
-  double Get_Insouciance() const { return insouciance; }
-
-private:
-  double insouciance;
-};
-
-namespace rtt_parser {
-//---------------------------------------------------------------------------//
-template <>
-class Class_Parse_Table<DummyClass>
-    : public Class_Parse_Table_Base<DummyClass, false> {
-public:
-  // TYPEDEFS
-
-  // MANAGEMENT
-
-  Class_Parse_Table(bool context = false);
-
-  // SERVICES
-
-  void check_completeness(Token_Stream &tokens);
-
-  std::shared_ptr<DummyClass> create_object();
-
-protected:
-  // DATA
-
-  double parsed_insouciance;
-  bool context;
-
-private:
-  // IMPLEMENTATION
-
-  static void parse_insouciance_(Token_Stream &tokens, int);
-
-  // STATIC
-};
-
-//---------------------------------------------------------------------------//
-template <>
-std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
-                                                    bool const &context) {
-  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens, context);
-}
-
-//---------------------------------------------------------------------------//
-template <>
-std::shared_ptr<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
-  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens, false);
-}
-
-//---------------------------------------------------------------------------//
-void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
-                                                       int) {
-  tokens.check_semantics(current_->parsed_insouciance < 0.0,
-                         "duplicate specification of insouciance");
-
-  current_->parsed_insouciance = parse_real(tokens);
-  if (current_->parsed_insouciance < 0) {
-    tokens.report_semantic_error("insouciance must be nonnegative");
-    current_->parsed_insouciance = 1;
-  }
-
-  if (current_->context) {
-    current_->parsed_insouciance = -current_->parsed_insouciance;
-  }
-}
-
-//---------------------------------------------------------------------------//
-Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const context)
-    : parsed_insouciance(-1.0), context(context) // sentinel value
-{
-  Keyword const keywords[] = {
-      {"insouciance", parse_insouciance_, 0, ""},
-  };
-  initialize(keywords, sizeof(keywords));
-}
-
-//---------------------------------------------------------------------------//
-void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
-  tokens.check_semantics(context || parsed_insouciance >= 0,
-                         "insouciance was not specified");
-}
-
-//---------------------------------------------------------------------------//
-std::shared_ptr<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
-  std::shared_ptr<DummyClass> Result =
-      std::shared_ptr<DummyClass>(new DummyClass(parsed_insouciance));
-  return Result;
-}
-
-} // namespace rtt_parser
+using namespace rtt_dsxx;
 
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 
-void tstClass_Parser(UnitTest &ut) {
-  double const eps = std::numeric_limits<double>::epsilon();
-  string text = "insouciance = 3.3\nend\n";
-  String_Token_Stream tokens(text);
+//---------------------------------------------------------------------------//
+// A model class parameter.
 
-  std::shared_ptr<DummyClass> dummy = parse_class<DummyClass>(tokens);
+enum Color { BLACK, BLUE, BLUE_GREEN, SENTINEL };
 
-  ut.check(dummy != nullptr, "parsed the class object", true);
-  ut.check(rtt_dsxx::soft_equiv(dummy->Get_Insouciance(), 3.3, eps),
-           "parsed the insouciance correctly");
+char const *color_table[] = {"BLACK", "BLUE", "BLUE_GREEN"};
 
-  tokens.rewind();
-  dummy = parse_class<DummyClass>(tokens, true);
+//---------------------------------------------------------------------------//
+// Model class for which we want to parse specifications
 
-  ut.check(dummy != nullptr, "parsed the indolent class object", true);
-  ut.check(rtt_dsxx::soft_equiv(dummy->Get_Insouciance(), -3.3, eps),
-           "parsed the indolent insouciance correctly");
+class Vehicle {
+public:
+  explicit Vehicle(Color const color) : color_(color) {}
 
-  // Test that missing end is caught.
+  Color color() const noexcept { return color_; }
 
-  text = "insouciance = 3.3\n";
-  String_Token_Stream etokens(text);
+private:
+  Color color_;
+};
 
-  bool good = false;
-  try {
-    std::shared_ptr<DummyClass> dum = parse_class<DummyClass>(etokens);
-  } catch (Syntax_Error &) {
-    good = true;
+//---------------------------------------------------------------------------//
+// Specialization of Class_Parser for our model class.
+
+template <>
+class rtt_parser::Class_Parser<Vehicle> : public Class_Parser_Base<Vehicle> {
+public:
+  Class_Parser();
+  // context argument is optional
+
+  void check_completeness(Token_Stream &ut) {
+    ut.check_semantics(color != SENTINEL, "no color specified");
   }
-  ut.check(good, "catches missing end");
 
-  tokens.rewind();
-  good = false;
-  try {
-    std::shared_ptr<DummyClass> dum = parse_class<DummyClass>(etokens, true);
-  } catch (Syntax_Error &) {
-    good = true;
-  }
-  ut.check(good, "indolent catches missing end");
+  Vehicle *create_object() { return new Vehicle(color); }
+
+protected:
+  // Data to be parsed which will be used to construct the class, for example:
+
+  Color color;
+
+  //private:
+public: // To facilitate keyword invariant testing
+  // Parse functions
+
+  void parse_color(Token_Stream &, int);
+  void parse_any_color(Token_Stream &, int);
+
+  // Raw parse table
+
+  static Class_Parser_Keyword<Vehicle> const raw_table[];
+};
+
+//---------------------------------------------------------------------------//
+// Raw keyword table for our Class_Parser specialization.
+
+Class_Parser_Keyword<Vehicle> const Class_Parser<Vehicle>::raw_table[] = {
+    {"BLUE", &rtt_parser::Class_Parser<Vehicle>::parse_color, 1, "main"},
+    {"BLACK", &rtt_parser::Class_Parser<Vehicle>::parse_color, 0, "main"},
+    {"BLUE GREEN", &rtt_parser::Class_Parser<Vehicle>::parse_color, 2, "main"},
+    {"BLUISH GREEN", &rtt_parser::Class_Parser<Vehicle>::parse_color, 2, "main",
+     "alternate keyword for same parmeter is permitted"},
+    {"color", &rtt_parser::Class_Parser<Vehicle>::parse_any_color, 0, "main"},
+};
+
+//---------------------------------------------------------------------------//
+// Mandatory constructor for our Class_Parser specialization.
+rtt_parser::Class_Parser<Vehicle>::Class_Parser()
+    : Class_Parser_Base<Vehicle>(*this, raw_table,
+                                 sizeof(raw_table) / sizeof(raw_table[0])),
+      color(SENTINEL) {}
+
+//---------------------------------------------------------------------------//
+// Optional parse functions for our Class_Parser specialization.
+
+void rtt_parser::Class_Parser<Vehicle>::parse_color(Token_Stream &tokens,
+                                                    int i) {
+  Require(i < SENTINEL);
+  tokens.check_semantics(color == SENTINEL, "duplicate color specification");
+  color = (Color)i;
+}
+
+void rtt_parser::Class_Parser<Vehicle>::parse_any_color(Token_Stream &tokens,
+                                                        int) {
+  Token token = tokens.shift();
+  for (unsigned i = 0; i < sizeof(color_table) / sizeof(const char *); i++)
+    if (!strcmp(token.text().c_str(), color_table[i])) {
+      color = (Color)i;
+      return;
+    }
+
+  tokens.report_syntax_error(token, "expected a color");
 }
 
 //---------------------------------------------------------------------------//
+// class_parse specialization for our model class.
+
+template <>
+shared_ptr<Vehicle> rtt_parser::parse_class<Vehicle>(Token_Stream &tokens) {
+  rtt_parser::Class_Parser<Vehicle> parser;
+  return parser.parse(tokens);
+}
+
+//---------------------------------------------------------------------------//
+// Now a model class that happens to have no parameters. While this may seem
+// pointless, we allow parsers for empty classes as placeholders.
+
+class Empty {};
+
+template <>
+class rtt_parser::Class_Parser<Empty>
+    : public rtt_parser::Class_Parser_Base<Empty, false, true> {
+public:
+  Class_Parser() : Class_Parser_Base<Empty, false, true>(*this) {}
+
+protected:
+  // IMPLEMENTATION
+
+  void check_completeness(Token_Stream &){};
+
+  Empty *create_object() { return new Empty(); }
+};
+
+template <>
+shared_ptr<Empty> rtt_parser::parse_class<Empty>(Token_Stream &tokens) {
+  rtt_parser::Class_Parser<Empty> parser;
+  return parser.parse(tokens);
+}
+
+//---------------------------------------------------------------------------//
+// Inheritance.
+
+//------- Father
+class Car : public Vehicle {
+public:
+  explicit Car(Color color) : Vehicle(color) {}
+};
+
+template <>
+class rtt_parser::Class_Parser<Car> : public Class_Parser<Vehicle>,
+                                      public Class_Parser_Base<Car> {
+public:
+  typedef Class_Parser_Base<Car> Base;
+
+  Class_Parser();
+};
+
+rtt_parser::Class_Parser<Car>::Class_Parser() : Class_Parser_Base<Car>(*this) {
+  static bool first_time = true;
+  if (first_time) {
+    Base::add(Class_Parser_Base<Vehicle>::table());
+    first_time = false;
+  }
+}
+
+//------- Child
+class Pickup : public Car {
+public:
+  explicit Pickup(Color color) : Car(color) {}
+};
+
+template <>
+class rtt_parser::Class_Parser<Pickup> : public Class_Parser<Car>,
+                                         public Class_Parser_Base<Pickup> {
+public:
+  typedef Class_Parser_Base<Pickup> Base;
+
+  Class_Parser();
+
+  void check_completeness(Token_Stream &) {
+    // No requirement here
+  }
+
+  Pickup *create_object() { return new Pickup(color); }
+
+  using Base::parse;
+
+protected:
+  // Data to be parsed which will be used to construct the class, for example:
+
+private:
+  // Parse functions
+
+  // Raw parse table
+};
+
+rtt_parser::Class_Parser<Pickup>::Class_Parser()
+    : Class_Parser_Base<Pickup>(*this) {
+  static bool first_time = true;
+  if (first_time) {
+    Base::add(Class_Parser_Base<Car>::table());
+    first_time = false;
+  }
+}
+
+template <>
+shared_ptr<Pickup> rtt_parser::parse_class<Pickup>(Token_Stream &tokens) {
+  rtt_parser::Class_Parser<Pickup> parser;
+  return parser.parse(tokens);
+}
+
+//---------------------------------------------------------------------------//
+// Ambiguous parse table.
+
+class Ambiguous {};
+
+template <>
+class rtt_parser::Class_Parser<Ambiguous>
+    : public Class_Parser_Base<Ambiguous> {
+public:
+  typedef Class_Parser_Base<Ambiguous> Base;
+
+  Class_Parser();
+
+  void check_completeness(Token_Stream &) {
+    // No requirement here
+  }
+
+  Ambiguous *create_object() { return new Ambiguous(); }
+
+  using Base::parse;
+
+protected:
+  // Data to be parsed which will be used to construct the class, for example:
+
+private:
+  // Parse functions
+
+  void parse_moniker(Token_Stream &, int) {}
+
+  // Raw parse table
+
+  static Class_Parser_Keyword<Ambiguous> const raw_table[];
+};
+
+Class_Parser_Keyword<Ambiguous> const Class_Parser<Ambiguous>::raw_table[] = {
+    {"moniker", &rtt_parser::Class_Parser<Ambiguous>::parse_moniker, 1, "main"},
+    {"moniker", &rtt_parser::Class_Parser<Ambiguous>::parse_moniker, 0, "main"},
+};
+
+rtt_parser::Class_Parser<Ambiguous>::Class_Parser()
+    : Class_Parser_Base<Ambiguous>(*this, raw_table,
+                                   sizeof(raw_table) / sizeof(raw_table[0])) {}
+
+template <>
+shared_ptr<Ambiguous> rtt_parser::parse_class<Ambiguous>(Token_Stream &tokens) {
+  rtt_parser::Class_Parser<Ambiguous> parser;
+  return parser.parse(tokens);
+}
+
+//---------------------------------------------------------------------------//
+// Once parse table.
+
+struct Once {
+  unsigned calls = 0;
+};
+
+template <>
+class rtt_parser::Class_Parser<Once>
+    : public Class_Parser_Base<Once, true, false> {
+public:
+  typedef Class_Parser_Base<Once, true, false> Base;
+
+  Class_Parser();
+
+  void check_completeness(Token_Stream &) {
+    // No requirement here
+  }
+
+  Once *create_object() { return new Once{calls}; }
+
+  using Base::parse;
+
+  unsigned calls;
+
+private:
+  // Parse functions
+
+  void parse_once(Token_Stream &, int) { calls++; }
+
+  // Raw parse table
+
+  static Class_Parser_Keyword<Once> const raw_table[];
+};
+
+Class_Parser_Keyword<Once> const Class_Parser<Once>::raw_table[] = {
+    {"once", &rtt_parser::Class_Parser<Once>::parse_once, 1, "main"},
+};
+
+rtt_parser::Class_Parser<Once>::Class_Parser()
+    : Class_Parser_Base<Once, true, false>(
+          *this, raw_table, sizeof(raw_table) / sizeof(raw_table[0])),
+      calls(0) {}
+
+template <>
+shared_ptr<Once> rtt_parser::parse_class<Once>(Token_Stream &tokens) {
+  rtt_parser::Class_Parser<Once> parser;
+  return parser.parse(tokens);
+}
+
+//--------------------------------------------- -----------------------------//
+// Specialized token streams for extending code coverage.
+
+class Error_Token_Stream : public Token_Stream {
+public:
+  void rewind() {}
+
+  void comment(string const & /*err*/) {
+    cout << "comment reported to Error_Token_Stream" << endl;
+  }
+
+protected:
+  void report(Token const &, string const & /*err*/) {
+    cout << "error reported to Error_Token_Stream" << endl;
+  }
+
+  void report(string const & /*err*/) {
+    cout << "error reported to Error_Token_Stream" << endl;
+  }
+
+  Token fill_() { return Token(rtt_parser::ERROR, "error"); }
+};
+
+class Colon_Token_Stream : public Token_Stream {
+public:
+  Colon_Token_Stream() : count_(0) {}
+
+  void rewind() {}
+
+  void comment(string const & /*err*/) {
+    cout << "comment reported to Colon_Token_Stream" << endl;
+  }
+
+protected:
+  void report(Token const &, string const & /*err*/) {
+    cout << "error reported to Colon_Token_Stream" << endl;
+  }
+
+  void report(string const & /*err*/) {
+    cout << "error reported to Colon_Token_Stream" << endl;
+  }
+
+  Token fill_() {
+    switch (count_++) {
+    case 0:
+      return Token(';', "");
+    case 1:
+      return Token(END, "end");
+    case 2:
+      return Token(EXIT, "");
+    default:
+      Insist(false, "bad case");
+      return Token(rtt_parser::ERROR, ""); // dummy return to eliminate warning
+    }
+  }
+
+private:
+  unsigned count_;
+};
+
+//----------------------------------------------------------------------------//
+void tstParse_Table(UnitTest &ut) {
+
+  // Test keyword checks
+  {
+    // Invalid for lack of moniker
+    Class_Parser_Keyword<Vehicle> k = {nullptr, nullptr, 0, "", ""};
+    ut.check(!Is_Well_Formed_Keyword(k), "lack of moniker caught");
+
+    // Invalid for lack of parse function
+    k = {"moniker", nullptr, 0, "", ""};
+    ut.check(!Is_Well_Formed_Keyword(k), "lack of func caught");
+
+    // Invalid moniker
+    k = {"0", &rtt_parser::Class_Parser<Vehicle>::parse_color, 0, "", ""};
+    ut.check(!Is_Well_Formed_Keyword(k), "lack of moniker caught");
+
+    // Invalid moniker
+    k = {"and &", &rtt_parser::Class_Parser<Vehicle>::parse_color, 0, "", ""};
+    ut.check(!Is_Well_Formed_Keyword(k), "lack of moniker caught");
+
+    // Invalid moniker
+    k = {"and&", &rtt_parser::Class_Parser<Vehicle>::parse_color, 0, "", ""};
+    ut.check(!Is_Well_Formed_Keyword(k), "lack of moniker caught");
+
+    // Valid
+    k = {"_color", &rtt_parser::Class_Parser<Vehicle>::parse_color, 0, "", ""};
+    ut.check(Is_Well_Formed_Keyword(k), "lack of moniker caught");
+  }
+
+  // Test parsing of a model class.
+  {
+    String_Token_Stream token_stream("BLUE\nend\n");
+
+    shared_ptr<Vehicle> spectrum = parse_class<Vehicle>(token_stream);
+    ut.check(token_stream.error_count() == 0, "Vehicle: no parse errors", true);
+    ut.check(spectrum->color() == BLUE, "parsed BLUE");
+
+    token_stream = String_Token_Stream("BLUISH GREEN\nend\n");
+
+    spectrum = parse_class<Vehicle>(token_stream);
+    ut.check(token_stream.error_count() == 0, "Vehicle: no parse errors", true);
+
+    ut.check(spectrum->color() == BLUE_GREEN, "parsed BLUISH GREEN");
+
+    token_stream = String_Token_Stream("color = BLACK\nend\n");
+
+    spectrum = parse_class<Vehicle>(token_stream);
+    ut.check(token_stream.error_count() == 0, "Vehicle: no parse errors", true);
+
+    ut.check(spectrum->color() == BLACK, "parsed color = BLACK");
+
+    // Deliberate error; unrecognized keyword
+
+    token_stream = String_Token_Stream("COLOR = BLACK\nend\n");
+
+    spectrum = parse_class<Vehicle>(token_stream);
+    ut.check(token_stream.error_count() != 0 && spectrum == nullptr,
+             "Vehicle: deliberate parse error");
+
+    // Deliberate error; no end
+
+    token_stream = String_Token_Stream("COLOR = BLACK\n");
+
+    try {
+      spectrum = parse_class<Vehicle>(token_stream);
+      ut.failure("catches missing end");
+    } catch (...) {
+      ut.passes("catches missing end");
+    }
+
+    // Deliberate error; syntax after keyword
+
+    token_stream = String_Token_Stream("COLOR = 1\n");
+
+    try {
+      spectrum = parse_class<Vehicle>(token_stream);
+      ut.failure("catches internal syntax");
+    } catch (...) {
+      ut.passes("catches internal syntax");
+    }
+
+    // Deliberate error; non keyword
+
+    token_stream = String_Token_Stream("1\n");
+
+    try {
+      spectrum = parse_class<Vehicle>(token_stream);
+      ut.failure("catches internal syntax");
+    } catch (...) {
+      ut.passes("catches internal syntax");
+    }
+
+    // Deliberate error; I/O error
+
+    Error_Token_Stream error_stream;
+
+    try {
+      spectrum = parse_class<Vehicle>(error_stream);
+      ut.failure("catches i/o error");
+    } catch (...) {
+      ut.passes("catches i/o error");
+    }
+  }
+
+  // Test parsing for case of empty class (supported as placeholder)
+  // Also tests allow_exit and colon.
+  {
+    String_Token_Stream token_stream("");
+
+    shared_ptr<Empty> empty = parse_class<Empty>(token_stream);
+
+    ut.check(token_stream.error_count() == 0, "Empty: no parse errors");
+
+    // Colon
+
+    Colon_Token_Stream colon_stream;
+
+    empty = parse_class<Empty>(colon_stream);
+    ut.check(colon_stream.error_count() == 0, "colon treated as empty", true);
+  }
+
+  // Test inheritance
+  {
+    String_Token_Stream token_stream("BLUE\nend\n");
+
+    shared_ptr<Pickup> spectrum = parse_class<Pickup>(token_stream);
+
+    ut.check(spectrum->color() == BLUE, "parsed BLUE");
+    ut.check(token_stream.error_count() == 0, "Pickup: no parse errors");
+  }
+
+  // Test detection of ambiguous keyword
+  {
+    String_Token_Stream token_stream("moniker\nend\n");
+
+    try {
+      shared_ptr<Ambiguous> spectrum = parse_class<Ambiguous>(token_stream);
+      ut.failure("catch of ambiguous keyword");
+    } catch (std::invalid_argument &) {
+      ut.passes("catch of ambiguous keyword");
+    }
+  }
+
+  // Test once parser
+  {
+    String_Token_Stream token_stream("once\nonce\nend\n");
+
+    shared_ptr<Once> spectrum = parse_class<Once>(token_stream);
+    ut.check(token_stream.error_count() == 0, "Vehicle: no parse errors", true);
+    ut.check(spectrum->calls == 1, "called once");
+  }
+
+  return;
+}
+
+//---------------------------------------------------------------------------------------//
+
 int main(int argc, char *argv[]) {
   ScalarUnitTest ut(argc, argv, release);
   try {
-    tstClass_Parser(ut);
+    tstParse_Table(ut);
   }
   UT_EPILOG(ut);
 }
 
-//---------------------------------------------------------------------------//
-// end of tstClass_Parser.cc
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
+// end of tstParse_Table.cc
+//---------------------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

The parser directory has a Class_Parse_Table template and associated supporting boilerplate for writing parsers to read a text file description of how to create a class object. This template is a bit clunky, with more in it than is needed (such as options for partial or case-insensitive keyword matching, which we have never used.) It also relies on static functions for parsing, with the need to manage an artificial global "this" pointer for the object in which parsed data is stored. This can be made reentrant but only with extra effort.

### Purpose of Pull Request

Add a new Class_Parser template that tries to bring everything into one place and streamline it.  The biggest change is to use pointers to member functions in the keyword tables as parse functions. This eliminates the artificial "this" pointer, simplifying code and making the parser automatically reentrant, but comes at the cost that it precludes diamond inheritance of class parsers. (Because a pointer to base class member function can be cast to pointer to derived class member function only if the base cass is nonvirtual.)

WIP: Offered for comment. Is this really a significant improvement?

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
