### PR TITLE
Updates for win32 regressions

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -680,6 +680,7 @@ macro( SetupVendorLibrariesWindows )
 
   setupGSL()
   setupParMETIS()
+  setupSuperLU_DIST()
   setupRandom123()
   setupCOMPTON()
   setupEospac()

--- a/regression/Draco_Win32.cmake
+++ b/regression/Draco_Win32.cmake
@@ -114,12 +114,14 @@ if( ${CTEST_BUILD} AND ${CTEST_AUTODOC} )
    TARGET autodoc
    NUMBER_ERRORS num_errors
    NUMBER_WARNINGS num_warnings
+   FLAGS -j 24
    RETURN_VALUE res )" )
   ctest_build(
     TARGET autodoc
     RETURN_VALUE res
     NUMBER_ERRORS num_errors
     NUMBER_WARNINGS num_warnings
+    FLAGS "-j 24"
     )
   message( "build result:
    ${res}
@@ -138,8 +140,7 @@ if( ${CTEST_BUILD} )
       TARGET install
       RETURN_VALUE res
       NUMBER_ERRORS num_errors
-      NUMBER_WARNINGS num_warnings
-      )
+      NUMBER_WARNINGS num_warnings )
    message( "build result:
    ${res}
    Build errors  : ${num_errors}

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -200,8 +200,8 @@ win32$ set work_dir=c:/full/path/to/work_dir
    #   many cores we can use.
    include(ProcessorCount)
    ProcessorCount(num_compile_procs)
-   if( NOT WIN32 )
-       if(NOT num_compile_procs EQUAL 0)
+   if(NOT "${num_compile_procs}" EQUAL 0)
+      if( NOT WIN32 )
          set(CTEST_BUILD_FLAGS "-j${num_compile_procs} -l${num_compile_procs}")
          if( "${sitename}" STREQUAL "Trinity" OR "${sitename}" STREQUAL "Trinitite")
            # We compile on the front end for this machine. Since we don't know
@@ -212,13 +212,11 @@ win32$ set work_dir=c:/full/path/to/work_dir
            math(EXPR half_num_compile_procs "${num_compile_procs} / 2" )
            set(CTEST_BUILD_FLAGS "-j ${half_num_compile_procs} -l ${num_compile_procs}")
          endif()
-       endif()
-   else()
-     if(NOT num_compile_procs EQUAL 0)
-       # Parallel builds for 'msbuild'
-       # Ref: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2015
-       set(CTEST_BUILD_FLAGS "-m:${num_compile_procs}")
-     endif()
+      else()
+         # Parallel builds for 'msbuild'
+         # Ref: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2015
+         set(CTEST_BUILD_FLAGS "-m:${num_compile_procs}")
+      endif()
    endif()
 
    # Testing parallelism

--- a/src/VendorChecks/test/tstSuperludist.cc
+++ b/src/VendorChecks/test/tstSuperludist.cc
@@ -17,12 +17,18 @@
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include "ds++/path.hh"
+#include <fstream>
 #include <sstream>
+#include <vector>
+
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundef"
+#endif
 #include <superlu_ddefs.h>
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
-#include <vector>
+#endif
 
 // forward declarations
 void test_superludist(rtt_c4::ParallelUnitTest &ut);
@@ -83,6 +89,20 @@ void test_superludist(rtt_c4::ParallelUnitTest &ut) {
   std::string const inpPath = ut.getTestSourcePath();
   std::string const filename(inpPath + "big.rua");
   FILE *fp;
+
+#if 0
+  // check the file
+  if (rtt_c4::node() == 0) {
+    std::string line;
+    std::ifstream myfile(filename.c_str());
+    if (myfile.is_open()) {
+      while (getline(myfile, line)) {
+        std::cout << line << '\n';
+      }
+      myfile.close();
+    }
+  }
+#endif
 
   //---------------------------------------------------------------------------//
   // Initialize the SuperLU process grid
@@ -263,7 +283,7 @@ int dcreate_matrix(SuperMatrix *A, int nrhs, double **rhs, int *ldb, double **x,
   double *nzval;                   /* global */
   double *nzval_loc;               /* local */
   int_t *colind, *rowptr;          /* local */
-  int_t m, n, nnz;
+  int_t m(0), n(0), nnz(0);
   int_t m_loc, fst_row, nnz_loc;
   int_t m_loc_fst; /* Record m_loc of the first p-1 processors,
                            when mod(m, p) is not zero. */


### PR DESCRIPTION
### Description of changes

+ These changes have been 'hot' in our regression system for several weeks.
+ Switch to parallel compiles for regressions.  Some of this is hard coded for now.
+ Incremental updates toward supporint SuperLU-DIST on win32/Visual Studio.
  - Loook for the superlu-dist library during vendor discovery.
  - Use proper CPP macros in `tstSuperludist.cc` to enable compiler specific pragmas.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
