### PR TITLE
Fix DBC mismatch in CDI_NDI

### DIFF
--- a/src/cdi_ndi/NDI_TN.cc
+++ b/src/cdi_ndi/NDI_TN.cc
@@ -292,7 +292,7 @@ std::vector<double> NDI_TN::get_PDF(const int product_zaid,
     Remember(dist_sum += pdf[n]);
   }
 
-  Insist(rtt_dsxx::soft_equiv(dist_sum, 1., 1.e-10), "PDF not normalized!");
+  Require(rtt_dsxx::soft_equiv(dist_sum, 1., 1.e-10));
 
   return pdf;
 }


### PR DESCRIPTION
### Background

* NDI_TN in CDI_NDI broke CI

### Purpose of Pull Request

* Fix error in this module to fix CI. 
* `Remember` pairs with `Require`, not `Insist`; the latter pairing can fail for `DRACO_DBC_LEVEL=0`

### Description of changes

* `Insist` -> `Require`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
