### PR TITLE
Simplify some function signatures in CDI calls

### DIFF
--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -299,6 +299,55 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 
 //---------------------------------------------------------------------------//
 /*!
+ * \brief Integrate the Planckian Specrum over an entire a set of frequency
+ *        groups directly returning the vector of the integrals
+ *
+ * \param bounds The vector of group boundaries. Size n+1
+ * \param T The temperature
+ * \return vector containing the Planckian integrals. Size n_groups
+ */
+std::vector<double>
+CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
+                                  double const T) {
+  Require(T >= 0.0);
+  Require(bounds.size() > 0);
+
+  size_t const groups(bounds.size() - 1);
+  std::vector<double> planck(groups, 0.0);
+
+  // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
+  // return early with planck == 0.0. This avoids a possible divide by zero.
+  if (T <= bounds[0] * std::numeric_limits<double>::min())
+    return planck;
+
+  // Initialize the loop:
+  double scaled_frequency = bounds[0] / T;
+  double planck_value = integrate_planck(scaled_frequency);
+
+  for (size_t group = 0; group < groups; ++group) {
+    // Shift the data down:
+    Remember(double const last_scaled_frequency = scaled_frequency;);
+    double const last_planck = planck_value;
+
+    // New values:
+    if (T <= bounds[group + 1] * std::numeric_limits<double>::min())
+      planck[group] = 0.0;
+    else {
+      scaled_frequency = bounds[group + 1] / T;
+      Ensure(scaled_frequency > last_scaled_frequency);
+      planck_value = integrate_planck(scaled_frequency);
+
+      // Record the definite integral between frequencies.
+      planck[group] = planck_value - last_planck;
+    }
+    Ensure(planck[group] >= 0.0);
+    Ensure(planck[group] <= 1.0);
+  }
+  return planck;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * \brief Integrate the Rosseland Spectrum over an entire a set of frequency
  *        groups, returning a vector of the integrals
  *
@@ -464,6 +513,67 @@ double CDI::collapseMultigroupOpacitiesPlanck(
     sig_planck_sum += planckSpectrum[g - 1] * opacity[g - 1];
     // Also collect some CDF data.
     emission_group_cdf[g - 1] = sig_planck_sum;
+  }
+
+  //                         int_{\nu_0}^{\nu_G}{d\nu sigma(\nu,T) * B(\nu,T)}
+  // Planck opac:  sigma_P = --------------------------------------------------
+  //                         int_{\nu_0}^{\nu_G}{d\nu * B(\nu,T)}
+
+  double planck_opacity(0.0);
+  if (planck_integral > 0.0)
+    planck_opacity = sig_planck_sum / planck_integral;
+  else {
+    // Weak check that the zero integrated Planck is due to a cold temperature
+    // whose Planckian peak is below the lowest (first) group boundary.
+    Check(rtt_dsxx::soft_equiv(sig_planck_sum, 0.0));
+    // Check( T >= 0.0 );
+    // Check( 3.0 * T <= groupBounds[0] );
+
+    // Set the ill-defined integrated Planck opacity to zero.
+    // planck_opacity = 0.0; // already initialized to zero.
+  }
+  Ensure(planck_opacity >= 0.0);
+  return planck_opacity;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Collapse a multigroup opacity set into a single representative value
+ *        weighted by the Planckian function without setting the emission CDF
+ *
+ * \param groupBounds The vector of group boundaries.
+ * \param opacity   A vector of multigroup opacity data.
+ * \param planckSpectrum A vector of Planck integrals for all groups in the
+ *                  spectrum (normally generated via
+ *                  CDI::integrate_Rosseland_Planckian_Sectrum(...).
+ * \return A single interval Planckian weighted opacity value.
+ *
+ * Typically, CDI::integrate_Rosseland_Planckian_Spectrum is called before this
+ * function to obtain planckSpectrum.
+ */
+double CDI::collapseMultigroupOpacitiesPlanck(
+    std::vector<double> const &groupBounds, std::vector<double> const &opacity,
+    std::vector<double> const &planckSpectrum) {
+  Require(groupBounds.size() > 0);
+  Require(opacity.size() == groupBounds.size() - 1);
+  Require(planckSpectrum.size() == groupBounds.size() - 1);
+
+  // Integrate the unnormalized Planckian over the group spectrum
+  // int_{\nu_0}^{\nu_G}{d\nu B(\nu,T)}
+  double const planck_integral =
+      std::accumulate(planckSpectrum.begin(), planckSpectrum.end(), 0.0);
+  Check(planck_integral >= 0.0);
+
+  // Perform integration of sigma * b_g over all groups:
+  // int_{\nu_0}^{\nu_G}{d\nu sigma(\nu,T) * B(\nu,T)}
+
+  // Initialize sum:
+  double sig_planck_sum(0.0);
+  // Multiply by the absorption opacity and accumulate.
+  for (size_t g = 1; g < groupBounds.size(); ++g) {
+    Check(planckSpectrum[g - 1] >= 0.0);
+    Check(opacity[g - 1] >= 0.0);
+    sig_planck_sum += planckSpectrum[g - 1] * opacity[g - 1];
   }
 
   //                         int_{\nu_0}^{\nu_G}{d\nu sigma(\nu,T) * B(\nu,T)}

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -590,6 +590,14 @@ public:
                                     std::vector<double> const &planckSpectrum,
                                     std::vector<double> &emission_group_cdf);
 
+  //! Collapse Multigroup data to single-interval data with Planck weighting
+  // (without setting the emission CDF)
+  static double
+  collapseMultigroupOpacitiesPlanck(std::vector<double> const &groupBounds,
+                                    // double              const & T,
+                                    std::vector<double> const &opacity,
+                                    std::vector<double> const &planckSpectrum);
+
   /*!
    * \brief Collapse Multigroup data to single-interval reciprocal data with
    *        Planck weighting.
@@ -696,6 +704,11 @@ public:
                                            double const T,
                                            std::vector<double> &planck);
 
+  //! Integrate the Planckian over all frequency groups and return vector
+  static std::vector<double>
+  integrate_Planckian_Spectrum(std::vector<double> const &bounds,
+                               double const T);
+
   //! Integrate the Rosseland over all frequency groups
   static void integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
                                            double const T,
@@ -731,7 +744,7 @@ double CDI::integrate_planck(double const scaled_freq) {
  *        (\frac{h\nu}{kT}) \f$.
  *
  * \param scaled_freq upper integration limit, scaled by the temperature.
- * \param exp_scaled_freq upper integration limit, scaled by an exponential 
+ * \param exp_scaled_freq upper integration limit, scaled by an exponential
  *           function.
  * \return integrated normalized Plankian from 0 to x \f$(\frac{h\nu}{kT})\f$
  *
@@ -772,7 +785,7 @@ double CDI::integrate_planck(double const scaled_freq,
  *         \f$ x (\frac{h\nu}{kT}) \f$.
  *
  * \param scaled_freq frequency upper integration limit scaled by temperature
- * \param exp_scaled_freq upper integration limit, scaled by an exponential 
+ * \param exp_scaled_freq upper integration limit, scaled by an exponential
  *           function.
  * \param planck Variable to return the Planck integral
  * \param rosseland Variable to return the Rosseland integral

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -707,6 +707,12 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
     double const T_eval = 1.0e-300;
     std::vector<double> planck;
     CDI::integrate_Planckian_Spectrum(bounds, T_eval, planck);
+
+    // make sure the alternate calling method returns the same values
+    auto planck_alt = CDI::integrate_Planckian_Spectrum(bounds, T_eval);
+
+    if (planck_alt != planck)
+      ITFAILS;
     if (!soft_equiv(planck[0], 0.0, tol))
       ITFAILS;
   }
@@ -717,6 +723,10 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
     double const T_eval = 1.0e-308;
     std::vector<double> planck;
     CDI::integrate_Planckian_Spectrum(bounds, T_eval, planck);
+    // make sure the alternate calling method returns the same values
+    auto planck_alt = CDI::integrate_Planckian_Spectrum(bounds, T_eval);
+    if (planck_alt != planck)
+      ITFAILS;
     if (!soft_equiv(planck, std::vector<double>(planck.size(), 0.0), tol))
       ITFAILS;
   }
@@ -727,6 +737,10 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
     double const T_eval = 1.0e-308;
     std::vector<double> planck;
     CDI::integrate_Planckian_Spectrum(bounds, T_eval, planck);
+    // make sure the alternate calling method returns the same values
+    auto planck_alt = CDI::integrate_Planckian_Spectrum(bounds, T_eval);
+    if (planck_alt != planck)
+      ITFAILS;
     if (!soft_equiv(planck, std::vector<double>(planck.size(), 0.0), tol))
       ITFAILS;
   }
@@ -808,6 +822,8 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
   std::vector<double> planck;
 
   CDI::integrate_Planckian_Spectrum(group_bounds, 1.0, planck);
+  // make sure the alternate calling method returns the same values
+  auto planck_alt = CDI::integrate_Planckian_Spectrum(group_bounds, 1.0);
 
   for (int group_index = 1; group_index <= 3; ++group_index) {
 
@@ -816,9 +832,13 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
     if (!soft_equiv(planck[group_index - 1], planck_g))
       ITFAILS;
   }
+  if (planck_alt != planck)
+    ITFAILS;
 
   // Test zero temperature special case
   CDI::integrate_Planckian_Spectrum(group_bounds, 0.0, planck);
+  // make sure the alternate calling method returns the same values
+  auto planck_alt_zero = CDI::integrate_Planckian_Spectrum(group_bounds, 0.0);
 
   for (int group_index = 1; group_index <= 3; ++group_index) {
 
@@ -827,6 +847,8 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
     if (!soft_equiv(planck[group_index - 1], planck_g))
       ITFAILS;
   }
+  if (planck_alt_zero == planck)
+    ITFAILS;
 
   if (ut.numFails == 0)
     PASSMSG("Group-wise and Full spectrum Planckian and Rosseland integrals "
@@ -1196,12 +1218,18 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
     // Collapse the opacities:
     double const opacity_pl = CDI::collapseMultigroupOpacitiesPlanck(
         bounds, mgOpacities, planck_spectrum, emission_group_cdf);
+    // Make sure you get the same answer with the version that doesn't
+    // calculate emission CDF
+    double const opacity_pl_alt = CDI::collapseMultigroupOpacitiesPlanck(
+        bounds, mgOpacities, planck_spectrum);
     double const opacity_pl_recip =
         CDI::collapseMultigroupReciprocalOpacitiesPlanck(bounds, mgOpacities,
                                                          planck_spectrum);
     double const opacity_ross = CDI::collapseMultigroupOpacitiesRosseland(
         bounds, mgOpacities, rosseland_spectrum);
 
+    if (!soft_equiv(opacity_pl, opacity_pl_alt, 1.0e-12))
+      ITFAILS;
     if (!soft_equiv(opacity_pl, opacity_pl_ref))
       ITFAILS;
     if (!soft_equiv(opacity_pl_recip, opacity_pl_recip_ref))
@@ -1234,6 +1262,11 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
     // Collapse the opacities:
     double const opacity_pl = CDI::collapseMultigroupOpacitiesPlanck(
         bounds, mgOpacities, planck_spectrum, emission_group_cdf);
+    // Make sure you get the same answer with the version that doesn't
+    // calculate emission CDF
+    double const opacity_pl_alt = CDI::collapseMultigroupOpacitiesPlanck(
+        bounds, mgOpacities, planck_spectrum);
+
     double const opacity_pl_recip =
         CDI::collapseMultigroupReciprocalOpacitiesPlanck(bounds, mgOpacities,
                                                          planck_spectrum);
@@ -1250,6 +1283,8 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
     double const opacity_pl_recip_ref(8.80345577340399);
     double const opacity_ross_ref(0.0778314764921229);
 
+    if (!soft_equiv(opacity_pl, opacity_pl_alt, 1.0e-12))
+      ITFAILS;
     if (!soft_equiv(opacity_pl, opacity_pl_ref))
       ITFAILS;
     if (!soft_equiv(opacity_pl_recip, opacity_pl_recip_ref))
@@ -1288,12 +1323,19 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
     // Collapse the opacities:
     double const opacity_pl = CDI::collapseMultigroupOpacitiesPlanck(
         bounds, mgOpac, planck_spectrum, emission_group_cdf);
+    // Make sure you get the same answer with the version that doesn't
+    // calculate emission CDF
+    double const opacity_pl_alt =
+        CDI::collapseMultigroupOpacitiesPlanck(bounds, mgOpac, planck_spectrum);
+
     double const opacity_pl_recip =
         CDI::collapseMultigroupReciprocalOpacitiesPlanck(bounds, mgOpac,
                                                          planck_spectrum);
     double const opacity_ross = CDI::collapseMultigroupOpacitiesRosseland(
         bounds, mgOpac, rosseland_spectrum);
 
+    if (!soft_equiv(opacity_pl, opacity_pl_alt, 1.0e-12))
+      ITFAILS;
     if (!soft_equiv(opacity_pl, opacity_pl_ref))
       ITFAILS;
     if (!soft_equiv(opacity_pl_recip, opacity_pl_recip_ref))
@@ -1330,9 +1372,16 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
     // Collapse the opacities:
     double const opacity_pl = CDI::collapseMultigroupOpacitiesPlanck(
         bounds, mgOpacities, planck_spectrum, emission_group_cdf);
+    // Make sure you get the same answer with the version that doesn't
+    // calculate emission CDF
+    double const opacity_pl_alt = CDI::collapseMultigroupOpacitiesPlanck(
+        bounds, mgOpacities, planck_spectrum);
+
     double const opacity_ross = CDI::collapseMultigroupOpacitiesRosseland(
         bounds, mgOpacities, rosseland_spectrum);
 
+    if (!soft_equiv(opacity_pl, opacity_pl_alt, 1.0e-12))
+      ITFAILS;
     if (!soft_equiv(opacity_pl, opacity_pl_ref))
       ITFAILS;
     if (!soft_equiv(opacity_ross, opacity_ross_ref))


### PR DESCRIPTION
### Background

* There are several places within the Jayenne library where we use `collapseMultigroupOpacitiesPlanck` and `integrate_Planck_Spectrum` where the function call site is a bit cluttered by building vectors to pass to these functions. In the case of `collapseMultigroupOpacitiesPlanck` we rarely use the CDF it takes as an argument and populates. This PR simplifies these two functions.

### Purpose of Pull Request

* Provide a version of `collapseMultigroupOpacitiesPlanck` that does not require a vector of CDFs as an argument.
* Provide a version of `integrate_Planck_Spectrum` that returns a vector instead of setting a passed in vector.
* [Fixes Redmine Issue #1401](https://rtt.lanl.gov/redmine/issues/1401)

### Description of changes

* Add a version of collapseMultigroupOpacitiesPlanck that doesn't calculate the groupwise CDF (this is not needed by several functions and complicates the surrounding call)
* Add a version of integrate_Planckian_Spectrum that simply returns a vector with the Planck integral over each group as opposed to passing in this vector
* Modifiy tCDI.cc so that any time the original version of these functions is called they are checked for consistency against the new alternate functions.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
