### PR TITLE
Fix MSVC build warnings.

### DIFF
--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -152,7 +152,7 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
 
   /*! \bug [1] this should be a 'constexpr if' to avoid build warnings from 
    *           MSVC. Remove MSVC pragma from top of file when fixed. */
-    if (reader->get_use_face_types()) {
+  if (reader->get_use_face_types()) {
 
     // reserve some space for face_type
     face_type.reserve(std::accumulate(cell_type.begin(), cell_type.end(), 0u));

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -15,6 +15,12 @@
 #include <iostream>
 #include <numeric>
 
+//! \bug this can be fixed when [1] is fixed via C++17 'constexpr if'
+#if defined(MSVC)
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif
+
 namespace rtt_mesh {
 
 //---------------------------------------------------------------------------//
@@ -143,7 +149,10 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
   }
 
   std::vector<unsigned> face_type;
-  if (reader->get_use_face_types()) {
+
+  /*! \bug [1] this should be a 'constexpr if' to avoid build warnings from 
+   *           MSVC. Remove MSVC pragma from top of file when fixed. */
+    if (reader->get_use_face_types()) {
 
     // reserve some space for face_type
     face_type.reserve(std::accumulate(cell_type.begin(), cell_type.end(), 0u));
@@ -151,9 +160,9 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
     // generate face_type vector
     unsigned cf_counter = 0;
     for (size_t cell = 0; cell < num_cells; ++cell) {
-      for (size_t face = 0; face < cell_type[cell]; ++face) {
+      for (unsigned face = 0; face < cell_type[cell]; ++face) {
 
-        // stor number of nodes for this face
+        // store number of nodes for this face
         face_type.push_back(static_cast<unsigned>(
             reader->get_cellfacenodes(cell, face).size()));
 
@@ -191,6 +200,10 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
 }
 
 } // end namespace rtt_mesh
+
+#if defined(MSVC)
+#pragma warning(pop)
+#endif
 
 //---------------------------------------------------------------------------//
 // end of mesh/Draco_Mesh_Builder.t.hh

--- a/src/mesh/test/tstDraco_Mesh.cc
+++ b/src/mesh/test/tstDraco_Mesh.cc
@@ -86,7 +86,7 @@ void spherical_mesh_1d(rtt_c4::ParallelUnitTest &ut) {
   FAIL_IF_NOT(layout.at(num_cells - 1)[0].second[0] == 2);
 
   // check internal connectivity
-  for (size_t cell = 1; cell < num_cells - 1; ++cell) {
+  for (unsigned cell = 1; cell < num_cells - 1; ++cell) {
 
     // check neighbor cells
     FAIL_IF_NOT(layout.at(cell).size() == 2);
@@ -107,7 +107,7 @@ void spherical_mesh_1d(rtt_c4::ParallelUnitTest &ut) {
 
   // successful test output
   if (ut.numFails == 0)
-    PASSMSG("1D Draco_Mesh tests ok.");
+    PASSMSG("1D Draco_Mesh tests okay.");
   return;
 }
 
@@ -123,10 +123,10 @@ void cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
   const size_t num_xdir = 2;
   const size_t num_ydir = 1;
 
-  // generate a constainer for data needed in mesh construction
+  // generate a container for data needed in mesh construction
   rtt_mesh_test::Test_Mesh_Interface mesh_iface(num_xdir, num_ydir);
 
-  // generate an interface for the alternate form of the mesh ctor
+  // generate an interface for the alternate form of the mesh constructor
   rtt_mesh_test::Test_Mesh_Interface mesh_iface_alt(num_xdir, num_ydir, {}, 0.0,
                                                     0.0, true);
 
@@ -162,7 +162,7 @@ void cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
   FAIL_IF_NOT(mesh->get_cell_type() == cell_type);
   FAIL_IF_NOT(mesh->get_cell_to_node_linkage() == cell_to_node_linkage);
 
-  // check that alterate cell type and cell-node linkage data is correct
+  // check that alternate cell type and cell-node linkage data is correct
   FAIL_IF_NOT(mesh_alt->get_cell_type() == mesh_iface_alt.cell_type);
   FAIL_IF_NOT(mesh_alt->get_cell_to_node_linkage() ==
               mesh_iface_alt.cell_to_node_linkage);
@@ -265,7 +265,7 @@ void cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
       test_cn_first += cell_type[cell];
     }
 
-    // check that flattend linkage from alternate mesh matches original
+    // check that flattened linkage from alternate mesh matches original
     std::vector<unsigned> test_cn_linkage_alt =
         mesh_iface.flatten_cn_linkage(layout_alt, bd_layout_alt, go_layout_alt);
     FAIL_IF_NOT(test_cn_linkage_alt == test_cn_linkage);
@@ -316,7 +316,7 @@ void cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
 
   // successful test output
   if (ut.numFails == 0)
-    PASSMSG("2D Draco_Mesh tests ok.");
+    PASSMSG("2D Draco_Mesh tests okay.");
   return;
 }
 


### PR DESCRIPTION
### Background

* There are some [build warnings](https://rtt.lanl.gov/cdash/index.php?project=Draco&date=2019-06-27) from MSVC in the current `develop` branch. 

### Description of changes

* Minor tweaks to fix a few types.
* @RyanWollaeger The 'unreachable code' warning is another case of our need for C++17's `constexpr if`.  I decided to suppress the warning for now.  The suppression can be removed when we adopt C++17.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
