### PR TITLE
WIP: Provide a 'view' wrapper for std::vector<T>.

### DIFF
--- a/src/ds++/VectorView.hh
+++ b/src/ds++/VectorView.hh
@@ -1,0 +1,138 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   ds++/VectorView.hh
+ * \author Kelly G. Thompson <kgt@lanl.gov>, Steve Nolen <sdnolen@lanl.gov>
+ * \date   Friday, Dec 13, 2019, 17:49 pm
+ * \brief  A view class that presents contiguous 1-D as multi-D.
+ * \note   Copyright (C) 2019 Triad National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#ifndef rtt_dsxx_VectorView_hh
+#define rtt_dsxx_VectorView_hh
+
+#include "Assert.hh"
+#include <array>
+#include <vector>
+
+namespace rtt_dsxx {
+
+//============================================================================//
+/*!
+ * \class VectorView
+ * \brief A wrapper for std::vector<T> that presents a compatible multi-D
+ *        'view'.
+ *
+ * \tparam T The data storage for the underlying std::vector<T>.
+ * \tparam Extents A variatic template list of integral values that represent
+ *         the max value of each dimension of the 'view'.
+ * \todo Add operator= to allow assignment operations.
+ *
+ * Example:
+ *
+ * \code
+ * vector<double> v1 = { 1,2,3,4,5,6,7,8,9 };
+ * VectorView<double,3,3,3> myvecview(v1);
+ * std::cout << myvecview(2,0,1) << endl;
+ *
+ * \endcode
+ */
+//============================================================================//
+
+template <typename T, unsigned... Extents> class VectorView {
+public:
+  //--------------------------------------------------------------------------//
+  /*! \brief Compute the 1-D index associated with the actual data storage from
+   *         provided multi-D index values.
+   *
+   * \tparam Indices variatic template that represents a set of integral values,
+   *         one for each dimension of the 'view'.
+   * \param indices a list of integral types that indicate the multi-D offset.
+   * \return An size_t index into the underlying std::vector<T>.
+   *
+   * \todo Once we adopt c++17, this logic can be simplified using 'fold
+   *       expressions'.
+   */
+  template <typename... Indices> size_t idx(Indices... indices) {
+    Insist(sizeof...(indices) == dim,
+           std::string("VectorView expected ") + std::to_string(dim) +
+               " arguments but only found " +
+               std::to_string(sizeof...(Indices)) + ".");
+    size_t idx = 0, i = 0;
+    using untilFold = int[];
+    // In the following line, the 'pack' is indices and the operation is the
+    // comma. For an explanation see
+    // https://www.codingame.com/playgrounds/2205/7-features-of-c17-that-will-simplify-your-code/fold-expressions
+    // Note that we don't use the computed value 'untilFold', but its
+    // construction has the side effect of setting idx.
+    (void)untilFold{((idx += indices * strides[i++]), 0)...};
+    Check(idx < data.size());
+    return idx;
+  }
+
+  //--------------------------------------------------------------------------//
+  /*! \brief Return the data associated with the provided multi-D view.
+   *
+   * \tparam Indices variatic template that represents a set of integral values,
+   *         one for each dimension of the 'view'.
+   * \param indices a list of integral types that indicate the multi-D offset.
+   * \return Data from the 1-D std::vector<T> associated with the provided
+   *         multi-D index set.
+   */
+  template <typename... Indices> T operator()(Indices... indices) {
+    return data[idx(indices...)];
+  }
+
+  //--------------------------------------------------------------------------//
+  /*! \brief Default constructor
+   *
+   * \param[in] data a reference to the underlying std::vector<T> that we are
+   *               creating a 'view' for.
+   *
+   * When the constructor is called, we must setup the 'stride' or offset values
+   * for each of indices that will be used for this view.
+   */
+  VectorView(std::vector<T> const &data_) : data(data_) {
+    Ensure(dim > 0);
+    // Member data 'strides' was initialized with Extents, but must now be
+    // replaced with actual offset values.
+    for (size_t i = dim - 1; i < dim; --i) {
+      Insist(strides[i] > 0, "Each dimension must have a positive length.");
+      strides[i] = 1;
+      for (size_t j = 0; j < i; j++) {
+        strides[i] *= strides[j];
+      }
+    }
+  }
+
+private:
+  //
+  // Disabled member functions to ensure correct behavior.
+  //
+
+  // Ensure that the idx member function is not defined for the template case
+  // of zero arguments.
+  size_t idx(void) = delete;
+  // Ensure that the paren-operator member function is not defined for the
+  // template case of zero arguments.
+  T operator()() = delete;
+
+  //
+  // >> MEMBER DATA (state)
+  //
+
+  //! The actual data container that we are creating a view for.
+  std::vector<T> const &data;
+  //! Max size of each dimension for the view.
+  size_t const dim = sizeof...(Extents);
+  //! Offsets associated with each of the view's dimensions.
+  std::array<size_t, sizeof...(Extents)> strides = {Extents...};
+};
+
+} // end namespace rtt_dsxx
+
+#endif // rtt_dsxx_VectorView_hh
+
+//---------------------------------------------------------------------------//
+// end of ds++/VectorView.hh
+//---------------------------------------------------------------------------//

--- a/src/ds++/test/tstVectorView.cc
+++ b/src/ds++/test/tstVectorView.cc
@@ -1,0 +1,71 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   ds++/test/tstVectorView.cc
+ * \author Kelly Thompson <kgt@lanl.gov>
+ * \date   Sunday, Dec 15, 2019, 17:50 pm
+ * \note   Copyright (C) 2019 Triad National Security, LLC.
+ *         All rights reserved. */
+//---------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include "ds++/Soft_Equivalence.hh"
+#include "ds++/VectorView.hh"
+#include <limits>
+#include <sstream>
+
+using namespace std;
+using namespace rtt_dsxx;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+void test_int_data(ScalarUnitTest &ut) {
+
+  // 120 length vector
+  vector<int> myvec(4 * 5 * 6, 0);
+  for (size_t i = 1; i < myvec.size(); ++i) // make value == index
+    myvec[i] = myvec[i - 1] + 1;
+
+  // test entries for 3-D view.
+  VectorView<int, 4, 5, 6> myvecview(
+      myvec); // recast 1D as 3D with these lengths.
+  FAIL_IF_NOT(myvecview(2, 0, 0) == 2);
+  FAIL_IF_NOT(myvecview(0, 2, 0) == 8);
+  FAIL_IF_NOT(myvecview(0, 0, 4) == 80);
+  FAIL_IF_NOT(myvecview(2, 3, 4) == 94);
+  FAIL_IF_NOT(myvecview(3, 4, 5) == 119);
+}
+
+//----------------------------------------------------------------------------//
+void test_double_data(ScalarUnitTest &ut) {
+
+  // 120 length vector
+  vector<double> myvec(4 * 5 * 6, 0.0);
+  for (size_t i = 1; i < myvec.size(); ++i) // make value == index
+    myvec[i] = myvec[i - 1] + 1.0001;
+
+  // test entries for 3-D view.
+  VectorView<double, 4, 5, 6> myvecview(
+      myvec); // recast 1D as 3D with these lengths.
+  FAIL_IF_NOT(soft_equiv(myvecview(2, 0, 0), 2.0002));
+  FAIL_IF_NOT(soft_equiv(myvecview(0, 2, 0), 8.0008));
+  FAIL_IF_NOT(soft_equiv(myvecview(0, 0, 4), 80.0080));
+  FAIL_IF_NOT(soft_equiv(myvecview(2, 3, 4), 94.0094));
+  FAIL_IF_NOT(soft_equiv(myvecview(3, 4, 5), 119.0119));
+}
+
+//---------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  rtt_dsxx::ScalarUnitTest ut(argc, argv, release);
+  try {
+    test_int_data(ut);
+    test_double_data(ut);
+    ut.passes("Just Because.");
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of tstVectorView.cc
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* A recurring request for Draco is a multi-dimensional array container that isn't too complicated (no need for slices, etc.).  I hope this _view_ class provides the desired capabilities as it is both lightweight and extensible.

### Description of changes

+ This small class provides a multi-D view of a 1-D std::vector.
+ It uses variadic templates and argument lists to support any number of dimensions.
+ Currently, it only supports read-only access to the underlying data, but could easily be extended to support a read-write model.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
