### PR TITLE
Fix spelling errors

### DIFF
--- a/src/cdi_eospac/Eospac.hh
+++ b/src/cdi_eospac/Eospac.hh
@@ -26,15 +26,14 @@ namespace rtt_cdi_eospac {
  * \sa The web page for <a
  *     href="http://xweb.lanl.gov/PROJECTS/DATA/">EOSPAC</a>.
  *
- * Eospac allows the client code to retrive equation of state (EoS) data for a
+ * Eospac allows the client code to retrieve equation of state (EoS) data for a
  * specified material.  The material is specified by the SesameTables object
  * which links a lookup table to each type of data requested.
  *
  * This is a concrete class derived from cdi/EoS.  This class allows the client
- * to access (interpolate) on the EoS tables provided by X-5 (sesame, sescu1,
- * sesou, sescu and sescu9).
+ * to access (interpolate) on the EoS tables.
  *
- * This class is designed to be used in conjuction with the CDI package. The
+ * This class is designed to be used in conjunction with the CDI package. The
  * client code will need to create a SesameTable object that is used in the
  * construction of Eospac.  The Eospac object is then used in the instantiation
  * of a CDI object.  The CDI object might contain other material data
@@ -43,11 +42,11 @@ namespace rtt_cdi_eospac {
  *
  * <b>User's environment</b>
  *
- * The eos data files live in specific locations on the X-Div LAN and ACL.  If
- * you are not working on one of these LANs you must set the following two
- * system environment variables (SESPATHU and SESPATHC) so that the EOSPAC
- * libraries can find the data tables.  On the CCS Linux LAN you can use the
- * following values:
+ * The equation of state data files live in specific locations on the X-Div LAN
+ * and ACL.  If you are not working on one of these LANs you must set the
+ * following two system environment variables (SESPATHU and SESPATHC) so that
+ * the EOSPAC libraries can find the data tables.  On the CCS Linux LAN you can
+ * use the following values:
  *
  * export SESPATHU=/ccs/codes/radtran/physical_data/eos
  * export SESPATHC=/ccs/codes/radtran/physical_data/eos
@@ -94,8 +93,7 @@ class Eospac : public rtt_cdi::EoS {
    * \brief The SesameTables object uniquely defines a material.
    *
    * The SesameTables object uniquely defines a material by linking specific
-   * lookup tables (sesame, sescu1, sesou, sescu and sescu9) to material
-   * identifiers.
+   * lookup tables (sesame, sesou) to material identifiers.
    *
    * \sa rtt_cdi_eospac::SesameTables class definition.
    *
@@ -108,21 +106,21 @@ class Eospac : public rtt_cdi::EoS {
   // Available data types //
   // -------------------- //
 
-  // These next four data members are mutalbe because they specify what data is
+  // These next four data members are mutable because they specify what data is
   // cached by the Eospac object.  The cached data set may be changed when the
   // user calls a get... function.
 
   /*!
-   * \brief List of materierial IDs that are specified by SesTabs.
+   * \brief List of material IDs that are specified by SesTabs.
    *
    * \sa returnTypes data member.
    *
    * These are the materials that are available for querying.  There is a
    * one-to-one correspondence between matIDs and returnTypes.  The returnTypes
-   * correspond to data that you can request from the sesame tables
-   * (e.g. electron based interal energy has returnType 12) and the
-   * corresponding matID value is the material identifier extracted from the
-   * associated SesameTables object.
+   * correspond to data that you can request from the sesame tables (e.g.
+   * electron based internal energy has returnType 12) and the corresponding
+   * matID value is the material identifier extracted from the associated
+   * SesameTables object.
    */
   mutable std::vector<int> matIDs;
 
@@ -134,10 +132,10 @@ class Eospac : public rtt_cdi::EoS {
    * List of numeric identifiers that specify what EoS data tables are available
    * from this object. (e.g. P(T,rho), internal energy, etc.).  There is a
    * one-to-one correspondence between matIDs and returnTypes.  The returnTypes
-   * correspond to data that you can request from the sesame tables
-   * (e.g. electron based interal energy has returnType 12) and the
-   * corresponding matID value is the material identifier extracted from the
-   * associated SesameTables object.
+   * correspond to data that you can request from the sesame tables (e.g.
+   * electron based internal energy has returnType 12) and the corresponding
+   * matID value is the material identifier extracted from the associated
+   * SesameTables object.
    */
   mutable std::vector<EOS_INTEGER> returnTypes;
 
@@ -166,12 +164,13 @@ public:
    *
    * \sa The definition of rtt_cdi_eospac::SesameTables.
    *
-   * \param in_SesTabs A rtt_cdi_eospac::SesameTables object that defines what
-   *           data tables will be available for queries from the Eospac object.
+   * \param[in] in_SesTabs A rtt_cdi_eospac::SesameTables object that defines
+   *           what data tables will be available for queries from the Eospac
+   *           object.
    */
   explicit Eospac(SesameTables const &in_SesTabs);
 
-  //! Create an Eospack by unpacking a vector<char> stream.
+  //! Create an Eospac by unpacking a vector<char> stream.
   explicit Eospac(std::vector<char> const &packed);
 
   // (defaulted) Eospac(const Eospac &rhs);
@@ -179,7 +178,7 @@ public:
   /*!
    * \brief Default Eospac() destructor.
    *
-   * This is required to correctly release memeroyt when an Eospac object is
+   * This is required to correctly release memory when an Eospac object is
    * destroyed.  We define the destructor in the implementation file to avoid
    * including the unnecessary header files.
    */
@@ -215,8 +214,8 @@ public:
    *        correspond to a tuple list of temperatures and densities for this
    *        material.
    *
-   * \param vdensity Density of the material in g/cm^3
-   * \param vtemperature Temperature of the material in keV.
+   * \param[in] vdensity Density of the material in g/cm^3
+   * \param[in] vtemperature Temperature of the material in keV.
    * \return The specific electron internal energy in kJ/g.
    */
   std::vector<double>
@@ -238,8 +237,8 @@ public:
    *        that correspond to the tuple list of provided densities and
    *        temperatures.
    *
-   * \param vdensity Density of the material in g/cm^3
-   * \param vtemperature Temperature of the material in keV.
+   * \param[in] vdensity Density of the material in g/cm^3
+   * \param[in] vtemperature Temperature of the material in keV.
    * \return The electron based heat capacity in kJ/g/keV.
    */
   std::vector<double>
@@ -441,7 +440,7 @@ private:
    * This is only used in getF() and getdFdT().
    */
   static inline double keV2K(double tempKeV) {
-    const double c = 1.1604412E+7; // Kelven per keV
+    const double c = 1.1604412E+7; // Kelvin per keV
     return c * tempKeV;
   }
 };

--- a/src/cdi_eospac/EospacException.hh
+++ b/src/cdi_eospac/EospacException.hh
@@ -20,27 +20,25 @@ namespace rtt_cdi_eospac {
 /*!
  * \class EospacException
  *
- * \brief This class handles exceptions thrown by Eospac when it
- *        calls the EOSPAC library functions.
+ * \brief This class handles exceptions thrown by Eospac when it calls the
+ *        EOSPAC library functions.
  *
  * This class provides an Eospac exception data object derived from
- * std::exception.  When an exception is thrown in the cdi_eospac
- * package an EospacException object is created and may be trapped
- * by the calling routine by using a try/catch block.
+ * std::exception.  When an exception is thrown in the cdi_eospac package an
+ * EospacException object is created and may be trapped by the calling routine
+ * by using a try/catch block.
  *
  * \sa cdi_eospac/test/tEospac.cc
  *
- * This example demonstrates how the try/catch blocks may be used
- * to trap errors thrown by the cdi_eospac package.  They also
- * demonstrate how the calling program can extract information about
- * the exception.
+ * This example demonstrates how the try/catch blocks may be used to trap errors
+ * thrown by the cdi_eospac package.  They also demonstrate how the calling
+ * program can extract information about the exception.
  */
 
 // Todo:
 // --------------------
-// 1. Add a specific class for each type of exception that we
-//    might want to catch (i.e. one for each integer error return
-//    code that EOSPAC can throw.
+// 1. Add a specific class for each type of exception that we might want to
+//    catch (i.e. one for each integer error return code that EOSPAC can throw.
 // 2. Review Alan Griffiths, "Here be Dragons,"
 //    http://www.cuj.com, March 2001.
 //    http://www.octopull.demon.co.uk/c++/dragons/
@@ -53,23 +51,20 @@ public:
   // CREATORS
 
   /*!
-     * \brief The standard EospacException constuctor.
+     * \brief The standard EospacException constructor.
      *
-     * When an error is thrown, the data member "message" is set
-     * and then std::exception is instantiated.
+     * When an error is thrown, the data member "message" is set and then
+     * std::exception is instantiated.
      *
-     * The throw() at the end of these declarations are exception
-     * specifiers.  I have not limited the types of exceptions
-     * that may be caught by this object (hense the empty parens).
-     * See Lippman and Lajoie, "C++ Primer" p. 1042ff for more
-     * information.
+     * The throw() at the end of these declarations are exception specifiers. I
+     * have not limited the types of exceptions that may be caught by this
+     * object (hence the empty parentheses). See Lippman and Lajoie, "C++
+     * Primer" p. 1042ff for more information.
      *
-     * \param msg A simple description of the exception.  In
-     *        some cases this may simply be the name of the
-     *        Gandolf function that failed.  In other cases it
-     *        might contain a detailed description of the error.
-     *        This string is used in the construction of
-     *        std::exception.
+     * \param[in] msg A simple description of the exception. In some cases this
+     *        may simply be the name of the Gandolf function that failed.  In
+     *        other cases it might contain a detailed description of the error.
+     *        This string is used in the construction of std::exception.
      */
   explicit EospacException(std::string const &msg) throw()
       : std::logic_error(msg) { /* empty */
@@ -80,10 +75,9 @@ public:
      *
      * \sa what()
      *
-     * The destructor frees memory that may have been allocated by
-     * the accessor what().  If what was never called then
-     * "message" was never allocated and no deallocation is
-     * required.
+     * The destructor frees memory that may have been allocated by the accessor
+     * what().  If what was never called then "message" was never allocated and
+     * no deallocation is required.
      *
      * Do not allow destructor to throw.
      */
@@ -92,9 +86,8 @@ public:
   // ACCESSORS
 
   /*!
-     * \brief EospacException overrides the default
-     *        std::exception.what() function so that a more
-     *        detailed message may be returned.
+     * \brief EospacException overrides the default std::exception.what()
+     *        function so that a more detailed message may be returned.
      */
   // virtual const char* what() const throw();
 

--- a/src/cdi_eospac/SesameTables.cc
+++ b/src/cdi_eospac/SesameTables.cc
@@ -6,10 +6,7 @@
  * \brief  Implementation file for SesameTables (mapping material IDs
  *         to Sesame table indexes).
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "SesameTables.hh"
@@ -78,9 +75,8 @@ SesameTables &SesameTables::addTable(EOS_INTEGER const tableID,
   // insert a new entry into the matMap.
   matMap[tableID] = matID;
   if (rtMap.count(matID)) {
-    // we've already used this mat ID so there should be an entry in the
-    // map.  Look to see if EOS_Ue_DT is already registered before adding
-    // it.
+    // we've already used this mat ID so there should be an entry in the map.
+    // Look to see if EOS_Ue_DT is already registered before adding it.
     bool found(false);
     for (size_t i = 0; i < rtMap[matID].size(); ++i)
       if (rtMap[matID][i] == tableID)
@@ -343,7 +339,7 @@ void SesameTables::printEosTableList() const {
 //----------------------------------------------------------------------------//
 std::vector<std::string>
 SesameTables::initializeTableNames(size_t const datasize) {
-  // Create a mapping between the enum and a string name
+  // Create a mapping between the Enum and a string name
   std::vector<std::string> tableName(datasize);
 
   tableName[EOS_NullTable] = std::string("EOS_NullTable");

--- a/src/cdi_eospac/SesameTables.hh
+++ b/src/cdi_eospac/SesameTables.hh
@@ -113,7 +113,7 @@ public:
   SesameTables& B_DT( unsigned matID );
   //! Shear Modulus (Gpa)
   SesameTables& Gs_D( unsigned matID );
-  //! Electron Conducitive Opacity (cm^2/g)
+  //! Electron Conductive Opacity (cm^2/g)
   SesameTables& Kc_DT( unsigned matID );
   //! Electrical Conductivity (1/s)
   SesameTables& Kec_DT( unsigned matID );
@@ -166,7 +166,7 @@ public:
   SesameTables& Ut_DPt( unsigned matID );
   //! Melt Specific-Internal-Energy (MJ/kg)
   SesameTables& Ut_DT( unsigned matID );
-  //! Mean Ion Charge (Opacity Modlel) (free electrons per atom)
+  //! Mean Ion Charge (Opacity Model) (free electrons per atom)
   SesameTables& Zfo_DT( unsigned matID );
 #endif
 


### PR DESCRIPTION
### Background

* While working on runtime failures related to eospac-6.4.0 under MSVC 2019, I fixed a number of spelling errors and formatting issues in `cdi_eospac`.
+ This commit is somewhat related to https://github.com/KineticTheory/eospac6/releases/tag/eospac-6.4.0 and https://github.com/KineticTheory/vcpkg. Both of these projects provide a modified version of eospac-6.4.0 that includes fixes related to MSVC 2019.

### Description of changes

+ Fix spelling errors
+ Rewrap comment blocks at 80 columns.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
