### PR TITLE
MSVC: Suppress link warning

### DIFF
--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -96,6 +96,10 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_CXX_FLAGS_MINSIZEREL "/${MD_or_MT} /O1 /DNDEBUG" )
   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "/${MD_or_MT} /O2 /Zi /DDEBUG" )
 
+  # Don't warn about missing pdb files.  We won't necessarily have these for 
+  # TPLs.
+  set( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099" )
+
 endif()
 
 ##---------------------------------------------------------------------------##

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -28,11 +28,6 @@ add_component_library(
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
 target_include_directories( Lib_cdi_eospac PUBLIC ${EOSPAC_INCLUDE_DIR} )
-if(MSVC)
-  # we don't normally have access to debug symbol file for eospac.lib, so
-  # ignore warnings about missing pdb files.
-  set_target_properties( Lib_cdi_eospac PROPERTIES LINK_OPTIONS "/ignore:4099" )
-endif()
 
 add_component_executable(
   TARGET      Exe_QueryEospac

--- a/src/cdi_eospac/test/tEospac.cc
+++ b/src/cdi_eospac/test/tEospac.cc
@@ -35,12 +35,12 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   // Create a SesameTables object //
   // ---------------------------- //
 
-  // The user must create a SesameTables object that links material ID
-  // numbers to EOSPAC data types (each SesameTables object only contains
-  // lookups for one material).  If the user needs heat capacity values for
-  // Al then he/she must create a SesameTables object for Aluminum and then
-  // assign an aluminum material ID (e.g. 3717) to the enelc EOSPAC data
-  // type.  See the tests below for more details.
+  // The user must create a SesameTables object that links material ID numbers
+  // to EOSPAC data types (each SesameTables object only contains lookups for
+  // one material).  If the user needs heat capacity values for Al then he/she
+  // must create a SesameTables object for Aluminum and then assign an aluminum
+  // material ID (e.g. 3717) to the enelc EOSPAC data type.  See the tests below
+  // for more details.
 
   // Set the material identifier
   // This one is for Aluminum (03717)
@@ -48,18 +48,18 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
 
   // See http://xweb.lanl.gov/projects/data/ for material ID information.
 
-  // This matID for Al has lookup tables for prtot, entot, tptot, tntot,
-  // pntot, eptot, prelc, enelc, tpelc, tnelc pnelc, epelc, prcld, and encld
-  // (see SesameTables.hh for an explanantion of these keywords).  I need
-  // the table that contains enion lookups so that I can query for Cve()
-  // values.
+  // This matID for Al has lookup tables for prtot, entot, tptot, tntot, pntot,
+  // eptot, prelc, enelc, tpelc, tnelc pnelc, epelc, prcld, and encld (see
+  // SesameTables.hh for an explanantion of these keywords).  I need the table
+  // that contains enion lookups so that I can query for Cve() values.
 
-  // Sesame Number 3717 provides data tables: 101 102 201 301 303 304 305 306 401
+  // Sesame Number 3717 provides data tables: 101 102 201 301 303 304 305 306
+  // 401
   int const Al3717 = 3717;
 
-  // I also want to lookup the mean ion charge (EOS_Zfc_DT) which is found
-  // in sesame table 601.  Add sesame number 23714 which provides data
-  // tables: 101 102 201 601 602 603 604
+  // I also want to lookup the mean ion charge (EOS_Zfc_DT) which is found in
+  // sesame table 601.  Add sesame number 23714 which provides data tables: 101
+  // 102 201 601 602 603 604
   int const Al23714 = 23714;
 
   // Create a SesameTables object for Aluminum.
@@ -68,9 +68,8 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   // Print a list of EosTables
   AlSt.printEosTableList();
 
-  // Assign matID Al3717 to enion lookups (used for Cvi) for AlSt.  We can
-  // also assign these tables when the Eospac object is created (see example
-  // below).
+  // Assign matID Al3717 to enion lookups (used for Cvi) for AlSt.  We can also
+  // assign these tables when the Eospac object is created (see example below).
 
   // Also assign matID Al23714 for temperature-based electron thermal
   // conductivity (tconde).
@@ -120,43 +119,14 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
     return;
   }
 
-  // CAUTION!!!  CAUTION!!!  CAUTION!!!  CAUTION!!!  CAUTION!!!  CAUTION!!!
-
-  // Adding this block breaks Eospac as currently implemented.  Effectively,
-  // the destructor for spEospacAlt destroys all of the table handles for
-  // libeospac.  This is a flaw in libeospac, but we may be forced to manage
-  // it in cdi_eospac by using a Singleton Eospac object that uses reference
-  // counting for each material+data tuple and calls eos_DestroyTables()
-  // instead of eos_DestroyAll().  A redesign is also required to make this
-  // package thread safe!
-
-  // {   // Test alternate ctor method:
-
-  //     // Alternatively, we can avoid carrying around the AlSt object.  We
-  //     // can, instead, create a temporary version that is only used here in
-  //     // the constructor of Eospac().
-
-  //     std::shared_ptr< rtt_cdi_eospac::Eospac const > spEospacAlt;
-  //     spEospacAlt = new rtt_cdi_eospac::Eospac(
-  //         rtt_cdi_eospac::SesameTables().Ue_DT( Al3717 ).Zfc_DT( Al23714
-  //             ).Uic_DT( Al3717 ).Ktc_DT( Al23714 ) );
-
-  //     if ( spEospacAlt )
-  //         PASSMSG("shared_ptr to new Eospac object created (Alternate "
-  //                "ctor).");
-  //     else
-  //         FAILMSG("Unable to create shared_ptr to new Eospac object " +
-  //                 "(Alternate ctor).");
-  // }
-
   // --------------------------- //
   // Test scalar access routines //
   // --------------------------- //
 
   double const K2keV = 1.0 / 1.1604412E+7; // keV/Kelvin
 
-  // All of these tests request an EoS value given a single temperature and
-  // a single density.
+  // All of these tests request an EoS value given a single temperature and a
+  // single density.
 
   // Retrieve an Electron internal energy value;
 
@@ -254,8 +224,6 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   }
 
   // Test the getElectronTemperature function
-
-  // spEospac->printTableInformation( EOS_T_DUic, std::cout );
 
   double SpecificIonInternalEnergy(10.0); // kJ/g
   Tout = spEospac->getIonTemperature(density, SpecificIonInternalEnergy); // keV
@@ -433,7 +401,7 @@ void cdi_eospac_except_test(rtt_dsxx::UnitTest &ut) {
     if (exceptionThrown)
       PASSMSG("Attempted access to unloaded table throws exception.");
     else
-      FAILMSG("Failed to throw exeption for invalid table access.");
+      FAILMSG("Failed to throw exception for invalid table access.");
   }
 
   return;

--- a/src/compton/CMakeLists.txt
+++ b/src/compton/CMakeLists.txt
@@ -2,7 +2,7 @@
 # file   src/compton/CMakeLists.txt
 # author Kendra Keady
 # date   2017 February 28
-# brief  Instructions for building compton Makefiles.
+# brief  Instructions for building Compton Makefiles.
 # note   Copyright (C) 2017-2019 Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
@@ -64,7 +64,7 @@ if( TARGET COMPTON::compton )
 
 else()
 
-  # If no compton library, only install headers (stubs).
+  # If no Compton library, only install headers (stubs).
   install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/compton )
 
 endif()


### PR DESCRIPTION
### Background

* Recent versions of MSVC have starting issuing warnings when the `.dbg` file associated with a library isn't found when linking Debug code.  I thought this issue was restricted to `libeospac.lib`, but it turns out other TPLs also cause this warning to be emitted.
* [Example of warnings](https://rtt.lanl.gov/cdash/viewBuildError.php?type=1&buildid=38735)

### Description of changes

* I'm pulling the change to `cdi_eospac/CMakeLists.txt` that I made in #649 and replacing it by moving the `ignore` link flag to the global `LINK_OPTIONS` CMake variable.
* Minor tweaks to comments.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
