### PR TITLE
Minor cleanup after debugging session on darwin with GPUs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,9 @@
 #   https://rtt.lanl.gov/redmine/projects/draco/wiki/Common_Configure_Options
 
 cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
-project( Draco
-  VERSION 7.4
-  DESCRIPTION "An object-oriented component library supporting radiation transport applications."
-  LANGUAGES CXX C )
+set(ddesc "An object-oriented component library supporting radiation")
+string(APPEND ddesc " transport applications.")
+project( Draco DESCRIPTION ${ddesc} VERSION 7.4 LANGUAGES CXX C)
 
 # Do not look for Fortran/CUDA for
 # 1. XCode based Generators, or

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -252,8 +252,8 @@ or the target must be labeled NOEXPORT.")
   ")
   unset(iid)
 
-  # Only publish information to draco-config.cmake for non-test
-  # libraries.  Also, omit any libraries that are marked as NOEXPORT
+  # Only publish information to draco-config.cmake for non-test libraries.
+  # Also, omit any libraries that are marked as NOEXPORT
   if( NOT ${ace_NOEXPORT} AND
       NOT "${CMAKE_CURRENT_SOURCE_DIR}" MATCHES "test" )
 
@@ -274,17 +274,19 @@ or the target must be labeled NOEXPORT.")
       list( REMOVE_DUPLICATES ${ace_PREFIX}_EXECUTABLES )
     endif()
 
-    set( ${ace_PREFIX}_EXECUTABLES "${${ace_PREFIX}_EXECUTABLES}"  CACHE INTERNAL "List of component targets" FORCE)
+    set( ${ace_PREFIX}_EXECUTABLES "${${ace_PREFIX}_EXECUTABLES}"  CACHE
+      INTERNAL "List of component targets" FORCE)
     set( ${ace_PREFIX}_TPL_LIST "${${ace_PREFIX}_TPL_LIST}"  CACHE INTERNAL
       "List of third party libraries known by ${ace_PREFIX}" FORCE)
-    set( ${ace_PREFIX}_TPL_INCLUDE_DIRS "${${ace_PREFIX}_TPL_INCLUDE_DIRS}"  CACHE
-      INTERNAL "List of include paths used by ${ace_PREFIX} to find third party vendor header files."
-      FORCE)
-    set( ${ace_PREFIX}_TPL_LIBRARIES "${${ace_PREFIX}_TPL_LIBRARIES}"  CACHE INTERNAL
-      "List of third party libraries used by ${ace_PREFIX}." FORCE)
+    set(desc "List of include paths used by ${ace_PREFIX} to find third")
+    string(APPEND desc " party vendor header files.")
+    set( ${ace_PREFIX}_TPL_INCLUDE_DIRS "${${ace_PREFIX}_TPL_INCLUDE_DIRS}"
+      CACHE INTERNAL ${desc} FORCE)
+    set( ${ace_PREFIX}_TPL_LIBRARIES "${${ace_PREFIX}_TPL_LIBRARIES}" CACHE
+      INTERNAL "List of third party libraries used by ${ace_PREFIX}." FORCE)
     set( ${ace_PREFIX}_EXPORT_TARGET_PROPERTIES
       "${${ace_PREFIX}_EXPORT_TARGET_PROPERTIES}" PARENT_SCOPE)
-
+    unset(desc)
   endif()
 
   # If Win32, copy dll files into binary directory.
@@ -362,7 +364,7 @@ macro( add_component_library )
   endif()
   if( "${acl_LINK_LANGUAGE}" STREQUAL "CUDA" )
     set_property( SOURCE ${acl_SOURCES} APPEND PROPERTY LANGUAGE CUDA )
-#    set( acl_LIBRARY_TYPE STATIC )
+    set( acl_LIBRARY_TYPE STATIC )
   endif()
 
   #
@@ -431,7 +433,7 @@ macro( add_component_library )
 
   # the above command returns the location in the build tree.  We need to
   # convert this to the install location.
-  if( DRACO_SHARED_LIBS )
+  if( ${DRACO_SHARED_LIBS} )
     set( imploc "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${impname}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
   else()
     set( imploc "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${impname}${CMAKE_STATIC_LIBRARY_SUFFIX}" )
@@ -486,21 +488,22 @@ macro( add_component_library )
       list( REMOVE_DUPLICATES ${acl_PREFIX}_TPL_LIST )
     endif()
 
-    set( ${acl_PREFIX}_LIBRARIES "${${acl_PREFIX}_LIBRARIES}"  CACHE INTERNAL
+    set( ${acl_PREFIX}_LIBRARIES "${${acl_PREFIX}_LIBRARIES}" CACHE INTERNAL
       "List of component targets" FORCE)
-    set( ${acl_PREFIX}_PACKAGE_LIST "${${acl_PREFIX}_PACKAGE_LIST}"  CACHE
+    set( ${acl_PREFIX}_PACKAGE_LIST "${${acl_PREFIX}_PACKAGE_LIST}" CACHE
       INTERNAL "List of known ${acl_PREFIX} targets" FORCE)
     set( ${acl_PREFIX}_TPL_LIST "${${acl_PREFIX}_TPL_LIST}"  CACHE INTERNAL
       "List of third party libraries known by ${acl_PREFIX}" FORCE)
+    set(desc "List of include paths used by ${acl_PREFIX} to find third")
+    string(APPEND desc " party vendor header files.")
     set( ${acl_PREFIX}_TPL_INCLUDE_DIRS "${${acl_PREFIX}_TPL_INCLUDE_DIRS}"
-      CACHE INTERNAL
-      "List of include paths used by ${acl_PREFIX} to find third party vendor header files."
-      FORCE)
-    set( ${acl_PREFIX}_TPL_LIBRARIES "${${acl_PREFIX}_TPL_LIBRARIES}"  CACHE
+      CACHE INTERNAL ${desc} FORCE)
+    set( ${acl_PREFIX}_TPL_LIBRARIES "${${acl_PREFIX}_TPL_LIBRARIES}" CACHE
       INTERNAL "List of third party libraries used by ${acl_PREFIX}." FORCE)
     set( ${acl_PREFIX}_EXPORT_TARGET_PROPERTIES
       "${${acl_PREFIX}_EXPORT_TARGET_PROPERTIES}" PARENT_SCOPE)
 
+    unset(desc)
   endif()
 
 endmacro()
@@ -663,7 +666,7 @@ function( copy_dll_link_libraries_to_build_dir target )
 
   # Debug dependencies for a particular target (uncomment the next line and
   # provide the targetname): "Ut_${compname}_${testname}_exe"
-  if( "XX_cdi_eospac_tEospac_exe" STREQUAL ${target} )
+  if( "Ut_rng_ut_gsl_exe_foo" STREQUAL ${target} )
      set(lverbose ON)
   endif()
   if( lverbose )

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -56,7 +56,7 @@ if test -n "$MODULESHOME"; then
           noflavor+=" cuda/10.1"
           cudaflavor="-cuda-10.1"
         fi
-        compflavor="cmake/3.15.3 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
+        compflavor="cmake/3.16.4 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
@@ -88,7 +88,7 @@ superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
         noflavor="git gcc/7.3.0 cuda/10.1"
-        compflavor="eospac/6.4.0-$cflavor cmake/3.15.3 random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
+        compflavor="eospac/6.4.0-$cflavor cmake/3.16.4-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
         mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
         ec_mf="csk/0.5.0-$cflavor" # ndi


### PR DESCRIPTION

### Background

* We were seeing build failures on nodes that had GPUs that we were targeting with Cuda.  These failures seem to be related to a bug in cmake. 

### Purpose of Pull Request

* [Fixes Redmine Issue #1812](https://rtt.lanl.gov/redmine/issues/18212)

### Description of changes

+ Change the default developer environment to use `cmake/3.16.4` instead of `cmake/3.15.3` This fixes some configuration/build issues when mixing C++ and Cuda.
+ Update some `CMakeLists.txt` files to shorten lines that were more than 80 columns wide.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
