### PR TITLE
Fix type conversion errors in GPU device helper

### DIFF
--- a/src/device/GPU_Device.hh
+++ b/src/device/GPU_Device.hh
@@ -83,7 +83,7 @@ public:
     return m_maxgridsize[devId][dim];
   }
   //! the total amount of shared memory available per block in bytes
-  int sharedMemPerBlock(int devId = 0) const {
+  size_t sharedMemPerBlock(size_t devId = 0) const {
     return m_sharedmemperblock[devId];
   }
   //! the total amount of constant memory available on the device in bytes;
@@ -94,7 +94,7 @@ public:
   int SIMDWidth(int devId = 0) const { return m_simdwidth[devId]; }
   /*! the maximum pitch allowed by the memory copy functions that involve memory
    *  regions allocated through cuMemAllocPitch() */
-  int memPitch(int devId = 0) const { return m_mempitch[devId]; }
+  size_t memPitch(size_t devId = 0) const { return m_mempitch[devId]; }
   //! the total number of registers available per block
   int regsPerBlock(int devId = 0) const { return m_regsperblock[devId]; }
   //! the clock frequency in kilohertz
@@ -142,10 +142,10 @@ private:
   std::vector<int> m_maxthreadsperblock;
   std::vector<std::array<int, 3>> m_maxthreadsdim;
   std::vector<std::array<int, 3>> m_maxgridsize;
-  std::vector<int> m_sharedmemperblock;
+  std::vector<size_t> m_sharedmemperblock;
   std::vector<int> m_totalconstantmemory;
   std::vector<int> m_simdwidth;
-  std::vector<int> m_mempitch;
+  std::vector<size_t> m_mempitch;
   std::vector<int> m_regsperblock;
   std::vector<int> m_clockrate;
   std::vector<int> m_texturealign;


### PR DESCRIPTION
### Background

* We're now compiling the GPU code nightly on darwin. This PR fixes type conversion warnings when device code is compiled.

### Purpose of Pull Request

* Clean up GPU code that's now being built and tested. 

### Description of changes

* Fix `int` to `size_t` conversions in `device/GPU_Device.hh`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
