### PR TITLE
Fix dev-env for LANL darwin.

### DIFF
--- a/config/unix-ifort.cmake
+++ b/config/unix-ifort.cmake
@@ -30,7 +30,7 @@ if( NOT Fortran_FLAGS_INITIALIZED )
   set( CMAKE_Fortran_FLAGS
     "-warn  -fpp -implicitnone -diag-disable 11060" )
   set( CMAKE_Fortran_FLAGS_DEBUG
-    "-g -O0 -traceback -ftrapuv -check -DDEBUG" )
+    "-g -O0 -traceback -ftrapuv -check -fno-omit-frame-pointer -DDEBUG" )
   set( CMAKE_Fortran_FLAGS_RELEASE
     "-O2 -inline-level=2 -fp-speculation fast -fp-model fast" )
   string(APPEND CMAKE_Fortran_FLAGS_RELEASE

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -38,7 +38,7 @@ if test -n "$MODULESHOME"; then
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
         noflavor="git gcc/8.2.0"
-        compflavor="cmake/3.14.2-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_8.2.0"
+        compflavor="cmake/3.15.3 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_8.2.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lflavor trilinos/12.14.1-$mflavor-$lflavor"
         ec_mf="csk/0.5.0-$cflavor" # ndi
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
@@ -56,7 +56,7 @@ if test -n "$MODULESHOME"; then
           noflavor+=" cuda/10.1"
           cudaflavor="-cuda-10.1"
         fi
-        compflavor="cmake/3.14.2-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
+        compflavor="cmake/3.15.3 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
@@ -88,7 +88,7 @@ superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
         noflavor="git gcc/7.3.0 cuda/10.1"
-        compflavor="eospac/6.4.0-$cflavor cmake/3.14.2-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
+        compflavor="eospac/6.4.0-$cflavor cmake/3.15.3 random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
         ec_mf="csk/0.5.0-$cflavor" # ndi


### PR DESCRIPTION
### Description of changes

+ CMake versions have changed. Update env files.
+ Add one more compile flag for Intel-based debug builds.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
