### PR TITLE
New docker container for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ env:
     - SOURCE_DIR=/home/travis/Draco
     - T_SOURCE_DIR=/home/travis/build/lanl/Draco
     - VENDOR_DIR=/vendors
+    - GCCVER=8
   matrix:
   - STYLE=ON
   - WERROR=ON COVERAGE=ON DRACO_C4=SCALAR
@@ -86,7 +87,7 @@ install:
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019may /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019may /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,11 @@ env:
 #  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
-  - travis_retry timeout 540 docker pull kinetictheory/draco-travis-ci
+  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2019may
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-travis-ci /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019may /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER KineticTheory "https://github.com/KineticTheory"
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV SPACK_ROOT=/vendors/spack
-ENV DRACO_TPL="cmake@3.11.4 gsl@2.4 numdiff@5.9.0 random123@1.09 openmpi@3.1.1 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist@5.2.2^netlib-lapack trilinos+nox~mumps~hdf5~hypre~suite-sparse~boost^superlu-dist@5.2.2^netlib-lapack"
+ENV DRACO_TPL="cmake@3.14.4 gsl@2.5 numdiff@5.9.0 random123@1.09 openmpi@3.1.4 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist@5.2.2^netlib-lapack trilinos"
 ENV FORCE_UNSAFE_CONFIGURE=1
 ENV DISTRO=bionic
 ENV CLANG_FORMAT_VER=6.0

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -1,4 +1,4 @@
-FROM kinetictheory/draco-travis-ci
+FROM kinetictheory/draco-ci-2019may
 
 # Use ubuntu if building from scratch
 #FROM ubuntu:latest
@@ -15,7 +15,7 @@ MAINTAINER KineticTheory "https://github.com/KineticTheory"
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV SPACK_ROOT=/vendors/spack
-ENV DRACO_TPL="cmake@3.14.4 gsl@2.5 numdiff@5.9.0 random123@1.09 openmpi@3.1.4 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist@5.2.2^netlib-lapack trilinos"
+ENV DRACO_TPL="cmake@3.14.4 gsl@2.5 numdiff@5.9.0 random123@1.09 openmpi@3.1.4 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist trilinos"
 ENV FORCE_UNSAFE_CONFIGURE=1
 ENV DISTRO=bionic
 ENV CLANG_FORMAT_VER=6.0
@@ -33,13 +33,13 @@ RUN echo "tzdata tzdata/Areas select US" > /tmp/preseed.txt; \
     echo "tzdata tzdata/Zones/US select Mountain" >> /tmp/preseed.txt; \
     debconf-set-selections /tmp/preseed.txt && \
     apt-get update && \
-    apt-get install -y tzdata
+    apt-get install -y --no-install-recommends tzdata
 
 ## Basic admin tools
-RUN apt-get -y install apt-utils autoconf python software-properties-common flex bison
+RUN apt-get install -y --no-install-recommends apt-utils automake autoconf autotools-dev python3 software-properties-common flex bison
 
 ## Basic developer tools
-RUN apt-get -y install build-essential ca-certificates coreutils ccache curl doxygen environment-modules gcc-7 g++-7 gfortran-7 git grace graphviz python-pip tar tcl tk unzip vim wget
+RUN apt-get install -y --no-install-recommends build-essential ca-certificates coreutils curl doxygen environment-modules gcc-8 g++-8 gfortran-8 git grace graphviz python3-pip tar tcl tk unzip wget
 # RUN apg-get upgrade
 RUN if ! test -f /etc/profile.d/modules.sh; then \
       echo "source /usr/share/modules/init/bash" > /etc/profile.d/modules.sh; \
@@ -48,24 +48,27 @@ RUN if ! test -f /etc/profile.d/modules.sh; then \
 ## LLVM tools like clang-format
 ## Note: we can't use variables in the add-apt-repository commmand as this
 ##       creates an invalid entry in /etc/apt/sources.list
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - ; \
-    add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main' ; \
-    apt-get update; \
-    apt-get install -y clang-format-${CLANG_FORMAT_VER}; \
-    export PATH=$PATH:/usr/bin
+#RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - ; \
+#    add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main' ; \
+#    apt-get update; \
+#    apt-get install -y clang-format-${CLANG_FORMAT_VER}; \
+#    export PATH=$PATH:/usr/bin
+RUN  apt-get install -y --no-install-recommends clang-format-${CLANG_FORMAT_VER}; \
+     ln -s /usr/bin/clang-format-6.0 /usr/bin/clang-format; \
+     export PATH=$PATH:/usr/bin
 
 ## code cov plugin...
-RUN python -m pip install --upgrade pip
-RUN python -m pip install codecov
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install codecov
 
 ## SPACK -----------------------------------------------------------------------------
 
 # install/setup spack
-RUN mkdir -p $SPACK_ROOT
+RUN mkdir -p $SPACK_ROOT/etc/spack/linux
 RUN curl -s -L https://api.github.com/repos/spack/spack/tarball | tar xzC $SPACK_ROOT --strip 1
 # note: if you wish to change default settings, add files alongside
 #       the Dockerfile with your desired settings. Then uncomment this line
-#COPY packages.yaml modules.yaml $SPACK_ROOT/etc/spack/
+COPY packages.yaml $SPACK_ROOT/etc/spack/linux
 RUN if ! test -f /etc/profile.d/spack.sh; then \
       echo "source $SPACK_ROOT/share/spack/setup-env.sh" > /etc/profile.d/spack.sh; \
     fi

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -36,7 +36,7 @@ RUN echo "tzdata tzdata/Areas select US" > /tmp/preseed.txt; \
     apt-get install -y --no-install-recommends tzdata
 
 ## Basic admin tools
-RUN apt-get install -y --no-install-recommends apt-utils automake autoconf autotools-dev python3 software-properties-common flex bison
+RUN apt-get install -y --no-install-recommends apt-utils automake autoconf autotools-dev python3 software-properties-common flex bison ssh
 
 ## Basic developer tools
 RUN apt-get install -y --no-install-recommends build-essential ca-certificates coreutils curl doxygen environment-modules gcc-8 g++-8 gfortran-8 git grace graphviz python3-pip tar tcl tk unzip wget

--- a/regression/packages.yaml
+++ b/regression/packages.yaml
@@ -1,0 +1,137 @@
+# -------------------------------------------------------------------------
+# This file controls default concretization preferences for Spack.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/packages.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/packages.yaml
+# -------------------------------------------------------------------------
+packages:
+  autoconf:
+    version: [2.69]
+    paths:
+      autoconf@2.69: /usr
+    buildable: False
+  automake:
+    version: [1.15.1]
+    paths:
+      automake@1.15.1: /usr
+    buildable: False
+  boost:
+    variants: [+mpi]
+  bzip2:
+    version: [1.0.6]
+    paths:
+      bzip2@1.0.6: /
+    buildable: False
+  cairo:
+    variants: [+X]
+  cgns:
+    variants: [+mpi]
+  graphviz:
+    variants: [+pangocairo]
+  gtkplus:
+    variants: [+X]
+  hdf5:
+    variants: [+mpi]
+  hypre:
+    variants: [+mpi~internal-superlu]
+    providers:
+      blas: [netlib-lapack]
+  llvm:
+    variants: build_type=Release
+  m4:
+    version: [1.4.18]
+    paths:
+      m4@1.4.18: /usr
+    buildable: False
+  matio:
+    variants: [+hdf5]
+  moab:
+    variants: [+mpi^netlib-lapack]
+  netlib-scalapack:
+    providers:
+      blas: [netlib-lapack]
+  pango:
+    variants: [+X]
+  parmetis:
+    variants: [build_type=Release]
+  perl:
+    version: [5.26.1]
+    paths:
+      perl@5.26.1: /usr
+    buildable: False
+  petsc:
+    variants: [+boost+hdf5+mpi]
+  py-gnuplot:
+    providers:
+      blas: [netlib-lapack]
+  py-numpy:
+    providers:
+      blas: [netlib-lapack]
+  qt:
+    variants: [+phonon+dbus]
+  superlu-dist:
+    version: [5.4.0]
+    providers:
+      blas: [netlib-lapack]
+  tar:
+    version: [1.29]
+    paths:
+      tar@1.29: /
+    buildable: False
+  trilinos:
+    # spack install trilinos host_arch=HSW cxxflags='-fpermissive'
+    # host_arch=HSW or Power9
+    # variants: [+cuda+amesos2+hdf5+hypre+intrepid2+isorropia+kokkos_enable_cuda_lambda+kokkos_enable_cuda_uvm+kokkos_enable_rdc+openmp+nox+phalanx+shards+shared+shylu+superlu-dist+teko+tempus~mumps~suite-sparse build_type=Release gpu_arch=Volta70]
+    variants: [+amesos2+nox+superlu-dist~mumps~hdf5~hypre~suite-sparse~boost build_type=Release]
+    providers:
+      blas: [netlib-lapack]
+  xz:
+    version: [5.2.2]
+    paths:
+      xz@5.2.2: /usr
+    buildable: False
+  all:
+    compiler: [gcc, intel, pgi, clang, xl, nag, fj]
+    providers:
+      D: [ldc]
+      awk: [gawk]
+      blas: [netlib-blas]
+      daal: [intel-daal]
+      elf: [elfutils]
+      fftw-api: [fftw]
+      gl: [mesa+opengl, opengl]
+      glx: [mesa+glx, opengl]
+      glu: [mesa-glu, openglu]
+      golang: [gcc]
+      ipp: [intel-ipp]
+      java: [jdk, openjdk, ibm-java]
+      jpeg: [libjpeg-turbo, libjpeg]
+      lapack: [netlib-lapack]
+      mariadb-client: [mariadb-c-client, mariadb]
+      mkl: [intel-mkl]
+      mpe: [mpe2]
+      mpi: [openmpi, mpich]
+      mysql-client: [mysql, mariadb-c-client]
+      ninja: [ninja, ninja-fortran]
+      ninja-fortran: [ninja-fortran, ninja@kitware]
+      opencl: [pocl]
+      openfoam: [openfoam-com, openfoam-org, foam-extend]
+      pil: [py-pillow]
+      pkgconfig: [pkgconf, pkg-config]
+      scalapack: [netlib-scalapack]
+      szip: [libszip, libaec]
+      tbb: [intel-tbb]
+      unwind: [libunwind]
+    permissions:
+      read: world
+      write: user
+      

--- a/regression/travis-run-tests.sh
+++ b/regression/travis-run-tests.sh
@@ -52,6 +52,8 @@ else
 
   # extract the TPL list from the Dockerfile
   export DRACO_TPL="`grep \"ENV DRACO_TPL\" regression/Dockerfile | sed -e 's/.*=//' | sed -e 's/\"//g'`"
+  echo "DRACO_TPL={DRACO_TPL}"
+  run "spack find -Lf"
 
   # Environment setup for the build...
   spack load ${DRACO_TPL}

--- a/regression/travis-run-tests.sh
+++ b/regression/travis-run-tests.sh
@@ -52,8 +52,6 @@ else
 
   # extract the TPL list from the Dockerfile
   export DRACO_TPL="`grep \"ENV DRACO_TPL\" regression/Dockerfile | sed -e 's/.*=//' | sed -e 's/\"//g'`"
-  echo "DRACO_TPL=${DRACO_TPL}"
-  run "spack find -Lf"
 
   # Environment setup for the build...
   for item in ${DRACO_TPL}; do

--- a/regression/travis-run-tests.sh
+++ b/regression/travis-run-tests.sh
@@ -52,11 +52,13 @@ else
 
   # extract the TPL list from the Dockerfile
   export DRACO_TPL="`grep \"ENV DRACO_TPL\" regression/Dockerfile | sed -e 's/.*=//' | sed -e 's/\"//g'`"
-  echo "DRACO_TPL={DRACO_TPL}"
+  echo "DRACO_TPL=${DRACO_TPL}"
   run "spack find -Lf"
 
   # Environment setup for the build...
-  spack load ${DRACO_TPL}
+  for item in ${DRACO_TPL}; do
+    run "spack load ${item}"
+  done
 
   if [[ $GCCVER ]]; then
     export CXX=`which g++-${GCCVER}`


### PR DESCRIPTION
### Background

* I created a new docker container that can be used for Travis CI tests.
* The goal was to update the toolchains used for Travis builds.

### Description of changes

* Begin using gcc-8.3.0.
* cmake 3.11.4 --> 3.14.4
* openmpi 3.1.1 --> 3.1.4
* superlu-dist 5.2.2 --> 5.4.0
* trilinos-12.12.1 --> 12.14.1
* gsl-2.3 --> 2.5
* python3 is provided in this container
* Build instructions:
```
# cd to directory with Dockerfile and packages.yaml
cd /D f:\work\docker
docker build --rm --pull --tag draco-ci-2019may:latest .   
docker commit -m "blah" -a kinetictheory <container-name> \
     kinetictheory/draco-ci-2019may:latest # queues for upload
docker login -u kinetictheory (and password)
docker tag draco-ci-2019may kinetictheory/draco-ci-2019may:latest
docker push kinetictheory/draco-ci-2019may
```

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
