### PR TITLE
Two minor tweaks and some formatting fixes.

### DIFF
--- a/src/c4/bin/ythi.cc
+++ b/src/c4/bin/ythi.cc
@@ -21,6 +21,7 @@
 //---------------------------------------------------------------------------//
 
 #include "c4/C4_Functions.hh"
+#include "c4/QueryEnv.hh"
 #include "c4/bin/xthi.hh"
 #include <atomic>
 #include <iomanip>
@@ -44,7 +45,11 @@ void run_thread(std::atomic<bool> &signal, std::string const &hostname,
 
 //----------------------------------------------------------------------------//
 int main(int argc, char **argv) {
-  size_t const YTHI_NUM_WORKERS = (argc > 1) ? std::stoi(argv[1]) : 1;
+  rtt_c4::SLURM_Task_Info sti;
+  size_t const numthreads =
+      sti.is_cpus_per_task_set() ? sti.get_cpus_per_task() : 1;
+  size_t const YTHI_NUM_WORKERS =
+      (argc > 1) ? std::stoi(argv[1]) : numthreads - 1;
   unsigned const num_cpus = std::thread::hardware_concurrency();
 
   rtt_c4::initialize(argc, argv);

--- a/src/c4/test/tstofpstream.cc
+++ b/src/c4/test/tstofpstream.cc
@@ -11,6 +11,7 @@
 #include "c4/ParallelUnitTest.hh"
 #include "c4/ofpstream.hh"
 #include "ds++/Release.hh"
+#include <sstream>
 
 using namespace std;
 using namespace rtt_dsxx;
@@ -36,7 +37,7 @@ void tstofpstream(UnitTest &ut) {
   PASSMSG("completed serialized write without hanging or segfaulting");
 }
 
-//----------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void tstofpstream_bin(UnitTest &ut) {
 
   int pid = rtt_c4::node();
@@ -51,12 +52,15 @@ void tstofpstream_bin(UnitTest &ut) {
 
   // Read file on head rank, check for correct conversion and ordering
   if (pid == 0) {
-    ifstream in("tstofpstream.bin", std::ofstream::binary);
-    int this_pid;
+    ifstream in("tstofpstream.bin", std::ifstream::binary);
+    int this_pid(-42);
     for (int a = 0; a < rtt_c4::nodes(); a++) {
       in.read(reinterpret_cast<char *>(&this_pid), sizeof(int));
       if (this_pid != a) {
-        ITFAILS;
+        std::ostringstream msg;
+        msg << "Unexpected value for this_pid = " << this_pid
+            << ". Expected value a = " << a;
+        FAILMSG(msg.str());
       }
     }
   }

--- a/src/diagnostics/draco_info.hh
+++ b/src/diagnostics/draco_info.hh
@@ -70,7 +70,7 @@ Build information:
  * \endverbatim
  */
 //===========================================================================//
-class DLL_PUBLIC_diagnostics DracoInfo {
+class DracoInfo {
 public:
   // IMPLELEMENTATION
   // ================

--- a/src/ds++/Assert.cc
+++ b/src/ds++/Assert.cc
@@ -1,10 +1,10 @@
-//----------------------------------*-C++-*----------------------------------//
+//----------------------------------*-C++-*-----------------------------------//
 /*!
  * \file   ds++/Assert.cc
  * \brief  Helper functions for the Assert facility.
  * \note   Copyright (C) 2016-2019 Triad National Security, LLC.
  *         All rights reserved. */
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 
 #include "Assert.hh"
 #include "StackTrace.hh"
@@ -14,9 +14,9 @@
 
 namespace rtt_dsxx {
 
-//===========================================================================//
+//============================================================================//
 // ASSERTION CLASS MEMBERS
-//===========================================================================//
+//============================================================================//
 
 //----------------------------------------------------------------------------//
 /*!
@@ -42,17 +42,15 @@ std::string assertion::build_message(std::string const &cond,
 
 //----------------------------------------------------------------------------//
 /*
- * Leave this definition in the .cc file!  This is a work-around for building
- * on Cielo.  Without this defintion in the .cc file, clubimc will not build
- * because it cannot resolve this symbol: undefined reference to
- * `__T_Q2_8rtt_dsxx9assertion'
+ * Leave this definition in the .cc file!  It needs to be saved to the dsxx 
+ * library.
  */
 assertion::~assertion() throw() { /* empty */
 }
 
-//===========================================================================//
+//============================================================================//
 // FREE FUNCTIONS
-//===========================================================================//
+//============================================================================//
 /*!
  * \brief Throw a rtt_dsxx::assertion for Require, Check, Ensure macros.
  * \return Throws an assertion.
@@ -97,7 +95,7 @@ void show_cookies(std::string const &cond, std::string const &file,
   std::cerr << assertion::build_message(cond, file, line) << std::endl;
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 //!  Throw a rtt_dsxx::assertion for Insist macros.
 void insist(std::string const &cond, std::string const &msg,
             std::string const &file, int const line) {
@@ -109,7 +107,7 @@ void insist(std::string const &cond, std::string const &msg,
   throw assertion(myMessage.str());
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Throw a rtt_dsxx::assertion for Insist_ptr macros.
  *
@@ -127,7 +125,7 @@ void insist_ptr(char const *const cond, char const *const msg,
 
 #if DBC & 16
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 //!  Conditionally throw a rtt_dsxx::assertion for Insist macros.
 void check_insist(bool const cond, char const *const condstr,
                   std::string const &msg, char const *const file,
@@ -142,7 +140,7 @@ void check_insist(bool const cond, char const *const condstr,
   }
 }
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Conditionally throw a rtt_dsxx::assertion for Insist_ptr macros.
  *
@@ -162,7 +160,7 @@ void check_insist_ptr(bool const cond, char const *const condstr,
 
 #endif
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! \brief Add hostname and pid to error messages.
  *
  * Several of the errors that might be reported by DACS_Device could be specific
@@ -183,6 +181,6 @@ std::string verbose_error(std::string const &message) {
 
 } // namespace rtt_dsxx
 
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of Assert.cc
-//---------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/ds++/DracoStrings.cc
+++ b/src/ds++/DracoStrings.cc
@@ -139,10 +139,7 @@ std::vector<std::string> tokenize(std::string const &str,
 }
 
 //----------------------------------------------------------------------------//
-/*!
- * \brief Parse msg to provide a list of words and the number of occurrences of
- *        each.
- */
+//! Parse msg to provide a list of words and the number of occurrences of each.
 std::map<std::string, unsigned> get_word_count(std::ostringstream const &msg,
                                                bool verbose) {
   using std::cout;

--- a/src/ds++/SystemCall.hh
+++ b/src/ds++/SystemCall.hh
@@ -13,6 +13,7 @@
 #include "ds++/config.h"
 #include <string>
 #ifdef WIN32
+#define _WINSOCKAPI_
 #include <WinSock2.h>
 #include <Windows.h>
 #include <sys/types.h>

--- a/src/ds++/path.hh
+++ b/src/ds++/path.hh
@@ -37,7 +37,7 @@ enum FilenameComponent {
 /*!
  * \brief Get a specific component of a full filename.
  * \param fqName a fully qualified pathname
- * \param fc Enum type FilenameComponent that specificies the action.
+ * \param fc Enum type FilenameComponent that specifies the action.
  */
 std::string getFilenameComponent(std::string const &fqName,
                                  FilenameComponent fc);
@@ -75,8 +75,8 @@ public:
  *      the directory. Recommend using wdtOpPrint or wdtOpRemove
  * \return void
  *
- * \sa draco_remove_dir Helper function to recurively delete a directory and all
- *     its contents.
+ * \sa draco_remove_dir Helper function to recursively delete a directory and
+ *     all its contents.
  * \sa draco_dir_print Helper function that will print a directory and all its
  *     contents.
  *

--- a/src/ds++/path_getFilenameComponent.cc
+++ b/src/ds++/path_getFilenameComponent.cc
@@ -18,7 +18,7 @@ namespace rtt_dsxx {
  * \param fqName A fully qualified filename (/path/to/the/unit/test)
  * \return filename only, or path to file only.
  *
- * This function expects a fully qualfied name of a unit test (e.g.: argv[0]).
+ * This function expects a fully qualified name of a unit test (e.g.: argv[0]).
  * It strips off the path and returns the name of the unit test.
  *
  * Options:
@@ -61,8 +61,7 @@ std::string getFilenameComponent(std::string const &fqName,
     break;
 
   case FC_NAME:
-    // if fqName is a directory and ends with "/", trim the trailing
-    // dirSep.
+    // if fqName is a directory and ends with "/", trim the trailing dirSep.
     if (fqName.rfind(rtt_dsxx::UnixDirSep) == fqName.length() - 1)
       fullName = fqName.substr(0, fqName.length() - 1);
     if (fqName.rfind(rtt_dsxx::WinDirSep) == fqName.length() - 1)

--- a/src/ds++/test/tstAssert.cc
+++ b/src/ds++/test/tstAssert.cc
@@ -21,7 +21,7 @@ using namespace std;
 
 //---------------------------------------------------------------------------//
 // The way this test article works is that each of the DBC macros are tested
-// in a seperate function.  A falst condition is asserted using each macro,
+// in a separate function.  A false condition is asserted using each macro,
 // and after this follows a throw.  Two catch clauses are available, one to
 // catch an assertion object, and one to catch anything else.  By comparing
 // the exception that is actually caught with the one that should be caught
@@ -30,7 +30,7 @@ using namespace std;
 //---------------------------------------------------------------------------//
 
 //---------------------------------------------------------------------------//
-// Make sure we can differentiate betweeen a std::runtime_error and a
+// Make sure we can differentiate between a std::runtime_error and a
 // rtt_dsxx::assertion.
 //---------------------------------------------------------------------------//
 
@@ -59,12 +59,12 @@ void t2(rtt_dsxx::UnitTest &ut) {
     PASSMSG("caught rtt_dsxx::assertion");
     error_message = std::string(a.what());
   } catch (...) {
-    FAILMSG("falied to catch rtt_dsxx:assertion");
+    FAILMSG("failed to catch rtt_dsxx:assertion");
   }
 
   // Make sure we can extract the error message.
   std::string const compare_value(
-      "Assertion: hello1, failed in myfile, line 42.\n");
+      "Assertion: hello1, failed in myfile, line 42.");
   std::regex rgx(std::string(".*") + compare_value + ".*");
   std::smatch match;
 
@@ -176,7 +176,7 @@ void tshow_cookies(rtt_dsxx::UnitTest &ut) {
       string const msg("testing show_cookies()");
       string const file("DummyFile.ext");
       int const line(55);
-      cout << "The following line should be an an error "
+      cout << "The following line should be an error "
            << "message...\n\t";
       rtt_dsxx::show_cookies(msg, file, line);
       throw "Bogus!";
@@ -303,7 +303,7 @@ void tensure(rtt_dsxx::UnitTest &ut) {
 }
 
 //---------------------------------------------------------------------------//
-// Check the operatio of the Remeber() macro.
+// Check the operation of the Remember() macro.
 //---------------------------------------------------------------------------//
 void tremember(rtt_dsxx::UnitTest &ut) {
   std::cout << "t-Remember test: ";
@@ -516,12 +516,12 @@ int main(int argc, char *argv[]) {
     t2(ut);
     t3(ut);
 
-    // Test mechanics of Assert funtions.
+    // Test mechanics of Assert functions.
     ttoss_cookies(ut);
     tshow_cookies(ut);
     tcheck_cookies(ut);
 
-    // Test Design-by-Constract macros.
+    // Test Design-by-Contract macros.
     trequire(ut);
     tcheck(ut);
     tensure(ut);
@@ -530,7 +530,7 @@ int main(int argc, char *argv[]) {
     tinsist(ut);
     tinsist_ptr(ut);
 
-    // fancy ouput
+    // fancy output
     tverbose_error(ut);
 
     // noexcept


### PR DESCRIPTION
### Background

* While working a couple of other issues, a handful of updates crept into my sandbox.  I think these changes are worth keeping.

### Description of changes

+ Change how `ythi` sets `YTHI_NUM_WORKERS` so that when run from a machine that is running SLURM, the `get_cpus_per_task` function is queried.
+ In `tstofpstream` change `ofstream` to `ifstream` to match actual use.  This showed up as a warning on one machine.  Also add a more verbose diagnostic if the test fails.
+ Remove `DLL_PUBLIC` decoration from `draco_info`.
+ MSVC only: Add a `define _WINSOCKAPI_` to prevent a possible system header conflict related to the order in which `windows.h` and `winsock2.h` are included.
+ Clean up comments, indentation, spelling length of divider lines, etc.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco) (on DST - no testing)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
