### PR TITLE
fix tstifpstream

### DIFF
--- a/src/c4/test/tstifpstream.cc
+++ b/src/c4/test/tstifpstream.cc
@@ -45,9 +45,11 @@ void tstifpstream(UnitTest &ut, const std::ios_base::openmode mode) {
 
   int pid = rtt_c4::node();
 
-  std::string filename = "tstifpstream.txt";
+  std::string filename =
+      "tstifpstream" + std::to_string(rtt_c4::nodes()) + ".txt";
   if (mode == std::ofstream::binary)
-    filename = "tstifpstream.bin";
+    std::string filename =
+        "tstifpstream" + std::to_string(rtt_c4::nodes()) + ".bin";
 
   write_stream(filename, mode);
   // Read file on head rank, check for correct conversion and ordering

--- a/src/c4/test/tstifpstream.cc
+++ b/src/c4/test/tstifpstream.cc
@@ -48,8 +48,7 @@ void tstifpstream(UnitTest &ut, const std::ios_base::openmode mode) {
   std::string filename =
       "tstifpstream" + std::to_string(rtt_c4::nodes()) + ".txt";
   if (mode == std::ofstream::binary)
-    std::string filename =
-        "tstifpstream" + std::to_string(rtt_c4::nodes()) + ".bin";
+    filename = "tstifpstream" + std::to_string(rtt_c4::nodes()) + ".bin";
 
   write_stream(filename, mode);
   // Read file on head rank, check for correct conversion and ordering


### PR DESCRIPTION
### Background

* We had parallel contention on the tstifpstream because we were overwriting the the parallel file for each parallel run case while it was still being read. This was fixed by using a different file name for each parallel instance of the test.

### Purpose of Pull Request

* Add number of nodes to the output/input filename

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
