### PR TITLE
Help FindNDI.cmake find the PIC version.

### DIFF
--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -84,7 +84,7 @@ find_path( NDI_INCLUDE_DIR
 #     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.dylib")
 # endif()
 
-set( NDI_LIBRARY_NAME ndi)
+set( NDI_LIBRARY_NAME ndipic ndi)
 
 find_library(NDI_LIBRARY
   NAMES ${NDI_LIBRARY_NAME}


### PR DESCRIPTION
### Background

* NDI version 2.1.4alpha uses a new cmake build system and PIC was not enabled by default.  For this release of NDI, w need to select the 'pic' version of the library.

### Purpose of Pull Request

* [Fixes Redmine Issue #1837](https://rtt.lanl.gov/redmine/issues/1837)
### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
