### PR TITLE
Add mscgen and sphinx to the CI docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,11 +83,11 @@ env:
 #  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
-  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2019may
+  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2019june
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019may /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019june /bin/bash -l -c "${SOURCE_DIR}/regression/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 # Don't build when repository is tagged.
 skip_tags: true
 max_jobs: 1
-image: Visual Studio 2017 Preview
+image: Visual Studio 2017
 clone_depth: 3
 
 environment:
@@ -18,6 +18,9 @@ build_script:
   - cd ..
   - curl -L -o win32-vendors.zip https://github.com/KineticTheory/ci-demo/releases/download/vendors-201809/win32-vendors.zip
   - 7z.exe -y x win32-vendors.zip
+  - curl -L -o cmake.zip https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-win64-x64.zip
+  - 7z.exe -y x cmake.zip
+  - set PATH=c:\projects\cmake-3.14.5-win64-x64\bin;%PATH%
   - mkdir build
   - cd build
 # no MPI installed so force scalar builds.

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -1,7 +1,15 @@
-FROM kinetictheory/draco-ci-2019may
+#FROM kinetictheory/draco-ci-2019june
 
 # Use ubuntu if building from scratch
-#FROM ubuntu:latest
+FROM ubuntu:latest
+
+# This image:
+# 1. cd /D f:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build --rm --pull --tag draco-ci-2019june:latest . 
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <container-name> kinetictheory/draco-ci-2019june:latest # queues for upload
+# 6. docker push kinetictheory/draco-ci-2019june:latest
 
 MAINTAINER KineticTheory "https://github.com/KineticTheory"
 
@@ -15,7 +23,7 @@ MAINTAINER KineticTheory "https://github.com/KineticTheory"
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV SPACK_ROOT=/vendors/spack
-ENV DRACO_TPL="cmake@3.14.4 gsl@2.5 numdiff@5.9.0 random123@1.09 openmpi@3.1.4 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist trilinos"
+ENV DRACO_TPL="cmake@3.14.4 gsl@2.5 numdiff@5.9.0 random123@1.09 openmpi@3.1.4 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist trilinos mscgen"
 ENV FORCE_UNSAFE_CONFIGURE=1
 ENV DISTRO=bionic
 ENV CLANG_FORMAT_VER=6.0
@@ -39,7 +47,7 @@ RUN echo "tzdata tzdata/Areas select US" > /tmp/preseed.txt; \
 RUN apt-get install -y --no-install-recommends apt-utils automake autoconf autotools-dev python3 software-properties-common flex bison ssh
 
 ## Basic developer tools
-RUN apt-get install -y --no-install-recommends build-essential ca-certificates coreutils curl doxygen environment-modules gcc-8 g++-8 gfortran-8 git grace graphviz python3-pip tar tcl tk unzip wget
+RUN apt-get install -y --no-install-recommends build-essential ca-certificates coreutils curl doxygen environment-modules gcc-8 g++-8 gfortran-8 git grace graphviz python3-pip python3-sphinx python3-sphinx-rtd-theme tar tcl tk unzip wget
 # RUN apg-get upgrade
 RUN if ! test -f /etc/profile.d/modules.sh; then \
       echo "source /usr/share/modules/init/bash" > /etc/profile.d/modules.sh; \
@@ -65,16 +73,27 @@ RUN python3 -m pip install codecov
 
 # install/setup spack
 RUN mkdir -p $SPACK_ROOT/etc/spack/linux
-RUN curl -s -L https://api.github.com/repos/spack/spack/tarball | tar xzC $SPACK_ROOT --strip 1
+# Only download spack if it doesn't already exist.
+RUN if ! test -d $SPACK_ROOT/opt/spack ; then \
+      curl -s -L https://api.github.com/repos/spack/spack/tarball | tar xzC $SPACK_ROOT --strip 1; \
+    fi
 # note: if you wish to change default settings, add files alongside
 #       the Dockerfile with your desired settings. Then uncomment this line
 COPY packages.yaml $SPACK_ROOT/etc/spack/linux
+
+# metis/parmetis downloads are broken right now, use a mirror.
+COPY mirrors.yaml $SPACK_ROOT/etc/spack
+RUN mkdir -p $SPACK_ROOT/spack.mirror/metis
+RUN mkdir -p $SPACK_ROOT/spack.mirror/parmetis
+COPY metis-5.1.0.tar.gz $SPACK_ROOT/spack.mirror/metis
+COPY parmetis-4.0.3.tar.gz $SPACK_ROOT/spack.mirror/parmetis
+
 RUN if ! test -f /etc/profile.d/spack.sh; then \
       echo "source $SPACK_ROOT/share/spack/setup-env.sh" > /etc/profile.d/spack.sh; \
     fi
 
 ## Provide some TPLs
-RUN export PATH=$SPACK_ROOT/bin:$PATH && spack install ${DRACO_TPL} && spack clean -a
+RUN export PATH=$SPACK_ROOT/bin:$PATH && spack install -n ${DRACO_TPL} && spack clean -a
 
 # image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
 CMD /bin/bash -l

--- a/regression/mirrors.yaml
+++ b/regression/mirrors.yaml
@@ -1,0 +1,2 @@
+mirrors:
+  filesystem: file:///vendors/spack/spack.mirror


### PR DESCRIPTION
### Background

* Alex noticed that the new docker image didn't have all of the autodoc tools needed to fully test this build mode.
* With this image in place, we now require cmake-3.14 or later due to python discovery patterns that not backward compatible with older cmake.  The new cmake is required for correct cuda discovery.

### Purpose of Pull Request

* fixes #628 

### Description of changes

* Add mscgen, python3-sphinx, and  python3-sphinx-rtd-theme to the Docker image used by Travis
* Update standard version of tools, including cmake and python both Travis and Appveyor.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
