### PR TITLE
Fix issue 1268 by documenting and testing report_leaks.

### DIFF
--- a/src/memory/memory.cc
+++ b/src/memory/memory.cc
@@ -103,7 +103,11 @@ uint64_t peak_allocation() { return peak; }
 uint64_t largest_allocation() { return largest; }
 
 //---------------------------------------------------------------------------//
-//! \bug Untested
+/*! Print a report on possible leaks.
+ *
+ * This function prints a report in a human-friendly format on possible memory
+ * leaks.
+ */
 void report_leaks(ostream &out) {
   if (is_active) {
 #if DRACO_DIAGNOSTICS & 2
@@ -240,7 +244,7 @@ void operator delete(void *ptr, size_t) throw() { operator delete(ptr); }
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Provide a special action when an out-of-memory condition is 
+ * \brief Provide a special action when an out-of-memory condition is
  *        encountered.
  *
  * The usual notion is that if new operator cannot allocate dynamic memory of
@@ -269,9 +273,9 @@ void operator delete(void *ptr, size_t) throw() { operator delete(ptr); }
  * \bug untested
  */
 void rtt_memory::out_of_memory_handler(void) {
+  std::set_new_handler(nullptr);
   std::cerr << "Unable to allocate requested memory.\n"
             << rtt_dsxx::print_stacktrace("bad_alloc");
-  throw std::bad_alloc();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/memory/memory.hh
+++ b/src/memory/memory.hh
@@ -2,9 +2,15 @@
 /*!
  * \file   memory/memory.hh
  * \author Kent G. Budge
- * \brief  memory utilities for diagnostic purposes
+ * \brief  Memory utilities for diagnostic purposes.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
- *         All rights reserved. */
+ *         All rights reserved.
+ *
+ * The memory utilities were written to address a need to identify the memory
+ * "high-water mark" in a call sequence. This was not available with the
+ * existing memory checking tools. Other capabilities gradually accreted
+ * themselves to this set of utilities, such as leak characterization.
+ */
 //---------------------------------------------------------------------------//
 
 #ifndef memory_memory_hh

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -20,6 +20,8 @@ using namespace rtt_memory;
 // TESTS
 //---------------------------------------------------------------------------//
 
+size_t get_really_big_size_t();
+
 void tst_memory(rtt_dsxx::UnitTest &ut) {
   if (total_allocation() == 0) {
     PASSMSG("correct initial total allocation");
@@ -59,11 +61,10 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
   } else {
     FAILMSG("NOT correct largest allocation");
   }
-
-  report_leaks(cerr);
 #else
   PASSMSG("memory diagnostics not checked for this build");
 #endif
+  report_leaks(cerr);
 
   delete[] array;
   delete[] array2;
@@ -133,22 +134,18 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
 void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
   size_t const num_fails_start(ut.numFails);
 
-#if DRACO_DIAGNOSTICS & 2
-
   std::cout << "\nTesting special handler (stack trace) for "
             << "std::bad_alloc...\n"
             << std::endl;
 
   // Set a specialized memory handler.
-  // std::set_new_handler(rtt_memory::out_of_memory_handler);
+  std::set_new_handler(rtt_memory::out_of_memory_handler);
 
   try {
     // trigger a std::bad_alloc exception
     std::cout << "Attempt to allocate some memory." << std::endl;
-    uint64_t const new_size(static_cast<uint64_t>(100 * 1024) *
-                            static_cast<uint64_t>(1024 * 1024));
 
-    char *pBigArray = new char[new_size];
+    char *pBigArray = new char[get_really_big_size_t()];
 
     // should never get here.
     {
@@ -165,17 +162,21 @@ void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
     FAILMSG("Failed to catch a bad_alloc.");
   }
 
-#else // DRACO_DIAGNOSTICS & 2
-
-#endif // DRACO_DIAGNOSTICS & 2
-
   if (ut.numFails > num_fails_start)
     FAILMSG("Test failures in tst_bad_alloc.");
   else
-    PASSMSG("tst_bad_alloc completed sucessfully.");
+    PASSMSG("tst_bad_alloc completed successfully.");
 
   return;
 }
+
+//----------------------------------------------------------------------------------------//
+// Some compilers are clever enough to figure out that if you pass
+// std::numeric_limits<size_t>::max() to the new operator, you will always
+// blow away member, and so they will refuse to compile the code. We have
+// to use a bit of indirection to get such compilers to swallow the huge
+// allocation meant to deliberately blow away memory.
+size_t get_really_big_size_t() { return numeric_limits<size_t>::max(); }
 
 //---------------------------------------------------------------------------//
 int main(int argc, char *argv[]) {

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -130,6 +130,11 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
 #endif
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than=0"
+#endif
+
 //---------------------------------------------------------------------------//
 void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
   size_t const num_fails_start(ut.numFails);
@@ -169,6 +174,10 @@ void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
 
   return;
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 //----------------------------------------------------------------------------------------//
 // Some compilers are clever enough to figure out that if you pass

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -130,11 +130,6 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
 #endif
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Walloc-size-larger-than=0"
-#endif
-
 //---------------------------------------------------------------------------//
 void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
   size_t const num_fails_start(ut.numFails);
@@ -175,17 +170,15 @@ void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
   return;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
 //----------------------------------------------------------------------------------------//
 // Some compilers are clever enough to figure out that if you pass
 // std::numeric_limits<size_t>::max() to the new operator, you will always
 // blow away member, and so they will refuse to compile the code. We have
 // to use a bit of indirection to get such compilers to swallow the huge
 // allocation meant to deliberately blow away memory.
-size_t get_really_big_size_t() { return numeric_limits<size_t>::max(); }
+size_t get_really_big_size_t() {
+  return numeric_limits<std::ptrdiff_t>::max() / sizeof(size_t);
+}
 
 //---------------------------------------------------------------------------//
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Take another stab at a portable test of rtt_memory::out_of_memory_handler. Also, bring this function into conformance with the standard, by having it set the memory handler to null and return rather than directly throw a bad_alloc.

### Background

Issue 1268 is that rtt_memory::report_leaks is neither documented nor tested. Coverage analysis also shows that rtt_memory::out_of_memory_handler is not tested. The line to install this handler is commented out of the unit test program.

The current implementation of rtt_memory::out_of_memory_handler does not conform to the standard, since it throws a bad_alloc directly. The standard calls for this function to set the out of memory handler to nullptr if it cannot resolve the allocation failure, and then the new allocator knows to throw bad_alloc itself. 

### Purpose of Pull Request

* [Fixes Redmine Issue #1268](https://rtt.lanl.gov/redmine/issues/1268)

### Description of changes

* Add test of report_leaks to tstmemory.cc
* Rewrite out_of_memory_handler to conform to the standard.
* Reactivate the test of out_of_memory_handler so it is covered.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
