### PR TITLE
Move export DRACO_ENV_DIR before use in path to alias script.

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -54,6 +54,13 @@ case ${-} in
     export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
     export TERM=xterm-256color
 
+    # Attempt to find DRACO
+    if ! [[ $DRACO_SRC_DIR ]]; then
+      _BINDIR=`dirname "$BASH_ARGV"`
+      export DRACO_SRC_DIR=`(cd $_BINDIR/../..;pwd)`
+      export DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment
+    fi
+
     ##------------------------------------------------------------------------##
     ## Common aliases
     ##------------------------------------------------------------------------##
@@ -82,13 +89,6 @@ esac
 
 # Bash functions are not inherited by subshells.
 if [[ ${INTERACTIVE} ]]; then
-
-  # Attempt to find DRACO
-  if ! [[ $DRACO_SRC_DIR ]]; then
-    _BINDIR=`dirname "$BASH_ARGV"`
-    export DRACO_SRC_DIR=`(cd $_BINDIR/../..;pwd)`
-    export DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment
-  fi
 
   # Common bash functions and alias definitions
   source ${DRACO_ENV_DIR}/bashrc/bash_functions.sh


### PR DESCRIPTION
### Background

* It appears that the bash_aliases.sh path variable can be empty before it is sourced for interactive sessions.
* Apologies - I may close this, having learned that DRACO_ENV_DIR is supposed to be set by users; something like this may still be useful if DRACO_SRC_DIR is not set.

### Purpose of Pull Request

* Export `DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment` before sourcing bash_aliases.sh.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
