### PR TITLE
Provide draco-config-version.cmake when installing.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -6,8 +6,10 @@
 # note   Copyright (C) 2016-2019, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.14.0)
 project( config )
+
+include(CMakePackageConfigHelpers)
 
 file( GLOB CMake_src *.cmake )
 file( GLOB Python_src *.py )
@@ -43,17 +45,22 @@ if( CMAKE_CONFIGURATION_TYPES )
       CACHE STRING "Available multiconfig builds." )
 endif()
 
-# Process the config file
+# Process the config files
 configure_file( draco-config-install.cmake.in
-   ${Draco_BINARY_DIR}/CMakeFiles/draco-config.cmake @ONLY)
+  "${CMAKE_CURRENT_BINARY_DIR}/draco-config.cmake" @ONLY)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/draco-config-version.cmake"
+  VERSION ${Draco_VERSION}
+  COMPATIBILITY AnyNewerVersion )
 
 # Install scripts and macros to make them available by other projects.
 set( file_list
   ${CMake_src}
   ${CMake_in}
   ${Python_src}
-  ${Draco_BINARY_DIR}/CMakeFiles/draco-config.cmake
-  ${Draco_SOURCE_DIR}/autodoc/html/doxygen.css)
+  ${CMAKE_CURRENT_BINARY_DIR}/draco-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/draco-config-version.cmake
+  ${Draco_SOURCE_DIR}/autodoc/html/doxygen.css )
 
 install( FILES ${file_list}  DESTINATION cmake )
 install( FILES ${CMake_AFSD} DESTINATION cmake/CMakeAddFortranSubdirectory )


### PR DESCRIPTION
### Background

* Consumers of TRT codes are switching to cmake-based build systems and have asked for this standard file used by `find_package`.

### Purpose of Pull Request

* [Fixes Redmine Issue #1670](https://rtt.lanl.gov/redmine/issues/1670)

### Description of changes

* Create and install the requested file.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
