### PR TITLE
Fix for NDI AMW usage

### DIFF
--- a/src/cdi_ndi/NDI_AtomicMass.cc
+++ b/src/cdi_ndi/NDI_AtomicMass.cc
@@ -69,15 +69,17 @@ double NDI_AtomicMass::get_amw(const int zaid) const {
       NDI2_set_option_gendir(gendir_handle, NDI_LIBRARY_DEFAULT, "mendf71x");
   Require(ndi_error == 0);
 
+  std::string zaid_formatted = std::to_string(zaid) + ".";
+
   int size = NDI2_get_size_x(gendir_handle, NDI_AT_WGT,
-                             std::to_string(zaid).c_str(), &ndi_error);
+                             zaid_formatted.c_str(), &ndi_error);
   Require(ndi_error == 0);
   Insist(size == 1, "NDI returned more or fewer than one atomic weight?");
 
   std::array<double, 1> arr;
   ndi_error =
       NDI2_get_float64_vec_x(gendir_handle, NDI_AT_WGT,
-                             std::to_string(zaid).c_str(), arr.data(), size);
+                             zaid_formatted.c_str(), arr.data(), size);
   Require(ndi_error == 0);
 
   ndi_error = NDI2_close_gendir(gendir_handle);

--- a/src/cdi_ndi/NDI_AtomicMass.cc
+++ b/src/cdi_ndi/NDI_AtomicMass.cc
@@ -71,15 +71,14 @@ double NDI_AtomicMass::get_amw(const int zaid) const {
 
   std::string zaid_formatted = std::to_string(zaid) + ".";
 
-  int size = NDI2_get_size_x(gendir_handle, NDI_AT_WGT,
-                             zaid_formatted.c_str(), &ndi_error);
+  int size = NDI2_get_size_x(gendir_handle, NDI_AT_WGT, zaid_formatted.c_str(),
+                             &ndi_error);
   Require(ndi_error == 0);
   Insist(size == 1, "NDI returned more or fewer than one atomic weight?");
 
   std::array<double, 1> arr;
-  ndi_error =
-      NDI2_get_float64_vec_x(gendir_handle, NDI_AT_WGT,
-                             zaid_formatted.c_str(), arr.data(), size);
+  ndi_error = NDI2_get_float64_vec_x(gendir_handle, NDI_AT_WGT,
+                                     zaid_formatted.c_str(), arr.data(), size);
   Require(ndi_error == 0);
 
   ndi_error = NDI2_close_gendir(gendir_handle);


### PR DESCRIPTION
### Background

* Passing zaid=2004 to NDI_AtomicMass would cause NDI to return 7 AMWs (for zaid=2004 and other zaids like 20040)
* Tom Saller showed me how to fix this: append a "." to the zaid.

### Purpose of Pull Request

* Fix this bug by passing e.g. "2004." instead of "2004"
* [Fixes Redmine Issue #1884](https://rtt.lanl.gov/redmine/issues/1884)

### Description of changes

* Reformat the ZAID when converting from an integer before passing to NDI.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
