### PR TITLE
Make finding the MPI version more robust.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -14,6 +14,8 @@
 # DRACO_C4   MPI|SCALAR
 # C4_SCALAR  BOOL
 # C4_MPI     BOOL
+# MPI_FLAVOR openmpi|mpih|intel|mvapich2|spectrum|msmpi
+# MPI_VERSION NN.NN.NN
 #
 #------------------------------------------------------------------------------#
 
@@ -35,7 +37,8 @@ function( setMPIflavorVer )
     set( MPI_FLAVOR "cray" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "openmpi")
     set( MPI_FLAVOR "openmpi" )
-  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mpich")
+  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mpich" OR
+      "${MPI_C_HEADER_DIR}" MATCHES "mpich")
     set( MPI_FLAVOR "mpich" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "impi" OR
       "${MPIEXEC_EXECUTABLE}" MATCHES "clusterstudio" )
@@ -83,9 +86,6 @@ function( setMPIflavorVer )
             DBS_MPI_VER_MINOR ${DBS_MPI_VER} )
           set( MPI_VERSION "${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR}" )
         endif()
-      else()
-        message(FATAL_ERROR "DBS did not find the MPI version string (is this "
-          "an older openmpi?)")
       endif()
 
       # if needed, make a 2nd pass at identifying the MPI flavor
@@ -178,8 +178,8 @@ endmacro()
 macro( query_topology )
 
   # These cmake commands, while useful, don't provide the topology detail that
-  # we are interested in (i.e. number of sockets per node). We could use the 
-  # results of these queries to know if hyper-threading is enabled (if logical 
+  # we are interested in (i.e. number of sockets per node). We could use the
+  # results of these queries to know if hyper-threading is enabled (if logical
   # != physical cores)
   # - cmake_host_system_information(RESULT MPI_PHYSICAL_CORES
   #   QUERY NUMBER_OF_PHYSICAL_CORES)
@@ -488,7 +488,7 @@ macro( setupMPILibrariesWindows )
     find_package( MPI QUIET )
 
     if( EXISTS "$ENV{MSMPI_INC}" )
-      # if msmpi is installed via vcpkg, then use the vcpkg include path 
+      # if msmpi is installed via vcpkg, then use the vcpkg include path
       # instead of the system one.
       file(TO_CMAKE_PATH $ENV{MSMPI_INC} MSMPI_INC)
       unset(tmp)
@@ -514,7 +514,7 @@ macro( setupMPILibrariesWindows )
         MPI_C_INCLUDE_DIRS = ${MPI_C_INCLUDE_DIRS}
         MPI_C_VERSION_MAJOR = ${MPI_C_VERSION_MAJOR}")
     endif()
-    
+
     # If this macro is called from a MinGW builds system (for a CAFS
     # subdirectory) and is trying to discover MS-MPI, the above check will fail
     # (when CMake > 3.12). However, MS-MPI is known to be good when linking with
@@ -526,7 +526,7 @@ macro( setupMPILibrariesWindows )
         set( MPI_Fortran_FOUND TRUE )
       endif()
     endif()
-    
+
     if(verbose)
       message("
         MPI_C_FOUND       = ${MPI_C_FOUND}
@@ -540,10 +540,10 @@ macro( setupMPILibrariesWindows )
       get_filename_component( MPI_Fortran_INCLUDE_PATH
         "${first_c_mpi_library}" DIRECTORY )
       if(EXISTS "${MPI_Fortran_INCLUDE_PATH}/../include/mpifptr.h")
-        get_filename_component( MPI_Fortran_INCLUDE_PATH 
+        get_filename_component( MPI_Fortran_INCLUDE_PATH
           "${MPI_Fortran_INCLUDE_PATH}/../include" REALPATH )
       elseif(EXISTS "${MPI_Fortran_INCLUDE_PATH}/../../include/mpifptr.h")
-        get_filename_component( MPI_Fortran_INCLUDE_PATH 
+        get_filename_component( MPI_Fortran_INCLUDE_PATH
           "${MPI_Fortran_INCLUDE_PATH}/../../include" REALPATH )
       else()
         string( REGEX REPLACE "[Ll]ib" "Include" MPI_Fortran_INCLUDE_PATH


### PR DESCRIPTION
### Background

* Capsaicin has requested better support in Draco for Intel-MPI and NGC has requested better support for MPICH.  Attempting to use either of these MPI implementations was causing Draco's configure stop to fail.

### Purpose of Pull Request

* [Fixes Redmine Issue #1803](https://rtt.lanl.gov/redmine/issues/1803)

### Description of changes

* Remove a `FATAL_ERROR` from `setupMPI.cmake`.
* Also fix a compile warning related to builds with CUDA enabled.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
