### PR TITLE
Only print help message related to CrayPE for non-spack builds.

### DIFF
--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -88,28 +88,31 @@ macro( query_craype )
       # We expect developers to use the Cray compiler wrappers (especially in
       # setupMPI.cmake). See also
       # https://cmake.org/cmake/help/latest/module/FindMPI.html
-      if( NOT "$ENV{CXX}" MATCHES "CC$" OR
-          NOT "$ENV{CC}" MATCHES "cc$" OR
-          NOT "$ENV{FC}" MATCHES "ftn$" OR
-          NOT "$ENV{CRAYPE_LINK_TYPE}" MATCHES "dynamic$" )
-        message( FATAL_ERROR
-"The build system requires that the Cray compiler wrappers (CC, cc, ftn) be "
-" used when configuring this product on a Cray system (CRAY_PE=${CRAY_PE}). The"
-" development environment must also support dynamic linking.  The build system "
-" thinks you are trying to use:\n"
-"  CMAKE_CXX_COMPILER     = ${CMAKE_CXX_COMPILER}\n"
-"  CMAKE_C_COMPILER       = ${CMAKE_C_COMPILER}\n"
-"  CMAKE_Fortran_COMPILER = ${CMAKE_Fortran_COMPILER}\n"
-"  CRAYPE_LINK_TYPE       = $ENV{CRAYPE_LINK_TYPE}\n"
-"If you are working on a system that runs the Cray Programming Environment, try"
-" setting the following variables and rerunning cmake from a clean build"
-" directory:\n"
-"   export CXX=`which CC`\n"
-"   export CC=`which cc`\n"
-"   export FC=`which ftn`\n"
-"   export CRAYPE_LINK_TYPE=dynamic\n"
-"Otherwise please email this error message and other related information to"
-" draco@lanl.gov.\n" )
+      if( NOT "$ENV{CXX}" MATCHES "spack/lib/spack" )
+        # skip this check if building from within spack.
+        if( NOT "$ENV{CXX}" MATCHES "CC$" OR
+            NOT "$ENV{CC}" MATCHES "cc$" OR
+            NOT "$ENV{FC}" MATCHES "ftn$" OR
+            NOT "$ENV{CRAYPE_LINK_TYPE}" MATCHES "dynamic$" )
+          message( FATAL_ERROR
+            "The build system requires that the Cray compiler wrappers (CC, cc, ftn) be "
+            " used when configuring this product on a Cray system (CRAY_PE=${CRAY_PE}). The"
+            " development environment must also support dynamic linking.  The build system "
+            " thinks you are trying to use:\n"
+            "  CMAKE_CXX_COMPILER     = ${CMAKE_CXX_COMPILER}\n"
+            "  CMAKE_C_COMPILER       = ${CMAKE_C_COMPILER}\n"
+            "  CMAKE_Fortran_COMPILER = ${CMAKE_Fortran_COMPILER}\n"
+            "  CRAYPE_LINK_TYPE       = $ENV{CRAYPE_LINK_TYPE}\n"
+            "If you are working on a system that runs the Cray Programming Environment, try"
+            " setting the following variables and rerunning cmake from a clean build"
+            " directory:\n"
+            "   export CXX=`which CC`\n"
+            "   export CC=`which cc`\n"
+            "   export FC=`which ftn`\n"
+            "   export CRAYPE_LINK_TYPE=dynamic\n"
+            "Otherwise please email this error message and other related information to"
+            " draco@lanl.gov.\n" )
+        endif()
       endif()
       message( STATUS
         "Looking to see if we are building in a Cray Environment..."


### PR DESCRIPTION
### Background

* An error message is printed when building on Cray machines when environment variables like `CC` and `CXX` don't point to the Cray compile wrappers.  While helpful to most developers, this error can break spack-based builds.

### Purpose of Pull Request

* [Fixes Redmine Issue #1788](https://rtt.lanl.gov/redmine/issues/1788)

### Description of changes

* Provide escape clause for this error.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
