### PR TITLE
Return uint32_t instead of int.

### DIFF
--- a/src/c4/QueryEnv.hh
+++ b/src/c4/QueryEnv.hh
@@ -72,16 +72,16 @@ std::pair<bool, T> get_env_val(std::string const &key, T default_value = T{}) {
 class SLURM_Task_Info {
 public:
   /**\brief Get SLURM_CPUS_PER_TASK */
-  int get_cpus_per_task() const { return cpus_per_task_; }
+  uint32_t get_cpus_per_task() const { return cpus_per_task_; }
 
   /**\brief Get SLURM_NTASKS */
-  int get_ntasks() const { return ntasks_; }
+  uint32_t get_ntasks() const { return ntasks_; }
 
   /**\brief Get SLURM_JOB_NUM_NODES */
-  int get_job_num_nodes() const { return job_num_nodes_; }
+  uint32_t get_job_num_nodes() const { return job_num_nodes_; }
 
   /**\brief Get SLURM_CPUS_ON_NODE */
-  int get_cpus_on_node() const { return cpus_on_node_; }
+  uint32_t get_cpus_on_node() const { return cpus_on_node_; }
 
   //! Return value of SLURM_NODELIST
   std::string get_nodelist() const { return nodelist_; }
@@ -114,17 +114,20 @@ public:
 
   // state
 private:
-  int cpus_per_task_{0xFFFFFFF};    //!< arg to -c
-  bool def_cpus_per_task_{false};   //!< whether SLURM_CPUS_PER_TASK was defined
-  int ntasks_{0xFFFFFFE};           //!< arg to -n
-  bool def_ntasks_{false};          //!< whether SLURM_NTASKS was defined
-  int job_num_nodes_{0xFFFFFFD};    //!< arg to -N
-  bool def_job_num_nodes_{false};   //!< whether SLURM_JOB_NUM_NODES was defined
-  int cpus_on_node_{0xFFFFFFD};     //!< SLURM_CPUS_ON_NODE
-  bool def_cpus_on_node_{false};    //!< was SLURM_CPUS_ON_NODE defined?
-  std::string nodelist_{"not set"}; //!< SLURM_NODELIST
-  bool def_nodelist_{false};        //!< was SLURM_NODELIST defined?
-};                                  // SLURM_Task_Info
+  uint32_t cpus_per_task_{0xFFFFFFF}; //!< arg to -c
+  //! whether SLURM_CPUS_PER_TASK was defined
+  bool def_cpus_per_task_{false};
+  uint32_t ntasks_{0xFFFFFFE};        //!< arg to -n
+  bool def_ntasks_{false};            //!< whether SLURM_NTASKS was defined
+  uint32_t job_num_nodes_{0xFFFFFFD}; //!< arg to -N
+  //! whether SLURM_JOB_NUM_NODES was defined
+  bool def_job_num_nodes_{false};
+  uint32_t cpus_on_node_{0xFFFFFFD}; //!< SLURM_CPUS_ON_NODE
+  bool def_cpus_on_node_{false};     //!< was SLURM_CPUS_ON_NODE defined?
+  std::string nodelist_{"not set"};  //!< SLURM_NODELIST
+  bool def_nodelist_{false};         //!< was SLURM_NODELIST defined?
+
+}; // SLURM_Task_Info
 
 } // namespace rtt_c4
 


### PR DESCRIPTION
### Background

* gcc on snow is reporting signed/unsigned comparison [warnings. ](https://rtt.lanl.gov/cdash/viewBuildError.php?type=1&buildid=8745)

### Description of changes

* Modify return types from `QueryEnv.hh` to fix warnings.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
