### PR TITLE
Fix issues that appeared after PR597 was merged

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,10 +21,21 @@ if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 )
     toggle_compiler_flag( TRUE "-fsanitize=bounds-strict" "CXX" "DEBUG")
   endif()
-  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0 AND
-      NOT "${CMAKE_CXX_COMPILER}" MATCHES "bullseye" )
-    toggle_compiler_flag( TRUE "-fsanitize=pointer-compare -fsanitize=pointer-subtract" "CXX" "DEBUG")
-  endif()
+#  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+#
+# '-fsanitize=address' Not working just yet.  Issues...
+# 1. libasan.so.5: warning: the use of `tempnam' is dangerous, better use
+#    `mkstemp'
+# 2.==134051==ASan runtime does not come first in initial library list; you
+#   should either link runtime to your application or manually preload it with
+#   LD_PRELOAD.
+# 3. many more run time issues, some may require suppression.
+#
+#    toggle_compiler_flag( TRUE
+#      "-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract"
+#      "CXX" "DEBUG")
+#
+#  endif()
 elseif( CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" )
   string( REPLACE "/W2" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
   string( REPLACE "/W2" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )


### PR DESCRIPTION
### Background

* PR #597 enabled `-fsanitize=address` options. The impact of testing this compiler option was not tested sufficiently by the automatic PR testing and it caused massive failure for the nightly regressions.

### Purpose of Pull Request

* Fixes #608 : compile/run failure when Draco is built with gcc in Debug mode.

### Description of changes

* Comment out these gcc-only compiler flags and provide a note about why they
  were removed

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
