### PR TITLE
Cleanup and shorten the cmake configure report.

### DIFF
--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -88,7 +88,7 @@ macro( query_craype )
       # We expect developers to use the Cray compiler wrappers (especially in
       # setupMPI.cmake). See also
       # https://cmake.org/cmake/help/latest/module/FindMPI.html
-      if( NOT "$ENV{CXX}" MATCHES "spack/lib/spack" )
+      if( NOT "$ENV{CXX}" MATCHES "$ENV{SPACK_ROOT}/lib/spack/env/" )
         # skip this check if building from within spack.
         if( NOT "$ENV{CXX}" MATCHES "CC$" OR
             NOT "$ENV{CC}" MATCHES "cc$" OR

--- a/config/string_manip.cmake
+++ b/config/string_manip.cmake
@@ -1,0 +1,55 @@
+#-----------------------------*-cmake-*----------------------------------------#
+# file   config/string_manip.cmake
+# brief  Functions for string/message manipulation
+# note   Copyright (C) 2019-2020 Triad National Security, LLC.
+#        All rights reserved.
+#------------------------------------------------------------------------------#
+
+include_guard(GLOBAL)
+
+#------------------------------------------------------------------------------#
+# Print the string ${message} formatted as a hanging indent. Text will be
+# wrapped at column ${width} and all lines after the first will be indented
+# ${indent} spaces.
+#
+# Example use:
+#
+# set( mymsg "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
+# eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut sem nulla \
+# pharetra diam sit amet nisl suscipit adipiscing. Venenatis a condimentum \
+# vitae sapien pellentesque habitant. Urna porttitor rhoncus dolor \
+# purus.")
+#
+# hanging_indent( 80 5 ${mymsg} )
+#
+# See src/CMakeLists.txt for an other example.
+#------------------------------------------------------------------------------#
+function (hanging_indent width indent message)
+
+  foreach(idx RANGE 1 ${indent})
+    string(APPEND padding " ")
+  endforeach()
+
+  string(REPLACE " " ";" msg_list "${message}" )
+  foreach(word ${msg_list} )
+    string(LENGTH "${word}" word_len)
+    string(LENGTH "${line}" line_len)
+    math( EXPR proposed_len "${word_len} + ${line_len}" )
+    if( ${word_len} GREATER ${width} )
+      message("${line}")
+      message("${padding}${word}")
+      set(line "${padding}")
+    elseif( ${proposed_len} LESS_EQUAL ${width} )
+      string(APPEND line "${word} ")
+    else()
+      message("${line}")
+      set(line "${padding}")
+    endif()
+  endforeach()
+  message("${line}")
+
+endfunction()
+
+#------------------------------------------------------------------------------#
+# End config/string_manip.cmake
+#------------------------------------------------------------------------------#

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ project( draco_src_dir )
 # Provide helper functions used by component CMakeLists.txt files
 include( component_macros )
 
-# Extra 'draco-only' flags 
+# Extra 'draco-only' flags
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
     toggle_compiler_flag( TRUE "-Wfloat-equal -Wunused-macros" "CXX;C" "DEBUG")
@@ -95,11 +95,13 @@ add_dir_if_exists( quadrature ) # needs mesh_element, parser, special_functions
 
 # Summary
 
-message(" ")
-feature_summary( WHAT ALL
-  INCLUDE_QUIET_PACKAGES
-  FATAL_ON_MISSING_REQUIRED_PACKAGES
-  QUIET_ON_EMPTY )
+if( VERBOSE OR ENV{VERBOSE} )
+  message(" ")
+  feature_summary( WHAT ALL
+    INCLUDE_QUIET_PACKAGES
+    FATAL_ON_MISSING_REQUIRED_PACKAGES
+    QUIET_ON_EMPTY )
+endif()
 
 message("
 Draco build summary:
@@ -115,15 +117,16 @@ Source dir  : ${Draco_SOURCE_DIR}
 Build dir   : ${Draco_BINARY_DIR}
 
 CXX Compiler: ${CMAKE_CXX_COMPILER}")
+include(string_manip)
 if( CMAKE_CONFIGURATION_TYPES )
-  message("CXX FLAGS   : ${CMAKE_CXX_FLAGS} ")
-  message("CXX Debug FL: ${CMAKE_CXX_FLAGS_DEBUG}")
-  message("CXX Release : ${CMAKE_CXX_FLAGS_RELEASE}")
+  hanging_indent( 100 5 "CXX FLAGS: ${CMAKE_CXX_FLAGS} ")
+  hanging_indent( 100 5 "CXX Debug FLAGS: ${CMAKE_CXX_FLAGS_DEBUG}")
+  hanging_indent( 100 5 "CXX Release FLAGS: ${CMAKE_CXX_FLAGS_RELEASE}")
   if( _LANGUAGES_ MATCHES Fortran)
-    message("Fortran     : ${CMAKE_Fortran_COMPILER}")
-    message("FC FLAGS    : ${CMAKE_Fortran_FLAGS}")
-    message("FC Debug FLA: ${CMAKE_Fortran_FLAGS_DEBUG}")
-    message("FC Release F: ${CMAKE_Fortran_FLAGS_RELEASE}")
+    hanging_indent( 100 5 "Fortran: ${CMAKE_Fortran_COMPILER}")
+    hanging_indent( 100 5 "FC FLAGS: ${CMAKE_Fortran_FLAGS}")
+    hanging_indent( 100 5 "FC Debug FLAGS: ${CMAKE_Fortran_FLAGS_DEBUG}")
+    hanging_indent( 100 5 "FC Release FLAGS: ${CMAKE_Fortran_FLAGS_RELEASE}")
   endif()
   if( _LANGUAGES_ MATCHES CUDA)
     message("CUDA        : ${CMAKE_CUDA_COMPILER}")
@@ -132,11 +135,11 @@ if( CMAKE_CONFIGURATION_TYPES )
     message("Cuda Release: ${CMAKE_CUDA_FLAGS_RELEASE}")
   endif()
 else()
-  message("C FLAGS     : ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${Draco_BUILD_TYPE}}")
-  message("CXX FLAGS   : ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${Draco_BUILD_TYPE}}")
+  hanging_indent( 100 5 "C FLAGS: ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${Draco_BUILD_TYPE}}")
+  hanging_indent( 100 5 "CXX FLAGS: ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${Draco_BUILD_TYPE}}")
   if( _LANGUAGES_ MATCHES Fortran)
-    message("Fortran     : ${CMAKE_Fortran_COMPILER}")
-    message("FC FLAGS    : ${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${Draco_BUILD_TYPE}}")
+    message("Fortran: ${CMAKE_Fortran_COMPILER}")
+    hanging_indent( 100 5 "FC FLAGS: ${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${Draco_BUILD_TYPE}}")
   endif()
   if( _LANGUAGES_ MATCHES CUDA)
     message("CUDA        : ${CMAKE_CUDA_COMPILER} (${CMAKE_CUDA_COMPILER_ID})")
@@ -147,8 +150,8 @@ if( CAFS_Fortran_COMPILER )
   message("CAFS Fortran: ${CAFS_Fortran_COMPILER}")
 endif()
 if( "${DRACO_C4}" STREQUAL "MPI" )
-  message(
-  "mpirun cmd  : ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} N ${MPIEXEC_POSTFLAGS}")
+  hanging_indent( 100 5
+  "mpirun command: ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} N ${MPIEXEC_POSTFLAGS}")
 endif()
 message("Library Type: ${DRACO_LIBRARY_TYPE}
 ")


### PR DESCRIPTION
### Background

* Make the cmake configure summary easier to read. 

### Description of changes

+ No longer print the full TPL/Vendor summary unless `-DVERBOSE=ON` is provided to CMake. This shortens the report significantly.  Note that we already print the discovered path to each TPL.
+ When printing a summary of current compiler flags and the mpirun command, use a hanging indent to make the text easier to parse.
+ Sneak in a small change in `platform_checks.cmake` to do a better job of detecting when Draco is being built by spack.

### Example 

```console
CXX Compiler: /scratch/vendors/spack.20180425/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-8.1.0-3c5hjkqndywdp3w2l5vts62xlllrsbtq/bin/g++
C FLAGS: -Wcast-align -Wpointer-arith -Wall -pedantic -Wno-expansion-to-defined -Wnarrowing 
     -fopenmp -Werror -g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef 
     -DDEBUG -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fdiagnostics-color=auto 
     -Wfloat-equal -Wunused-macros 
CXX FLAGS: -Wcast-align -Wpointer-arith -Wall -pedantic -Wno-expansion-to-defined -Wnarrowing 
     -fopenmp -Werror -g -gdwarf-3 -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra -Wundef 
     -DDEBUG -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fdiagnostics-color=auto 
     -Woverloaded-virtual -Wnoexcept -Wsuggest-attribute=const -Wunused-local-typedefs -Wfloat-equal 
     -fsanitize=bounds-strict -Wconversion -Wdouble-promotion -Wshadow -Wformat=2 
Fortran: /scratch/vendors/spack.20180425/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-8.1.0-3c5hjkqndywdp3w2l5vts62xlllrsbtq/bin/gfortran
FC FLAGS: -ffree-line-length-none -cpp -march=native -fopenmp -g -gdwarf-3 -fbounds-check 
     -ffpe-trap=invalid,zero,overflow -fbacktrace -finit-integer=2147483647 -finit-real=NAN 
     -DDEBUG 
mpirun command: 
     /scratch/vendors/spack.20180425/opt/spack/linux-rhel7-x86_64/gcc-8.1.0/openmpi-3.1.0-fjn4gororh26g7hczlwyxt6d6elbtzjg/bin/mpiexec
     -n N -bind-to none 
Library Type: SHARED

```

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
