### PR TITLE
Update compile flags for XL.

### DIFF
--- a/config/unix-xlf.cmake
+++ b/config/unix-xlf.cmake
@@ -13,16 +13,11 @@ set( CMAKE_Fortran_COMPILER_FLAVOR "XL" )
 
 if( NOT Fortran_FLAGS_INITIALIZED )
    set( Fortran_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
-   set( CMAKE_Fortran_COMPILER_VERSION ${CMAKE_Fortran_COMPILER_VERSION} CACHE
-        STRING "Fortran compiler version string" FORCE )
-   mark_as_advanced( CMAKE_Fortran_COMPILER_VERSION )
-
-   set( CMAKE_Fortran_FLAGS                "-qlanglvl=2003std -qinfo=all -qflag=i:w -qarch=auto" )
-   set( CMAKE_Fortran_FLAGS_DEBUG          "-g -O0 -qnosmp -qcheck" )
+   set( CMAKE_Fortran_FLAGS                "-qlanglvl=2008std -qinfo=all -qflag=i:w -qarch=auto" )
+   set( CMAKE_Fortran_FLAGS_DEBUG          "-g -O0 -qcheck" ) #-qsmp=noauto
    set( CMAKE_Fortran_FLAGS_RELEASE        "-O3 -qhot=novector -qsimd=auto -qstrict=nans:operationprecision" )
    set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_RELEASE}" )
    set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -O3 -qhot=novector -qsimd=auto -qstrict=nans:operationprecision" )
-
 endif()
 
 ##---------------------------------------------------------------------------##
@@ -37,7 +32,8 @@ set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}" 
 #
 # Toggle compiler flags for optional features
 #
-toggle_compiler_flag( OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "" )
+#toggle_compiler_flag( OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "" )
+#toggle_compiler_flag( OPENMP_FOUND "-qsmp=noauto" "Fortran" "" )
 
 # ----------------------------------------------------------------------------
 # Helper macro to fix the value of
@@ -48,25 +44,25 @@ toggle_compiler_flag( OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "" )
 # link line when a C++ main the link line and actually causes the link
 # to fail on SQ.
 # ----------------------------------------------------------------------------
-macro( remove_lib_from_link lib_for_removal )
+# macro( remove_lib_from_link lib_for_removal )
 
-   set( tmp "" )
-   foreach( lib ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES} )
-      if( ${lib} MATCHES ${lib_for_removal} )
-         message("Removing ${lib_for_removal} from CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES")
-         # do not add ${lib_for_removal} to the list ${tmp}.
-      else()
-         # Add a libraries except for the above match to the new list.
-         list( APPEND tmp ${lib} )
-      endif()
-   endforeach()
+#    set( tmp "" )
+#    foreach( lib ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES} )
+#       if( ${lib} MATCHES ${lib_for_removal} )
+#          message("Removing ${lib_for_removal} from CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES")
+#          # do not add ${lib_for_removal} to the list ${tmp}.
+#       else()
+#          # Add a libraries except for the above match to the new list.
+#          list( APPEND tmp ${lib} )
+#       endif()
+#    endforeach()
 
-   # Ensure that the value is saved to CMakeCache.txt
-   set( CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "${tmp}" CACHE STRING
-      "Extra Fortran libraries needed when linking to Fortral library from C++ target"
-      FORCE )
+#    # Ensure that the value is saved to CMakeCache.txt
+#    set( CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "${tmp}" CACHE STRING
+#       "Extra Fortran libraries needed when linking to Fortral library from C++ target"
+#       FORCE )
 
-endmacro()
+# endmacro()
 
 # When building on SQ with XLC/XLF90, ensure that libxlomp_ser is not
 # on the link line

--- a/src/FortranChecks/test/CMakeLists.txt
+++ b/src/FortranChecks/test/CMakeLists.txt
@@ -34,9 +34,9 @@ set( ptest_sources
 
 # When building on SQ with XLC/XLF90, ensure that libxlomp_ser is not
 # on the link line.  This macro is defined in config/unix-xlf.cmake.
-if( ${CMAKE_Fortran_COMPILER_FLAVOR} MATCHES "XL" )
-  remove_lib_from_link( "xlomp_ser" )
-endif()
+#if( ${CMAKE_Fortran_COMPILER_ID} MATCHES "XL" )
+#  remove_lib_from_link( "xlomp_ser" )
+#endif()
 
 # When building with MVSE and linking Fortran libraries generated with MinGW's
 # gfortran, the libquadmath-0.dll library must be found in the path.


### PR DESCRIPTION
### Background

* We were asked to evaluate the latest XL compilers on Darwin.  Bottom line is that the XL compilers don't seem to have support for C++14.  
* We still want to capture the updated compiler flags and options so more testing can be done on Sierra.

### Purpose of Pull Request

* [Fixes Redmine Issue #1126](https://rtt.lanl.gov/redmine/issues/1126)

### Description of changes

+ Tested on Darwin/p9 (`module load ibm/xlc-16.1.1.2-xlf-16.1.1.2-gcc-7.3.0`)
+ This version of XL will not compile Draco.  It breaks when we use `std::unique` from `<algorithm>`.
+ This change set captures flags used while testing on Darwin.  This work will continue on Sierra.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
