### PR TITLE
Fix merge conflict that broke the gcov builds

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -649,11 +649,12 @@ macro( toggle_compiler_flag switch compiler_flag
     if( NOT ${comp} STREQUAL "C" AND
         NOT ${comp} STREQUAL "CXX" AND
         NOT ${comp} STREQUAL "Fortran" AND
-        NOT ${comp} STREQUAL "EXE_LINKER")
-      message(FATAL_ERROR "When calling
-toggle_compiler_flag(switch, compiler_flag, compiler_flag_var_names),
-compiler_flag_var_names must be set to one or more of these valid
-names: C;CXX;EXE_LINKER.")
+        NOT ${comp} STREQUAL "EXE_LINKER" AND
+        NOT ${comp} STREQUAL "SHARED_LINKER")
+      message(FATAL_ERROR "When calling "
+"toggle_compiler_flag(switch, compiler_flag, compiler_flag_var_names), "
+"compiler_flag_var_names must be set to one or more of these valid "
+"names: C;CXX;EXE_LINKER.")
     endif()
 
     string( REPLACE "+" "x" safe_CMAKE_${comp}_FLAGS


### PR DESCRIPTION
### Background

+ Configuring the gcov-based coverage regression is broken.
+ Ref: https://rtt.lanl.gov/cdash/viewConfigure.php?buildid=10643

### Purpose of Pull Request

+ Fixes #720

### Description of changes

+ Minor logic tweak in `compilerEnv.cmake` should fix the problem.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
