### PR TITLE
More Python 3.0 changes for python ipcress reader

### DIFF
--- a/src/cdi_ipcress/python/demo_read_data.py
+++ b/src/cdi_ipcress/python/demo_read_data.py
@@ -42,7 +42,7 @@ print("\n")
 
 # check for data set I want to use
 mat_ID = 10001
-if ipcress_data.has_key("{0}_{1}".format("rgray",  mat_ID)):
+if "{0}_{1}".format("rgray",  mat_ID) in ipcress_data:
   print("File has Rosseland gray data for {0}".format(mat_ID))
 else:
   print("File does not have Rosseland gray data for {0}".format(mat_ID))

--- a/src/cdi_ipcress/python/ipcress_reader.py
+++ b/src/cdi_ipcress/python/ipcress_reader.py
@@ -62,9 +62,10 @@ def interpolate_mg_opacity_data(T_grid, rho_grid, hnu_grid, op_data, \
   if (target_rho  > np.max(rho_grid)):  target_rho = np.max(rho_grid)
   if (target_T    < np.min(T_grid)):    target_T = np.min(T_grid)
   if (target_T    > np.max(T_grid)):    target_T = np.max(T_grid)
-  print( \
-    "Interpolating {0}--Target rho: {1} , target T: {2}".format( \
-    print_str, target_rho, target_T))
+  if (print_str is not None):
+    print( \
+      "Interpolating {0}--Target rho: {1} , target T: {2}".format( \
+      print_str, target_rho, target_T))
 
   # get correct index of adjacent density points
   rho_L = 1000; rho_G =0
@@ -110,7 +111,8 @@ def interpolate_mg_opacity_data(T_grid, rho_grid, hnu_grid, op_data, \
 ###############################################################################
 
 ################################################################################
-def interpolate_gray_opacity_data(T_grid, rho_grid, op_data, target_rho, target_T):
+def interpolate_gray_opacity_data(T_grid, rho_grid, op_data, target_rho, \
+    target_T, print_str = ""):
   n_rho = len(rho_grid)
   n_T = len(T_grid)
 
@@ -119,7 +121,10 @@ def interpolate_gray_opacity_data(T_grid, rho_grid, op_data, target_rho, target_
   if (target_rho  > np.max(rho_grid)):  target_rho = np.max(rho_grid)
   if (target_T    < np.min(T_grid)):    target_T = np.min(T_grid)
   if (target_T    > np.max(T_grid)):    target_T = np.max(T_grid)
-  print("Target rho: {0} , target T: {1}".format(target_rho, target_T))
+  if (print_str is not None):
+    print( \
+      "Interpolating {0}--Target rho: {1} , target T: {2}".format( \
+      print_str, target_rho, target_T))
 
   rho_L = 1000; rho_G =0
   for rho_i, rho in enumerate(rho_grid[:-1]):
@@ -228,7 +233,12 @@ def read_information_from_file(ipcress_file):
         if (j==0): temp_property.append(three_string[2].strip() )
         elif (j==1): temp_property.append(three_string[0].strip())
         else: temp_property.append(i) #index of data table containing values
-      mat_property.append(temp_property)
+      try:
+        temp_property = [temp_property[0].decode('ascii'), \
+                         temp_property[1].decode('ascii'), temp_property[2]]
+        mat_property.append(temp_property)
+      except:
+        mat_property.append(temp_property)
 
   materials = []
   for m in range(num_mats):


### PR DESCRIPTION
### Background

* @attom fixed some file reading errors in the python ipcress file reader. He added an ASCII decode step from the `UTF-8` read that fixed some parsing errors.  I've applied those fixes and tested them on several ipcress files.

### Purpose of Pull Request

* Better python 3.0 compatibility for python ipcress reader

### Description of changes

* Decode utf-8 read to ascii in the dictionary build phase of ipcress_reader.py
* Change "has_key" in demo_read_data.py to python 3 style string in  dictionary

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
