### PR TITLE
Fix build warnings related to superlu_ddefs.h.

### DIFF
--- a/src/VendorChecks/test/CMakeLists.txt
+++ b/src/VendorChecks/test/CMakeLists.txt
@@ -31,6 +31,8 @@ if( TARGET ParMETIS::parmetis AND ${DRACO_C4} STREQUAL "MPI" )
        SOURCES "tstSuperludist.cc"
        DEPS    "Lib_c4;SuperLU_DIST::superludist;ParMETIS::parmetis;lapack"
        PE_LIST "4" )
+     target_include_directories( Ut_VendorsChecks_tstSuperludist_exe
+       PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> )
 
    endif()
 

--- a/src/VendorChecks/test/superlu-dist-wrapper.h
+++ b/src/VendorChecks/test/superlu-dist-wrapper.h
@@ -1,0 +1,22 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   VendorChecks/test/superlu-dist-wrapper.h
+ * \date   Wednesday, May 01, 2019, 09:52 am
+ * \brief  Wrapper for superlu_ddefs.h to allow warning suppression
+ * \note   Copyright (C) 2019, Triad National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
+#pragma GCC system_header
+#endif
+#include <superlu_ddefs.h>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+//----------------------------------------------------------------------------//
+// End superlu-dist-wrapper.h
+//----------------------------------------------------------------------------//

--- a/src/VendorChecks/test/tstSuperludist.cc
+++ b/src/VendorChecks/test/tstSuperludist.cc
@@ -13,6 +13,7 @@
  */
 //---------------------------------------------------------------------------//
 
+#include "superlu-dist-wrapper.h"
 #include "c4/ParallelUnitTest.hh"
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
@@ -20,15 +21,6 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif
-#include <superlu_ddefs.h>
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 // forward declarations
 void test_superludist(rtt_c4::ParallelUnitTest &ut);


### PR DESCRIPTION
### Background

+ Recently, gcc-8.1.0 regressions have started to generate the following compile warning:

```
superlu_dist_config.h:2:6: warning: "XSDK_INDEX_SIZE" is not defined, evaluates to 0 [-Wundef]
```

+ Since the issue isn't related to code that we own, I have created a
  suppression as described below.

### Purpose of Pull Request

* Fixes #614

### Description of changes

+ Wrap the inclusion of this header in a new file `superlu-dist-wrapper.h` and update the list of include directories to allow the build system to find the new file.
+ Tag `superlu_ddefs.h` with `pragma GCC system_header` to prevent GCC from creating warnings about code found in the TPL header.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
