### PR TITLE
Relocate the installed cmake config directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ add_custom_target( uninstall
 # Export targets
 install(
   EXPORT draco-targets
-  DESTINATION cmake/draco
+  DESTINATION cmake
   EXPORT_LINK_INTERFACE_LIBRARIES )
 
 ##---------------------------------------------------------------------------##

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -55,9 +55,8 @@ set( file_list
   ${Draco_BINARY_DIR}/CMakeFiles/draco-config.cmake
   ${Draco_SOURCE_DIR}/autodoc/html/doxygen.css)
 
-install( FILES ${file_list}  DESTINATION cmake/draco )
-install( FILES ${CMake_AFSD}
-  DESTINATION cmake/draco/CMakeAddFortranSubdirectory )
+install( FILES ${file_list}  DESTINATION cmake )
+install( FILES ${CMake_AFSD} DESTINATION cmake/CMakeAddFortranSubdirectory )
 
 ##---------------------------------------------------------------------------##
 ## End of config/CMakeLists.txt

--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -133,8 +133,8 @@ macro( dbsSetDefaults )
   endif()
 
   if( "${DRACO_LIBRARY_TYPE}" MATCHES "SHARED" )
-     # Set replacement RPATH for installed libraries and executables
-     # See http://www.cmake.org/Wiki/CMake_RPATH_handling
+     # Set replacement RPATH for installed libraries and executables. See
+     # http://www.cmake.org/Wiki/CMake_RPATH_handling
 
      # Do not skip the full RPATH for the build tree
      set( CMAKE_SKIP_BUILD_RPATH OFF )
@@ -142,8 +142,8 @@ macro( dbsSetDefaults )
      # installing)
      set( CMAKE_BUILD_WITH_INSTALL_RPATH OFF )
 
-     # For libraries created within the build tree, replace the RPATH
-     # in the installed files with the install location.
+     # For libraries created within the build tree, replace the RPATH in the
+     # installed files with the install location.
      set( CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH
        "RPATH to embed in dynamic libraries and executables when
 targets are installed." FORCE )
@@ -159,7 +159,7 @@ endmacro()
 ## dbsInitExportTargets
 ##
 ## These fields are constructed during Draco configure and are
-## saved/installed to lib/cmake/draco-X.X/draco-config.cmake.
+## saved/installed to cmake/draco-config.cmake.
 ##---------------------------------------------------------------------------##
 macro( dbsInitExportTargets PREFIX )
   # Data for exporting during install


### PR DESCRIPTION
### Background

+ The previous install location (`<prefix>/cmake/draco/`) is no longer considered a standard location.
  + historical note: an even older location was `<prefix>/cmake/draco-X.X.X/` but this was difficult to maintain and the version number was dropped.
+ The current preferred location is `<prefix>/cmake`.

### Purpose of Pull Request

* [Fixes Redmine Issue #1573](https://rtt.lanl.gov/redmine/issues/1573)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
