### PR TITLE
Darwin environment updates.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -60,7 +60,8 @@ function( setMPIflavorVer )
     foreach( line ${TEMP} )
 
       # extract the version...
-      if( ${line} MATCHES "Version" OR ${line} MATCHES "OpenRTE")
+      if( ${line} MATCHES "Version" OR ${line} MATCHES "OpenRTE" OR
+          ${line} MATCHES "Open MPI" )
         set(DBS_MPI_VER "${line}")
         if( "${DBS_MPI_VER}" MATCHES "[0-9]+[.][0-9]+[.][0-9]+" )
           string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\1"

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -35,9 +35,9 @@ if test -n "$MODULESHOME"; then
     case $DRACO_ARCH in
       arm)
         cflavor="gcc-8.2.0"
-        mflavor="$cflavor-openmpi-3.1.2"
+        mflavor="$cflavor-openmpi-3.1.3"
         noflavor="git cmake gcc/8.2.0"
-        compflavor="gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.3.1-$cflavor openmpi/3.1.2-gcc_8.2.0"
+        compflavor="gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.2-gcc_8.2.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-netlib trilinos/12.12.1-$mflavor-netlib"
         # ec_mf="ndi"
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
@@ -47,15 +47,16 @@ if test -n "$MODULESHOME"; then
 
       x86_64)
         cflavor="gcc-7.3.0"
-        mflavor="$cflavor-openmpi-3.1.2"
-        noflavor="emacs git cmake/3.14.0-$cflavor gcc/7.3.0 ack"
-        compflavor="gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.3.1-$cflavor openmpi/3.1.2-gcc_7.3.0"
-        mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-netlib trilinos/12.12.1-$mflavor-netlib"
-        ec_mf="ndi"
+        mflavor="$cflavor-openmpi-3.1.3"
+        lapackflavor="lapack-3.8.0"
+        noflavor="emacs git ack gcc/7.3.0"
         if [[ ${SLURM_JOB_PARTITION} =~ "volta" ]]; then
           # If we have GPUs on this node, then load the cuda toolkit module by default
-          compflavor+=" cuda/9.2"
+          noflavor+=" cuda/10.1"
         fi
+        compflavor="cmake/3.14.2-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.2-gcc_7.3.0"
+        mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1-$mflavor-$lapackflavor"
+        ec_mf="ndi"
         # Add clang-format (version 6) to the default environment.
         if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
           export PATH=$PATH:/projects/opt/centos7/clang/6.0.0/bin
@@ -84,8 +85,8 @@ superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
         cflavor="gcc-7.3.0"
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
-        noflavor="git cmake gcc/7.3.0"
-        compflavor="random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
+        noflavor="git gcc/7.3.0 cuda/10.1"
+        compflavor="eospac/6.4.0-$cflavor cmake/3.14.2-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
         # ec_mf="ndi eospac/6.3.0"

--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -83,7 +83,7 @@ auto-mode-alist."
 auto-mode-alist."
   (interactive)
       (progn
-      (autoload 'python-mode "python-mode" "Python editing mode." t)
+      (autoload 'python "python" "Python editing mode." t)
       (setq auto-mode-alist
 	    (cons '("\\.py$" . python-mode) auto-mode-alist))
       (defun draco-python-mode-hook ()

--- a/regression/darwin-regress.msub
+++ b/regression/darwin-regress.msub
@@ -121,7 +121,7 @@ case $DRACO_ARCH in
     mflavor="$cflavor-openmpi-3.1.2"
     noflavor="git cmake gcc/8.2.0"
     compflavor="gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.3.1-$cflavor openmpi/3.1.2-gcc_8.2.0"
-    mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-netlib trilinos/12.12.1-$mflavor-netlib"
+    mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-lapack-3.8.0 trilinos/12.14.1-$mflavor-lapack-3.8.0"
     # ec_mf="ndi"
     # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
     # eliminates warnings: "there are more than one active ports on host"
@@ -138,15 +138,15 @@ case $DRACO_ARCH in
 
   x86_64)
     cflavor="gcc-7.3.0"
-    mflavor="$cflavor-openmpi-3.1.2"
-    noflavor="emacs git cmake/3.14.0-$cflavor gcc/7.3.0 ack"
-    compflavor="gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.3.1-$cflavor openmpi/3.1.2-gcc_7.3.0"
-    mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-netlib trilinos/12.12.1-$mflavor-netlib"
-    ec_mf="ndi"
+    mflavor="$cflavor-openmpi-3.1.3"
+    noflavor="emacs git gcc/7.3.0 ack"
+    compflavor="cmake/3.14.2-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.3.1-$cflavor openmpi/3.1.2-gcc_7.3.0"
     if [[ ${SLURM_JOB_PARTITION} == "volta-x86" ]]; then
       # If we have GPUs on this node, then load the cuda toolkit module by default
-      compflavor+=" cuda/9.2"
+      compflavor+=" cuda/10.1"
     fi
+    mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-lapack-3.8.0 trilinos/12.14.1-$mflavor-lapack-3.8.0"
+    ec_mf="ndi"
     # Add clang-format (version 6) to the default environment.
     if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
       export PATH=$PATH:/projects/opt/centos7/clang/6.0.0/bin
@@ -169,9 +169,9 @@ superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
   power9*)
     cflavor="gcc-7.3.0"
     mflavor="$cflavor-openmpi-3.1.3"
-    noflavor="git cmake gcc/7.3.0"
-    compflavor="random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
-    mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-netlib trilinos/12.12.1-${mflavor}-netlib cuda/9.2"
+    noflavor="git gcc/7.3.0 cuda/10.1"
+    compflavor="cmake/3.14.2-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
+    mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-lapack-3.8.0 trilinos/12.14.1-${mflavor}-lapack-3.8.0"
     # These aren't built for power architectures?
     # ec_mf="ndi eospac/6.3.0"
     # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
@@ -242,7 +242,7 @@ comp=$comp-$featurebranch
 # https://www.funtoo.org/Subarches
 if [[ ${regress_mode} == "on" ]]; then
   run "module load git"
-  keychain=keychain-2.8.2
+  keychain=keychain-2.8.5
   $VENDOR_DIR/$keychain/keychain $HOME/.ssh/regress_rsa
   if test -f $HOME/.keychain/$machine-sh; then
     run "source $HOME/.keychain/$machine-sh"


### PR DESCRIPTION
### Background

* Supported TPLs and development environment continues to evolve on Darwin ARM, Power9 and Volta nodes.

### Description of changes

+ Update default module sets for ARM, Power9+CUDA and x86+CUDA.
+ Update emacs python-mode defaults.
+ Update regression scripts to use newer TPLs.
+ Tweak setupMPI.cmake to support more versions of OpenMPI that are found on Darwin.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
