### PR TITLE
Find draco's TPL via draco-config.cmake.

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -852,13 +852,14 @@ Looking for Draco...\")
   # CMake macros like 'add_component_library' and 'add_component_executable'
   include( component_macros )
 
-  # CMake macros to query the availability of TPLs.
-  include( vendor_libraries )
-
-  # Provide targets for MPI, Metis, etc.
-  setupVendorLibraries()
 
 endmacro()
+
+# CMake macros to query the availability of TPLs.
+# Provide targets for MPI, Metis, etc.
+include( vendor_libraries )
+setupVendorLibraries()
+
 ")
 
   message( " " )


### PR DESCRIPTION
### Background

* Client projects should use CMake's `find_package(Draco)` macro to find and define Draco targets and TPLs.  TPL link requirements should be transitive and automatic.  This small change in the installed `draco-config.cmake` script should fix current deficiencies.
* This design deficiency was discovered recently when Draco builds began linking against _libquo_ but client projects didn't have any knowledge of this dependency and the _libquo_ requirements were not provided transitively.

### Description of changes

* When `draco-config.cmake` is sourced by client projects, ensure that all required TPLs are also found and associated _import targets_ are created.  This is done via the Draco CMake macro `setupVendorLibraries`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
