### PR TITLE
MSVC: Fix link issue related to CSK for Debug builds.

### DIFF
--- a/config/FindEOSPAC.cmake
+++ b/config/FindEOSPAC.cmake
@@ -103,17 +103,6 @@ set( EOSPAC_LIBRARIES ${EOSPAC_LIBRARY} )
 
 # Try to find the version.
 if( NOT EOSPAC_VERSION )
-#   if( EXISTS "${EOSPAC_INCLUDE_DIRS}/eospac.h" )
-#     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_major
-#         REGEX "define EOSPAC_VER_MAJOR" )
-#     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_minor
-#         REGEX "define EOSPAC_VER_MINOR" )
-#     file( STRINGS "${EOSPAC_INCLUDE_DIRS}/eospac.h" eospac_h_subminor
-#         REGEX "define EOSPAC_VER_SUBMINOR" )
-#     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_MAJOR ${eospac_h_major} )
-#     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_MINOR ${eospac_h_minor} )
-#     string( REGEX REPLACE ".*([0-9]+)" "\\1" EOSPAC_SUBMINOR ${eospac_h_subminor} )
-#   endif()
   # We might also try scraping the directory name for a regex match
   # "eospac-X.X.X"
   if( NOT EOSPAC_MAJOR )
@@ -191,6 +180,9 @@ if( EOSPAC_FOUND AND NOT TARGET EOSPAC::eospac )
         set_target_properties( EOSPAC::eospac PROPERTIES
           IMPORTED_LOCATION_DEBUG           "${EOSPAC_LIBRARY_DEBUG_DLL}"
           IMPORTED_IMPLIB_DEBUG             "${EOSPAC_LIBRARY_DEBUG}" )
+      else()
+         set_target_properties( EOSPAC::eospac PROPERTIES
+           IMPORTED_LOCATION "${EOSPAC_LIBRARY_DLL}" )
       endif()
 
     else()

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -643,22 +643,19 @@ macro( register_parallel_test targetname numPE command cmd_args )
   unset( lverbose )
 endmacro()
 
-#----------------------------------------------------------------------#
+#------------------------------------------------------------------------------#
 # Special post-build options for Win32 platforms
-# ---------------------------------------------------------------------#
+# -----------------------------------------------------------------------------#
 # copy_dll_link_libraries_to_build_dir( target )
 #
-# For Win32 with shared libraries, all dll dependencies must be located
-# in the PATH or in the application directory.  This cmake function
-# creates POST_BUILD rules for unit tests and applications to ensure
-# that the most up-to-date versions of all dependencies are in the same
-# directory as the application.
-#
-# Consider replacing this functionality with CMake's BundleUtilities.
-#----------------------------------------------------------------------#
+# For Win32 with shared libraries, all dll dependencies must be located in the 
+# PATH or in the application directory.  This cmake function creates POST_BUILD 
+# rules for unit tests and applications to ensure that the most up-to-date 
+# versions of all dependencies are in the same directory as the application.
+#------------------------------------------------------------------------------#
 function( copy_dll_link_libraries_to_build_dir target )
 
-  if( NOT WIN32 )
+  if( NOT MSVC )
     # Win32 platforms require all dll libraries to be in the local directory
     # (or $PATH)
     return()
@@ -666,7 +663,7 @@ function( copy_dll_link_libraries_to_build_dir target )
 
   # Debug dependencies for a particular target (uncomment the next line and
   # provide the targetname): "Ut_${compname}_${testname}_exe"
-  if( "Ut_rng_ut_gsl_exe_foo" STREQUAL ${target} )
+  if( "Ut_FortranChecks_cppmain_exe" STREQUAL ${target} )
      set(lverbose ON)
   endif()
   if( lverbose )
@@ -680,7 +677,6 @@ function( copy_dll_link_libraries_to_build_dir target )
   get_target_property( link_libs ${target} LINK_LIBRARIES )
   if( lverbose )
     message("\nDebugging dependencies for target ${target}")
-    # "${compname}_${testname}")
     message("  Dependencies = ${link_libs}\n")
   endif()
   if( "${link_libs}" MATCHES NOTFOUND )
@@ -692,7 +688,8 @@ function( copy_dll_link_libraries_to_build_dir target )
   # dependencies.
   while( NOT "${old_link_libs}" STREQUAL "${link_libs}" )
     if(lverbose)
-       message("Found new libraries (old_link_libs != link_libs).  Restarting search loop...\n")
+       message("Found new libraries (old_link_libs != link_libs).  Restarting"
+       " search loop...\n")
     endif()
     set( old_link_libs ${link_libs} )
     foreach( lib ${link_libs} )
@@ -705,7 +702,8 @@ function( copy_dll_link_libraries_to_build_dir target )
       if( NOT EXISTS ${lib} AND TARGET ${lib} )
           # Must be a CMake target... find it's dependencies...
           # The target may be
-          # 1. A target defined within the current build system (e.g.: Lib_c4), or
+          # 1. A target defined within the current build system (e.g.: Lib_c4),
+          #    or
           # 2. an 'imported' targets like GSL::gsl.
           get_target_property( isimp ${lib} IMPORTED )
           if(isimp)
@@ -728,10 +726,12 @@ function( copy_dll_link_libraries_to_build_dir target )
           message("lib = ${lib} is NOTFOUND --> remove it from the list")
         endif()
       elseif( "${lib}" MATCHES "[$]<")
-        # We have a generator expression.  This routine does not support this, so drop it.
+        # We have a generator expression.  This routine does not support this, 
+        # so drop it.
         list( REMOVE_ITEM link_libs ${lib} )
         if( lverbose )
-          message("lib = ${lib} is a generator expression --> remove it from the list")
+          message("lib = ${lib} is a generator expression --> remove it from"
+            " the list")
         endif()
       elseif( "${lib}" MATCHES ".[lL]ib$" )
         # We have a path to a static library. Static libraries do not
@@ -787,25 +787,27 @@ function( copy_dll_link_libraries_to_build_dir target )
       get_target_property(lib_type ${lib} TYPE )
       if( ${lib_type} STREQUAL "INTERFACE_LIBRARY" )
         if( lverbose )
-          message("  I think ${lib} is an INTERFACE_LIBRARY. Skipping to next dependency.")
+          message("  I think ${lib} is an INTERFACE_LIBRARY. Skipping to next "
+            "dependency.")
         endif()
         continue()
       endif()
       get_target_property(is_imported ${lib} IMPORTED )
       if( is_imported )
-        get_target_property(target_loc ${lib} IMPORTED_LOCATION_RELEASE )
-        if( ${target_loc} MATCHES "NOTFOUND" )
-          get_target_property(target_loc ${lib} IMPORTED_LOCATION_DEBUG )
-        endif()
-        if( ${target_loc} MATCHES "NOTFOUND" )
-          get_target_property(target_loc ${lib} IMPORTED_LOCATION )
-        endif()
-        if( ${target_loc} MATCHES "NOTFOUND" )
+        get_target_property(target_loc_rel ${lib} IMPORTED_LOCATION_RELEASE )
+        get_target_property(target_loc_deb ${lib} IMPORTED_LOCATION_DEBUG )
+        get_target_property(target_loc ${lib} IMPORTED_LOCATION )
+        if( ${target_loc_rel} MATCHES "NOTFOUND" AND
+            ${target_loc_deb} MATCHES "NOTFOUND" AND
+            ${target_loc} MATCHES "NOTFOUND" )
           # path not found, ignore.
           if (lverbose )
-            message("  ${lib} does not have an IMPORTED_LOCATION value. skip it.")
+            message("  ${lib} does not have an IMPORTED_LOCATION value. "
+              "skip it.")
           endif()
           continue()
+        else()       
+          set(target_loc "$<TARGET_FILE:${lib}>")
         endif()
         get_target_property(target_gnutoms ${lib} GNUtoMS)
       elseif( EXISTS ${lib} )
@@ -828,7 +830,8 @@ function( copy_dll_link_libraries_to_build_dir target )
                 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR} )
 
       if( lverbose )
-        message("  CMAKE_COMMAND -E copy_if_different ${target_loc} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
+        message("  CMAKE_COMMAND -E copy_if_different ${target_loc} "
+          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
       endif()
 
     endif()

--- a/config/generate_dll_declspec.cmake
+++ b/config/generate_dll_declspec.cmake
@@ -58,8 +58,8 @@ set( dll_declspec_content
  */
 /*---------------------------------------------------------------------------*/
 
-#ifndef rtt_dsxx_config_h
-#error \"Do not call this file directly. Call ds++/config.h instead.\"
+#ifndef rtt_${safedir}_config_h
+#error \"Do not call this file directly. Call ${dir}/config.h instead.\"
 #endif
 
 #ifndef rtt_${safedir}_declspec_h

--- a/config/print_target_properties.cmake
+++ b/config/print_target_properties.cmake
@@ -59,17 +59,25 @@ function(echo_target tgt)
   # Convert command output into a CMake list
   string(REGEX REPLACE ";" "\\\\;" CMAKE_PROPERTY_LIST "${CMAKE_PROPERTY_LIST}")
   string(REGEX REPLACE "\n" ";" CMAKE_PROPERTY_LIST "${CMAKE_PROPERTY_LIST}")
-
   list(REMOVE_DUPLICATES CMAKE_PROPERTY_LIST)
+
+  # Is this an INTERFACE_LIBRARY?  If so, most properties cannot be queried.
+  get_property(type TARGET ${tgt} PROPERTY TYPE)
+  if(NOT "${type}" STREQUAL "INTERFACE_LIBRARY")
 
   foreach(prop ${CMAKE_PROPERTY_LIST})
     # special cases first
 
     # Some targets aren't allowed:
     # Ref: https://stackoverflow.com/questions/32197663/how-can-i-remove-the-the-location-property-may-not-be-read-from-target-error-i
-    if(prop STREQUAL "LOCATION" OR prop MATCHES "^LOCATION_" OR prop MATCHES "_LOCATION$")
+    if(prop STREQUAL "LOCATION" OR prop MATCHES "^LOCATION_" OR 
+      prop MATCHES "_LOCATION$")
       continue()
     elseif( prop MATCHES "<LANG>" )
+      continue()
+    endif()
+
+    if(prop STREQUAL "DEBUG_OUTPUT_NAME")
       continue()
     endif()
 
@@ -84,6 +92,7 @@ function(echo_target tgt)
     # everything else
     echo_target_property("${tgt}" "${prop}")
   endforeach()
+  endif()
   message("")
 endfunction()
 


### PR DESCRIPTION
### Background

+ Nightly regressions that target Visual Studio 2019 show `compton_tCompton_1` failing. I discovered that this test failure was cased by linking to one compton.dll file by when the test was executed a different dynamic library was called.

### Description of changes

+ I modified the logic in `copy_dll_link_libraries_to_build_dir` (`component_macros.cmake`) to copy the correct flavor (Debug vs. Release) to the test installation.  This change required a small chagne to `FindEOSPAC.cmake` to keep it working.
+ Also fix a minor typo in `generate_dll_declspec.cmake` that could prevent `DLL_PUBLIC` function decoration from working properly.
+ Minor updates were added to the build system's debug helper `print_target_properties.cmake`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
