### PR TITLE
WIP: Modified CMake to not override language standards

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -144,16 +144,17 @@ macro(dbsSetupCxx)
   # set_target_properties( <tgt> PROPERTIES C_STANDARD 11 ... )
 
   # C11 support:
-  set( CMAKE_C_STANDARD 11 )
+  if( CMAKE_C_STANDARD LESS 11)
+	  message(FATAL_ERROR "Draco Requires C standard >= 11")
+  endif()
 
   # C++14 support:
-  set( CMAKE_CXX_STANDARD 14 )
-  set( CMAKE_CXX_STANDARD_REQUIRED ON )
+  if( CMAKE_CXX_STANDARD LESS 14 )
+	  message(FATAL_ERROR "Draco Requires C++ standard >= 14")
+  endif()
 
   # Do not enable extensions (e.g.: --std=gnu++11)
   # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
-  set( CMAKE_CXX_EXTENSIONS OFF )
-  set( CMAKE_C_EXTENSIONS   OFF )
 
   # -fPIC by default
   set( CMAKE_POSITION_INDEPENDENT_CODE ON )


### PR DESCRIPTION
Fixed issues where Draco would override language standards for projects including it with find_package(Draco)

### Background

A lot of Draco's logic when included as a target is fairly invasive and overrides project defaults. A proper investigation is needed, but for now we can make progress by fixing this issue.

As it stands, Draco will force any project to C++14 and C11. This is problematic for codes that may require C++17 features

### Purpose of Pull Request

Change check for C11 and C++14 support into checks, not sets.

### Description of changes

Changed check for C11 and C++14 to check if the project's standard meets requirements and errror if otherwise.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
