### PR TITLE
nGray_Analytic_MultigroupOpacity to Compound_Analytic_MultigroupOpacity

### DIFF
--- a/src/cdi_analytic/Compound_Analytic_MultigroupOpacity.hh
+++ b/src/cdi_analytic/Compound_Analytic_MultigroupOpacity.hh
@@ -1,15 +1,15 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   cdi_analytic/nGray_Analytic_MultigroupOpacity.hh
+ * \file   cdi_analytic/Compound_Analytic_MultigroupOpacity.hh
  * \author Thomas M. Evans
  * \date   Tue Nov 13 11:19:59 2001
- * \brief  nGray_Analytic_MultigroupOpacity class definition.
+ * \brief  Compound_Analytic_MultigroupOpacity class definition.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#ifndef __cdi_analytic_nGray_Analytic_MultigroupOpacity_hh__
-#define __cdi_analytic_nGray_Analytic_MultigroupOpacity_hh__
+#ifndef __cdi_analytic_Compound_Analytic_MultigroupOpacity_hh__
+#define __cdi_analytic_Compound_Analytic_MultigroupOpacity_hh__
 
 #include "Analytic_MultigroupOpacity.hh"
 
@@ -17,11 +17,11 @@ namespace rtt_cdi_analytic {
 
 //===========================================================================//
 /*!
- * \class nGray_Analytic_MultigroupOpacity
+ * \class Compound_Analytic_MultigroupOpacity
  *
  * \brief Derived Analytic_MultigroupOpacity class for analytic opacities.
  *
- * The nGray_Analytic_MultigroupOpacity class is a derived
+ * The Compound_Analytic_MultigroupOpacity class is a derived
  * Analytic_MultigroupOpacity class.  It provides analytic opacity data. The
  * specific analytic opacity model is derived from the
  * rtt_cdi_analytic::Analytic_Opacity_Model base class.  Several pre-built
@@ -56,14 +56,14 @@ namespace rtt_cdi_analytic {
  * Analytic_MultigroupOpacity and can be used with rtt_cdi::CDI to get
  * analytic opacities.
  *
- * \example cdi_analytic/test/tstnGray_Analytic_MultigroupOpacity.cc
+ * \example cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
  *
- * Example usage of nGray_Analytic_MultigroupOpacity, Analytic_Opacity_Model,
+ * Example usage of Compound_Analytic_MultigroupOpacity, Analytic_Opacity_Model,
  * and their incorporation into rtt_cdi::CDI.
  */
 //===========================================================================//
 
-class nGray_Analytic_MultigroupOpacity : public Analytic_MultigroupOpacity {
+class Compound_Analytic_MultigroupOpacity : public Analytic_MultigroupOpacity {
 public:
   // Useful typedefs.
   typedef std::shared_ptr<Analytic_Opacity_Model> SP_Analytic_Model;
@@ -80,13 +80,16 @@ private:
 
 public:
   // Constructor.
-  nGray_Analytic_MultigroupOpacity(const sf_double &groups,
-                                   const sf_Analytic_Model &models,
-                                   rtt_cdi::Reaction reaction_in,
-                                   rtt_cdi::Model model_in = rtt_cdi::ANALYTIC);
+  Compound_Analytic_MultigroupOpacity(
+      const sf_double &groups, const sf_Analytic_Model &models,
+      rtt_cdi::Reaction reaction_in,
+      rtt_cdi::Model model_in = rtt_cdi::ANALYTIC);
 
   // Constructor for packed Analytic_Multigroup_Opacities
-  explicit nGray_Analytic_MultigroupOpacity(const sf_char &packed);
+  explicit Compound_Analytic_MultigroupOpacity(const sf_char &packed);
+
+  // Check that the class invariant is not violated.
+  bool check_class_invariant() const;
 
   // >>> ACCESSORS
   const_Model get_Analytic_Model(size_t g) const { return group_models[g - 1]; }
@@ -105,7 +108,7 @@ public:
   // Get the data description of the opacity.
   inline std_string getDataDescriptor(void) const;
 
-  // Pack the nGray_Analytic_MultigroupOpacity into a character string.
+  // Pack the Compound_Analytic_MultigroupOpacity into a character string.
   sf_char pack(void) const;
 };
 
@@ -113,22 +116,22 @@ public:
 // INLINE FUNCTIONS
 //---------------------------------------------------------------------------//
 //! Return a string describing the opacity model.
-nGray_Analytic_MultigroupOpacity::std_string
-nGray_Analytic_MultigroupOpacity::getDataDescriptor() const {
+Compound_Analytic_MultigroupOpacity::std_string
+Compound_Analytic_MultigroupOpacity::getDataDescriptor() const {
   std_string descriptor;
 
   rtt_cdi::Reaction const rxn = getReactionType();
 
   if (rxn == rtt_cdi::TOTAL)
-    descriptor = "nGray Multigroup Total";
+    descriptor = "Compound Multigroup Total";
   else if (rxn == rtt_cdi::ABSORPTION)
-    descriptor = "nGray Multigroup Absorption";
+    descriptor = "Compound Multigroup Absorption";
   else if (rxn == rtt_cdi::SCATTERING)
-    descriptor = "nGray Multigroup Scattering";
+    descriptor = "Compound Multigroup Scattering";
   else {
     Insist(rxn == rtt_cdi::TOTAL || rxn == rtt_cdi::ABSORPTION ||
                rxn == rtt_cdi::SCATTERING,
-           "Invalid nGray multigroup model opacity!");
+           "Invalid Compound multigroup model opacity!");
   }
 
   return descriptor;
@@ -136,8 +139,8 @@ nGray_Analytic_MultigroupOpacity::getDataDescriptor() const {
 
 } // namespace rtt_cdi_analytic
 
-#endif // __cdi_analytic_nGray_Analytic_MultigroupOpacity_hh__
+#endif // __cdi_analytic_Compound_Analytic_MultigroupOpacity_hh__
 
 //---------------------------------------------------------------------------//
-// end of cdi_analytic/nGray_Analytic_MultigroupOpacity.hh
+// end of cdi_analytic/Compound_Analytic_MultigroupOpacity.hh
 //---------------------------------------------------------------------------//

--- a/src/cdi_analytic/Compound_Analytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/Compound_Analytic_Odfmg_Opacity.cc
@@ -1,15 +1,15 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   cdi_analytic/nGray_Analytic_Odfmg_Opacity.cc
+ * \file   cdi_analytic/Compound_Analytic_Odfmg_Opacity.cc
  * \author Thomas M. Evans
  * \date   Tue Nov 13 11:19:59 2001
- * \brief  nGray_Analytic_Odfmg_Opacity class member definitions.
+ * \brief  Compound_Analytic_Odfmg_Opacity class member definitions.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include "nGray_Analytic_Odfmg_Opacity.hh"
-#include "nGray_Analytic_MultigroupOpacity.hh"
+#include "Compound_Analytic_Odfmg_Opacity.hh"
+#include "Compound_Analytic_MultigroupOpacity.hh"
 #include "ds++/Packing_Utils.hh"
 #include "ds++/dbc.hh"
 
@@ -22,13 +22,13 @@ namespace rtt_cdi_analytic {
  * \brief Constructor for an analytic multigroup opacity model.
  *
  * This constructor builds an opacity model defined by the
- * rtt_cdi_analytic::nGray_Analytic_Opacity_Model derived class argument.
+ * rtt_cdi_analytic::Compound_Analytic_Opacity_Model derived class argument.
  *
  * The reaction type for this instance of the class is determined by the
  * rtt_cdi::Reaction argument.
  *
  * The group structure (in keV) must be provided by the groups argument.  The
- * number of nGray_Analytic_Opacity_Model objects given in the models argument
+ * number of Compound_Analytic_Opacity_Model objects given in the models argument
  * must be equal to the number of groups.
  *
  * \param groups vector containing the group boundaries in keV from lowest to
@@ -40,7 +40,7 @@ namespace rtt_cdi_analytic {
  * \param reaction_in rtt_cdi::Reaction type (enumeration)
  * \param model_in An enumeration for the model.
  */
-nGray_Analytic_Odfmg_Opacity::nGray_Analytic_Odfmg_Opacity(
+Compound_Analytic_Odfmg_Opacity::Compound_Analytic_Odfmg_Opacity(
     const sf_double &groups, const sf_double &bands,
     const sf_Analytic_Model &models, rtt_cdi::Reaction reaction_in,
     rtt_cdi::Model model_in)
@@ -56,12 +56,12 @@ nGray_Analytic_Odfmg_Opacity::nGray_Analytic_Odfmg_Opacity(
 /*!
  * \brief Unpacking constructor.
  *
- * This constructor rebuilds and nGray_Analytic_Odfmg_Opacity from a
+ * This constructor rebuilds and Compound_Analytic_Odfmg_Opacity from a
  * vector<char> that was created by a call to pack().  It can only rebuild
  * Analytic_Model types that have been registered in the
  * rtt_cdi_analytic::Opacity_Models enumeration.
  */
-nGray_Analytic_Odfmg_Opacity::nGray_Analytic_Odfmg_Opacity(
+Compound_Analytic_Odfmg_Opacity::Compound_Analytic_Odfmg_Opacity(
     const sf_char &packed)
     : Analytic_Odfmg_Opacity(packed), group_models() {
   // the packed size must be at least 5 integers (number of groups, number of
@@ -131,15 +131,15 @@ nGray_Analytic_Odfmg_Opacity::nGray_Analytic_Odfmg_Opacity(
  * Given a scalar temperature and density, return the group opacities
  * (vector<double>) for the reaction type specified by the constructor.  The
  * analytic opacity model is specified in the constructor
- * (nGray_Analytic_Odfmg_Opacity()).
+ * (Compound_Analytic_Odfmg_Opacity()).
  *
  * \param targetTemperature material temperature in keV
  * \param targetDensity material density in g/cm^3
  * \return group opacities (coefficients) in cm^2/g
  */
 std::vector<std::vector<double>>
-nGray_Analytic_Odfmg_Opacity::getOpacity(double targetTemperature,
-                                         double targetDensity) const {
+Compound_Analytic_Odfmg_Opacity::getOpacity(double targetTemperature,
+                                            double targetDensity) const {
   Require(targetTemperature >= 0.0);
   Require(targetDensity >= 0.0);
 
@@ -180,7 +180,7 @@ nGray_Analytic_Odfmg_Opacity::getOpacity(double targetTemperature,
  *        single density value.
  */
 std::vector<std::vector<std::vector<double>>>
-nGray_Analytic_Odfmg_Opacity::getOpacity(
+Compound_Analytic_Odfmg_Opacity::getOpacity(
     const std::vector<double> &targetTemperature, double targetDensity) const {
   std::vector<std::vector<std::vector<double>>> opacity(
       targetTemperature.size());
@@ -198,7 +198,7 @@ nGray_Analytic_Odfmg_Opacity::getOpacity(
  *        density values.
  */
 std::vector<std::vector<std::vector<double>>>
-nGray_Analytic_Odfmg_Opacity::getOpacity(
+Compound_Analytic_Odfmg_Opacity::getOpacity(
     double targetTemperature, const std::vector<double> &targetDensity) const {
   std::vector<std::vector<std::vector<double>>> opacity(targetDensity.size());
 
@@ -214,12 +214,12 @@ nGray_Analytic_Odfmg_Opacity::getOpacity(
  * \brief Pack an analytic odfmg opacity.
  *
  * This function will pack up the Analytic_Mulitgroup_Opacity into a char array
- * (represented by a vector<char>).  The nGray_Analytic_Opacity_Model derived
+ * (represented by a vector<char>).  The Compound_Analytic_Opacity_Model derived
  * class must have a pack function; this is enforced by the virtual
- * nGray_Analytic_Opacity_Model base class.
+ * Compound_Analytic_Opacity_Model base class.
  */
-nGray_Analytic_Odfmg_Opacity::sf_char
-nGray_Analytic_Odfmg_Opacity::pack() const {
+Compound_Analytic_Odfmg_Opacity::sf_char
+Compound_Analytic_Odfmg_Opacity::pack() const {
   // make a packer
   rtt_dsxx::Packer packer;
 
@@ -268,5 +268,5 @@ nGray_Analytic_Odfmg_Opacity::pack() const {
 } // end namespace rtt_cdi_analytic
 
 //---------------------------------------------------------------------------//
-// end of nGray_Analytic_Odfmg_Opacity.cc
+// end of Compound_Analytic_Odfmg_Opacity.cc
 //---------------------------------------------------------------------------//

--- a/src/cdi_analytic/Compound_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/Compound_Analytic_Odfmg_Opacity.hh
@@ -1,15 +1,15 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
+ * \file   cdi_analytic/Compound_Analytic_Odfmg_Opacity.hh
  * \author Thomas M. Evans
  * \date   Tue Nov 13 11:19:59 2001
- * \brief  nGray_Analytic_Odfmg_Opacity class definition.
+ * \brief  Compound_Analytic_Odfmg_Opacity class definition.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#ifndef __cdi_analytic_nGray_Analytic_Odfmg_Opacity_hh__
-#define __cdi_analytic_nGray_Analytic_Odfmg_Opacity_hh__
+#ifndef __cdi_analytic_Compound_Analytic_Odfmg_Opacity_hh__
+#define __cdi_analytic_Compound_Analytic_Odfmg_Opacity_hh__
 
 #include "Analytic_Odfmg_Opacity.hh"
 
@@ -17,7 +17,7 @@ namespace rtt_cdi_analytic {
 
 //===========================================================================//
 /*!
- * \class nGray_Analytic_Odfmg_Opacity
+ * \class Compound_Analytic_Odfmg_Opacity
  *
  * \brief Derived rtt_cdi::OdfmgOpacity class for analytic opacities.
  *
@@ -25,7 +25,7 @@ namespace rtt_cdi_analytic {
  */
 //===========================================================================//
 
-class nGray_Analytic_Odfmg_Opacity : public Analytic_Odfmg_Opacity {
+class Compound_Analytic_Odfmg_Opacity : public Analytic_Odfmg_Opacity {
 public:
   // Useful typedefs.
   typedef std::shared_ptr<Analytic_Opacity_Model> SP_Analytic_Model;
@@ -42,13 +42,14 @@ private:
 
 public:
   // Constructor.
-  nGray_Analytic_Odfmg_Opacity(const sf_double &groups, const sf_double &bands,
-                               const sf_Analytic_Model &models,
-                               rtt_cdi::Reaction reaction_in,
-                               rtt_cdi::Model model_in = rtt_cdi::ANALYTIC);
+  Compound_Analytic_Odfmg_Opacity(const sf_double &groups,
+                                  const sf_double &bands,
+                                  const sf_Analytic_Model &models,
+                                  rtt_cdi::Reaction reaction_in,
+                                  rtt_cdi::Model model_in = rtt_cdi::ANALYTIC);
 
-  // Constructor for packed nGray_Analytic_Odfmg_Opacities
-  explicit nGray_Analytic_Odfmg_Opacity(const sf_char &);
+  // Constructor for packed Compound_Analytic_Odfmg_Opacities
+  explicit Compound_Analytic_Odfmg_Opacity(const sf_char &);
 
   // >>> ACCESSORS
   const_Model get_Analytic_Model(int g) const { return group_models[g - 1]; }
@@ -85,14 +86,14 @@ public:
   // Get the data description of the opacity.
   inline std_string getDataDescriptor() const;
 
-  // Pack the nGray_Analytic_Odfmg_Opacity into a character string.
+  // Pack the Compound_Analytic_Odfmg_Opacity into a character string.
   sf_char pack() const;
 };
 
 //---------------------------------------------------------------------------//
 //! Return a string describing the opacity model.
-nGray_Analytic_Odfmg_Opacity::std_string
-nGray_Analytic_Odfmg_Opacity::getDataDescriptor() const {
+Compound_Analytic_Odfmg_Opacity::std_string
+Compound_Analytic_Odfmg_Opacity::getDataDescriptor() const {
   std_string descriptor;
 
   rtt_cdi::Reaction const rxn = getReactionType();
@@ -111,8 +112,8 @@ nGray_Analytic_Odfmg_Opacity::getDataDescriptor() const {
 
 } // end namespace rtt_cdi_analytic
 
-#endif // __cdi_analytic_nGray_Analytic_Odfmg_Opacity_hh__
+#endif // __cdi_analytic_Compound_Analytic_Odfmg_Opacity_hh__
 
 //---------------------------------------------------------------------------//
-// end of cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
+// end of cdi_analytic/Compound_Analytic_Odfmg_Opacity.hh
 //---------------------------------------------------------------------------//

--- a/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Gray_Opacity.cc
@@ -11,7 +11,7 @@
 #include "cdi_analytic_test.hh"
 #include "cdi/CDI.hh"
 #include "cdi_analytic/Analytic_Gray_Opacity.hh"
-#include "cdi_analytic/nGray_Analytic_MultigroupOpacity.hh"
+#include "cdi_analytic/Compound_Analytic_MultigroupOpacity.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include <sstream>
@@ -22,8 +22,8 @@ using rtt_cdi::CDI;
 using rtt_cdi::GrayOpacity;
 using rtt_cdi_analytic::Analytic_Gray_Opacity;
 using rtt_cdi_analytic::Analytic_Opacity_Model;
+using rtt_cdi_analytic::Compound_Analytic_MultigroupOpacity;
 using rtt_cdi_analytic::Constant_Analytic_Opacity_Model;
-using rtt_cdi_analytic::nGray_Analytic_MultigroupOpacity;
 using rtt_cdi_analytic::Polynomial_Analytic_Opacity_Model;
 using rtt_dsxx::soft_equiv;
 using std::dynamic_pointer_cast;
@@ -341,8 +341,8 @@ void type_test(rtt_dsxx::UnitTest &ut) {
     ITFAILS;
 
   // another way to do this
-  nGray_Analytic_MultigroupOpacity *m =
-      dynamic_cast<nGray_Analytic_MultigroupOpacity *>(&*op);
+  Compound_Analytic_MultigroupOpacity *m =
+      dynamic_cast<Compound_Analytic_MultigroupOpacity *>(&*op);
   Analytic_Gray_Opacity *o = dynamic_cast<Analytic_Gray_Opacity *>(&*op);
 
   if (m)

--- a/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
+++ b/src/cdi_analytic/test/tstAnalytic_Odfmg_Opacity.cc
@@ -11,8 +11,8 @@
 #include "cdi_analytic_test.hh"
 #include "c4/ParallelUnitTest.hh"
 #include "cdi/CDI.hh"
+#include "cdi_analytic/Compound_Analytic_Odfmg_Opacity.hh"
 #include "cdi_analytic/Pseudo_Line_Analytic_Odfmg_Opacity.hh"
-#include "cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "parser/Constant_Expression.hh"
@@ -74,8 +74,8 @@ void odfmg_test(UnitTest &ut) {
   models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
   // make an analytic multigroup opacity object for absorption
-  nGray_Analytic_Odfmg_Opacity opacity(groups, bands, models,
-                                       rtt_cdi::ABSORPTION);
+  Compound_Analytic_Odfmg_Opacity opacity(groups, bands, models,
+                                          rtt_cdi::ABSORPTION);
 
   // check the interface to multigroup opacity
   {
@@ -122,8 +122,8 @@ void odfmg_test(UnitTest &ut) {
 
   {
     // make an analytic multigroup opacity object for scattering
-    nGray_Analytic_Odfmg_Opacity opac(groups, bands, models,
-                                      rtt_cdi::SCATTERING);
+    Compound_Analytic_Odfmg_Opacity opac(groups, bands, models,
+                                         rtt_cdi::SCATTERING);
     string desc = "Analytic Odfmg Scattering";
 
     if (opac.getDataDescriptor() != desc)
@@ -131,7 +131,7 @@ void odfmg_test(UnitTest &ut) {
   }
   {
     // make an analytic multigroup opacity object for scattering
-    nGray_Analytic_Odfmg_Opacity opac(groups, bands, models, rtt_cdi::TOTAL);
+    Compound_Analytic_Odfmg_Opacity opac(groups, bands, models, rtt_cdi::TOTAL);
     string desc = "Analytic Odfmg Total";
 
     if (opac.getDataDescriptor() != desc)
@@ -257,7 +257,7 @@ void test_CDI(UnitTest &ut) {
   models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
   // make an analytic multigroup opacity object for absorption
-  std::shared_ptr<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
+  std::shared_ptr<const OdfmgOpacity> odfmg(new Compound_Analytic_Odfmg_Opacity(
       groups, bands, models, rtt_cdi::ABSORPTION));
 
   // make a CDI object
@@ -332,15 +332,16 @@ void packing_test(UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    std::shared_ptr<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
-        groups, bands, models, rtt_cdi::ABSORPTION));
+    std::shared_ptr<const OdfmgOpacity> odfmg(
+        new Compound_Analytic_Odfmg_Opacity(groups, bands, models,
+                                            rtt_cdi::ABSORPTION));
 
     // pack it
     packed = odfmg->pack();
   }
 
   // now unpack it
-  nGray_Analytic_Odfmg_Opacity opacity(packed);
+  Compound_Analytic_Odfmg_Opacity opacity(packed);
 
   // now check it
 
@@ -434,8 +435,9 @@ void packing_test(UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    std::shared_ptr<const OdfmgOpacity> odfmg(new nGray_Analytic_Odfmg_Opacity(
-        groups, bands, models, rtt_cdi::ABSORPTION));
+    std::shared_ptr<const OdfmgOpacity> odfmg(
+        new Compound_Analytic_Odfmg_Opacity(groups, bands, models,
+                                            rtt_cdi::ABSORPTION));
 
     packed = odfmg->pack();
   }
@@ -444,7 +446,7 @@ void packing_test(UnitTest &ut) {
   // Marshak_Model is not registered in rtt_cdi::Opacity_Models
   bool caught = false;
   try {
-    nGray_Analytic_Odfmg_Opacity nmg(packed);
+    Compound_Analytic_Odfmg_Opacity nmg(packed);
   } catch (const rtt_dsxx::assertion &err) {
     caught = true;
     ostringstream message;

--- a/src/cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
@@ -1,16 +1,16 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   cdi_analytic/test/tstnGray_Analytic_MultigroupOpacity.cc
+ * \file   cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
  * \author Thomas M. Evans
  * \date   Tue Nov 13 17:24:12 2001
- * \brief  nGray_Analytic_MultigroupOpacity test.
+ * \brief  Compound_Analytic_MultigroupOpacity test.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "cdi_analytic_test.hh"
 #include "cdi/CDI.hh"
-#include "cdi_analytic/nGray_Analytic_MultigroupOpacity.hh"
+#include "cdi_analytic/Compound_Analytic_MultigroupOpacity.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include <memory>
@@ -21,8 +21,8 @@ using namespace std;
 using rtt_cdi::CDI;
 using rtt_cdi::MultigroupOpacity;
 using rtt_cdi_analytic::Analytic_Opacity_Model;
+using rtt_cdi_analytic::Compound_Analytic_MultigroupOpacity;
 using rtt_cdi_analytic::Constant_Analytic_Opacity_Model;
-using rtt_cdi_analytic::nGray_Analytic_MultigroupOpacity;
 using rtt_cdi_analytic::Polynomial_Analytic_Opacity_Model;
 using rtt_dsxx::soft_equiv;
 
@@ -53,11 +53,12 @@ void multigroup_test(rtt_dsxx::UnitTest &ut) {
   models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
   // make an analytic multigroup opacity object for absorption
-  nGray_Analytic_MultigroupOpacity opacity(groups, models, rtt_cdi::ABSORPTION);
+  Compound_Analytic_MultigroupOpacity opacity(groups, models,
+                                              rtt_cdi::ABSORPTION);
 
   // check the interface to multigroup opacity
   {
-    string desc = "nGray Multigroup Absorption";
+    string desc = "Compound Multigroup Absorption";
 
     if (opacity.data_in_tabular_form())
       ITFAILS;
@@ -88,15 +89,15 @@ void multigroup_test(rtt_dsxx::UnitTest &ut) {
       ITFAILS;
   }
   {
-    nGray_Analytic_MultigroupOpacity anal_opacity(groups, models,
-                                                  rtt_cdi::SCATTERING);
-    if (anal_opacity.getDataDescriptor() != "nGray Multigroup Scattering")
+    Compound_Analytic_MultigroupOpacity anal_opacity(groups, models,
+                                                     rtt_cdi::SCATTERING);
+    if (anal_opacity.getDataDescriptor() != "Compound Multigroup Scattering")
       ITFAILS;
   }
   {
-    nGray_Analytic_MultigroupOpacity anal_opacity(groups, models,
-                                                  rtt_cdi::TOTAL);
-    if (anal_opacity.getDataDescriptor() != "nGray Multigroup Total")
+    Compound_Analytic_MultigroupOpacity anal_opacity(groups, models,
+                                                     rtt_cdi::TOTAL);
+    if (anal_opacity.getDataDescriptor() != "Compound Multigroup Total")
       ITFAILS;
   }
 
@@ -208,8 +209,9 @@ void test_CDI(rtt_dsxx::UnitTest &ut) {
   models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
   // make an analytic multigroup opacity object for absorption
-  shared_ptr<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
-      groups, models, rtt_cdi::ABSORPTION));
+  shared_ptr<const MultigroupOpacity> mg(
+      new Compound_Analytic_MultigroupOpacity(groups, models,
+                                              rtt_cdi::ABSORPTION));
 
   // make a CDI object
   CDI cdi;
@@ -280,21 +282,22 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    shared_ptr<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
-        groups, models, rtt_cdi::ABSORPTION));
+    shared_ptr<const MultigroupOpacity> mg(
+        new Compound_Analytic_MultigroupOpacity(groups, models,
+                                                rtt_cdi::ABSORPTION));
 
     // pack it
     packed = mg->pack();
   }
 
   // now unpack it
-  nGray_Analytic_MultigroupOpacity opacity(packed);
+  Compound_Analytic_MultigroupOpacity opacity(packed);
 
   // now check it
 
   // check the interface to multigroup opacity
   {
-    string desc = "nGray Multigroup Absorption";
+    string desc = "Compound Multigroup Absorption";
 
     if (opacity.data_in_tabular_form())
       ITFAILS;
@@ -372,8 +375,9 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
     models[2].reset(new rtt_cdi_analytic::Constant_Analytic_Opacity_Model(3.0));
 
     // make an analytic multigroup opacity object for absorption
-    shared_ptr<const MultigroupOpacity> mg(new nGray_Analytic_MultigroupOpacity(
-        groups, models, rtt_cdi::ABSORPTION));
+    shared_ptr<const MultigroupOpacity> mg(
+        new Compound_Analytic_MultigroupOpacity(groups, models,
+                                                rtt_cdi::ABSORPTION));
 
     packed = mg->pack();
   }
@@ -382,7 +386,7 @@ void packing_test(rtt_dsxx::UnitTest &ut) {
   // Marshak_Model is not registered in rtt_cdi::Opacity_Models
   bool caught = false;
   try {
-    nGray_Analytic_MultigroupOpacity nmg(packed);
+    Compound_Analytic_MultigroupOpacity nmg(packed);
   } catch (const rtt_dsxx::assertion &ass) {
     caught = true;
     ostringstream message;
@@ -408,5 +412,5 @@ int main(int argc, char *argv[]) {
 }
 
 //---------------------------------------------------------------------------//
-// end of tstnGray_Analytic_MultigroupOpacity.cc
+// end of tstCompound_Analytic_MultigroupOpacity.cc
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Likewise rename nGray_Analytic_Odfmg_Opacity to Compound_Analytic_Odfmg_Opacity.

Change Compound_Analytic_MultigroupOpacity to use group structure when calculating opacities, to make it consistent with Compound_Analytic_Odfmg_Opacity previously used in Capsaicin.

### Background

The Capsaicin project is, so far as we know, the only client for the OdfmgOpacity class hierarchy. This was written to support experiments on using opacity distribution functions for thermal transport calculations. The results were not encouraging and no further work has been done in this direction in years, nor do we foresee any further work in the future. Capsaicin has therefore abandoned support of opacity distribution functions.

This removes significant code bloat from Capsaicin, but falling back to MultigroupOpacity from Odfmg_Opacity revealed that the nGray_Analytic_MultigroupOpacity class does not produce the same opacities as nGray_Analytic_Odfmg_Opacity does for a single distribution band. Further investigation showed thatn nGray_Analytic_MultigroupOpacity ignores frequency dependence in its opacity calculation. 

It was not clear at first whether this was deliberate. Digging into the code convinced me that I had not intended nGray_Analytic_MultigroupOpacity to have the same opacity in all groups in all cases. The name seems confusing enough that Compound_Analytic_... seemed more appropriate to capture the concept, which is of an opacity built on a set of individual group models.

### Purpose of Pull Request

Give nGray ... classes a more appropriate name, Compound...
Make Compound_Analytic_MultigroupOpacity match Compound_Analytic_OdfmgOpacity for a single band per group.

### Description of changes

Renamed classes.
Modified opacity calculation loop to use the frequency dependent interface of the Analytic_Opacity_Model class.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
