### PR TITLE
Add graphic dump reset time, to refine overwrite behavior.

### DIFF
--- a/src/viz/Ensight_Translator.hh
+++ b/src/viz/Ensight_Translator.hh
@@ -229,7 +229,8 @@ public:
   Ensight_Translator(const std_string &prefix, const std_string &gd_wpath,
                      const SSF &vdata_names, const SSF &cdata_names,
                      const bool overwrite = false,
-                     const bool static_geom = false, const bool binary = false);
+                     const bool static_geom = false, const bool binary = false,
+                     const double reset_time = -1.0);
 
   // Do an Ensight_Dump.
   template <typename ISF, typename IVF, typename SSF, typename FVF>

--- a/src/viz/test/tstEnsight_Translator.cc
+++ b/src/viz/test/tstEnsight_Translator.cc
@@ -181,7 +181,7 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, bool const binary) {
   // build another ensight translator; this should overwrite the existing
   // directories
   Ensight_Translator translator2(prefix, gd_wpath, vdata_names, cdata_names,
-                                 true, static_geom, binary);
+                                 false, static_geom, binary);
 
   translator2.ensight_dump(icycle, time, dt, ipar, iel_type, rgn_index, pt_coor,
                            vrtx_data, cell_data, rgn_data, rgn_name);
@@ -196,9 +196,9 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, bool const binary) {
   translator3.ensight_dump(2, .05, dt, ipar, iel_type, rgn_index, pt_coor,
                            vrtx_data, cell_data, rgn_data, rgn_name);
 
-  // make yet a fourth translator that will append
+  // make yet a fourth translator that will append from the reset time
   Ensight_Translator translator4(prefix, gd_wpath, vdata_names, cdata_names,
-                                 false, static_geom, binary);
+                                 false, static_geom, binary, .05);
 
   // add yet another dump to the existing data
   translator4.ensight_dump(3, .10, dt, ipar, iel_type, rgn_index, pt_coor,


### PR DESCRIPTION
### Background

* Ensight file generation either appends existing ensight files or fully overwrites them.
* For better consistency with restart behavior, it may be worthwhile to permit partial rewriting of Ensight dump files: overwriting dumps after a time provided to the Ensight translator.
*  The implementation in this PR is supposed to be flexible enough to preserve old behavior, and even permit overwriting Ensight dumps some number of cycles after a restart.

### Purpose of Pull Request

* Permit partial overwriting of Ensight dumps when not fully overwriting.
* [Fixes Redmine Issue #1425](https://rtt.lanl.gov/redmine/issues/1425)

### Description of changes

+ Add optional reset time parameter to ctor of Ensight_Translator.
+ Erase dump times after reset time from case file parsed in ctor.
+ Update Ensight_Translator unit test to test a partial overwrite.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
