### PR TITLE
Updates to the regression system to support TRT and NPT

### DIFF
--- a/regression/ccscs-job-launch.sh
+++ b/regression/ccscs-job-launch.sh
@@ -58,7 +58,8 @@ done
 if ! test -d $logdir; then
   mkdir -p $logdir
   chgrp ccsrad $logdir
-  chmod g+rsX $logdir
+  chmod g+rwX $logdir
+  chmod g+s $logdir
 fi
 
 # Configure, Build, Test and Submit (no Torque batch system here).

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -330,6 +330,7 @@ if [[ ${regress_mode} == "on" ]]; then
   echo " "
   run "chgrp -R draco ${work_dir}"
   run "chmod -R g+rwX,o-rwX ${work_dir}"
+#  run "find ${work_dir} -type d -exec chmod g+s {} \;"
 fi
 
 echo "All done."

--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -368,6 +368,7 @@ if [[ ${regress_mode} == "on" ]]; then
   echo " "
   run "chgrp -R ccsrad ${work_dir}"
   run "chmod -R g+rX,o-rwX ${work_dir}"
+#  run "find ${work_dir} -type d -exec chmod g+s {} \;"
 fi
 
 echo "All done."

--- a/regression/darwin-regress.msub
+++ b/regression/darwin-regress.msub
@@ -238,6 +238,7 @@ ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctes
 
 run "chgrp -R draco ${work_dir}"
 run "chmod -R g+rwX,o-rwX ${work_dir}"
+#  run "find ${work_dir} -type d -exec chmod g+s {} \;"
 
 echo "All done."
 

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -802,7 +802,6 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   # Assume that draco_work_dir is parallel to our current location, but only
   # replace the directory name preceeding the dashboard name.
   file( TO_CMAKE_PATH "$ENV{work_dir}" work_dir )
-  # ${dep_pkg_caps}_DIR == {DRACO_DIR, CORE_DIR}
   file( TO_CMAKE_PATH "$ENV{${dep_pkg_caps}_DIR}" ${dep_pkg_caps}_DIR )
   string( REGEX REPLACE "${this_pkg}[/\\](Nightly|Experimental|Continuous)"
     "${dep_pkg}/\\1" ${dep_pkg}_work_dir ${work_dir} )
@@ -816,22 +815,17 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   # *-perfbench-*       *-*
   # *-knl-perfbench-*   *-knl-*
 
-  if( "${dep_pkg}" MATCHES "draco" )
-    # not any ${extraparam} since many map to draco builds that have the same
-    # ${extraparam}.  For example: *-newtools-*.
-    foreach( extraparam nr perfbench vtest )
-      string( REGEX REPLACE "[-_]${extraparam}[-_]" "-" ${dep_pkg}_work_dir
-        ${${dep_pkg}_work_dir} )
-    endforeach()
-    if( "${this_pkg}" MATCHES "jayenne"   OR
-        "${this_pkg}" MATCHES "capsaicin" OR
-        "${this_pkg}" MATCHES "core")
-      # If this is jayenne, we might be building a pull request. Replace the PR
-      # number in the path with '-develop' before looking for draco.
-      string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/"
-        "\\1_\\2-develop/" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    endif()
-  endif()
+  # not any ${extraparam} since many map to draco builds that have the same
+  # ${extraparam}.  For example: *-newtools-*.
+  foreach( extraparam nr perfbench vtest )
+    string( REGEX REPLACE "[-_]${extraparam}[-_]" "-" ${dep_pkg}_work_dir
+      ${${dep_pkg}_work_dir} )
+  endforeach()
+
+  # If this is jayenne, we might be building a pull request. Replace the PR
+  # number in the path with '-develop' before looking for draco.
+  string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/"
+    "\\1_\\2-develop/" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
 
   find_file( ${dep_pkg}_target_dir
     NAMES README.${dep_pkg} README.md
@@ -843,8 +837,8 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     NO_DEFAULT_PATH
   )
   if( NOT EXISTS ${${dep_pkg}_target_dir} )
-    message( FATAL_ERROR
-      "Could not locate the ${dep_pkg} installation directory.
+    message( FATAL_ERROR "
+      Could not locate the ${dep_pkg} installation directory.
       ${dep_pkg}_target_dir = ${${dep_pkg}_target_dir}
       ${dep_pkg}_work_dir   = ${${dep_pkg}_work_dir}")
   endif()

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -57,7 +57,7 @@ echo -e "umask: `umask`\n"
 #
 # 1. It mirrors git@github.com/lanl/Draco.git,
 #    git@gitlab.lanl.gov/jayenne/jayenne.git and
-#    git@gitlab.lanl.gov/capsaicin/capsaicin to these locations:
+#    git@gitlab.lanl.gov/capsaicin/core to these locations:
 #    - ccscs7:/ccs/codes/radtran/git
 #    - darwin-fe:/usr/projects/draco/regress/git
 #    On ccscs7, this is done to allow Redmine to parse the current repository
@@ -207,6 +207,7 @@ for project in ${github_projects[@]}; do
   fi
   run "chgrp -R draco $gitroot/${namespace}"
   run "chmod -R g+rwX,o=g-w $gitroot/${namespace}"
+  run "find draco -type d -exec chmod g+s {} \;"
 done
 
 # Gitlab.lanl.gov repositories:
@@ -237,6 +238,7 @@ for project in ${gitlab_projects[@]}; do
   fi
   run "chgrp -R ccsrad $gitroot/${namespace}"
   run "chmod -R g+rwX,o-rwX $gitroot/${namespace}"
+  run "find $gitroot/$namespace -type d -exec chmod g+s {} \;"
 
 done
 
@@ -248,7 +250,7 @@ if [[ ${target} == "ccscs7" ]]; then
 
   # Keep a copy of the bare repo for Redmine.  This version doesn't have the
   # PRs since this seems to confuse Redmine.
-  redmine_projects="jayenne capsaicin"
+  redmine_projects="jayenne core trt npt"
   for p in $redmine_projects; do
     echo -e "\n(Redmine) Copy ${p} git repository to the local file system..."
     if [[ -d $gitroot/${p}-redmine.git ]]; then
@@ -257,6 +259,8 @@ if [[ ${target} == "ccscs7" ]]; then
       run "git reset --soft"
       run "cd $gitroot"
       run "chmod -R g+rwX,o-rwX $gitroot/${p}-redmine.git"
+      run "find $gitroot/${p}-redmine.git -type d -exec chmod g+s {} \;"
+
     else
       run "mkdir -p $gitroot"
       run "cd $gitroot"
@@ -266,7 +270,7 @@ if [[ ${target} == "ccscs7" ]]; then
         run "git clone --bare git@gitlab.lanl.gov:${p}/${p}.git ${p}-redmine.git"
       fi
       run "chmod -R g+rwX,o-rwX ${p}-redmine.git"
-      run "chmod g+s ${p}-redmine.git"
+      run "find ${p}-redmine.git -type d -exec chmod g+s {} \;"
     fi
   done
 
@@ -324,14 +328,14 @@ for project in ${git_projects[@]}; do
       prs=`cat ${tmpfiles[${project}]} | grep -e 'refs/pull/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
       ;;
 
-    jayenne | capsaicin)
+    jayenne | core | trt | npt)
       # Extract PR number (if any)
       prs=`cat ${tmpfiles[${project}]} | grep -e 'refs/merge-requests/[0-9]*/\(head\|merge\)' | sed -e 's%.*/\([0-9][0-9]*\)/.*%\1%'`
       ;;
   esac
 
   case $repo in
-    Draco | jayenne | capsaicin )
+    Draco | jayenne | core | trt | npt)
       repo_lc=`echo $repo | tr '[:upper:]' '[:lower:]'`
       # remove any duplicates
       prs=`echo $prs | xargs -n1 | sort -u | xargs`

--- a/regression/sync_vendors.sh
+++ b/regression/sync_vendors.sh
@@ -91,6 +91,7 @@ vdir_subdirs=`\ls -1 $vdir`
 for dir in $vdir_subdirs; do
   run "chgrp -R draco $dir &> /dev/null"
   run "chmod -R g+rX,o+rX $dir &> /dev/null"
+  run "find $dir -type d -exec chmod g+s {} \;"
 done
 
 run "cd ${vdir}-ec"
@@ -98,6 +99,7 @@ vdir_subdirs=`\ls -1 ${vdir}-ec`
 for dir in $vdir_subdirs; do
   run "chgrp -R ccsrad $dir &> /dev/null"
   run "chmod -R g+rX,o-rwX $dir &> /dev/null"
+  run "find $dir -type d -exec chmod g+s {} \;"
 done
 
 #echo " "

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -324,6 +324,7 @@ if [[ ${regress_mode} == "on" ]]; then
   echo " "
   run "chgrp -R ccsrad ${work_dir}"
   run "chmod -R g+rX,o-rwX ${work_dir}"
+  run "chmod g+s ${work_dir}"
 fi
 
 echo "All done."


### PR DESCRIPTION
### Background

* The Transport teams use the scripts found in Draco's regression directory to control CI and nightly testing.  A code restructuring in one of these projects necessitates an update to the regression system.  This PR attempts to implement all the necessary changes.
* In reality, the non-draco, project specific scripts should probably be moved away from the Draco code repository.

### Purpose of Pull Request

* [Fixes Redmine Issue #1378](https://rtt.lanl.gov/redmine/issues/1378)

### Description of changes

+ Many changes to scripts to improve how file and directory permissions are established.  The biggest change is to try and set the group sticky bit (GID) for newly created directories.
+ Remove references to capsaicin by replacing them with core, npt or trt.
+ Update `checkpr.sh` to teach it about trt and npt dependencies.  In particular, trt-vtest regression runs will link to non-vtest versions of core. While, this logic should probably be generalized and moved into core, I didn't want to make those changes right now out of fear of creating too much new work associated with standing up regression and CI testing for trt and npt.
+ Simplify some of the logic in `draco_regression_macros.cmake` when trt or npt are looking for a core or draco installation.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
