### PR TITLE
cleanup ei-coupling comments about units

### DIFF
--- a/src/cdi/test/DummyEICoupling.cc
+++ b/src/cdi/test/DummyEICoupling.cc
@@ -61,7 +61,7 @@ DummyEICoupling::~DummyEICoupling() {
  *        requested (g/cm^3).
  * \param[in] w_e the electron screening coeffiecent [1/s]
  * \param[in] w_i the ion screening coeffiecent [1/s]
- * \return An electron-ion coupling coeffient [KJ/g/K/s].
+ * \return An electron-ion coupling coeffient [kJ/cc/keV/s].
  */
 double DummyEICoupling::getElectronIonCoupling(const double etemperature,
                                                const double itemperature,
@@ -89,7 +89,7 @@ double DummyEICoupling::getElectronIonCoupling(const double etemperature,
  *        requested (g/cm^3).
  * \param[in] w_e the electron screening coeffiecent vector [1/s]
  * \param[in] w_i the ion screening coeffiecent vector [1/s]
- * \return An electron-ion coupling coeffient vector [kJ/g/K/s].
+ * \return An electron-ion coupling coeffient vector [kJ/cc/keV/s].
  */
 std::vector<double> DummyEICoupling::getElectronIonCoupling(
     const std::vector<double> &etemperature,

--- a/src/cdi/test/tDummyEICoupling.cc
+++ b/src/cdi/test/tDummyEICoupling.cc
@@ -45,8 +45,8 @@ void test_EICoupling(rtt_dsxx::UnitTest &ut) {
   // EoS Tests //
   // --------- //
 
-  double etemperature = 1.0; // Kelvin
-  double itemperature = 2.0; // Kelvin
+  double etemperature = 1.0; // keV
+  double itemperature = 2.0; // keV
   double density = 3.0;      // g/cm^3
   double w_e = 4.0;
   double w_i = 5.0;

--- a/src/cdi_analytic/Analytic_EICoupling.cc
+++ b/src/cdi_analytic/Analytic_EICoupling.cc
@@ -133,7 +133,7 @@ double Analytic_EICoupling::getElectronIonCoupling(const double eTemperature,
  *     Brown, Preston, and Singleton, 'Physics Reports', V410, Issue 4, 2005)
  * \param[in] vw_i is the average plasma ion frequency (as defined by Eq. 3.61 in
  *     Brown, Preston, and Singleton, 'Physics Reports', V410, Issue 4, 2005)
- * \return A vector of electron-ion coupling coeffiecent (1/s).
+ * \return A vector of electron-ion coupling coeffiecent (kJ/cc/keV/s).
 
  */
 Analytic_EICoupling::sf_double Analytic_EICoupling::getElectronIonCoupling(

--- a/src/cdi_analytic/Analytic_Models.hh
+++ b/src/cdi_analytic/Analytic_Models.hh
@@ -622,7 +622,7 @@ public:
  *
  * where the coefficient has the following units:
  *
- * \arg alpha = [kJ/g/K/s]
+ * \arg alpha = [kJ/cc/keV/s]
  */
 class Constant_Analytic_EICoupling_Model : public Analytic_EICoupling_Model {
 private:
@@ -639,7 +639,7 @@ public:
   //! Constructor for packed state.
   explicit Constant_Analytic_EICoupling_Model(const sf_char &packed);
 
-  //! Calculate the ei_coupling in units of kJ/g/K/s.
+  //! Calculate the ei_coupling in units of kJ/cc/keV/s.
   double calculate_ei_coupling(double /*Te*/, double /*Ti*/, double /*rho*/,
                                double /*w_e*/, double /*w_i*/) const {
     return ei_coupling;


### PR DESCRIPTION
### Purpose of Pull Request

* Fix comments about ei_coupling units to be consistent [kJ/cc/keV/s]
* [Fixes Redmine Issue #1610](https://rtt.lanl.gov/redmine/issues/1610)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
