### PR TITLE
Fix some Win32 issues related to CAFS.

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -479,14 +479,22 @@ function( cafs_create_imported_targets targetName libName targetPath linkLang)
   #
   # Generate the imported library target and set properties...
   #
+  if( DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY )
+    set(dll_loc "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" )
+    set(dll_loc_debug "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" )
+  else()
+    set(dll_loc "${libloc}" )
+    set(dll_loc_debug "${libloc_debug}" )
+  endif() 
+  
   add_library( ${targetName} SHARED IMPORTED GLOBAL)
   set_target_properties( ${targetName} PROPERTIES
-    IMPORTED_LOCATION "${libloc}/${CMAKE_SHARED_LIBRARY_PREFIX}${libName}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    IMPORTED_LOCATION "${dll_loc}/${CMAKE_SHARED_LIBRARY_PREFIX}${libName}${CMAKE_SHARED_LIBRARY_SUFFIX}"
     IMPORTED_LINK_INTERFACE_LANGUAGES ${linkLang}
     )
   if( lib_debug )
     set_target_properties( ${targetName} PROPERTIES
-      IMPORTED_LOCATION_DEBUG "${libloc_debug}/${CMAKE_SHARED_LIBRARY_PREFIX}${libName}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
+      IMPORTED_LOCATION_DEBUG "${dll_loc_debug}/${CMAKE_SHARED_LIBRARY_PREFIX}${libName}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
   endif()
 
   # platform specific properties

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -126,7 +126,7 @@ endfunction()
 macro( setupDracoMPIVars )
 
   # Set Draco build system variables based on what we know about MPI.
-  if( MPI_CXX_FOUND )
+  if( MPI_CXX_FOUND OR MPI_C_FOUND )
     set( DRACO_C4 "MPI" )
   else()
     set( DRACO_C4 "SCALAR" )

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -28,6 +28,11 @@ add_component_library(
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
 target_include_directories( Lib_cdi_eospac PUBLIC ${EOSPAC_INCLUDE_DIR} )
+if(MSVC)
+  # we don't normally have access to debug symbol file for eospac.lib, so
+  # ignore warnings about missing pdb files.
+  set_target_properties( Lib_cdi_eospac PROPERTIES LINK_OPTIONS "/ignore:4099" )
+endif()
 
 add_component_executable(
   TARGET      Exe_QueryEospac


### PR DESCRIPTION
### Background

* CAFS stopped working recently for one client project.  The main issue is that FindMPI was failing for a MInGW Makefile project spawned from a MSVC project. It is unclear what changed to cause this UseCase to fail, but it is likely that updating the CMake version was the issue.
* A new warning `LNK4099` is also being issued when pdb files for TPLs aren't found.  I will suppress this warning as a link flag.

### Description of changes

* When defining an import library as used by CAFS, look for the lib in the project build directory, but look for the dll in the `${CMAKE_RUNTIME_OUTPUT_DIRECTORY}`.
* When setting up C4 variables, allow MPI to remain active if *either* `MPI_CXX_FOUND` or `MPI_C_FOUND` are true.  This allows cmake projects that use C but not C++ to work properly. 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
