### PR TITLE
Move draco_setenv to systemcall.hh

### DIFF
--- a/src/c4/test/tstQueryEnv.cc
+++ b/src/c4/test/tstQueryEnv.cc
@@ -10,6 +10,7 @@
 #include "c4/QueryEnv.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
+#include "ds++/SystemCall.hh"
 #include <cstdlib>
 #include <functional> // std::function
 #include <map>
@@ -19,14 +20,6 @@ using rtt_dsxx::UnitTest;
 
 using env_store_value = std::pair<bool, std::string>;
 using env_store_t = std::map<std::string, env_store_value>;
-
-#ifdef MSVC
-#define draco_unsetenv(k) _putenv_s(k, "")
-#define draco_setenv(k, v) _putenv_s(k, v)
-#else
-#define draco_unsetenv(k) unsetenv(k)
-#define draco_setenv(k, v) setenv(k, v, 1)
-#endif
 
 //----------------------------------------------------------------------------//
 /* Helper function: Record SLURM keys and values, if any, then remove them from

--- a/src/ds++/SystemCall.hh
+++ b/src/ds++/SystemCall.hh
@@ -114,6 +114,17 @@ DLL_PUBLIC_dsxx void draco_remove(std::string const &path);
 
 } // namespace rtt_dsxx
 
+/*!
+ * \brief set and unset environment variables.
+ */
+#ifdef MSVC
+#define draco_unsetenv(k) _putenv_s(k, "")
+#define draco_setenv(k, v) _putenv_s(k, v)
+#else
+#define draco_unsetenv(k) unsetenv(k)
+#define draco_setenv(k, v) setenv(k, v, 1)
+#endif
+
 #endif // rtt_dsxx_SystemCall_hh
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* We use a macro to wrap the set/unset environment calls since these are system dependent.  Move the definitions to an easily accessed location so other codes can make use of these CPP macros.

### Description of changes

* Move these definitions of `draco_setenv` and `draco_unsetenv` from `test/tstQueryEnv.cc` to `ds++/SystemCall.hh` so it can also be used by other codes.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
