### PR TITLE
Allow QuoWrapper to work correctly when mpi_init called from F90.

### DIFF
--- a/src/FortranChecks/f90sub/Draco_MPI.F90
+++ b/src/FortranChecks/f90sub/Draco_MPI.F90
@@ -28,6 +28,15 @@ module draco_mpi
   public f90_mpi_finalize
   public f90_mpi_barrier
 
+  interface
+
+     ! Set c4's global 'initialzied' boolean.
+     subroutine setMpiInit() bind(C, name="setMpiInit")
+       implicit none
+     end subroutine setMpiInit
+
+  end interface
+
 contains
 
   ! ---------------------------------------------------------------------------
@@ -62,6 +71,7 @@ contains
 #ifdef C4_MPI
     call mpi_init(ierr)
     call check_mpi_error(ierr)
+    call setMpiInit
 
     call mpi_comm_size(MPI_COMM_WORLD, f90_num_ranks, ierr)
     call check_mpi_error(ierr)

--- a/src/c4/C4_MPI.cc
+++ b/src/c4/C4_MPI.cc
@@ -199,12 +199,18 @@ int abort(int error) {
 }
 
 //----------------------------------------------------------------------------//
-// isScalar
+// Helpers
 //----------------------------------------------------------------------------//
 bool isScalar() { return !initialized; }
 bool isMpiInit() { return initialized; }
 
 } // end namespace rtt_c4
+
+//! Set c4's initialzed variable to true (called from Fortran tests)
+void setMpiInit() {
+  rtt_c4::initialized = true;
+  return;
+}
 
 #endif // C4_MPI
 

--- a/src/c4/C4_MPI.hh
+++ b/src/c4/C4_MPI.hh
@@ -20,6 +20,13 @@
 #include "c4_mpi.h"
 #include "ds++/Assert.hh"
 
+//----------------------------------------------------------------------------//
+// Prototypes
+//----------------------------------------------------------------------------//
+
+//! Set c4's initialzed variable to true (called from Fortran tests)
+extern "C" void setMpiInit();
+
 namespace rtt_c4 {
 
 //----------------------------------------------------------------------------//
@@ -27,7 +34,7 @@ namespace rtt_c4 {
 //----------------------------------------------------------------------------//
 
 DLL_PUBLIC_c4 extern MPI_Comm communicator;
-extern bool initialized;
+DLL_PUBLIC_c4 extern bool initialized;
 
 //----------------------------------------------------------------------------//
 // SETUP FUNCTIONS


### PR DESCRIPTION
### Purpose of Pull Request

* [Fixes Redmine Issue #1873](https://rtt.lanl.gov/redmine/issues/1873)

### Description of changes

+ Provide a new `extern "c"` function that allows us to set `rtt_c4::initialized` from a Fortran function.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
