### PR TITLE
Attempt to fix a static initialization fiasco issue.

### DIFF
--- a/src/units/FundUnit.hh
+++ b/src/units/FundUnit.hh
@@ -25,7 +25,7 @@ namespace rtt_units {
 //============================================================================//
 
 template <typename F>           // T is one of { Ltype, Mtype, etc. }
-class DLL_PUBLIC_units FundUnit // Length, Mass, time, etc...
+class FundUnit                  // Length, Mass, time, etc...
 {
 public:
   //! default constructor

--- a/src/units/FundUnit.hh
+++ b/src/units/FundUnit.hh
@@ -24,8 +24,8 @@ namespace rtt_units {
  */
 //============================================================================//
 
-template <typename F>           // T is one of { Ltype, Mtype, etc. }
-class FundUnit                  // Length, Mass, time, etc...
+template <typename F> // T is one of { Ltype, Mtype, etc. }
+class FundUnit        // Length, Mass, time, etc...
 {
 public:
   //! default constructor

--- a/src/units/MathConstants.hh
+++ b/src/units/MathConstants.hh
@@ -19,10 +19,10 @@ namespace rtt_units {
 // standard C++.
 
 //! pi the ratio of a circle's circumference to its diameter (dimensionless)
-static double const PI = 3.141592653589793238462643383279;
+static double constexpr PI = 3.141592653589793238462643383279;
 
 // Euler's number (dimensionless)
-static double const N_EULER = 2.7182818284590452353602874;
+static double constexpr N_EULER = 2.7182818284590452353602874;
 
 } // end namespace rtt_units
 

--- a/src/units/PhysicalConstants.hh
+++ b/src/units/PhysicalConstants.hh
@@ -54,80 +54,90 @@ public:
   //! \todo Make electronCharge and Avaragodo adjustable based on units.
 
   //! accesses Avogadro's number (1/mole)
-  double avogadro() { return d_avogadro; }
+  constexpr double avogadro() { return d_avogadro; }
 
   //! see avogadro()
-  double Na() { return avogadro(); }
+  constexpr double Na() { return avogadro(); }
 
   //! access the Planck constant (units of energy-time)
-  double planck() const { return d_planck; }
+  constexpr double planck() const { return d_planck; }
   //! see planck()
-  double h() const { return planck(); }
+  constexpr double h() const { return planck(); }
 
   //! access the Gas constant (units of energy/mol/temp)
-  double gasConstant() const { return d_gasConstant; }
+  constexpr double gasConstant() const { return d_gasConstant; }
   //! see gasConstant()
-  double R() const { return gasConstant(); }
+  constexpr double R() const { return gasConstant(); }
 
   //! accesses the Boltzmann constant (Energy/Temp)
-  double boltzmann() const { return d_boltzmann; }
+  constexpr double boltzmann() const { return d_boltzmann; }
   //! see boltzmann()
-  double k() const { return boltzmann(); }
+  constexpr double k() const { return boltzmann(); }
 
   //! accesses the electron charge (Charge)
-  double electronCharge() const { return d_electronCharge; }
+  constexpr double electronCharge() const { return d_electronCharge; }
   //! see electronCharge()
-  double e() const { return electronCharge(); }
+  constexpr double e() const { return electronCharge(); }
 
   //! accesses the speed of light (units of velocity)
-  double speedOfLight() const { return d_cLight; }
+  constexpr double speedOfLight() const { return d_cLight; }
   //! see speedOfLight()
-  double c() const { return speedOfLight(); }
+  constexpr double c() const { return speedOfLight(); }
 
   //! accesses the StefanBoltzmann constant (Work/Area/Temp^4 )
-  double stefanBoltzmann() const { return d_stefanBoltzmann; }
+  constexpr double stefanBoltzmann() const { return d_stefanBoltzmann; }
   //! see stefanBoltzmann()
-  double sigma() const { return stefanBoltzmann(); }
+  constexpr double sigma() const { return stefanBoltzmann(); }
 
   //! accesses the gravitational constant
-  double gravitationalConstant() const { return d_gravitationalConstant; }
+  constexpr double gravitationalConstant() const {
+    return d_gravitationalConstant;
+  }
   //! see gravitationalConstant()
-  double G() const { return gravitationalConstant(); }
+  constexpr double G() const { return gravitationalConstant(); }
 
   //! access the acceleration due to gravity (standard).
-  double accelerationFromGravity() const { return d_accelerationFromGravity; }
+  constexpr double accelerationFromGravity() const {
+    return d_accelerationFromGravity;
+  }
   //! see accelerationFromGravity()
-  double g() const { return accelerationFromGravity(); }
+  constexpr double g() const { return accelerationFromGravity(); }
 
   //! access the Faraday constant
-  double faradayConstant() const { return d_faradayConstant; }
+  constexpr double faradayConstant() const { return d_faradayConstant; }
   //! see faradayConstant()
-  double F() const { return faradayConstant(); }
+  constexpr double F() const { return faradayConstant(); }
 
   //! access the Permeability of vacuum (free space)
-  double permeabilityOfVacuum() const { return d_permeabilityOfVacuum; }
+  constexpr double permeabilityOfVacuum() const {
+    return d_permeabilityOfVacuum;
+  }
   //! see permeabilityOfVacuum()
-  double mu0() const { return permeabilityOfVacuum(); }
+  constexpr double mu0() const { return permeabilityOfVacuum(); }
 
   //! accesses the permittivity of free space (units of force/length)
-  double permittivityOfFreeSpace() const { return d_permittivityOfFreeSpace; }
+  constexpr double permittivityOfFreeSpace() const {
+    return d_permittivityOfFreeSpace;
+  }
   //! see permittivityOfFreeSpace()
-  double epsi0() const { return permittivityOfFreeSpace(); }
+  constexpr double epsi0() const { return permittivityOfFreeSpace(); }
 
   //! accesses the classical electron radius (units of length)
-  double classicalElectronRadius() const { return d_classicalElectronRadius; }
+  constexpr double classicalElectronRadius() const {
+    return d_classicalElectronRadius;
+  }
   //! see classicalElectronRadius()
-  double re() const { return classicalElectronRadius(); }
+  constexpr double re() const { return classicalElectronRadius(); }
 
   //! accesses the electron mass (units of mass)
-  double electronMass() const { return d_electronMass; }
+  constexpr double electronMass() const { return d_electronMass; }
   //! see electronMass()
-  double me() const { return electronMass(); }
+  constexpr double me() const { return electronMass(); }
 
   //! accesses the proton mass (units of mass)
-  double protonMass() const { return d_protonMass; }
+  constexpr double protonMass() const { return d_protonMass; }
   //! see protonMass()
-  double mp() const { return protonMass(); }
+  constexpr double mp() const { return protonMass(); }
 
 private:
   // Base physical constants in SI units:

--- a/src/units/PhysicalConstantsSI.hh
+++ b/src/units/PhysicalConstantsSI.hh
@@ -115,8 +115,8 @@ static double constexpr EV2K = electronChargeSI / boltzmannSI;
  * \f]
  */
 static double constexpr stefanBoltzmannSI =
-    2.0 * std::pow(PI, 5) * std::pow(boltzmannSI, 4) /
-    (15.0 * std::pow(planckSI, 3) * std::pow(cLightSI, 2));
+    2.0 * PI * PI * PI * PI * PI * boltzmannSI * boltzmannSI * boltzmannSI *
+    boltzmannSI / (15.0 * planckSI * planckSI * planckSI * cLightSI * cLightSI);
 
 //! [F] Faraday constant == Na * e
 static double constexpr faradayConstantSI = AVOGADRO * electronChargeSI;
@@ -126,12 +126,12 @@ static double constexpr permeabilityOfVacuumSI = 4.0 * PI * 1.0e-7; // Henry/m
 
 //! [epsi0] PERMITTIVITY OF FREE SPACE (F/M)
 static double constexpr permittivityOfFreeSpaceSI =
-    1.0 / permeabilityOfVacuumSI / cLightSI / cLightSI; // Coloumb^2/J/m
+    1.0 / permeabilityOfVacuumSI / cLightSI / cLightSI; // Coulomb^2/J/m
 
 //! [re] Classical electron radius (M)
 static double constexpr classicalElectronRadiusSI =
-    std::pow(electronChargeSI, 2) / (4 * PI * permittivityOfFreeSpaceSI *
-                                     electronMassSI * std::pow(cLightSI, 2));
+    electronChargeSI * electronChargeSI /
+    (4 * PI * permittivityOfFreeSpaceSI * electronMassSI * cLightSI * cLightSI);
 
 } // end namespace rtt_units
 

--- a/src/units/PhysicalConstantsSI.hh
+++ b/src/units/PhysicalConstantsSI.hh
@@ -43,19 +43,19 @@ namespace rtt_units {
 
 //! [c] SPEED OF LIGHT (M/S)
 // exact value by NIST definition
-static double const cLightSI = 2.99792458e8; // m s^-1
+static double constexpr cLightSI = 2.99792458e8; // m s^-1
 
 //! [Na] AVOGADRO'S NUMBER ("entities"/MOLE)
 // Wikipedia (2013-12-3) == NIST Codata 2010
-static double const AVOGADRO = 6.02214129e23; // entities/mol
+static double constexpr AVOGADRO = 6.02214129e23; // entities/mol
 
 //! [h] Planck constant ( Energy seconds )
 // Wikipedia (2013-12-3) == NIST Codata 2010 (eps = 4.4e-8)
-static double const planckSI = 6.62606957e-34; // J s
+static double constexpr planckSI = 6.62606957e-34; // J s
 
 //! [R] Molar Gas constant
 // Wikipedia (2013-12-3) == NIST Codata 2010 (eps 9.1e-7)
-static double const gasConstantSI = 8.3144621; // J/mol/K
+static double constexpr gasConstantSI = 8.3144621; // J/mol/K
 
 /*!
  * \brief [k] BOLTZMANN'S CONSTANT == R/Na (JOULES/K)
@@ -63,7 +63,7 @@ static double const gasConstantSI = 8.3144621; // J/mol/K
  * \note If this changes you msut update the Enumerated Temperature Type in
  *       UnitSystemEnusm.hh!
  */
-static double const boltzmannSI = 1.380648800E-23; // J K^-1
+static double constexpr boltzmannSI = 1.380648800E-23; // J K^-1
 
 /*!
  * \brief [e] ELECTRON CHARGE (COULOMBS)
@@ -72,23 +72,23 @@ static double const boltzmannSI = 1.380648800E-23; // J K^-1
  * \note If this changes you msut update the Enumerated Temperature Type in
  *       UnitSystemEnusm.hh!
  */
-static double const electronChargeSI = 1.602176565e-19; // Amp / sec
+static double constexpr electronChargeSI = 1.602176565e-19; // Amp / sec
 
 //! [me] ELECTRON REST MASS (KG)	 s
 // Wikipedia (2013-12-3) == NIST Codata 2010 (eps = 4e-8)
-static double const electronMassSI = 9.10938291e-31; // kg
+static double constexpr electronMassSI = 9.10938291e-31; // kg
 
 //! [G] Gravitational Constant
 // Wikipedia (2013-12-3) == NIST Codata 2010 (eps = 1.2e-4)
-static double const gravitationalConstantSI = 6.67384e-11; // m^3/kg/s^2
+static double constexpr gravitationalConstantSI = 6.67384e-11; // m^3/kg/s^2
 
 //! [g] Acceleration due to gravity (standard)
 // Wikipedia (2013-12-3)
-static double const accelerationFromGravitySI = 9.80665; // m/s^2
+static double constexpr accelerationFromGravitySI = 9.80665; // m/s^2
 
 //! [mp] PROTON REST MASS (KG)
 // Wikipedia (2013-12-3) == NIST Codata 2010 (eps = 4.4e-8)
-static double const protonMassSI = 1.672621777e-27; // kg
+static double constexpr protonMassSI = 1.672621777e-27; // kg
 
 //---------------------------------------------------------------------------//
 // DERIVED CONSTANTS
@@ -104,9 +104,9 @@ static double const protonMassSI = 1.672621777e-27; // kg
  * \note If this number is changed, you must also update the conversion factor
  *       found in UniSystemUnums.hh.
  */
-static double const EV2K = electronChargeSI / boltzmannSI;
+static double constexpr EV2K = electronChargeSI / boltzmannSI;
 
-/*! 
+/*!
  * \brief [sigma] STEFAN-BOLTZMANN CONSTANT (WATTS/(M**2-K**4)
  *
  * \f[
@@ -114,22 +114,22 @@ static double const EV2K = electronChargeSI / boltzmannSI;
  *             = 5.670373e-8
  * \f]
  */
-static double const stefanBoltzmannSI =
+static double constexpr stefanBoltzmannSI =
     2.0 * std::pow(PI, 5) * std::pow(boltzmannSI, 4) /
     (15.0 * std::pow(planckSI, 3) * std::pow(cLightSI, 2));
 
 //! [F] Faraday constant == Na * e
-static double const faradayConstantSI = AVOGADRO * electronChargeSI;
+static double constexpr faradayConstantSI = AVOGADRO * electronChargeSI;
 
 //! [mu0] Permeability of vacuum (free space)
-static double const permeabilityOfVacuumSI = 4.0 * PI * 1.0e-7; // Henry/m
+static double constexpr permeabilityOfVacuumSI = 4.0 * PI * 1.0e-7; // Henry/m
 
 //! [epsi0] PERMITTIVITY OF FREE SPACE (F/M)
-static double const permittivityOfFreeSpaceSI =
+static double constexpr permittivityOfFreeSpaceSI =
     1.0 / permeabilityOfVacuumSI / cLightSI / cLightSI; // Coloumb^2/J/m
 
 //! [re] Classical electron radius (M)
-static double const classicalElectronRadiusSI =
+static double constexpr classicalElectronRadiusSI =
     std::pow(electronChargeSI, 2) / (4 * PI * permittivityOfFreeSpaceSI *
                                      electronMassSI * std::pow(cLightSI, 2));
 

--- a/src/units/UnitSystem.hh
+++ b/src/units/UnitSystem.hh
@@ -5,10 +5,7 @@
  *          mass, time, temperature, current, angle, quantity).
  *  \date   Fri Oct 24 15:07:43 2003
  *  \note   Copyright (C) 2016-2019 Triad National Security, LLC.
- *          All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef rtt_units_UnitSystem_hh
@@ -23,15 +20,14 @@ namespace rtt_units {
 //===========================================================================//
 /*! \class UnitSystem
  *
- * \brief Provide a units system object for Draco. 
+ * \brief Provide a units system object for Draco.
  *
- * This unit system consists of 7 unit types (Length, Mass, time,
- * Temperature, Current, Angle and Quantity).  The class then provides simple
- * accessors that allow conversion between unit systems and unit label
- * names.  The general format for an accessor is u.L() or u.Lname().  L can
- * be replaced with M, t, T, I, A or Q to access the confersion factor for
- * different fundamental units.  The accessor Xname() returns the label name
- * for a unit.
+ * This unit system consists of 7 unit types (Length, Mass, time, Temperature,
+ * Current, Angle and Quantity).  The class then provides simple accessors that
+ * allow conversion between unit systems and unit label names.  The general
+ * format for an accessor is u.L() or u.Lname().  L can be replaced with M, t,
+ * T, I, A or Q to access the confersion factor for different fundamental units.
+ * The accessor Xname() returns the label name for a unit.
  *
  * \verbatim
  * SI units are:
@@ -46,16 +42,16 @@ namespace rtt_units {
  * Derived units are:
  *    area             :         L^2
  *    volume           :         L^3
- *    velocity (v)     :         L   / t           
+ *    velocity (v)     :         L   / t
  *    acceleration (a) :         L   / t^2
  *    density (rho)    :     M / L^3
  *    angular velocity : rad     / t
  *    force (f)        :     M * L   / t^2
- *    power (P)        :     M * L^2 / t^3 
+ *    power (P)        :     M * L^2 / t^3
  *    torque           :     M * L^2 / t^2
  *    pressure (p)     :     M / L   / t^2
- *    energy           :     M * L^2 / t^2 
- * 
+ *    energy           :     M * L^2 / t^2
+ *
  *    charge                (q) : I * t     (Coulombs = Amp * sec)
  *    electrical potential  (V) : P / I     (Volt = Watt/Amp)
  *    electrical resistance (R) : V / I     (Ohm  = Volt/Amp)
@@ -73,7 +69,7 @@ namespace rtt_units {
  *
  * \sa FundUnit
  * \sa PhysicalConstants
- *  
+ *
  * \example test/tstUnitSystemType.cc
  * \example test/tstUnitSystem.cc
  *
@@ -97,28 +93,17 @@ namespace rtt_units {
  *                                      .M( rtt_units::M_g  );
  * \endverbatim
  */
-//
-// revision history:
-// -----------------
-// 0) original
-//
 //===========================================================================//
 
-class DLL_PUBLIC_units UnitSystem {
+class UnitSystem {
 public:
   // FRIENDS
 
-  //     //! Define the divisor operator for Units/Units.
-  //     friend UnitSystem operator/( UnitSystem const & op1,
-  // 				 UnitSystem const & op2 );
+  //! Define the equality operator for Units==Units.
+  friend bool operator==(UnitSystem const &op1, UnitSystem const &op2);
 
   //! Define the equality operator for Units==Units.
-  friend DLL_PUBLIC_units bool operator==(UnitSystem const &op1,
-                                          UnitSystem const &op2);
-
-  //! Define the equality operator for Units==Units.
-  friend DLL_PUBLIC_units bool operator!=(UnitSystem const &op1,
-                                          UnitSystem const &op2);
+  friend bool operator!=(UnitSystem const &op1, UnitSystem const &op2);
   // CREATORS
 
   //! Prefered constructor

--- a/src/units/UnitSystemEnums.cc
+++ b/src/units/UnitSystemEnums.cc
@@ -2,7 +2,7 @@
 /*! \file   UnitSystemEnums.cc
  *  \author Kelly Thompson
  *  \brief  This file contains enums, conversion factors and labels that help
- *          define a UnitSystem. 
+ *          define a UnitSystem.
  *  \date   Mon Nov 03 20:54:05 2003
  *  \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *          All rights reserved. */
@@ -32,19 +32,18 @@ namespace rtt_units {
  * \return A std::string that contains only one label
  */
 std::string setUnitLabel(size_t const pos, std::string const &labels) {
-  using std::string;
 
   Require(labels.length() > 0);
 
   // Store the location of the first letter of each label.  Also append the
   // position for one past the end of the original string.
-  std::vector<string::size_type> word_positions;
+  std::vector<std::string::size_type> word_positions;
 
   // idx is the index for the first character of the lable.
   // numChars is the length of the label.
-  string::size_type idx(0), numChars(0);
+  std::string::size_type idx(0), numChars(0);
   word_positions.push_back(0);
-  while ((idx = labels.find(",", idx)) != string::npos)
+  while ((idx = labels.find(",", idx)) != std::string::npos)
     word_positions.push_back(++idx);
 
   // append one past the end the string.  This lets us compute the label
@@ -52,7 +51,7 @@ std::string setUnitLabel(size_t const pos, std::string const &labels) {
   word_positions.push_back(labels.length() + 1);
   idx = word_positions[pos];
   numChars = word_positions[pos + 1] - idx - 1;
-  string retVal = labels.substr(idx, numChars);
+  std::string retVal = labels.substr(idx, numChars);
 
   return retVal;
 

--- a/src/units/UnitSystemEnums.hh
+++ b/src/units/UnitSystemEnums.hh
@@ -2,13 +2,10 @@
 /*! \file   UnitSystemEnums.hh
  *  \author Kelly Thompson
  *  \brief  This file contains enums, conversion factors and labels that help
- *          define a UnitSystem. 
+ *          define a UnitSystem.
  *  \date   Fri Oct 24 15:57:09 2003
  *  \note   Copyright (C) 2016-2019 Triad National Security, LLC.
- *          All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __units_UnitSystemEnums_hh__
@@ -29,10 +26,10 @@ enum Ltype {
   L_cm = 2    //!< centimeters (1 m = 100 cm)
 };
 
-int const num_Ltype(3);
-double const L_cf[num_Ltype] = {0.0, 1.0, 100.0};
-std::string const L_labels("NA,m,cm");
-std::string const L_long_labels("no length unit specified,meter,centimeter");
+int constexpr num_Ltype = 3;
+double constexpr L_cf[] = {0.0, 1.0, 100.0};
+char constexpr L_labels[] = "NA,m,cm";
+char constexpr L_long_labels[] = "no length unit specified,meter,centimeter";
 
 //========================================//
 // ENUMERATED MASS TYPES
@@ -44,10 +41,10 @@ enum Mtype {
   M_g = 2     //!< gram (1 g = 1e-3 kg)
 };
 
-int const num_Mtype(3);
-double const M_cf[num_Mtype] = {0.0, 1.0, 1000.0};
-std::string const M_labels("NA,kg,g");
-std::string const M_long_labels("no mass unit specified,kilogram,gram");
+int constexpr num_Mtype = 3;
+double constexpr M_cf[] = {0.0, 1.0, 1000.0};
+char constexpr M_labels[] = "NA,kg,g";
+char constexpr M_long_labels[] = "no mass unit specified,kilogram,gram";
 
 //========================================//
 // ENUMERATED TIME TYPES
@@ -62,11 +59,11 @@ enum ttype {
   t_ns    //!< nanoseconds  (1 ns = 1e-9 s)
 };
 
-int const num_ttype(6);
-double const t_cf[num_ttype] = {0.0, 1.0, 1.0e3, 1.0e6, 1.0e8, 1.0e9};
-std::string const t_labels("NA,s,ms,us,sh,ns");
-std::string const t_long_labels(
-    "no time unit specified,second,milisecond,microsecond,shake,nanosecond");
+int constexpr num_ttype = 6;
+double constexpr t_cf[] = {0.0, 1.0, 1.0e3, 1.0e6, 1.0e8, 1.0e9};
+char constexpr t_labels[] = "NA,s,ms,us,sh,ns";
+char constexpr t_long_labels[] =
+  "no time unit specified,second,milisecond,microsecond,shake,nanosecond";
 
 //========================================//
 // ENUMERATED TEMPERATURE TYPES
@@ -81,10 +78,10 @@ enum Ttype {
   T_eV //!< eV      (1 K = 8.61733238496e-5 keV or 1 eV = 11604.519302808940 K)
 };
 
-int const num_Ttype(4);
-double const T_cf[num_Ttype] = {0.0, 1.0, 1.0 / 1.1604519302808940e7,
-                                1.0 / 1.1604519302808940e4};
-std::string const T_labels("NA,K,keV,eV");
+int constexpr num_Ttype = 4;
+double constexpr T_cf[] = {0.0, 1.0, 1.0 / 1.1604519302808940e7,
+                           1.0 / 1.1604519302808940e4};
+char constexpr T_labels[] = "NA,K,keV,eV";
 
 //========================================//
 // ENUMERATED CURRENT TYPES
@@ -95,9 +92,9 @@ enum Itype {
   I_amp   //!< Amp (SI)
 };
 
-int const num_Itype(2);
-double const I_cf[num_Itype] = {0.0, 1.0};
-std::string const I_labels("NA,Amp");
+int constexpr num_Itype = 2;
+double constexpr I_cf[] = {0.0, 1.0};
+char constexpr I_labels[] = "NA,Amp";
 
 //========================================//
 // ENUMERATED ANGLE TYPES
@@ -109,9 +106,9 @@ enum Atype {
   A_deg   //!< degrees (PI rad = 180 deg)
 };
 
-int const num_Atype(3);
-double const A_cf[num_Atype] = {0.0, 1.0, 57.295779512896171};
-std::string const A_labels("NA,rad,deg");
+int constexpr num_Atype = 3;
+double constexpr A_cf[] = {0.0, 1.0, 57.295779512896171};
+char constexpr A_labels[] = "NA,rad,deg";
 
 //========================================//
 // ENUMERATED QUANTITY TYPES
@@ -122,17 +119,16 @@ enum Qtype {
   Q_mol   //!< mole (SI)
 };
 
-int const num_Qtype(2);
-double const Q_cf[num_Qtype] = {0.0, 1.0};
-std::string const Q_labels("NA,mol");
+int constexpr num_Qtype = 2;
+double constexpr Q_cf[] = {0.0, 1.0};
+char constexpr Q_labels[] = "NA,mol";
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
 
 //! Extract unit labels from list in UnitSystemEnums.hh.
-DLL_PUBLIC_units std::string setUnitLabel(size_t const pos,
-                                          std::string const &labels);
+std::string setUnitLabel(size_t const pos, std::string const &labels);
 
 } // end namespace rtt_units
 

--- a/src/units/UnitSystemEnums.hh
+++ b/src/units/UnitSystemEnums.hh
@@ -63,7 +63,7 @@ int constexpr num_ttype = 6;
 double constexpr t_cf[] = {0.0, 1.0, 1.0e3, 1.0e6, 1.0e8, 1.0e9};
 char constexpr t_labels[] = "NA,s,ms,us,sh,ns";
 char constexpr t_long_labels[] =
-  "no time unit specified,second,milisecond,microsecond,shake,nanosecond";
+    "no time unit specified,second,milisecond,microsecond,shake,nanosecond";
 
 //========================================//
 // ENUMERATED TEMPERATURE TYPES

--- a/src/units/UnitSystemType.cc
+++ b/src/units/UnitSystemType.cc
@@ -1,14 +1,11 @@
 //----------------------------------*-C++-*----------------------------------//
 /*! \file   UnitSystemType.cc
  *  \author Kelly Thompson
- *  \brief  Aggregates a collection of FundUnits to create a complete 
+ *  \brief  Aggregates a collection of FundUnits to create a complete
  *          UnitSystemType.
  *  \date   Fri Oct 24 15:04:41 2003
  *  \note   Copyright (C) 2016-2019 Triad National Security, LLC.
- *          All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *          All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "UnitSystemType.hh"

--- a/src/units/UnitSystemType.hh
+++ b/src/units/UnitSystemType.hh
@@ -1,7 +1,7 @@
 //----------------------------------*-C++-*----------------------------------//
 /*! \file   UnitSystemType.hh
  *  \author Kelly Thompson
- *  \brief  Aggregates a collection of FundUnits to create a complete 
+ *  \brief  Aggregates a collection of FundUnits to create a complete
  *          UnitSystemType.
  *  \date   Fri Oct 24 15:04:41 2003
  *  \note   Copyright (C) 2016-2019 Triad National Security, LLC.
@@ -16,10 +16,10 @@
 namespace rtt_units {
 
 //============================================================================//
-/*! 
+/*!
  * \class UnitSystemType
  *
- * \brief Aggregates a collection of FundUnits to create a complete 
+ * \brief Aggregates a collection of FundUnits to create a complete
  *        UnitSystemType.  Also provides a tool for constructing UnitSystems
  *        on the fly.
  *
@@ -28,7 +28,7 @@ namespace rtt_units {
  * \sa test/tstUnitSystem.cc - a demonstration of using UnitSystemTypoe
  *
  * Different ways to construct a UnitSystem
- 
+
  * \verbatim
  * using rtt_units::UnitSystemType;
  * using rtt_units::UnitSystem;
@@ -43,7 +43,7 @@ namespace rtt_units {
  */
 //============================================================================//
 
-class DLL_PUBLIC_units UnitSystemType {
+class UnitSystemType {
 public:
   // CONSTRUCTORS AND DESTRUCTOR
 

--- a/src/units/test/tstFundUnit.cc
+++ b/src/units/test/tstFundUnit.cc
@@ -8,11 +8,11 @@
  *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
-#include <sstream>
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include "units/FundUnit.hh"
+#include <sstream>
 
 //---------------------------------------------------------------------------//
 // TESTS

--- a/src/units/test/tstFundUnit.cc
+++ b/src/units/test/tstFundUnit.cc
@@ -3,16 +3,12 @@
  * \file   units/test/tstFundUnit.cc
  * \author Kelly Thompson
  * \date   Wed Oct  8 13:50:19 2003
- * \brief  
+ * \brief
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include <sstream>
-
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"


### PR DESCRIPTION
### Background

+ If client codes are built statically, they fail to run because portions of the unit package are initialized in the wrong order.  Some of the global static variables use other global static data during initialization and if the order is wrong, the code with generate a segmentation violation.
+ A discussion on this and the associated remedy is provided at https://isocpp.org/wiki/faq/ctors#static-init-order.
+ This fixes a long standing issue in our codes.

### Purpose of Pull Request

* [Fixes Redmine Issue #962](https://rtt.lanl.gov/redmine/issues/962)

### Description of changes

+ Mark global static data `constexpr`.
+ In `UnitSystemEnums.hh`, also change the global static data types to `constexpr`.  This required transforming `std::string` data types to string literals (e.g.: `char constexpr foo[]`).  The array size for `double[]` was removed because the new initializer syntax auto-sizes these arrays.
+ Also, removed `DLL_PUBLIC_units` in a few places where this decoration is no longer needed.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
    * [x] Fix windows build issues (Appveyor - `WIP` added as blocker)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
