### PR TITLE
Fix a couple of clang-tidy warnings.

### DIFF
--- a/src/ds++/Packing_Utils.hh
+++ b/src/ds++/Packing_Utils.hh
@@ -539,7 +539,7 @@ void pack_data(FT const &field, std::vector<char> &packed) {
 
   // determine the number of bytes in the field
   Check(field_size * sizeof(typename FT::value_type) + sizeof(int) < INT32_MAX);
-  int const size = static_cast<int>(
+  auto const size = static_cast<int>(
       field_size * sizeof(typename FT::value_type) + sizeof(int));
 
   // make a vector<char> large enough to hold the packed field

--- a/src/ds++/Soft_Equivalence.hh
+++ b/src/ds++/Soft_Equivalence.hh
@@ -62,7 +62,7 @@ constexpr inline
     passed = false;
 
   // second chance for passing if reference is within machine error of zero
-  T const ztol = static_cast<T>(1.0e-14);
+  auto const ztol = static_cast<T>(1.0e-14);
   if (!passed && (fabs(reference) < ztol))
     if (fabs(value) < precision)
       passed = true;


### PR DESCRIPTION
### Background

* These are showing up on the CDash report.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
