### PR TITLE
Fix RelWithDebInfo builds.

### DIFF
--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -24,7 +24,7 @@
 
 /* Version Inforation */
 #define Draco_BUILD_DATE "@Draco_BUILD_DATE@"
-#define Draco_BUILD_TYPE "@Draco_BUILD_TYPE@"
+#define Draco_BUILD_TYPE @Draco_BUILD_TYPE@
 #cmakedefine Draco_VERSION @Draco_VERSION@
 #cmakedefine Draco_VERSION_FULL @Draco_VERSION_FULL@
 #define Draco_VERSION_MAJOR "@Draco_VERSION_MAJOR@"

--- a/src/ds++/test/CMakeLists.txt
+++ b/src/ds++/test/CMakeLists.txt
@@ -56,6 +56,11 @@ if( draco_isPGI )
    )
 endif()
 
+# tstData_Table.cc will fail for RelWithDebugInfo. Set extra CPP macros as a
+# work-around:
+set_target_properties( Ut_dsxx_tstData_Table_exe
+  PROPERTIES COMPILE_DEFINITIONS $<UPPER_CASE:$<CONFIG>> )
+
 # create the do_exception execurtable.
 add_executable( Exe_do_exception ${PROJECT_SOURCE_DIR}/do_exception.cc )
 target_link_libraries( Exe_do_exception Lib_dsxx )

--- a/src/ds++/test/tstData_Table.cc
+++ b/src/ds++/test/tstData_Table.cc
@@ -128,6 +128,8 @@ void test_scalar(rtt_dsxx::UnitTest &ut) {
   }
   FAIL_IF(caught);
 
+#ifndef RELWITHDEBINFO
+
   caught = false;
   try {
     std::cout << dt[1];
@@ -135,6 +137,8 @@ void test_scalar(rtt_dsxx::UnitTest &ut) {
     caught = true;
   }
   FAIL_IF_NOT(caught);
+
+#endif
 
   if (ut.numFails == 0)
     PASSMSG("test_scalar");


### PR DESCRIPTION
### Details

+ An older test fails to compile for RelWithDebInfo build type. This is due to new sanitizer checks and is correct behavior.  Use CPP macros to remove this portion of the test for RelWithDebInfo build types.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
