### PR TITLE
Address regression issues reported on Darwin:

### DIFF
--- a/config/FindGrace.cmake
+++ b/config/FindGrace.cmake
@@ -75,10 +75,28 @@ endif()
 # If environment variables are not set (GRACE_INC_DIR), look for the binary and
 # try to guess appropriate location of library and headers.
 find_program( Grace_EXECUTABLE NAMES xmgrace ggrace)
-
 if( EXISTS ${Grace_EXECUTABLE} AND NOT IS_DIRECTORY "${GRACE_HOME}" )
   get_filename_component( GRACE_HOME ${Grace_EXECUTABLE} DIRECTORY )
   get_filename_component( GRACE_HOME "${GRACE_HOME}/.." REALPATH )
+endif()
+
+# plot2D also needs a working gracebat application
+find_program( Gracebat_EXECUTABLE NAMES gracebat)
+if( EXISTS ${Gracebat_EXECUTABLE} )
+  execute_process(
+    COMMAND ${Gracebat_EXECUTABLE} --version
+    OUTPUT_VARIABLE gracebat_ver_out
+    ERROR_VARIABLE gracebat_ver_err
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE )
+  message("
+ gracebat_ver_out = ${gracebat_ver_out}${gracebat_ver_err}
+")
+  if( "${gracebat_ver_out}${gracebat_ver_err}" MATCHES "Broken" )
+    set( Gracebat_EXECUTABLE "NOTFOUND" CACHE STRING "working gracebat found?"
+      FORCE)
+  endif()
+
 endif()
 
 #=============================================================================
@@ -144,12 +162,12 @@ endif()
 # handle the QUIETLY and REQUIRED arg
 find_package_handle_standard_args(Grace
   FOUND_VAR     Grace_FOUND
-  REQUIRED_VARS Grace_INCLUDE_DIR Grace_LIBRARY
+  REQUIRED_VARS Grace_INCLUDE_DIR Grace_LIBRARY Gracebat_EXECUTABLE
   VERSION_VAR   Grace_VERSION
   )
 
 mark_as_advanced( GRACE_HOME Grace_VERSION Grace_LIBRARY Grace_LIBRARY_DEBUG
-  Grace_INCLUDE_DIR Grace_EXECUTABLE)
+  Grace_INCLUDE_DIR Grace_EXECUTABLE Gracebat_EXECUTABLE)
 
 #=============================================================================
 # Register imported libraries:

--- a/config/FindGrace.cmake
+++ b/config/FindGrace.cmake
@@ -89,9 +89,6 @@ if( EXISTS ${Gracebat_EXECUTABLE} )
     ERROR_VARIABLE gracebat_ver_err
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE )
-  message("
- gracebat_ver_out = ${gracebat_ver_out}${gracebat_ver_err}
-")
   if( "${gracebat_ver_out}${gracebat_ver_err}" MATCHES "Broken" )
     set( Gracebat_EXECUTABLE "NOTFOUND" CACHE STRING "working gracebat found?"
       FORCE)

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -37,6 +37,7 @@ endif()
 #
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+# arm --> -mcpu=thunderx2t99 ??? Darwin volta nodes?
 check_c_compiler_flag(   "-march=native" HAS_MARCH_NATIVE )
 if( DEFINED CMAKE_CXX_COMPILER_ID )
   check_cxx_compiler_flag( "-Wnoexcept"    HAS_WNOEXCEPT )

--- a/config/unix-pgf90.cmake
+++ b/config/unix-pgf90.cmake
@@ -25,11 +25,11 @@ endif()
 ##---------------------------------------------------------------------------##
 # Ensure cache values always match current selection
 ##---------------------------------------------------------------------------##
-set( CMAKE_Fortran_FLAGS                "${CMAKE_Fortran_FLAGS}"                CACHE STRIG "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_DEBUG          "${CMAKE_Fortran_FLAGS_DEBUG}"          CACHE STRIG "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_RELEASE        "${CMAKE_Fortran_FLAGS_RELEASE}"        CACHE STRIG "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_MINSIZEREL}"     CACHE STRIG "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}" CACHE STRIG "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS                "${CMAKE_Fortran_FLAGS}"                CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_DEBUG          "${CMAKE_Fortran_FLAGS_DEBUG}"          CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_RELEASE        "${CMAKE_Fortran_FLAGS_RELEASE}"        CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_MINSIZEREL}"     CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}" CACHE STRING "compiler flags" FORCE )
 
 #
 # Toggle compiler flags for optional features

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -40,7 +40,7 @@ if test -n "$MODULESHOME"; then
         noflavor="git gcc/8.2.0"
         compflavor="cmake/3.14.2-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_8.2.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lflavor trilinos/12.14.1-$mflavor-$lflavor"
-        # ec_mf="ndi"
+        ec_mf="csk/0.5.0-$cflavor" # ndi
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
         export OMPI_MCA_btl=^openib
         export UCX_NET_DEVICES=mlx5_0:1
@@ -58,7 +58,7 @@ if test -n "$MODULESHOME"; then
         fi
         compflavor="cmake/3.14.2-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
-        ec_mf="ndi"
+        ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
         if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
           export PATH=$PATH:/projects/opt/centos7/clang/6.0.0/bin
@@ -91,7 +91,7 @@ superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
         compflavor="eospac/6.4.0-$cflavor cmake/3.14.2-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
-        # ec_mf="ndi eospac/6.3.0"
+        ec_mf="csk/0.5.0-$cflavor" # ndi
 
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
         # eliminates warnings: "there are more than one active ports on host"

--- a/src/ds++/terminal/terminal.h
+++ b/src/ds++/terminal/terminal.h
@@ -1,4 +1,28 @@
+//----------------------------------------------------------------------------//
+// Draco supressions
+//----------------------------------------------------------------------------//
 // clang-format off
+
+#include "ds++/config.h"
+
+#ifdef __GNUC__
+#if (DBS_GNUC_VERSION >= 40204) && !defined(__ICC) && !defined(NVCC)
+// Suppress GCC's "unused variable" warning.
+#if (DBS_GNUC_VERSION >= 40600)
+#pragma GCC diagnostic push
+#endif
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#endif
+
+#ifdef __CUDACC__
+// https://stackoverflow.com/questions/14831051/how-to-disable-a-specific-nvcc-compiler-warnings
+// http://www.ssl.berkeley.edu/~jimm/grizzly_docs/SSL/opt/intel/cc/9.0/lib/locale/en_US/mcpcom.msg
+#pragma diag_suppress unsigned_compare_with_negative
+#endif
+
+
+//----------------------------------------------------------------------------//
 
 #ifndef TERMINAL_H
 #define TERMINAL_H
@@ -13,7 +37,6 @@
  *
  * https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
  */
-
 
 #include "terminal_base.h"
 
@@ -754,4 +777,24 @@ public:
 } // namespace Term
 
 #endif // TERMINAL_H
+
+//----------------------------------------------------------------------------//
+// Draco supressions
+//----------------------------------------------------------------------------//
+
+// This is defined by <termios.h> but causes conflicts with some TRT code.
+#undef B0
+
+#ifdef __CUDACC__
+#pragma diag_default unsigned_compare_with_negative
+#endif
+
+#ifdef __GNUC__
+#if (DBS_GNUC_VERSION >= 40600)
+// Restore GCC diagnostics to previous state.
+#pragma GCC diagnostic pop
+#endif
+#endif
 // clang-format on
+
+//----------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

+ On Darwin, serveral new regression failures are being reported.  Fix these issues.
+ Also, install csk/0.5.0 and use it in the nightly regression tests.

### Purpose of Pull Request

* [Fixes Redmine Issue #1746](https://rtt.lanl.gov/redmine/issues/1746)

### Description of changes

+ Update `FindGrace.cmake` to be more agressive in checking the the local Grace (ggrace or xmagrace) install is fully functional.  If `gracebat` fails, then report that Grace is not available.  This will fix the broken `plot2D` tests because we will no longer build or test this package on Darwin.
+ Add a note to `unix-g++.cmake` about possible ARM-specific compile flags.
+ Fix a spelling error in `unix-pgif90.cmake` that prevented the compile flags from being used.
+ Update the environment bashrc files to load csk/0.5.0 by default.
+ Add some guards around `terminal.h` to suppress compile warnings from g++ and nvcc and undef some CPP constants defined in `bits/termios.h` that broke our codes.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
