### PR TITLE
Performance tweaks for Planck and Rosseland integration

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -163,7 +163,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
     string( APPEND CMAKE_C_FLAGS " -march=native" )
   endif()
 
-  set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS} -fconstexpr-depth=1024")
+  set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS}")
   set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
   set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
   set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -163,7 +163,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
     string( APPEND CMAKE_C_FLAGS " -march=native" )
   endif()
 
-  set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS}" )
+  set( CMAKE_CXX_FLAGS                "${CMAKE_C_FLAGS} -fconstexpr-depth=1024")
   set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
   set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
   set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -54,7 +54,7 @@ if( "${numproc}notfound" STREQUAL "notfound" )
 endif()
 
 if( NOT CXX_FLAGS_INITIALIZED )
-  set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+  set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using Draco settings." )
 
   # Alternative for per-directory, or per-target specific flags:
   # add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/MP>")
@@ -63,9 +63,9 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # - /wd 4251 disable warning #4251: 'identifier' : class 'type' needs to have
   #   dll-interface to be used by clients of class 'type2'
   # - /arch:[SSE|SSE2|AVX|AVX2|IA32]
-  # - /W[1234] Warning levels. Draco is currently using /W4 (see 
+  # - /W[1234] Warning levels. Draco is currently using /W4 (see
   #            src/CMakeLists.txt), but clients default to /W2.
-  # - /std:c++14 (should be added by cmake in compilerEnv.cmake)
+  # - /std:c++14 (should be added by CMake in compilerEnv.cmake)
   # - /showIncludes
   # - /FC
   set( CMAKE_C_FLAGS "/W2 /Gy /fp:precise /DWIN32 /D_WINDOWS /MP /wd4251" )
@@ -85,7 +85,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
     #        "${CMAKE_C_FLAGS_DEBUG} /D_HAS_ITERATOR_DEBUGGING=0" )
   endif()
 
-  # If building static libraries, inlcude debugging information in the library.
+  # If building static libraries, include debugging information in the library.
   if( ${DRACO_LIBRARY_TYPE} MATCHES "STATIC" )
     string( APPEND CMAKE_C_FLAGS_DEBUG " /Z7"   )
   endif()

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -263,12 +263,11 @@ int scatterv(T *send_buffer, int *send_sizes, int *send_displs,
 //---------------------------------------------------------------------------//
 
 template <typename T> void global_sum(T &x) {
-  // copy data into send buffer
-  T y = x;
 
   // do global MPI reduction (result is on all processors) into x
-  Remember(int check =) MPI_Allreduce(&y, &x, 1, MPI_Traits<T>::element_type(),
-                                      MPI_SUM, communicator);
+  Remember(int check =)
+      MPI_Allreduce(MPI_IN_PLACE, &x, 1, MPI_Traits<T>::element_type(), MPI_SUM,
+                    communicator);
   Check(check == MPI_SUCCESS);
   return;
 }
@@ -289,33 +288,27 @@ void global_isum(T &send_buffer, T &recv_buffer, C4_Req &request) {
 
 //---------------------------------------------------------------------------//
 template <typename T> void global_prod(T &x) {
-  // copy data into send buffer
-  T y = x;
 
   // do global MPI reduction (result is on all processors) into x
-  MPI_Allreduce(&y, &x, 1, MPI_Traits<T>::element_type(), MPI_PROD,
+  MPI_Allreduce(MPI_IN_PLACE, &x, 1, MPI_Traits<T>::element_type(), MPI_PROD,
                 communicator);
 }
 
 //---------------------------------------------------------------------------//
 
 template <typename T> void global_min(T &x) {
-  // copy data into send buffer
-  T y = x;
 
   // do global MPI reduction (result is on all processors) into x
-  MPI_Allreduce(&y, &x, 1, MPI_Traits<T>::element_type(), MPI_MIN,
+  MPI_Allreduce(MPI_IN_PLACE, &x, 1, MPI_Traits<T>::element_type(), MPI_MIN,
                 communicator);
 }
 
 //---------------------------------------------------------------------------//
 
 template <typename T> void global_max(T &x) {
-  // copy data into send buffer
-  T y = x;
 
   // do global MPI reduction (result is on all processors) into x
-  MPI_Allreduce(&y, &x, 1, MPI_Traits<T>::element_type(), MPI_MAX,
+  MPI_Allreduce(MPI_IN_PLACE, &x, 1, MPI_Traits<T>::element_type(), MPI_MAX,
                 communicator);
 }
 
@@ -324,12 +317,10 @@ template <typename T> void global_max(T &x) {
 template <typename T> void global_sum(T *x, int n) {
   Require(x != nullptr);
   Require(n > 0);
-  // copy data into a send buffer
-  std::vector<T> send_buffer(x, x + n);
 
   // do a element-wise global reduction (result is on all processors) into
   // x
-  MPI_Allreduce(&send_buffer[0], x, n, MPI_Traits<T>::element_type(), MPI_SUM,
+  MPI_Allreduce(MPI_IN_PLACE, x, n, MPI_Traits<T>::element_type(), MPI_SUM,
                 communicator);
 }
 
@@ -338,12 +329,10 @@ template <typename T> void global_sum(T *x, int n) {
 template <typename T> void global_prod(T *x, int n) {
   Require(x != nullptr);
   Require(n > 0);
-  // copy data into a send buffer
-  std::vector<T> send_buffer(x, x + n);
 
   // do a element-wise global reduction (result is on all processors) into
   // x
-  MPI_Allreduce(&send_buffer[0], x, n, MPI_Traits<T>::element_type(), MPI_PROD,
+  MPI_Allreduce(MPI_IN_PLACE, x, n, MPI_Traits<T>::element_type(), MPI_PROD,
                 communicator);
 }
 
@@ -352,12 +341,10 @@ template <typename T> void global_prod(T *x, int n) {
 template <typename T> void global_min(T *x, int n) {
   Require(x != nullptr);
   Require(n > 0);
-  // copy data into a send buffer
-  std::vector<T> send_buffer(x, x + n);
 
   // do a element-wise global reduction (result is on all processors) into
   // x
-  MPI_Allreduce(&send_buffer[0], x, n, MPI_Traits<T>::element_type(), MPI_MIN,
+  MPI_Allreduce(MPI_IN_PLACE, x, n, MPI_Traits<T>::element_type(), MPI_MIN,
                 communicator);
 }
 
@@ -366,12 +353,10 @@ template <typename T> void global_min(T *x, int n) {
 template <typename T> void global_max(T *x, int n) {
   Require(x != nullptr);
   Require(n > 0);
-  // copy data into a send buffer
-  std::vector<T> send_buffer(x, x + n);
 
   // do a element-wise global reduction (result is on all processors) into
   // x
-  MPI_Allreduce(&send_buffer[0], x, n, MPI_Traits<T>::element_type(), MPI_MAX,
+  MPI_Allreduce(MPI_IN_PLACE, x, n, MPI_Traits<T>::element_type(), MPI_MAX,
                 communicator);
 }
 

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -260,18 +260,16 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(const size_t groupIndex,
 void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
                                        double const T,
                                        std::vector<double> &planck) {
-  Require(T >= 0.0);
+  Require(T >= std::numeric_limits<double>::min() &&
+          T < std::numeric_limits<double>::max());
   Require(bounds.size() > 0);
 
   size_t const groups(bounds.size() - 1);
   planck.resize(groups, 0.0);
 
-  // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with planck == 0.0. This avoids a possible divide by zero but
-  // it doesn't catch the case where bounds[0] == 0.0 and T is a denormal so
-  // make it the more restrictive T <= numeric_limits<double>::min()
-  if (T <= std::numeric_limits<double>::min())
-    return;
+  // nu/T must be < numeric_limits<double>::max(), throw assertion in DBC mode
+  // if this occurs
+  Check(T > bounds.back() * std::numeric_limits<double>::min());
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
@@ -307,19 +305,17 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 std::vector<double>
 CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
                                   double const T) {
-  Require(T >= 0.0);
+
+  Require(T >= std::numeric_limits<double>::min() &&
+          T < std::numeric_limits<double>::max());
   Require(bounds.size() > 0);
 
   size_t const groups(bounds.size() - 1);
   std::vector<double> planck(groups, 0.0);
 
-  // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with planck == 0.0. This avoids a possible divide by zero but
-  // it doesn't catch the case where bounds[0] == 0.0 and T is a denormal so
-  // make it the more restrictive T <= numeric_limits<double>::min()
-
-  if (T <= std::numeric_limits<double>::min())
-    return planck;
+  // nu/T must be < numeric_limits<double>::max(), throw assertion in DBC mode
+  // if this occurs
+  Check(T > bounds.back() * std::numeric_limits<double>::min());
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
@@ -355,18 +351,16 @@ CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
 void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
                                        double const T,
                                        std::vector<double> &rosseland) {
-  Require(T >= 0.0);
+  Require(T >= std::numeric_limits<double>::min() &&
+          T < std::numeric_limits<double>::max());
   Require(bounds.size() > 0);
 
   size_t const groups(bounds.size() - 1);
   rosseland.resize(groups, 0.0);
 
-  // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with rosseland == 0.0. This avoids a possible divide by zero
-  // but it doesn't catch the case where bounds[0] == 0.0 and T is a denormal so
-  // make it the more restrictive T <= numeric_limits<double>::min()
-  if (T <= std::numeric_limits<double>::min())
-    return;
+  // nu/T must be < numeric_limits<double>::max(), throw assertion in DBC mode
+  // if this occurs
+  Check(T > bounds.back() * std::numeric_limits<double>::min());
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
@@ -412,20 +406,17 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
     std::vector<double> const &bounds, double const T,
     std::vector<double> &planck, std::vector<double> &rosseland) {
 
-  Require(T >= 0.0);
+  Require(T >= std::numeric_limits<double>::min() &&
+          T < std::numeric_limits<double>::max());
   Require(bounds.size() > 0);
   size_t const groups(bounds.size() - 1);
 
   planck.resize(groups, 0.0);
   rosseland.resize(groups, 0.0);
 
-  // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with planck ==0.0 and rosseland == 0.0. This avoids a possible
-  // divide by zero but it doesn't catch the case where bounds[0] == 0.0 and T
-  // is a denormal so make it the more restrictive
-  // T <= numeric_limits<double>::min()
-  if (T <= std::numeric_limits<double>::min())
-    return;
+  // nu/T must be < numeric_limits<double>::max(), throw assertion in DBC mode
+  // if this occurs
+  Check(T > bounds.back() * std::numeric_limits<double>::min());
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -267,8 +267,10 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
   planck.resize(groups, 0.0);
 
   // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with planck == 0.0. This avoids a possible divide by zero.
-  if (T <= bounds[0] * std::numeric_limits<double>::min())
+  // return early with planck == 0.0. This avoids a possible divide by zero but
+  // it doesn't catch the case where bounds[0] == 0.0 and T is a denormal so
+  // make it the more restrictive T <= numeric_limits<double>::min()
+  if (T <= std::numeric_limits<double>::min())
     return;
 
   // Initialize the loop:
@@ -281,16 +283,12 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
     double const last_planck = planck_value;
 
     // New values:
-    if (T <= bounds[group + 1] * std::numeric_limits<double>::min())
-      planck[group] = 0.0;
-    else {
-      scaled_frequency = bounds[group + 1] / T;
-      Ensure(scaled_frequency > last_scaled_frequency);
-      planck_value = integrate_planck(scaled_frequency);
+    scaled_frequency = bounds[group + 1] / T;
+    Ensure(scaled_frequency > last_scaled_frequency);
+    planck_value = integrate_planck(scaled_frequency);
 
-      // Record the definite integral between frequencies.
-      planck[group] = planck_value - last_planck;
-    }
+    // Record the definite integral between frequencies.
+    planck[group] = planck_value - last_planck;
     Ensure(planck[group] >= 0.0);
     Ensure(planck[group] <= 1.0);
   }
@@ -316,8 +314,11 @@ CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
   std::vector<double> planck(groups, 0.0);
 
   // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with planck == 0.0. This avoids a possible divide by zero.
-  if (T <= bounds[0] * std::numeric_limits<double>::min())
+  // return early with planck == 0.0. This avoids a possible divide by zero but
+  // it doesn't catch the case where bounds[0] == 0.0 and T is a denormal so
+  // make it the more restrictive T <= numeric_limits<double>::min()
+
+  if (T <= std::numeric_limits<double>::min())
     return planck;
 
   // Initialize the loop:
@@ -330,16 +331,12 @@ CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds,
     double const last_planck = planck_value;
 
     // New values:
-    if (T <= bounds[group + 1] * std::numeric_limits<double>::min())
-      planck[group] = 0.0;
-    else {
-      scaled_frequency = bounds[group + 1] / T;
-      Ensure(scaled_frequency > last_scaled_frequency);
-      planck_value = integrate_planck(scaled_frequency);
+    scaled_frequency = bounds[group + 1] / T;
+    Ensure(scaled_frequency > last_scaled_frequency);
+    planck_value = integrate_planck(scaled_frequency);
 
-      // Record the definite integral between frequencies.
-      planck[group] = planck_value - last_planck;
-    }
+    // Record the definite integral between frequencies.
+    planck[group] = planck_value - last_planck;
     Ensure(planck[group] >= 0.0);
     Ensure(planck[group] <= 1.0);
   }
@@ -365,8 +362,10 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
   rosseland.resize(groups, 0.0);
 
   // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
-  // return early with rosseland == 0.0. This avoids a possible divide by zero.
-  if (T <= bounds[0] * std::numeric_limits<double>::min())
+  // return early with rosseland == 0.0. This avoids a possible divide by zero
+  // but it doesn't catch the case where bounds[0] == 0.0 and T is a denormal so
+  // make it the more restrictive T <= numeric_limits<double>::min()
+  if (T <= std::numeric_limits<double>::min())
     return;
 
   // Initialize the loop:
@@ -385,18 +384,14 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds,
     double const last_rosseland = rosseland_value;
 
     // New values:
-    if (T <= bounds[group + 1] * std::numeric_limits<double>::min())
-      rosseland[group] = 0.0;
-    else {
-      scaled_frequency = bounds[group + 1] / T;
-      Check(scaled_frequency > last_scaled_frequency);
-      exp_scaled_frequency = std::exp(-scaled_frequency);
-      integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency,
-                                 planck_value, rosseland_value);
+    scaled_frequency = bounds[group + 1] / T;
+    Check(scaled_frequency > last_scaled_frequency);
+    exp_scaled_frequency = std::exp(-scaled_frequency);
+    integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency,
+                               planck_value, rosseland_value);
 
-      // Record the definite integral between frequencies.
-      rosseland[group] = rosseland_value - last_rosseland;
-    }
+    // Record the definite integral between frequencies.
+    rosseland[group] = rosseland_value - last_rosseland;
     Ensure(rosseland[group] >= 0.0);
     Ensure(rosseland[group] <= 1.0);
   }
@@ -426,8 +421,10 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
 
   // nu/T must be < numeric_limits<double>::max().  So, if T < nu*min(), then
   // return early with planck ==0.0 and rosseland == 0.0. This avoids a possible
-  // divide by zero
-  if (T <= bounds[0] * std::numeric_limits<double>::min())
+  // divide by zero but it doesn't catch the case where bounds[0] == 0.0 and T
+  // is a denormal so make it the more restrictive
+  // T <= numeric_limits<double>::min()
+  if (T <= std::numeric_limits<double>::min())
     return;
 
   // Initialize the loop:
@@ -447,21 +444,15 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(
     double const last_rosseland = rosseland_value;
 
     // New values:
-    if (T <= bounds[group + 1] * std::numeric_limits<double>::min()) {
-      planck[group] = 0.0;
-      rosseland[group] = 0.0;
-    } else {
+    scaled_frequency = bounds[group + 1] / T;
+    Check(scaled_frequency > last_scaled_frequency);
+    exp_scaled_frequency = std::exp(-scaled_frequency);
+    integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency,
+                               planck_value, rosseland_value);
 
-      scaled_frequency = bounds[group + 1] / T;
-      Check(scaled_frequency > last_scaled_frequency);
-      exp_scaled_frequency = std::exp(-scaled_frequency);
-      integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency,
-                                 planck_value, rosseland_value);
-
-      // Record the definite integral between frequencies.
-      planck[group] = planck_value - last_planck;
-      rosseland[group] = rosseland_value - last_rosseland;
-    }
+    // Record the definite integral between frequencies.
+    planck[group] = planck_value - last_planck;
+    rosseland[group] = rosseland_value - last_rosseland;
     Ensure(planck[group] >= 0.0);
     Ensure(planck[group] <= 1.0);
     Ensure(rosseland[group] >= 0.0);

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -16,6 +16,7 @@
 #include "GrayOpacity.hh"
 #include "MultigroupOpacity.hh"
 #include "OdfmgOpacity.hh"
+#include "ds++/Constexpr_Functions.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <algorithm>
 #include <limits>
@@ -124,7 +125,7 @@ static inline double taylor_series_planck(double x) {
 static double polylog_series_minus_one_planck(double const x,
                                               double const eix) {
   Require(x >= 0.0);
-  Require(x < std::sqrt(std::numeric_limits<double>::max()));
+  Require(x < rtt_dsxx::ce_sqrt(std::numeric_limits<double>::max()));
   Require(rtt_dsxx::soft_equiv(std::exp(-x), eix));
 
   double const xsqrd = x * x;
@@ -776,8 +777,12 @@ double CDI::integrate_planck(double const scaled_freq,
                              double const exp_scaled_freq) {
   Require(scaled_freq >= 0);
 
+  // use the constexpr sqrt
+  constexpr double sqrt_max =
+      rtt_dsxx::ce_sqrt(std::numeric_limits<double>::max());
+
   // Case 1: nu/T very large -> integral == 1.0
-  if (scaled_freq > std::sqrt(std::numeric_limits<double>::max()))
+  if (scaled_freq > sqrt_max)
     return 1.0;
 
   // Case 2: nu/T is sufficiently small

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -769,7 +769,7 @@ double CDI::integrate_planck(double const scaled_freq) {
  * 1. nu/T is very large
  *    If nu/T is large enough, then the integral will be 1.0.
  * 2. nu/T is small
- *    Represent the integral via Taylor series exapansion (this will be
+ *    Represent the integral via Taylor series expansion (this will be
  *    more efficient than case 3).
  * 3. All other cases. Use the polylog algorithm.
  */
@@ -777,12 +777,8 @@ double CDI::integrate_planck(double const scaled_freq,
                              double const exp_scaled_freq) {
   Require(scaled_freq >= 0);
 
-  // use the constexpr sqrt
-  constexpr double sqrt_max =
-      rtt_dsxx::ce_sqrt(std::numeric_limits<double>::max());
-
   // Case 1: nu/T very large -> integral == 1.0
-  if (scaled_freq > sqrt_max)
+  if (scaled_freq > 1.0e100)
     return 1.0;
 
   // Case 2: nu/T is sufficiently small

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -719,32 +719,40 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
     if (!soft_equiv(planck[0], 0.0, tol))
       ITFAILS;
   }
-  // Extreme case 4a. T < numeric_limits<double>::min() --> follow special logic
-  // and return zero.
-  {
+  // Extreme case 4a. T < numeric_limits<double>::min() --> catch the thrown
+  // exception
+  caught = true;
+  Remember(caught = false;);
+  try {
     std::vector<double> const bounds = {1.0, 3.0, 30.0};
     double const T_eval = 1.0e-308;
     std::vector<double> planck;
     CDI::integrate_Planckian_Spectrum(bounds, T_eval, planck);
-    // make sure the alternate calling method returns the same values
-    auto planck_alt = CDI::integrate_Planckian_Spectrum(bounds, T_eval);
-    if (planck_alt != planck)
-      ITFAILS;
-    if (!soft_equiv(planck, std::vector<double>(planck.size(), 0.0), tol))
-      ITFAILS;
+  } catch (const rtt_dsxx::assertion &error) {
+    ostringstream message;
+    message << "Good, we caught the following exception: \n" << error.what();
+    PASSMSG(message.str());
+    caught = true;
   }
-  // Extreme case 4b. T < numeric_limits<double>::min() --> follow special logic
-  // and return zero. Also, let v_0 == 0.0
+  if (!caught) {
+    ostringstream message;
+    message
+        << "Failed to catch an exception when passing a denorm temperature.";
+  }
+
+  // Extreme case 4b. bounds < numeric_limits<double>::min() --> return 1.0, 0.0
   {
     std::vector<double> const bounds = {0.0, 3.0, 30.0};
-    double const T_eval = 1.0e-308;
+    double const T_eval = 1.0e-300;
     std::vector<double> planck;
     CDI::integrate_Planckian_Spectrum(bounds, T_eval, planck);
     // make sure the alternate calling method returns the same values
     auto planck_alt = CDI::integrate_Planckian_Spectrum(bounds, T_eval);
     if (planck_alt != planck)
       ITFAILS;
-    if (!soft_equiv(planck, std::vector<double>(planck.size(), 0.0), tol))
+    if (!soft_equiv(planck[0], 1.0, tol))
+      ITFAILS;
+    if (!soft_equiv(planck[1], 0.0, tol))
       ITFAILS;
   }
 
@@ -836,21 +844,6 @@ void test_planck_integration(rtt_dsxx::UnitTest &ut) {
       ITFAILS;
   }
   if (planck_alt != planck)
-    ITFAILS;
-
-  // Test zero temperature special case
-  CDI::integrate_Planckian_Spectrum(group_bounds, 0.0, planck);
-  // make sure the alternate calling method returns the same values
-  auto planck_alt_zero = CDI::integrate_Planckian_Spectrum(group_bounds, 0.0);
-
-  for (int group_index = 1; group_index <= 3; ++group_index) {
-
-    double planck_g = CDI::integratePlanckSpectrum(group_index, 1.0);
-
-    if (!soft_equiv(planck[group_index - 1], planck_g))
-      ITFAILS;
-  }
-  if (planck_alt_zero == planck)
     ITFAILS;
 
   if (ut.numFails == 0)
@@ -1127,14 +1120,25 @@ void test_rosseland_integration(rtt_dsxx::UnitTest &ut) {
   }
   // Extreme case 2. T < numeric_limits<double>::min() --> follow special logic
   // and return zero.
-  {
+  bool caught = true;
+  Remember(caught = false;);
+  try {
     std::vector<double> const bounds = {0.1, 0.3, 1.0, 3.0, 30.0};
     double const T_eval = 1.0e-308;
     std::vector<double> lrosseland;
     CDI::integrate_Rosseland_Spectrum(bounds, T_eval, lrosseland);
-    if (!soft_equiv(lrosseland, std::vector<double>(lrosseland.size(), 0.0)))
-      ITFAILS;
+  } catch (const rtt_dsxx::assertion &error) {
+    ostringstream message;
+    message << "Good, we caught the following exception: \n" << error.what();
+    PASSMSG(message.str());
+    caught = true;
   }
+  if (!caught) {
+    ostringstream message;
+    message
+        << "Failed to catch an exception when passing a denorm temperature.";
+  }
+
   // Extreme case 3. This should do the normal computation, but the result is
   // zero.
   {
@@ -1151,17 +1155,25 @@ void test_rosseland_integration(rtt_dsxx::UnitTest &ut) {
   }
   // Extreme case 4. T < numeric_limits<double>::min() --> follow special logic
   // and return zero.
-  {
+  caught = true;
+  Remember(caught = false;);
+  try {
     std::vector<double> const bounds = {0.1, 0.3, 1.0, 3.0, 30.0};
     double const T_eval = 1.0e-308;
     std::vector<double> lplanck;
     std::vector<double> lrosseland;
     CDI::integrate_Rosseland_Planckian_Spectrum(bounds, T_eval, lplanck,
                                                 lrosseland);
-    if (!soft_equiv(lrosseland, std::vector<double>(lrosseland.size(), 0.0)))
-      ITFAILS;
-    if (!soft_equiv(lplanck, std::vector<double>(lplanck.size(), 0.0)))
-      ITFAILS;
+  } catch (const rtt_dsxx::assertion &error) {
+    ostringstream message;
+    message << "Good, we caught the following exception: \n" << error.what();
+    PASSMSG(message.str());
+    caught = true;
+  }
+  if (!caught) {
+    ostringstream message;
+    message
+        << "Failed to catch an exception when passing a denorm temperature.";
   }
 
   if (ut.numFails == 0) {

--- a/src/ds++/Constexpr_Functions.hh
+++ b/src/ds++/Constexpr_Functions.hh
@@ -11,7 +11,7 @@
 #ifndef rtt_dsxx_Constexpr_Functions_hh
 #define rtt_dsxx_Constexpr_Functions_hh
 
-#include <numeric>
+#include <limits>
 
 namespace rtt_dsxx {
 

--- a/src/ds++/Constexpr_Functions.hh
+++ b/src/ds++/Constexpr_Functions.hh
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   ds++/Constexpr_Functions.hh
  * \author Alex R. Long
@@ -6,7 +6,7 @@
  * \brief  Constexpr versions of math calls
  * \note   Copyright (C) 2019 Triad National Security, LLC.
  *         All rights reserved. */
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_Constexpr_Functions_hh
 #define rtt_dsxx_Constexpr_Functions_hh
@@ -15,7 +15,8 @@
 
 namespace rtt_dsxx {
 
-double constexpr ce_fabs(double x) {
+//----------------------------------------------------------------------------//
+double constexpr ce_fabs(double const x) {
   if (x >= 0 && x < std::numeric_limits<double>::infinity())
     return x;
   else if (x < 0)
@@ -23,17 +24,25 @@ double constexpr ce_fabs(double x) {
   return std::numeric_limits<double>::quiet_NaN();
 }
 
+//----------------------------------------------------------------------------//
 //! Simple recursive Newtwon Raphson used in square root
-double constexpr sqrtNewtonRaphson(double x, double curr, double prev) {
+double constexpr sqrtNewtonRaphson(double const x, double const curr,
+                                   double const prev) {
   return (ce_fabs((curr - prev) / curr) < 1.0e-15)
              ? curr
              : sqrtNewtonRaphson(x, 0.5 * (curr + x / curr), curr);
 }
 
-//! Constexpr version of the square root
-// For a finite and non-negative value of "x", returns an approximation for the
-// square root of "x", Otherwise, returns NaN.
-double constexpr ce_sqrt(double x) {
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Constexpr version of the square root
+ *
+ * For a finite and non-negative value of "x", returns an approximation for the
+ * square root of "x", Otherwise, returns NaN.
+ *
+ * \note \c HUGE_VAL == \c std::numeric_limits<double>::infinity()
+ */
+double constexpr ce_sqrt(double const x) {
   return x >= 0 && x < std::numeric_limits<double>::infinity()
              ? sqrtNewtonRaphson(x, x, 0)
              : std::numeric_limits<double>::quiet_NaN();

--- a/src/ds++/Constexpr_Functions.hh
+++ b/src/ds++/Constexpr_Functions.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   ds++/Constexpr_Functions.hh
+ * \author Alex R. Long
+ * \date   Tue July 2 16:56:16 2019
+ * \brief  Constexpr versions of math calls
+ * \note   Copyright (C) 2019 Triad National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_dsxx_Constexpr_Functions_hh
+#define rtt_dsxx_Constexpr_Functions_hh
+
+#include <numeric>
+
+namespace rtt_dsxx {
+
+double constexpr ce_fabs(double x) {
+  if (x >= 0 && x < std::numeric_limits<double>::infinity())
+    return x;
+  else if (x < 0)
+    return -1.0 * x;
+  return std::numeric_limits<double>::quiet_NaN();
+}
+
+//! Simple recursive Newtwon Raphson used in square root
+double constexpr sqrtNewtonRaphson(double x, double curr, double prev) {
+  return (ce_fabs((curr - prev) / curr) < 1.0e-15)
+             ? curr
+             : sqrtNewtonRaphson(x, 0.5 * (curr + x / curr), curr);
+}
+
+//! Constexpr version of the square root
+// For a finite and non-negative value of "x", returns an approximation for the
+// square root of "x", Otherwise, returns NaN.
+double constexpr ce_sqrt(double x) {
+  return x >= 0 && x < std::numeric_limits<double>::infinity()
+             ? sqrtNewtonRaphson(x, x, 0)
+             : std::numeric_limits<double>::quiet_NaN();
+}
+
+} // namespace rtt_dsxx
+
+#endif // rtt_dsxx_Constexpr_Functions_hh
+
+//---------------------------------------------------------------------------//
+// end of ds++/Constexpr_Functions.hh
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* I've been looking into the cycle initialization and finalization times in Jayenne and Draco's various Planck and Rosseland integration functions show up as being fairly expensive in the profiler. I've tried to reduce the number of times they're called in Jayenne but I also noticed a few possible improvements to the integration routines themselves. The two main improvements are relaxing some input checking and making a comparison value `constexpr`. Currently, `sqrt(std::numeric_limits<double>::max()` is calculated every time a Planck integration routine is called. This value should be a `constexpr` but due to `sqrt` not being marked as `constexpr` the function is evaluated every time. I introduced a very simple version of `sqrt` for these kinds of cases into `ds++`.

* This PR also removes the unnecessary copying in some C4 calls.`MPI_IN_PLACE` takes care of this--I think there used to be a bug in Open_MPI related to this keyword but it's been fixed since around version 1.10.

### Purpose of Pull Request

* [Fixes Redmine Issue #1565](https://rtt.lanl.gov/redmine/issues/1565)

### Description of changes
* Introduce a Constexpr_Functions file to help define constant values
* Use MPI_IN_PLACE whenever possible in c4
* Allow for more stack depth in constexpr functions calls in gcc
### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [x] Test under Cray and XL compilers before merging.
