### PR TITLE
Mark some functions constexpr

### DIFF
--- a/src/ds++/Data_Table.hh
+++ b/src/ds++/Data_Table.hh
@@ -23,8 +23,9 @@ namespace rtt_dsxx {
  *
  * Data_Table provides read-only, DBC-checked, container-like access to a
  * sequential range of memory locations, or a scalar.  This is useful in
- * situations where the amount of data changes depending on compile-time 
- * factors, but you always want to access it as an array.
+ * situations where the amount of data changes depending on compile-time
+ * factors, but you always want to access it as an array. Because this class is
+ * read only all of it's functions and constructor can be marked constexpr.
  */
 //===========================================================================//
 template <typename T> class Data_Table {
@@ -33,27 +34,28 @@ public:
 
 public:
   //! copy constructor
-  inline Data_Table(Data_Table const &);
+  constexpr inline Data_Table(Data_Table const &);
   //! Constructor
-  inline explicit Data_Table(std::vector<T> const &v);
+  constexpr inline explicit Data_Table(std::vector<T> const &v);
   //! Constructor
-  inline Data_Table(const_iterator const begin, const_iterator const end);
+  constexpr inline Data_Table(const_iterator const begin,
+                              const_iterator const end);
   //! Constructor
-  inline explicit Data_Table(T const &value);
+  constexpr inline explicit Data_Table(T const &value);
   //! Default constructor
-  inline Data_Table(void);
+  constexpr inline Data_Table(void);
   //! Access operator
-  inline T const &operator[](const unsigned i) const;
+  constexpr inline T const &operator[](const unsigned i) const;
   //! begin iterator
-  inline const_iterator begin() const { return d_begin; }
+  constexpr inline const_iterator begin() const { return d_begin; }
   //! end iterator
-  inline const_iterator end() const { return d_end; }
-  inline uint64_t size() const { return d_end - d_begin; }
-  inline T const &front() const;
-  inline T const &back() const;
-  inline T *access();
+  constexpr inline const_iterator end() const { return d_end; }
+  constexpr inline uint64_t size() const { return d_end - d_begin; }
+  constexpr inline T const &front() const;
+  constexpr inline T const &back() const;
+  constexpr inline T *access();
   //! equality operator
-  Data_Table &operator=(Data_Table const &);
+  constexpr Data_Table &operator=(Data_Table const &);
 
 private:
   const_iterator const d_begin;
@@ -70,7 +72,7 @@ private:
  * they pointed to the d_value in the RHS.
 */
 template <typename T>
-Data_Table<T>::Data_Table(Data_Table<T> const &rhs)
+constexpr Data_Table<T>::Data_Table(Data_Table<T> const &rhs)
     : d_begin(rhs.d_begin), d_end(rhs.d_end), d_value(rhs.d_value) {
   if (rhs.d_begin == &(rhs.d_value)) {
     const_cast<const_iterator &>(d_begin) = &d_value;
@@ -80,7 +82,7 @@ Data_Table<T>::Data_Table(Data_Table<T> const &rhs)
 
 //---------------------------------------------------------------------------//
 template <typename T>
-Data_Table<T> &Data_Table<T>::operator=(Data_Table<T> const &rhs) {
+constexpr Data_Table<T> &Data_Table<T>::operator=(Data_Table<T> const &rhs) {
   if (&rhs != this) {
     if (rhs.d_begin == &(rhs.d_value)) {
       const_cast<const_iterator &>(d_begin) = &d_value;
@@ -96,8 +98,8 @@ Data_Table<T> &Data_Table<T>::operator=(Data_Table<T> const &rhs) {
 
 //---------------------------------------------------------------------------//
 template <typename T>
-inline Data_Table<T>::Data_Table(const_iterator const begin,
-                                 const_iterator const end)
+constexpr inline Data_Table<T>::Data_Table(const_iterator const begin,
+                                           const_iterator const end)
     : d_begin(begin), d_end(end), d_value() {
   Require(!(begin > end));
 }
@@ -107,34 +109,35 @@ inline Data_Table<T>::Data_Table(const_iterator const begin,
  * Copy the scalar into a local variable, and set the pointers to that copy.
  */
 template <typename T>
-inline Data_Table<T>::Data_Table(T const &value)
+constexpr inline Data_Table<T>::Data_Table(T const &value)
     : d_begin(&d_value), d_end(&d_value + 1), d_value(value) {}
 
 //---------------------------------------------------------------------------//
 template <typename T>
-inline Data_Table<T>::Data_Table() : d_begin(0), d_end(0), d_value() {}
+constexpr inline Data_Table<T>::Data_Table()
+    : d_begin(0), d_end(0), d_value() {}
 
 //---------------------------------------------------------------------------//
 template <typename T>
-inline T const &Data_Table<T>::operator[](unsigned const i) const {
+constexpr inline T const &Data_Table<T>::operator[](unsigned const i) const {
   Require(static_cast<int>(i) < (d_end - d_begin));
   return d_begin[i];
 }
 
 //---------------------------------------------------------------------------//
-template <typename T> inline T const &Data_Table<T>::front() const {
+template <typename T> constexpr inline T const &Data_Table<T>::front() const {
   Require((d_end - d_begin) > 0);
   return *d_begin;
 }
 
 //---------------------------------------------------------------------------//
-template <typename T> inline T const &Data_Table<T>::back() const {
+template <typename T> constexpr inline T const &Data_Table<T>::back() const {
   Require((d_end - d_begin) > 0);
   return *(d_end - 1);
 }
 
 //---------------------------------------------------------------------------//
-template <typename T> inline T *Data_Table<T>::access() {
+template <typename T> constexpr inline T *Data_Table<T>::access() {
   Require((d_end - d_begin) > 0);
   return const_cast<T *>(d_begin);
 }

--- a/src/ds++/DracoMath.hh
+++ b/src/ds++/DracoMath.hh
@@ -215,9 +215,9 @@ inline Ordered_Group sign(Ordered_Group a, Ordered_Group b) {
  * \pre  x in (x1,x2), extrapolation is not allowed.
  * \post y in (y1,y2), extrapolation is not allowed.
  */
-inline double linear_interpolate(double const x1, double const x2,
-                                 double const y1, double const y2,
-                                 double const x) {
+constexpr inline double linear_interpolate(double const x1, double const x2,
+                                           double const y1, double const y2,
+                                           double const x) {
   Require(std::abs(x2 - x1) > std::numeric_limits<double>::epsilon());
   Require(((x >= x1) && (x <= x2)) || ((x >= x2) && (x <= x1)));
 

--- a/src/ds++/DracoMath.hh
+++ b/src/ds++/DracoMath.hh
@@ -11,6 +11,7 @@
 #ifndef rtt_dsxx_DracoMath_hh
 #define rtt_dsxx_DracoMath_hh
 
+#include "Constexpr_Functions.hh"
 #include "Soft_Equivalence.hh"
 #include <algorithm>
 #include <complex>
@@ -218,7 +219,7 @@ inline Ordered_Group sign(Ordered_Group a, Ordered_Group b) {
 constexpr inline double linear_interpolate(double const x1, double const x2,
                                            double const y1, double const y2,
                                            double const x) {
-  Require(std::abs(x2 - x1) > std::numeric_limits<double>::epsilon());
+  Require(ce_fabs(x2 - x1) > std::numeric_limits<double>::epsilon());
   Require(((x >= x1) && (x <= x2)) || ((x >= x2) && (x <= x1)));
 
   // return value


### PR DESCRIPTION
### Background

* A new feature of the NVCC compiler allows device code to call host code if it's marked with `constexpr` (https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#options-for-altering-compiler-linker-behavior-expt-relaxed-constexpr). Draco has not been thoroughly marked for `constexpr` but this practice makes compiling GPU code much easier as constexpr functions work naturally on the CPU and GPU without any decoration or special compilation steps. When compiling the GPU libraries needed by Jayenne the `Data_Table` and `linear_interpolate` functions were needed in GPU code. These can both be marked `constexpr` (if `constexpr` values were passed to these functions they would return `constexpr` values and be evaluated at compile time).

### Purpose of Pull Request

* Allow GPU libraries to link against more Draco functions
* [Fixes Redmine Issue #](https://rtt.lanl.gov/redmine/issues/1430)

### Description of changes

* Mark the Data_Table class as constexpr
* Mark the linear_interpolate function as constexpr

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
