### PR TITLE
Disable build of xthi if OpenMP is not found.

### DIFF
--- a/src/c4/bin/CMakeLists.txt
+++ b/src/c4/bin/CMakeLists.txt
@@ -11,6 +11,8 @@ project( c4_bin CXX )
 # Build package library
 # ---------------------------------------------------------------------------- #
 
+# xthi depends on OpenMP, don't attempt to build it if we don't have it
+if(OPENMP_FOUND)
 add_component_executable(
   TARGET      Exe_xthi
   TARGET_DEPS Lib_c4
@@ -18,6 +20,8 @@ add_component_executable(
   PREFIX       Draco )
 #target_include_directories( Exe_xthi
 #  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
+install( TARGETS Exe_xthi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
+endif(OPENMP_FOUND)
 
 add_component_executable(
   TARGET      Exe_ythi
@@ -31,7 +35,6 @@ add_component_executable(
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 
-install( TARGETS Exe_xthi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 install( TARGETS Exe_ythi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 
 # ---------------------------------------------------------------------------- #

--- a/src/c4/bin/CMakeLists.txt
+++ b/src/c4/bin/CMakeLists.txt
@@ -18,8 +18,6 @@ add_component_executable(
   TARGET_DEPS Lib_c4
   SOURCES     ${PROJECT_SOURCE_DIR}/xthi.cc
   PREFIX       Draco )
-#target_include_directories( Exe_xthi
-#  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 install( TARGETS Exe_xthi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 endif(OPENMP_FOUND)
 
@@ -28,8 +26,6 @@ add_component_executable(
   TARGET_DEPS Lib_c4
   SOURCES     ${PROJECT_SOURCE_DIR}/ythi.cc
   PREFIX       Draco )
-#target_include_directories( Exe_ythi
-#  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions


### PR DESCRIPTION
### Background

* If OpenMP is not found, xthi will not build

### Purpose of Pull Request

* skip building xthi with compilers that do not support OpenMP.

### Description of changes

* place xthi target and install directives in conditional block

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
