### PR TITLE
Ensure that the ythi test uses more than 1 thread to improve code cov

### DIFF
--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -125,6 +125,7 @@ if( NOT APPLE )
   add_app_unit_test(
     DRIVER    ${CMAKE_CURRENT_SOURCE_DIR}/tstYthi.py
     APP       $<TARGET_FILE_DIR:Exe_ythi>/$<TARGET_FILE_NAME:Exe_ythi>
+    TEST_ARGS 2
     PE_LIST   "1;2" )
 endif()
 


### PR DESCRIPTION
### Background

* For regression runs that test code coverage, `tstythi` was only using 1 thread per MPI rank.  This left the `run_thread` function in `ythi.hh` untested.
* Forcing this test to use 2 threads fixed this missing code coverage check.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
