### PR TITLE
Modify check_style.sh to use target branch for merge as baseline

### DIFF
--- a/regression/check_style.sh
+++ b/regression/check_style.sh
@@ -125,7 +125,7 @@ echo " "
 patchfile_c=$(mktemp /tmp/gcf.patch.XXXXXXXX)
 
 # don't actually modify the files (compare to branch 'develop')
-cmd="${gcf} --binary ${cf} -f --diff --extensions hh,cc,cu develop"
+cmd="${gcf} --binary ${cf} -f --diff --extensions hh,cc,cu ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}"
 run "${cmd}" &> $patchfile_c
 
 # if the patch file has the string "no modified files to format", the check


### PR DESCRIPTION

### Background

check_style.sh currently hardwires "develop" as the branch against which a merge request is to be compared when checking code style. This fails for the Capsaicin team, where merges are often targeted to branch "refactor" rather than "develop" and the "develop" branch is not a parent of "refactor".

### Purpose of Pull Request

Modify the script to make the style check against the branch that is being targeted for the merge.

### Description of changes

Modify check_style.sh to substitute ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} for develop.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
