### PR TITLE
Update algorithm for exporting target properties.

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -95,6 +95,10 @@ endfunction()
 #   SOURCES      "${PROJECT_SOURCE_DIR}/draco_info_main.cc"
 #   FOLDER       diagnostics
 #   )
+#
+# Note: directories listed as VENDOR_INCLUDE_DIRS will be exported in the
+#       INTERFACE_INCLUDE_DIRECTORIES target property.
+#
 #------------------------------------------------------------------------------
 macro( add_component_executable )
 
@@ -180,8 +184,9 @@ or the target must be labeled NOEXPORT.")
   if( DEFINED ace_VENDOR_LIBS )
     target_link_libraries( ${ace_TARGET} ${ace_VENDOR_LIBS} )
   endif()
-  if( DEFINED ace_VENDOR_INCLUDE_DIRS )
-    include_directories( ${ace_VENDOR_INCLUDE_DIRS} )
+  if( ace_VENDOR_INCLUDE_DIRS )
+    set_property(TARGET ${ace_TARGET} APPEND PROPERTY 
+      INTERFACE_INCLUDE_DIRECTORIES "${ace_VENDOR_INCLUDE_DIRS}")
   endif()
 
   #
@@ -212,21 +217,20 @@ or the target must be labeled NOEXPORT.")
   endif()
 
   # For non-test libraries, save properties to the project-config.cmake file
-  if( "${ilil}x" STREQUAL "x" )
-    set( ${ace_PREFIX}_EXPORT_TARGET_PROPERTIES
-      "${${ace_PREFIX}_EXPORT_TARGET_PROPERTIES}
-    set_target_properties(${ace_TARGET} PROPERTIES
-      IMPORTED_LINK_INTERFACE_LANGUAGES \"${ace_LINK_LANGUAGE}\"
-      INTERFACE_INCLUDE_DIRECTORIES     \"${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include\" )
-    ")
+  get_target_property( iid ${ace_TARGET} INTERFACE_INCLUDE_DIRECTORIES )
+  if( iid )
+    list(APPEND iid "${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include" )
   else()
-    set( ${ace_PREFIX}_EXPORT_TARGET_PROPERTIES
-      "${${ace_PREFIX}_EXPORT_TARGET_PROPERTIES}
-    set_target_properties(${ace_TARGET} PROPERTIES
-      IMPORTED_LINK_INTERFACE_LANGUAGES \"${ace_LINK_LANGUAGE}\"
-      INTERFACE_INCLUDE_DIRECTORIES     \"${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include\" )
-  ")
+    set( iid "${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include" )
   endif()
+  list(REMOVE_DUPLICATES iid)
+  set( ${ace_PREFIX}_EXPORT_TARGET_PROPERTIES
+    "${${ace_PREFIX}_EXPORT_TARGET_PROPERTIES}
+  set_target_properties(${ace_TARGET} PROPERTIES
+    IMPORTED_LINK_INTERFACE_LANGUAGES \"${ace_LINK_LANGUAGE}\"
+    INTERFACE_INCLUDE_DIRECTORIES     \"${iid}\" )
+  ")
+  unset(iid)
 
   # Only publish information to draco-config.cmake for non-test
   # libraries.  Also, omit any libraries that are marked as NOEXPORT
@@ -266,7 +270,7 @@ or the target must be labeled NOEXPORT.")
   # If Win32, copy dll files into binary directory.
   copy_dll_link_libraries_to_build_dir( ${ace_TARGET} )
 
-endmacro( add_component_executable )
+endmacro()
 
 #------------------------------------------------------------------------------
 # replacement for built in command 'add_library'
@@ -307,6 +311,9 @@ endmacro( add_component_executable )
 #   PREFIX       "Draco"
 #   SOURCES      "${sources}"
 #   )
+#
+# Note: directories listed as VENDOR_INCLUDE_DIRS will be exported in the
+#       INTERFACE_INCLUDE_DIRECTORIES target property.
 #
 # Note: you must use quotes around ${list_of_sources} to preserve the list.
 #------------------------------------------------------------------------------
@@ -378,8 +385,9 @@ macro( add_component_library )
   if( NOT "${acl_VENDOR_LIBS}x" STREQUAL "x" )
     target_link_libraries( ${acl_TARGET} ${acl_VENDOR_LIBS} )
   endif()
-  if( NOT "${acl_VENDOR_INCLUDE_DIRS}x" STREQUAL "x" )
-    include_directories( ${acl_VENDOR_INCLUDE_DIRS} )
+  if( acl_VENDOR_INCLUDE_DIRS )
+    set_property(TARGET ${acl_TARGET} APPEND PROPERTY 
+      INTERFACE_INCLUDE_DIRECTORIES "${acl_VENDOR_INCLUDE_DIRS}")
   endif()
 
   #
@@ -414,22 +422,20 @@ macro( add_component_library )
   endif()
 
   # For non-test libraries, save properties to the project-config.cmake file
-  if( "${ilil}x" STREQUAL "x" )
-    set( ${acl_PREFIX}_EXPORT_TARGET_PROPERTIES
-      "${${acl_PREFIX}_EXPORT_TARGET_PROPERTIES}
-    set_target_properties(${acl_TARGET} PROPERTIES
-      IMPORTED_LINK_INTERFACE_LANGUAGES \"${acl_LINK_LANGUAGE}\"
-      INTERFACE_INCLUDE_DIRECTORIES     \"${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include\" )
-    ")
+  get_target_property( iid ${acl_TARGET} INTERFACE_INCLUDE_DIRECTORIES )
+  if( iid )
+    list(APPEND iid "${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include" )
   else()
-#      IMPORTED_LINK_INTERFACE_LIBRARIES \"${ilil}\"
-    set( ${acl_PREFIX}_EXPORT_TARGET_PROPERTIES
-      "${${acl_PREFIX}_EXPORT_TARGET_PROPERTIES}
-    set_target_properties(${acl_TARGET} PROPERTIES
-      IMPORTED_LINK_INTERFACE_LANGUAGES \"${acl_LINK_LANGUAGE}\"
-      INTERFACE_INCLUDE_DIRECTORIES     \"${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include\" )
+    set( iid "${CMAKE_INSTALL_PREFIX}/${DBSCFGDIR}include" )
+  endif()  
+  list(REMOVE_DUPLICATES iid)
+  set( ${acl_PREFIX}_EXPORT_TARGET_PROPERTIES
+    "${${acl_PREFIX}_EXPORT_TARGET_PROPERTIES}
+  set_target_properties(${acl_TARGET} PROPERTIES
+    IMPORTED_LINK_INTERFACE_LANGUAGES \"${acl_LINK_LANGUAGE}\"
+    INTERFACE_INCLUDE_DIRECTORIES     \"${iid}\" )
   ")
-  endif()
+  unset(iid)
 
   # Only publish information to draco-config.cmake for non-test libraries.
   # Also, omit any libraries that are marked as NOEXPORT

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -13,16 +13,28 @@ project( rng CXX )
 # Generate config.h (only occurs when cmake is run)
 # ---------------------------------------------------------------------------- #
 # default to using C++11 features of Random123.
-set( R123_USE_CXX11 1 )
+get_target_property( cxxstd Lib_dsxx CXX_STANDARD )
+if( cxxstd AND NOT ${cxxstd} STREQUAL 98 )
+  set( R123_USE_CXX11 1 )
+endif()
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/rng/config.h )
+set( pkg_config_h "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/rng/config.h>")
+#\bug can't add "$<INSTALL_INTERFACE:$<CONFIG>/include/rng/config.h>"
 
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
 
-file( GLOB sources *.cc *.c )
-file( GLOB headers *.hh *.h *.hpp)
-list( APPEND headers ${PROJECT_BINARY_DIR}/rng/config.h )
+file( GLOB sources_glob RELATIVE "${PROJECT_SOURCE_DIR}" *.cc *.c )
+file( GLOB headers_glob RELATIVE "${PROJECT_SOURCE_DIR}" *.hh *.h *.hpp)
+
+# prefix header files with appropriate paths (build vs install).
+foreach( file ${headers_glob} )    
+  list(APPEND headers_public "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${file}>")
+  #\bug can't add $<INSTALL_INTERFACE:$<CONFIG>/include/rng>
+endforeach()
+list(APPEND headers_public "${pkg_config_h}" )
+list(APPEND headers_glob ${PROJECT_BINARY_DIR}/rng/config.h ) # install these!
 
 # ---------------------------------------------------------------------------- #
 # Build package library
@@ -31,22 +43,29 @@ list( APPEND headers ${PROJECT_BINARY_DIR}/rng/config.h )
 add_component_library(
    TARGET       Lib_rng
    TARGET_DEPS  "Lib_dsxx;GSL::gsl"
-   LIBRARY_NAME ${PROJECT_NAME}
-   SOURCES      "${sources}"
-   HEADERS      "${headers}"
-   )
-target_include_directories( Lib_rng
-  PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> # config.h
-    $<BUILD_INTERFACE:${RANDOM123_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:${RANDOM123_INCLUDE_DIR}> )
+   LIBRARY_NAME ${PROJECT_NAME} 
+   VENDOR_INCLUDE_DIRS "${RANDOM123_INCLUDE_DIR}" )
+target_sources( Lib_rng PUBLIC "${headers_public}" PRIVATE "${sources_glob}" )
+set_target_properties(Lib_rng PROPERTIES PUBLIC_HEADER "${headers_public}" )
+target_include_directories( Lib_rng PUBLIC 
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> 
+  ${RANDOM123_INCLUDE_DIR} )
+  
+# \bug I would like to use the following property so that CMake can 
+# auto-generate draco-targets.cmake.  However, as of cmake-3.15, I can't write 
+# '$<CONFIG>' to exported properties for target Lib_rng.  If this issue fixed 
+# by CMake, then all of the machinery in compnent_macros.cmake that sets 
+# INTERFACE_INCLUDE_DIRECTORIES in draco-config.cmake can be retired.
+# \sa https://gitlab.kitware.com/cmake/cmake/issues/19791
+#
+#  INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:$<CONFIG>>/include>"
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 
 install( TARGETS Lib_rng EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
-install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/rng )
+install( FILES ${headers_glob} DESTINATION ${DBSCFGDIR}include/rng )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests


### PR DESCRIPTION
### Background

* The _rng_ package was not correctly exporting a transitive dependency on Random123's include directory forcing client codes to manually add this dependency.  This TPL dependency is slightly different than others in Draco because it is a header-only package.

### Purpose of Pull Request

* [Fixes Redmine Issue #1712](https://rtt.lanl.gov/redmine/issues/1712)

### Description of changes

* I attempted to update the logic to use CMake's built-in capabilities for exporting targets, including their `INTERFACE_INCLUDE_DIRECTORIES` property.  However, CMake doesn't seem to be able to use generator expressions for values assigned to this property (issue reported [here](https://gitlab.kitware.com/cmake/cmake/issues/19791)).
* So, for now, I'm sticking with the existing hack that manually exports target properties.  With the changes provided in this PR, the installed `draco-config.cmake` will have the entries similar to
```cmake
  set_target_properties(Lib_rng PROPERTIES
    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
    INTERFACE_INCLUDE_DIRECTORIES     "C:/work/vendors64/Random123-1.08/include;C:/work/vs2017/install/$<CONFIG>/include" )
```
* This allows client code to simply register a dependency on _Lib_rng_ to also import the include path to _Random123_'s include directory.
* The big change is that the `add_component_library` helper macro was updated so that any paths provided to the `VENDOR_INCLUDE_DIRS` field will be appended to the `INTERFACE_INCLUDE_DIRECTORIES` for the current target.
* I also updated `rng/CMakeListst.txt` so that `R123_USE_CXX11` is only enabled if the current C++ compiler is being used in a mode that supports C++11 or later.


### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
