### PR TITLE
Fix errors in CMake CUDA flags and set the NVCC language level to 14

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -306,16 +306,17 @@ macro( setupCudaEnv )
     execute_process(COMMAND ${OUTPUTFILE}
                     RESULT_VARIABLE CUDA_RETURN_CODE OUTPUT_VARIABLE ARCH)
 
-    if (${CUDA_RETURN_CODE EQUAL 0})
+    if (${CUDA_RETURN_CODE} EQUAL 0)
       message(STATUS "CUDA Architecture: ${ARCH}")
-      set(CMAKE_CUDA_FLAGS "${ARCH} -g -G" CACHE STRING
-      set(CMAKE_CUDA_FLAGS_DEBUG "-O0" CACHE STRING
-        "CUDA debug flags" FORCE)
-        "CUDA debug flags" FORCE)
-      set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-O2 --generate-line-info" CACHE STRING
-        "CUDA release with debug information flags" FORCE)
-      set(CMAKE_CUDA_FLAGS_RELEASE "-O2" CACHE STRING
-        "CUDA release flags" FORCE)
+      # CMAKE currently only allows up to C++14 as the NVCC language level
+      set(CMAKE_CUDA_STANDARD "14")
+      set(CMAKE_CUDA_FLAGS "${ARCH} -g -G" CACHE STRING "Standard CUDA flags"
+        FORCE)
+      set(CMAKE_CUDA_FLAGS_DEBUG "-O0" CACHE STRING "CUDA debug flags" FORCE)
+      set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-O2 --generate-line-info" CACHE
+        STRING "CUDA release with debug information flags" FORCE)
+      set(CMAKE_CUDA_FLAGS_RELEASE "-O2" CACHE STRING "CUDA release flags"
+        FORCE)
     else()
       message(WARNING ${ARCH})
     endif()


### PR DESCRIPTION
### Background

* I didn't fully test some of the CMake for the new `CUDA specific device code and I had a few syntax errors in CMake. This pull request corrects those errors and adds a language level to the `nvcc` compiler, set through the `CMAKE_CUDA_STANDARD` variable.

### Purpose of Pull Request

* Fixes bug in CUDA specific CMake code

### Description of changes

* Fix `set` statements that were not terminated properly
* Add `FORCE` to the set statement for `CMAKE_CUDA_FLAGS`
* Set the `CMAKE_CUDA_STANDARD` to 14

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
