### PR TITLE
Cleanup warnings/errors reported on CDash.

### DIFF
--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -143,6 +143,9 @@ function dracoenv ()
 
 function rmdracoenv ()
 {
+  # this setting recommended by Sam Guiterrez to allow correct core binding for
+  # C++ threads (maybe OpeNMP threads also) on KNLs.
+  export KMP_AFFINITY=disabled
   export LD_LIBRARY_PATH=$DRACO_OLD_LD_LIBRARY_PATH
   # unload in reverse order.
   mods=( ${dracomodules} )

--- a/regression/push_repositories_xf.sh
+++ b/regression/push_repositories_xf.sh
@@ -7,6 +7,11 @@
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
+# Run from ccscs2
+if [[ `uname -n | sed -e 's/[.].*//'` != "ccscs2" ]]; then
+  die "This script should be run from ccscs2."
+fi
+
 # switch to group 'ccsrad' and set umask
 if [[ $(id -gn) != ccsrad ]]; then
   exec sg ccsrad "$0 $*"
@@ -19,7 +24,12 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Redirect all output to a log file.
 timestamp=`date +%Y%m%d-%H%M`
 target="`uname -n | sed -e s/[.].*//`"
-logdir="$( cd $scriptdir/../../logs && pwd )"
+if [[ $USER == "kellyt" ]]; then
+  logdir="$( cd $scriptdir/../../logs && pwd )"
+else
+  logdir=$HOME/logs
+fi
+if ! [[ -d $logdir ]]; mkdir -p $logdir; fi
 logfile=$logdir/push_repositories_xf-$target-$timestamp.log
 exec > $logfile
 exec 2>&1
@@ -48,7 +58,7 @@ if [[ $USER == "kellyt" ]] ; then
 fi
 
 # Sanity check
-if test `klist -l | grep -c $USER` = 0; then
+if [[ `klist -l | grep -c $USER` == 0 ]]; then
     die "You must have an active kerberos ticket to run this script."
 fi
 

--- a/src/VendorChecks/test/CMakeLists.txt
+++ b/src/VendorChecks/test/CMakeLists.txt
@@ -25,7 +25,7 @@ if( TARGET ParMETIS::parmetis AND ${DRACO_C4} STREQUAL "MPI" )
       DEPS    "Lib_c4;ParMETIS::parmetis"
       PE_LIST "3" )
 
-   if ( TARGET SuperLU_DIST::superludist AND TARGET lapack )
+   if ( TARGET SuperLU_DIST::superludist AND TARGET lapack AND NOT WIN32)
 
      add_parallel_tests(
        SOURCES "tstSuperludist.cc"

--- a/src/memory/test/CMakeLists.txt
+++ b/src/memory/test/CMakeLists.txt
@@ -8,17 +8,13 @@
 #------------------------------------------------------------------------------#
 project( memory_test CXX )
 
-# ---------------------------------------------------------------------------- #
-# Source files
-# ---------------------------------------------------------------------------- #
-
-file( GLOB test_sources *.cc )
-
-# ---------------------------------------------------------------------------- #
-# Build Unit tests
-# ---------------------------------------------------------------------------- #
-
-add_scalar_tests( SOURCES "${test_sources}"  DEPS Lib_memory  )
+if( NOT "${DRACO_DIAGNOSTICS}" STREQUAL "7" )
+  # This test fails when fpe_trap is enabled.
+  #
+  add_scalar_tests(
+    SOURCES "tstmemory.cc"
+    DEPS Lib_memory  )
+endif()
 
 #------------------------------------------------------------------------------#
 # End memory/test/CMakeLists.txt

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -1,11 +1,11 @@
-//----------------------------------*-C++-*----------------------------------//
+//-----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   memory/test/tstmemory.cc
  * \author Kent G. Budge, Kelly G. Thompson
  * \brief  memory test.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *         All rights reserved. */
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
@@ -16,9 +16,9 @@
 using namespace std;
 using namespace rtt_memory;
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // TESTS
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 size_t get_really_big_size_t();
 
@@ -130,7 +130,7 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
 #endif
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
   size_t const num_fails_start(ut.numFails);
 
@@ -155,7 +155,7 @@ void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
     }
 
     delete[] pBigArray;
-  } catch (std::bad_alloc &ba) {
+  } catch (std::bad_alloc & /*error*/) {
     std::cout << "Successfully caught an expected std::bad_alloc exception."
               << std::endl;
   } catch (...) {
@@ -170,17 +170,17 @@ void tst_bad_alloc(rtt_dsxx::UnitTest &ut) {
   return;
 }
 
-//----------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // Some compilers are clever enough to figure out that if you pass
-// std::numeric_limits<size_t>::max() to the new operator, you will always
-// blow away member, and so they will refuse to compile the code. We have
-// to use a bit of indirection to get such compilers to swallow the huge
-// allocation meant to deliberately blow away memory.
+// std::numeric_limits<size_t>::max() to the new operator, you will always blow
+// away member, and so they will refuse to compile the code. We have to use a
+// bit of indirection to get such compilers to swallow the huge allocation meant
+// to deliberately blow away memory.
 size_t get_really_big_size_t() {
   return numeric_limits<std::ptrdiff_t>::max() / sizeof(size_t);
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {
@@ -190,6 +190,6 @@ int main(int argc, char *argv[]) {
   UT_EPILOG(ut);
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of tstmemory.cc
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//


### PR DESCRIPTION
### Background:

+ `VendorsChecks_tstSuperludist_4` has been failing for Win32 for a while.  There is a problem with the the Win32 build of superlu-dist.  I don't have time to fix this right now and this test isn't particularly important for Draco or Jayenne.
+ A new 'unused variable' warning showed up late last week (`tstmemory`).  This test also fails when `fpe_trap` is enabled.

### Changes:

+ Disable tstsuperludist for WIN32 platforms.
+ Comment out unused variable.
+ Disable `memory_tstmemory` when `DRACO_DIAGNOSTICS=7` (fpe_trap enabled).  This removes it from the _fulldiagnostics_ regression suite.
+ Also
  - For Cray systems, force `KMP_AFFINITY=disabled` via the developer bashrc files to avoid a thread affinity issue identified by Tim.
  - Add sanity checks to `push_repository_xf.sh` after Jae reported issues when trying to run this script.

