### PR TITLE
WIP: One-line change to remove specific csk version for ats-2 environment

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -48,7 +48,7 @@ else
 
 # StdEnv
 
-  export dracomodules="python/3.7.2 gcc/7.3.1 spectrum-mpi/2019.01.30 cmake/3.14.5 git gsl numdiff random123 metis netlib-lapack eospac/6.4.0 parmetis superlu-dist trilinos csk/0.4.2 ack htop"
+  export dracomodules="python/3.7.2 gcc/7.3.1 spectrum-mpi/2019.01.30 cmake/3.14.5 git gsl numdiff random123 metis netlib-lapack eospac/6.4.0 parmetis superlu-dist trilinos csk ack htop"
 
 fi
 


### PR DESCRIPTION
### Background

*  I am in the process of releasing csk-0.5.0 for ats-2

### Purpose of Pull Request

* remove version specifier from module load statement for ats-2 environment setup
* this should permit the latest csk-0.5.0 module to load for available compilers

### Description of changes

* see above :)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
