### PR TITLE
Change authentication method for nightly regression.

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -106,7 +106,7 @@ macro( setupLAPACKLibraries )
 
     # The above might define blas, or it might not. Double check:
     if( NOT TARGET blas )
-      find_package( BLAS )
+      find_package( BLAS QUIET)
       if( BLAS_FOUND )
         add_library( blas STATIC IMPORTED)
         set_target_properties( blas PROPERTIES
@@ -193,7 +193,8 @@ macro( setupLAPACKLibraries )
         set_target_properties( blas PROPERTIES
           IMPORTED_LOCATION                 "${BLAS_mkl_intel_lp64_LIBRARY}"
           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-          IMPORTED_LINK_INTERFACE_LIBRARIES "-Wl,--start-group;${BLAS_mkl_core_LIBRARY};${BLAS_${tlib}_LIBRARY};-Wl,--end-group"
+          IMPORTED_LINK_INTERFACE_LIBRARIES blas::mkl_core
+#          IMPORTED_LINK_INTERFACE_LIBRARIES "-Wl,--start-group;${BLAS_mkl_core_LIBRARY};${BLAS_${tlib}_LIBRARY};-Wl,--end-group"
           IMPORTED_LINK_INTERFACE_MULTIPLICITY 20)
         set_target_properties( lapack PROPERTIES
           IMPORTED_LOCATION                 "${BLAS_mkl_intel_lp64_LIBRARY}"

--- a/environment/bashrc/.bashrc_slurm
+++ b/environment/bashrc/.bashrc_slurm
@@ -105,7 +105,7 @@ case ${-} in
    # %F - Number of nodes by state in the form allocated/idle/other/total
    alias idle='sinfo -l | egrep "(idle|PARTITION)"; echo " "; sinfo -o "%P %t %F" -p standard -t idle; echo "(A)llocated, (I)dle, (O)ther, (T)otal"'
    alias sfeatures='sinfo -o "%P %.5a %.10l %.6D %.6t %N %f"'
-   alias slimits='sacctmgr show QOS'
+   alias slimits='sacctmgr show qos format=name%12,priority%3,MaxTRES%8,MaxWall,MaxTRESPU%9,MaxJobsPU%6,GraceTime,Preempt%20,Flags%40'
    alias knownqos='sacctmgr show qos format=name,priority'
    alias knownaccounts='sacctmgr show account format=account%20,description'
    alias knownreservations='sacctmgr show reservation' # format=Nane%20,Start,End

--- a/regression/cts1-regress.msub
+++ b/regression/cts1-regress.msub
@@ -232,13 +232,15 @@ comp=$comp-$featurebranch
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
+  target=`uname -n | sed -e 's/[.].*//g'`
   keychain=keychain-2.8.5
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
-  if test -f $HOME/.keychain/$machine-sh; then
-    run "source $HOME/.keychain/$machine-sh"
-  else
-    echo "Error: could not find $HOME/.keychain/$machine-sh"
+  run "$VENDOR_DIR/$keychain/keychain --agents ssh regress_rsa"
+  if [[ `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c Error` != 0 ||
+        `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c authentication` != 0 ]]; then
+    run "source ~/.keychain/${target}-sh"
   fi
+  # run "$VENDOR_DIR/$keychain/keychain -l"
+  # run "ssh-add -L"
 fi
 
 # ----------------------------------------

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -113,7 +113,7 @@ case ${target} in
     regdir=/usr/projects/draco/regress
     gitroot=$regdir/git
     VENDOR_DIR=/usr/projects/draco/vendors
-    keychain=keychain-2.7.1
+    keychain=keychain-2.8.5
     ;;
   sn-fey*)
     run "module use --append /usr/projects/hpcsoft/modulefiles/toss3/snow/compiler"
@@ -125,7 +125,7 @@ case ${target} in
     regdir=/usr/projects/jayenne/regress
     gitroot=$regdir/git.sn
     VENDOR_DIR=/usr/projects/draco/vendors
-    keychain=keychain-2.8.2
+    keychain=keychain-2.8.5
     ;;
   tt-fey*)
     run "module use /usr/projects/hpcsoft/modulefiles/cle6.0/trinitite/misc"
@@ -134,7 +134,7 @@ case ${target} in
     regdir=/usr/projects/jayenne/regress
     gitroot=$regdir/git.tt
     VENDOR_DIR=/usr/projects/draco/vendors
-    keychain=keychain-2.8.2
+    keychain=keychain-2.8.5
     ;;
 esac
 
@@ -144,14 +144,14 @@ fi
 
 # Credentials via Keychain (SSH)
 # http://www.cyberciti.biz/faq/ssh-passwordless-login-with-keychain-for-scripts
-if [[ -f $HOME/.ssh/id_rsa ]]; then
-  MYHOSTNAME="`uname -n`"
-  run "$VENDOR_DIR/$keychain/keychain $HOME/.ssh/id_rsa"
-  if [[ -f $HOME/.keychain/$MYHOSTNAME-sh ]]; then
-    run "source $HOME/.keychain/$MYHOSTNAME-sh"
-  else
-    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+if [[ -f $HOME/.ssh/regress_rsa ]]; then
+  run "$VENDOR_DIR/$keychain/keychain --agents ssh regress_rsa"
+  if [[ `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c Error` != 0 ||
+        `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c authentication` != 0 ]]; then
+    run "source ~/.keychain/${target}-sh"
   fi
+  #run "$VENDOR_DIR/$keychain/keychain -l"
+  #run "ssh-add -L"
 fi
 
 # ---------------------------------------------------------------------------- #

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -183,13 +183,14 @@ comp=$comp-$featurebranch
 # When run by crontab, use a special ssh-key to allow authentication to gitlab
 if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
-  keychain=keychain-2.8.2
-  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
-  if test -f $HOME/.keychain/$machine-sh; then
-    run "source $HOME/.keychain/$machine-sh"
-  else
-    echo "Error: could not find $HOME/.keychain/$machine-sh"
+  keychain=keychain-2.8.5
+  run "$VENDOR_DIR/$keychain/keychain --agents ssh regress_rsa"
+  if [[ `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c Error` != 0 ||
+        `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c authentication` != 0 ]]; then
+    run "source ~/.keychain/${machine}-sh"
   fi
+  #run "$VENDOR_DIR/$keychain/keychain -l"
+  #run "ssh-add -L"
 fi
 
 # ----------------------------------------

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -38,7 +38,7 @@ echo -e "umask: `umask` \n"
 case ${target} in
   darwin-fe* | cn[0-9]*)
     REGDIR=/usr/projects/draco/regress
-    keychain=keychain-2.7.1
+    keychain=keychain-2.8.5
     VENDOR_DIR=/usr/projects/draco/vendors
     # personal copy of ssh-agent.
     export PATH=$HOME/bin:$PATH
@@ -57,6 +57,7 @@ case ${target} in
   sn-* | ba-* | tt-* )
     REGDIR=/usr/projects/jayenne/regress
     VENDOR_DIR=/usr/projects/draco/vendors
+    keychain=keychain-2.8.5
     ;;
   *)
     REGDIR=/scratch/regress
@@ -64,14 +65,14 @@ case ${target} in
 esac
 
 # Load some identities used for accessing gitlab.
-if [[ -f $HOME/.ssh/id_rsa ]]; then
-  MYHOSTNAME="`uname -n`"
-  run "$VENDOR_DIR/$keychain/keychain $HOME/.ssh/id_rsa"
-  if [[ -f $HOME/.keychain/$MYHOSTNAME-sh ]]; then
-    run "source $HOME/.keychain/$MYHOSTNAME-sh"
-  else
-    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+if [[ -f $HOME/.ssh/regress_rsa ]]; then
+  run "$VENDOR_DIR/$keychain/keychain --agents ssh regress_rsa"
+  if [[ `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c Error` != 0 ||
+        `$VENDOR_DIR/$keychain/keychain -l 2>&1 | grep -c authentication` != 0 ]]; then
+    run "source ~/.keychain/${target}-sh"
   fi
+  #run "$VENDOR_DIR/$keychain/keychain -l"
+  #run "ssh-add -L"
 fi
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
### Background

* Regression testing has had some issues lately with accessing the github and gitlab repositories.  Rework the authentication method used by these scripts to improve robustness.
* Also tweak a couple of other items like MKL discovery and linking and output formatting for the bash alias `slimits`.

### Description of changes

+ Rework the way the regression system authenticates so that access to the code repositories is more robust.
+ Make the bash function 'slimits' a little more useful
+ Also tweak MKL discovery and link commands.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
