### PR TITLE
Fix build warnings issued by LLVM related to illegal symbol names.

### DIFF
--- a/src/compton/config.h.in
+++ b/src/compton/config.h.in
@@ -6,8 +6,8 @@
  *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
-#ifndef __compton_config_h__
-#define __compton_config_h__
+#ifndef rtt_compton_config_h
+#define rtt_compton_config_h
 
 #cmakedefine COMPTON_FOUND
 
@@ -22,7 +22,7 @@
 
 #endif
 
-#endif /* __compton_config_h__ */
+#endif /* rtt_compton_config_h */
 
 /*---------------------------------------------------------------------------*/
 /* end of compton/config.h */

--- a/src/diagnostics/config.h.in
+++ b/src/diagnostics/config.h.in
@@ -8,8 +8,8 @@
  *         All rights reserved. */
 /*---------------------------------------------------------------------------*/
 
-#ifndef __diagnostics_config_h__
-#define __diagnostics_config_h__
+#ifndef rtt_diagnostics_config_h
+#define rtt_diagnostics_config_h
 
 /* DRACO TIMING LEVEL */
 #cmakedefine DRACO_TIMING @DRACO_TIMING@
@@ -17,7 +17,7 @@
 /* USE PROCMON - snapshot in time memory reporting via getrusage */
 #cmakedefine USE_PROCMON @USE_PROCMON@
 
-#endif /* __diagnostics_config_h__ */
+#endif /* rtt_diagnostics_config_h */
 
 /*---------------------------------------------------------------------------*/
 /* end of diagnostics/config.h */

--- a/src/experimental/mdspan
+++ b/src/experimental/mdspan
@@ -53,6 +53,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif
 
 #include "__p0009_bits/accessor_basic.hpp"


### PR DESCRIPTION
### Background

+ Provide a bit of cleanup after #714 and #715 to keep LLVM-based builds free of warnings.  The first of these PRs added `mdspan`.  The second turned on LLVM build warning for illegal CPP macro names.
+ Ref: https://rtt.lanl.gov/cdash/viewBuildError.php?type=1&buildid=10669

### Purpose of Pull Request

+ Fixes #718

### Description of changes

+ Remove double underscores from CPP macros found in config.h.in files.
+ Add warnings suppressions for mdspan.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
