### PR TITLE
In application_unit_test.py, fix numdiff argument order.

### DIFF
--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -528,7 +528,8 @@ class UnitTest:
       if self.gold.strip():
         clean_run_args.append(self.gold.strip())
       for arg in numdiff_args.split():
-        if arg: clean_run_args.append(arg)
+        if arg:
+          clean_run_args.insert(-2,arg)
 
       # run numdiff command, redirecting stdout and stderr, get a unique
       # filename for the numdiff output and error files


### PR DESCRIPTION
### Background

+ The win32 version of `numdiff.exe` is sensitive to the order of arguments.  Specifically, optional arguments must be listed before the two file names.

### Purpose of Pull Request

* [Fixes Redmine Issue #1513](https://rtt.lanl.gov/redmine/issues/1513)

### Description of changes

+ Update the python to fix argument order when there are optional arguments.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
