### PR TITLE
Wrap call to readlink in macro to avoid failure on OSX.

### DIFF
--- a/src/ds++/StackTrace.cc
+++ b/src/ds++/StackTrace.cc
@@ -46,16 +46,26 @@ std::string rtt_dsxx::print_stacktrace(std::string const &error_message) {
   // Get our PID and build the name of the link in /proc
   pid_t const pid = getpid();
 
+  // Now read the symbolic link (process name)
+  unsigned const buf_size(512);
+  char buf[buf_size];
+#ifdef APPLE
+  int ret = -1; // This scheme won't work on OSX: no /proc fs
+#else
   // Build linkname
   std::string const linkname =
       std::string("/proc/") + st_to_string(pid) + std::string("/exe");
 
-  // Now read the symbolic link (process name)
-  unsigned const buf_size(512);
-  char buf[buf_size];
   auto ret = readlink(linkname.c_str(), buf, buf_size);
-  buf[ret] = 0;
+#endif
+  if (ret >= 0) /* readlink succeeded */
+  {
+    buf[ret] = 0;
+  }
   std::string process_name(buf);
+  if (ret < 0) {
+    process_name = "UNAVAILABLE";
+  }
 
   // retrieve current stack addresses
   int const max_frames = 64;


### PR DESCRIPTION
### print_stacktrace uses /proc filesystem to find process name; 
* This fails on OSX: causes the stacktrace printout to segfault

### Fix stack trace printing on OSX

* wrap call to readlink in macro to avoid its ineffective use on OSX
* on OSX, proc name is just "UNAVAILABLE"

### Description of changes

* ^^^

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
