### PR TITLE
Minor fix: xthi & ythi output formatting

### DIFF
--- a/src/c4/bin/xthi.hh
+++ b/src/c4/bin/xthi.hh
@@ -106,7 +106,7 @@ std::string cpuset_to_string(unsigned const /*num_cpu*/) {
       if (run == 0)
         cpuset << i << ",";
       else
-        cpuset << i << "" << i + run << ",";
+        cpuset << i << "-" << i + run << ",";
       i += run;
     }
   }


### PR DESCRIPTION
### Background

* Change output format of xthi/ythi so it's closer to the usual.

### Purpose of Pull Request

* See above

### Description of changes

* As above

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
