### PR TITLE
Fix broken codecov logic run by Travis and CodeCov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ env:
   - WERROR=ON COVERAGE=ON DRACO_C4=MPI
   - WERROR=ON DRACO_C4=MPI AUTODOC=ON
 
+jobs:
+  fast_finish: true
+
 # matrix:
 #   allow_failures:
 #     - compiler: gcc

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -134,8 +134,9 @@ macro(dbsSetupCompilers)
         )
       target_link_options(coverage_config INTERFACE --coverage)
 
-      find_program( LCOV NAMES lcov "$ENV{LCOV}" )
-      find_program( GCOV gcov "$ENV{GCOV}" )
+      # If env variable is set use it, otherwise search for default name.
+      find_program( LCOV NAMES "$ENV{LCOV}" lcov )
+      find_program( GCOV NAMES "$ENV{GCOV}" gcov )
       if( EXISTS "${LCOV}" AND EXISTS "${GCOV}" )
         # Add a custom target that prints the coverage report
         set(lcovopts1 --gcov-tool ${GCOV})

--- a/tools/spack/lcov/package.py
+++ b/tools/spack/lcov/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Lcov(MakefilePackage):
+    """LCOV is a graphical front-end for GCC's coverage testing tool gcov.
+    It collects gcov data for multiple source files and creates HTML pages
+    containing the source code annotated with coverage information. It also
+    adds overview pages for easy navigation within the file structure. LCOV
+    supports statement, function and branch coverage measurement."""
+
+    homepage = "http://ltp.sourceforge.net/coverage/lcov.php"
+    url      = "https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-1.14.tar.gz"
+
+    version('1.14', sha256='14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a')
+
+    def install(self, spec, prefix):
+        make("DESTDIR=", "PREFIX=%s" % prefix, "install")


### PR DESCRIPTION
### Background

* Travis isn't reporting code coverage (CodeCov.io).  The cause appears to be mismatch between gcc (version 8) and gcov (version 7).  Errors in the travis log look like the ones discussed [here](https://github.com/conan-io/conan-docker-tools/issues/161). 

### Description of changes

* Attempt to install gcov-8 and use it instead of the default version of gcov.
* I also needed to install lcov-1.14 since older versions of lcov can't read the gcov-8 files.
* Use Draco's new ability to generate lcov-based reports (`cmake -DCODE_COVERAGE=ON; make covrep`).
* Enable the `fast_finish` option for Travis CI (report fail as soon as any of the four checks reports a failure).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
