### PR TITLE
Update docker image used by CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,11 +83,11 @@ env:
 #  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
-  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2019june
+  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2019aug
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019june /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019aug /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,9 +7,13 @@ FROM ubuntu:latest
 # 1. cd /D f:\work\docker (copy Dockerfile and packages.yaml to this location).
 # 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
 # 3. docker build --rm --pull --tag draco-ci-2019june:latest . 
+#    OR: docker run -it kinetictheory/draco-ci-2019june /bin/bash -l
+#        apt-get install -y --no-install-recommends [ghostview]
+#        exit
 # 4. docker image ls -a ==> find container name (or docker ps)
-# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <container-name> kinetictheory/draco-ci-2019june:latest # queues for upload
+# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <hash> kinetictheory/draco-ci-2019june:latest # queues for upload
 # 6. docker push kinetictheory/draco-ci-2019june:latest
+# 7. docker system prune -a (remove old dangling data)
 
 MAINTAINER KineticTheory "https://github.com/KineticTheory"
 
@@ -47,7 +51,7 @@ RUN echo "tzdata tzdata/Areas select US" > /tmp/preseed.txt; \
 RUN apt-get install -y --no-install-recommends apt-utils automake autoconf autotools-dev python3 software-properties-common flex bison ssh
 
 ## Basic developer tools
-RUN apt-get install -y --no-install-recommends build-essential ca-certificates coreutils curl doxygen environment-modules gcc-8 g++-8 gfortran-8 git grace graphviz python3-pip python3-sphinx python3-sphinx-rtd-theme tar tcl tk unzip wget
+RUN apt-get install -y --no-install-recommends build-essential ca-certificates coreutils curl doxygen environment-modules gcc-8 g++-8 gfortran-8 ghostscript git grace graphviz python3-pip python3-sphinx python3-sphinx-rtd-theme tar tcl texlive tk unzip wget
 # RUN apg-get upgrade
 RUN if ! test -f /etc/profile.d/modules.sh; then \
       echo "source /usr/share/modules/init/bash" > /etc/profile.d/modules.sh; \


### PR DESCRIPTION
### Background

* Autodoc checks were issuing warnings/errors because latex and ghostscript were not provided in the docker image.  These tools are needed for doxygen to generate graphics from latex style formulas.

### Description of changes

+ new docker image: draco-ci-2019aug
  + includes ghostscript and texworks.
+ Also add more notes about how to update the docker image.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
