### PR TITLE
Fix constexpr compilation error with intel 17

### DIFF
--- a/src/units/PhysicalConstants.cc
+++ b/src/units/PhysicalConstants.cc
@@ -9,32 +9,11 @@
 //---------------------------------------------------------------------------//
 
 #include "PhysicalConstants.hh"
-#include "PhysicalConstantsSI.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <iomanip>
 #include <iostream>
 
 namespace rtt_units {
-
-//----------------------------------------------------------------------------//
-/*!
- * \brief Default constructor provides physical constants with SI units (kg,
- *        m, seconds, degree K, amp, radian, mole).
- * \return A PhysicalConstants object.
- */
-PhysicalConstants::PhysicalConstants()
-    : d_avogadro(AVOGADRO), d_planck(planckSI), d_gasConstant(gasConstantSI),
-      d_boltzmann(boltzmannSI), d_electronCharge(electronChargeSI),
-      d_cLight(cLightSI), d_stefanBoltzmann(stefanBoltzmannSI),
-      d_gravitationalConstant(gravitationalConstantSI),
-      d_accelerationFromGravity(accelerationFromGravitySI),
-      d_faradayConstant(faradayConstantSI),
-      d_permeabilityOfVacuum(permeabilityOfVacuumSI),
-      d_permittivityOfFreeSpace(permittivityOfFreeSpaceSI),
-      d_classicalElectronRadius(classicalElectronRadiusSI),
-      d_electronMass(electronMassSI), d_protonMass(protonMassSI) {
-  // empty
-}
 
 //----------------------------------------------------------------------------//
 /*!

--- a/src/units/PhysicalConstants.hh
+++ b/src/units/PhysicalConstants.hh
@@ -13,6 +13,7 @@
 
 #include "MathConstants.hh"
 #include "UnitSystem.hh"
+#include "PhysicalConstantsSI.hh"
 
 //! \namespace rtt_units Namespace for units and physical constants
 namespace rtt_units {
@@ -48,7 +49,25 @@ namespace rtt_units {
 class PhysicalConstants {
 public:
   // Constructors.
-  PhysicalConstants();
+  //----------------------------------------------------------------------------// 
+  /*!                                                                              
+   * \brief Default constructor provides physical constants with SI units (kg,        
+   *        m, seconds, degree K, amp, radian, mole).                              
+   * \return A PhysicalConstants object.                                           
+   */                                                                              
+  constexpr PhysicalConstants()                                           
+      : d_avogadro(AVOGADRO), d_planck(planckSI), d_gasConstant(gasConstantSI),       
+        d_boltzmann(boltzmannSI), d_electronCharge(electronChargeSI),              
+        d_cLight(cLightSI), d_stefanBoltzmann(stefanBoltzmannSI),                  
+        d_gravitationalConstant(gravitationalConstantSI),                          
+        d_accelerationFromGravity(accelerationFromGravitySI),                      
+        d_faradayConstant(faradayConstantSI),                                      
+        d_permeabilityOfVacuum(permeabilityOfVacuumSI),                            
+        d_permittivityOfFreeSpace(permittivityOfFreeSpaceSI),                      
+        d_classicalElectronRadius(classicalElectronRadiusSI),                      
+        d_electronMass(electronMassSI), d_protonMass(protonMassSI) {               
+    // empty                                                                       
+  } 
   explicit PhysicalConstants(UnitSystem const &u);
 
   //! \todo Make electronCharge and Avaragodo adjustable based on units.


### PR DESCRIPTION
### Background

* intel 17 fails to compile Draco 7.2.0

### Purpose of Pull Request

* The PhysicalConstants class was reorganized slightly so as to become literal, thereby accommodating the `constexpr` methods in that class.
* Fixed in coordination with @RyanWollaeger.
* [Fixes Redmine Issue #1551](https://rtt.lanl.gov/redmine/issues/1551)

### Description of changes

* Default `PhysicalConstants` constructor definition moved to `PhysicalConstants.hh` and decorated with `constexpr` tag.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
