### PR TITLE
Use CMake  to set C++ standard flags for Intel

### DIFF
--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -47,8 +47,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO
     "-g -debug inline-debug-info -O3 -pthread -fp-model precise -fp-speculation safe -fno-omit-frame-pointer" )
 
-  set( CMAKE_CXX_FLAGS
-    "${CMAKE_C_FLAGS} -std=c++11" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
   set( CMAKE_CXX_FLAGS_DEBUG
     "${CMAKE_C_FLAGS_DEBUG} -early-template-check")
   set( CMAKE_CXX_FLAGS_RELEASE


### PR DESCRIPTION
### Background

* There was an additional C++ standard flag set in the Intel CMake file. As far as I can tell, it was being overridden by the actual C++ flag set through CMake commands but it's still confusing to see two `-std=c++XX` flags on a verbose compile line.

### Purpose of Pull Request

* Let CMake set the c++ standard

### Description of changes

* Remove `-std=c++11` from `unix-intel.cmake`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
