### PR TITLE
Power9 CMake fixes

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -98,7 +98,7 @@ with the gfortran option." )
     else()
       # GNU gfortran with Ninja generator or clang CXX compiler.
       if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(_cafs_fortran_target_arch "Target: x86_64*")
+        set(_cafs_fortran_target_arch "Target: x86_64*|ppc64")
       else()
         set(_cafs_fortran_target_arch "Target:.*86*")
       endif()

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -61,7 +61,7 @@ function( setMPIflavorVer )
 
       # extract the version...
       if( ${line} MATCHES "Version" OR ${line} MATCHES "OpenRTE" OR
-          ${line} MATCHES "Open MPI" )
+          ${line} MATCHES "Open MPI" OR ${line} MATCHES "Spectrum")
         set(DBS_MPI_VER "${line}")
         if( "${DBS_MPI_VER}" MATCHES "[0-9]+[.][0-9]+[.][0-9]+" )
           string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\1"


### PR DESCRIPTION
### Background

* I'm trying to get Draco to build on IBM Power9 systems

### Purpose of Pull Request

* This adds two fixes that allow detecting Spectrum MPI and detecting that GFortran is built for PowerPC

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Double check that this is needed.  We are already building/releasing a different branch of Draco on Power9 systems w/o this fix (KT).
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
