### PR TITLE
Fix static build.

### DIFF
--- a/config/generate_dll_declspec.cmake
+++ b/config/generate_dll_declspec.cmake
@@ -58,7 +58,7 @@ set( dll_declspec_content
  */
 /*---------------------------------------------------------------------------*/
 
-#ifndef DRACO_SHARED_LIBS
+#ifndef rtt_dsxx_config_h
 #error \"Do not call this file directly. Call ds++/config.h instead.\"
 #endif
 

--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -55,6 +55,7 @@ target_include_directories( Lib_c4
 if( NOT APPLE )
   add_subdirectory( bin )
 endif()
+list( APPEND headers ${PROJECT_SOURCE_DIR}/bin/xthi.hh )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions


### PR DESCRIPTION
### Background

* After a recent PR was merged (#700), static builds were broken.

### Description of changes

+ A change in `generate_dll_declspec.cmake` introduced a build failures for `DRACO_LIBRARY_TYPE=STATIC`.  Instead of triggering the CPP `#error` based on the CPP symbol `DRACO_SHARED_LIBS` use `rtt_dsxx_config_h` as this will exist for static builds while the previous symbol will not exist.
+ Also, install `xthi.hh` as part of c4 as this is needed by one of our clients.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
