### PR TITLE
Make language standards target properties.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -133,25 +133,6 @@ macro(dbsSetupCxx)
     set( my_cxx_compiler ${CMAKE_CXX_COMPILER} )
   endif()
 
-  # These CMAKE_* variables create defaults for the entire project so that we no
-  # longer need to set 'per_target' properties using:
-  # set_target_properties( <tgt> PROPERTIES C_STANDARD 11 ... )
-
-  # C11 support:
-  set( CMAKE_C_STANDARD 11 )
-
-  # C++14 support:
-  set( CMAKE_CXX_STANDARD 14 )
-  set( CMAKE_CXX_STANDARD_REQUIRED ON )
-
-  # Do not enable extensions (e.g.: --std=gnu++11)
-  # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
-  set( CMAKE_CXX_EXTENSIONS OFF )
-  set( CMAKE_C_EXTENSIONS   OFF )
-
-  # -fPIC by default
-  set( CMAKE_POSITION_INDEPENDENT_CODE ON )
-
   # Setup compiler flags
   get_filename_component( my_cxx_compiler "${my_cxx_compiler}" NAME )
 

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -10,6 +10,16 @@
 
 include_guard(GLOBAL)
 
+#------------------------------------------------------------------------------#
+# Standards
+#------------------------------------------------------------------------------#
+
+# ANSI-C 11 support:
+set( Draco_C_STANDARD c_std_11 )
+
+# C++14 support:
+set( Draco_CXX_STANDARD cxx_std_14 )
+
 #------------------------------------------------------------------------------
 # replacement for built in command 'add_executable'
 #
@@ -118,16 +128,17 @@ or the target must be labeled NOEXPORT.")
   else()
     add_executable( ${ace_TARGET} ${ace_SOURCES} )
   endif()
-
-  # Some properties are set at a global scope in compilerEnv.cmake:
-  # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
-  #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
+  target_compile_features( ${ace_TARGET} PUBLIC ${Draco_C_STANDARD} )
+  target_compile_features( ${ace_TARGET} PUBLIC ${Draco_CXX_STANDARD} )
   set_target_properties( ${ace_TARGET} PROPERTIES
     OUTPUT_NAME ${ace_EXE_NAME}
     FOLDER      ${ace_FOLDER}
     INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
-#    ENABLE_EXPORTS TRUE # See cmake policy cmp0065
     COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\";PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\""
+    CXX_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+    CXX_EXTENSIONS OFF
+    POSITION_INDEPENDENT_CODE ON
     )
   if( DEFINED ace_PROJECT_LABEL )
     set_target_properties( ${ace_TARGET} PROPERTIES PROJECT_LABEL ${ace_PROJECT_LABEL} )
@@ -321,19 +332,20 @@ macro( add_component_library )
   string( REPLACE "Lib_" "" folder_name ${acl_TARGET} )
 
   add_library( ${acl_TARGET} ${acl_LIBRARY_TYPE} ${acl_SOURCES} )
-  # Some properties are set at a global scope in compilerEnv.cmake:
-  # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
-  #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
+  target_compile_features( ${acl_TARGET} PUBLIC ${Draco_C_STANDARD} )
+  target_compile_features( ${acl_TARGET} PUBLIC ${Draco_CXX_STANDARD} )
   set_target_properties( ${acl_TARGET} PROPERTIES
-    # ${compdefs}
-    # Use custom library naming
     OUTPUT_NAME ${acl_LIBRARY_NAME_PREFIX}${acl_LIBRARY_NAME}
     FOLDER      ${folder_name}
     INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
     WINDOWS_EXPORT_ALL_SYMBOLS ON
+    CXX_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+    CXX_EXTENSIONS OFF
+    POSITION_INDEPENDENT_CODE ON
     )
   if( DEFINED DRACO_LINK_OPTIONS )
-    set_target_properties( ${acl_TARGET} PROPERTIES 
+    set_target_properties( ${acl_TARGET} PROPERTIES
       LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
   endif()
 
@@ -872,18 +884,23 @@ macro( add_scalar_tests test_sources )
 
     get_filename_component( testname ${file} NAME_WE )
     add_executable( Ut_${compname}_${testname}_exe ${file} )
-    # Some properties are set at a global scope in compilerEnv.cmake:
-    # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
-    #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
+    target_compile_features( Ut_${compname}_${testname}_exe
+      PUBLIC ${Draco_C_STANDARD} )
+    target_compile_features( Ut_${compname}_${testname}_exe
+      PUBLIC ${Draco_CXX_STANDARD} )
     set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
       OUTPUT_NAME ${testname}
       VS_KEYWORD  ${testname}
       FOLDER      ${compname}_test
       INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
       COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\";PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\""
+      CXX_STANDARD_REQUIRED ON
+      C_EXTENSIONS OFF
+      CXX_EXTENSIONS OFF
+      POSITION_INDEPENDENT_CODE ON
       )
     if( DEFINED DRACO_LINK_OPTIONS )
-      set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES 
+      set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
         LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
     endif()
     # Do we need to use the Fortran compiler as the linker?
@@ -1024,18 +1041,23 @@ macro( add_parallel_tests )
       )")
     endif()
     add_executable( Ut_${compname}_${testname}_exe ${file} )
-    # Some properties are set at a global scope in compilerEnv.cmake:
-    # - C_STANDARD, C_EXTENSIONS, CXX_STANDARD, CXX_EXTENSIONS,
-    #   CXX_STANDARD_REQUIRED, and POSITION_INDEPENDENT_CODE
+    target_compile_features( Ut_${compname}_${testname}_exe
+      PUBLIC ${Draco_C_STANDARD} )
+    target_compile_features( Ut_${compname}_${testname}_exe
+      PUBLIC ${Draco_CXX_STANDARD} )
     set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
       OUTPUT_NAME ${testname}
       VS_KEYWORD  ${testname}
       FOLDER      ${compname}_test
       INTERPROCEDURAL_OPTIMIZATION_RELEASE;${USE_IPO}
       COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\";PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\""
+      CXX_STANDARD_REQUIRED ON
+      C_EXTENSIONS OFF
+      CXX_EXTENSIONS OFF
+      POSITION_INDEPENDENT_CODE ON
       )
     if( DEFINED DRACO_LINK_OPTIONS )
-      set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES 
+      set_target_properties( Ut_${compname}_${testname}_exe PROPERTIES
         LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
     endif()
     if( addparalleltest_MPI_PLUS_OMP )
@@ -1199,8 +1221,7 @@ targets for copying support files.")
   endif()
   set_target_properties(
     Ut_${compname}_install_inputs_${Ut_${compname}_install_inputs_iarg}
-    PROPERTIES FOLDER ${folder_name}
-    )
+    PROPERTIES FOLDER ${folder_name} )
 
 endmacro()
 

--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -85,21 +85,6 @@ macro( query_craype )
       set( CRAY_PE ON CACHE BOOL
         "Are we building in a Cray Programming Environment?")
 
-      # override default compiler wrapper flags for linking so that dynamic
-      # libraries are allowed.  This does not prevent us from generating static
-      # libraries if requested with DRACO_LIBRARY_TYPE=STATIC.
-      # if( DEFINED ENV{CMAKE_EXE_LINKER_FLAGS} )
-      #   set( CMAKE_EXE_LINKER_FLAGS "$ENV{CMAKE_EXE_LINKER_FLAGS}")
-      # else()
-      #   if( DEFINED CMAKE_EXE_LINKER_FLAGS )
-      #     string( APPEND CMAKE_EXE_LINKER_FLAGS " -dynamic" )
-      #   else()
-      #     set( CMAKE_EXE_LINKER_FLAGS "-dynamic" )
-      #   endif()
-      # endif()
-      # set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}" CACHE STRING
-      #   "Extra flags for linking executables")
-
       # We expect developers to use the Cray compiler wrappers (especially in
       # setupMPI.cmake). See also
       # https://cmake.org/cmake/help/latest/module/FindMPI.html


### PR DESCRIPTION
### Background

+ Instead of slamming language standards into global CMake variables, choose to specify these as target properties.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
