### PR TITLE
Fix power9 regression.

### DIFF
--- a/config/unix-cuda.cmake
+++ b/config/unix-cuda.cmake
@@ -19,6 +19,9 @@ include_guard(GLOBAL)
 
 # Discover CUDA compute capabilities.
 if( NOT DEFINED Draco_CUDA_ARCH )
+  if( NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/config )
+    file(MAKE_DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/config )
+  endif()
   set(OUTPUTFILE ${CMAKE_CURRENT_BINARY_DIR}/config/cuda_script)
   set(CUDAFILE ${CMAKE_CURRENT_SOURCE_DIR}/config/query_gpu.cu)
   execute_process( COMMAND ${CMAKE_CUDA_COMPILER}


### PR DESCRIPTION
### Background

* After #731, the power9 regressions fail to configure.

### Description of changes

* Ensure `${CMAKE_CURRENT_BINARY_DIR}/config` exists before trying to create a file at that location.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
