### PR TITLE
Add support for Capulin and Thunder (LANL ARM systems)

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -36,7 +36,7 @@ case ${-} in
     shopt -s cdspell      # autocorrect spelling errors on cd command line.
     shopt -s histappend   # append to the history file, don't overwrite it
     # shopt -s direxpand  # Doesn't work on toss22 machines. Move this command to
-                          # .bashrc_toss3 and .bashrc_tt
+                          # .bashrc_toss3 and .bashrc_cray
 
     # don't put duplicate lines or lines starting with space in the history. See
     # bash(1) for more options
@@ -280,9 +280,9 @@ if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
     red-wtrw* | rfta* | redcap* )
       source ${DRACO_ENV_DIR}/bashrc/.bashrc_rfta ;;
 
-    # trinitite (tt-fey) | trinity (tr-fe)
-    tt-fey* | tt-login* | tr-fe* | tr-login* | nid* )
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_tt ;;
+    # capulin, thunder, trinitite (tt-fey) | trinity (tr-fe)
+    cp-login* | th-login* |tt-fey* | tt-login* | tr-fe* | tr-login* | nid* )
+      source ${DRACO_ENV_DIR}/bashrc/.bashrc_cray ;;
 
     # LLNL ATS-2
     rzmanta* | rzansel* | sierra* )

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -39,13 +39,24 @@ if [[ -n "${LESS}" ]]; then
 fi
 
 #
+# Cray environment and options
+#
+# CRAY_CPU_TARGET=arm-thunderx2 ==> capulin, thunder
+#
+
+#
 # OpenMP
 #
 # export OMP_PLACES=threads # lmdm says do not set this!
-if [[ `lscpu | grep Flags | grep -c avx512` == 0 ]]; then
+
+if [[ ${CRAY_CPU_TARGET} =~ arm ]]; then
+  export OMP_NUM_THREADS=28
+  export NRANKS_PER_NODE=56
+#if [[ `lscpu | grep Flags | grep -c avx512` == 0 ]]; then
+elif [[ ${CRAY_CPU_TARGET} =~ haswell ]]; then
   export OMP_NUM_THREADS=16
   export NRANKS_PER_NODE=32
-else
+elif [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
   export OMP_NUM_THREADS=17
   export NRANKS_PER_NODE=68
 fi
@@ -71,21 +82,48 @@ if [[ ${SLURM_JOB_PARTITION} == "knl" ]]; then
   module swap craype-haswell craype-mic-knl
 fi
 
-export dracomodules="cmake/3.12.1 git \
-clang-format eospac/6.3.0 gsl/2.3 metis numdiff random123 \
-parmetis/4.0.3 superlu-dist/5.1.3 trilinos/12.10.1"
+dracomodules="git cmake numdiff gsl metis eospac random123 parmetis \
+superlu-dist trilinos"
 
-if [[ -d ${VENDOR_DIR}-ec ]]; then
-  group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`
-  if [[ `groups | grep -c $group_for_vendor_ec` != 0 ]]; then
-    dracomodules="$dracomodules csk ndi"
+if [[ ${CRAY_CPU_TARGET} =~ haswell ]] || [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
+
+  dracomodules="$dracomodules clang-format"
+
+  if [[ -d ${VENDOR_DIR}-ec ]]; then
+    group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`
+    if [[ `groups | grep -c $group_for_vendor_ec` != 0 ]]; then
+      dracomodules="$dracomodules csk ndi"
+    fi
   fi
+
+elif [[ ${CRAY_CPU_TARGET} =~ arm ]]; then
+
+  dracomodules="$dracomodules cray-python/3.6.5.6"
+
+#  if [[ -d ${VENDOR_DIR}-ec ]]; then
+#    group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`
+#    if [[ `groups | grep -c $group_for_vendor_ec` != 0 ]]; then
+#      dracomodules="$dracomodules csk ndi"
+#    fi
+#  fi
+
 fi
+
+export dracomodules
+
+# ---------------------------------------------------------------------------- #
+# Trinity
+# ---------------------------------------------------------------------------- #
 
 function dracoenv ()
 {
-  module unload gcc/6.1.0 cray-libsci intel
-  module load intel/18.0.2
+  if [[ ${CRAY_CPU_TARGET} =~ haswell ]] || [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
+    module unload gcc cray-libsci intel
+    module load intel/18.0.2
+  else
+    module unload PrgEnv-cray gcc
+    module load PrgEnv-gnu
+  fi
   for m in $dracomodules; do
     module load $m
   done
@@ -100,7 +138,7 @@ function dracoenv ()
     # Now prepend each $dir w/o respect to if it was removed above.
     LD_LIBRARY_PATH=$dir:$LD_LIBRARY_PATH
   done
-#  export MPIEXEC_EXECUTABLE=`which srun`
+  #  export MPIEXEC_EXECUTABLE=`which srun`
 }
 
 function rmdracoenv ()
@@ -111,12 +149,17 @@ function rmdracoenv ()
   for ((i=${#mods[@]}-1; i>=0; i--)); do
     # loaded=`echo $LOADEDMODULES | grep -c ${mods[$i]}`
     #if test $loaded = 1; then
-      module unload ${mods[$i]}
+    module unload ${mods[$i]}
     #fi
   done
-  module unload intel
-  module unload PrgEnv-intel
-  module load PrgEnv-intel
+  if [[ ${CRAY_CPU_TARGET} =~ haswell ]] || [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
+    module unload intel
+    module unload PrgEnv-intel
+    module load PrgEnv-intel
+  else
+    module unload PrgEnv-gnu gcc
+    module load PrgEnv-cray
+  fi
 }
 
 # Do not escape $ for bash completion

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,10 +163,12 @@ if( "${DRACO_C4}" STREQUAL "MPI" )
 endif()
 message("Library Type: ${DRACO_LIBRARY_TYPE}
 ")
+
 if( CRAY_PE AND ENV{CRAYPE_VERSION} )
-  message("Cray system detected: CC -craype-verbose -V:
+  message("Cray system detected: CC -craype-verbose -V|--version:
 ")
-  if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel" )
+  if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel" OR
+      ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" )
     set( ver_opt "--version")
   else( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Cray" )
     set( ver_opt "-V")


### PR DESCRIPTION

### Background

* LANL has two new HPC resources, Capulin and Thunder.  These are ARM machines with a Cray software stack.
* For now, we will only support the GNU toolchain on these systems.

### Purpose of Pull Request

* [Related to Redmine Issue #1229](https://rtt.lanl.gov/redmine/issues/1229)

### Description of changes

- Rename `.bashrc_tt` to `.bashrc_cray`
- Update `.bashrc_cray` to query and setup different Cray systems in slightly different ways.
  - Use PrgEnv-intel on Trinity/Trinitite
  - Use PrgEnv-gnu on Capulin/Thunder (at least for now).
  - A few TPLs aren't available on Capulin/Thunder just yet (csk, ndi, clang-format).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
