### PR TITLE
Another attempt to suppress MSVC warnings about .dbg files.

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -332,6 +332,10 @@ macro( add_component_library )
     INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
     WINDOWS_EXPORT_ALL_SYMBOLS ON
     )
+  if( DEFINED DRACO_LINK_OPTIONS )
+    set_target_properties( ${acl_TARGET} PROPERTIES 
+      LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
+  endif()
 
   #
   # Generate properties related to library dependencies
@@ -871,14 +875,17 @@ macro( add_scalar_tests test_sources )
     # Some properties are set at a global scope in compilerEnv.cmake:
     # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
     #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
-    set_target_properties( Ut_${compname}_${testname}_exe
-      PROPERTIES
+    set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
       OUTPUT_NAME ${testname}
       VS_KEYWORD  ${testname}
       FOLDER      ${compname}_test
       INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
       COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\";PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\""
       )
+    if( DEFINED DRACO_LINK_OPTIONS )
+      set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES 
+        LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
+    endif()
     # Do we need to use the Fortran compiler as the linker?
     if( addscalartest_LINK_WITH_FORTRAN )
       set_target_properties( Ut_${compname}_${testname}_exe
@@ -1008,9 +1015,7 @@ macro( add_parallel_tests )
     get_filename_component( testname ${file} NAME_WE )
     if( lverbose )
       message( "   add_executable( Ut_${compname}_${testname}_exe ${file} )
-   set_target_properties(
-      Ut_${compname}_${testname}_exe
-      PROPERTIES
+   set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
       OUTPUT_NAME ${testname}
       VS_KEYWORD  ${testname}
       FOLDER      ${compname}_test
@@ -1022,15 +1027,17 @@ macro( add_parallel_tests )
     # Some properties are set at a global scope in compilerEnv.cmake:
     # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
     #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
-    set_target_properties(
-      Ut_${compname}_${testname}_exe
-      PROPERTIES
+    set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
       OUTPUT_NAME ${testname}
       VS_KEYWORD  ${testname}
       FOLDER      ${compname}_test
       INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
       COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\";PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\""
       )
+    if( DEFINED DRACO_LINK_OPTIONS )
+      set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES 
+        LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
+    endif()
     if( addparalleltest_MPI_PLUS_OMP )
       if( ${CMAKE_GENERATOR} MATCHES Xcode )
         set_target_properties( Ut_${compname}_${testname}_exe

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -97,8 +97,9 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "/${MD_or_MT} /O2 /Zi /DDEBUG" )
 
   # Don't warn about missing pdb files.  We won't necessarily have these for 
-  # TPLs.
-  set( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099" )
+  # TPLs. Link options are applied in component_macros.cmake near calls to 
+  # add_libarary or add_executable.
+  set( DRACO_LINK_OPTIONS "$<$<CONFIG:DEBUG>:/ignore:4099>")
 
 endif()
 


### PR DESCRIPTION
### Background

* #650 didn't completely eliminate a build warnings issued by MSVC.  It eliminated build warnings related to linking libraries, but did not address identical warnings issued when creating executables.
* Ref [CDash report](https://rtt.lanl.gov/cdash/viewBuildError.php?type=1&onlydeltap&buildid=40109)

### Description of changes

* No longer set `CMAKE_EXE_LINKER_FLAGS` in `windows-cl.cmake`.  Instead, set a build system variable `CMAKE_EXE_LINKER_FLAGS`.  In `component_macros.cmake`, set the `LINK_OPTIONS` target property the new variable for `LINK_FLAGS`.
* Use generator expressions to limit the use of this flag to _Debug_ builds.
* This model serves as a prototype of how compiler flags will be set in the near future.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
