### PR TITLE
Fix variable name MPIEXEC_PREFLAGS.

### DIFF
--- a/config/ApplicationUnitTest.cmake
+++ b/config/ApplicationUnitTest.cmake
@@ -376,7 +376,7 @@ macro( add_app_unit_test )
     if( "${MPIEXEC_EXECUTABLE}" MATCHES "aprun" )
       set( RUN_CMD "aprun -n" )
     else()
-      set( RUN_CMD "${MPIEXEC_EXECUTABLE} ${MPIEXEC_POSTFLAGS} ${MPIEXEC_NUMPROC_FLAG}")
+      set( RUN_CMD "${MPIEXEC_EXECUTABLE} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG}")
     endif()
 
   else()
@@ -385,7 +385,7 @@ macro( add_app_unit_test )
     if( "${MPIEXEC_EXECUTABLE}" MATCHES "aprun" OR
         "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" OR
         "${MPIEXEC_EXECUTABLE}" MATCHES "srun" )
-      set( RUN_CMD "${MPIEXEC_EXECUTABLE} ${MPIEXEC_POSTFLAGS} ${MPIEXEC_NUMPROC_FLAG} 1" )
+      set( RUN_CMD "${MPIEXEC_EXECUTABLE} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} 1" )
     endif()
   endif()
 

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -584,11 +584,11 @@ macro( register_parallel_test targetname numPE command cmd_args )
   unset( RUN_CMD )
 
   if( addparalleltest_MPI_PLUS_OMP )
-    string( REPLACE " " ";" mpiexec_omp_postflags_list "${MPIEXEC_OMP_POSTFLAGS}" )
+    string( REPLACE " " ";" mpiexec_omp_preflags_list "${MPIEXEC_OMP_PREFLAGS}" )
     add_test(
       NAME    ${targetname}
       COMMAND ${RUN_CMD} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${numPE}
-              ${mpiexec_omp_postflags_list}
+              ${mpiexec_omp_preflags_list}
               ${command}
               ${cmdarg}
               )
@@ -596,7 +596,7 @@ macro( register_parallel_test targetname numPE command cmd_args )
     add_test(
       NAME    ${targetname}
       COMMAND ${RUN_CMD} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${numPE}
-              ${MPIRUN_POSTFLAGS}
+              ${MPIRUN_PREFLAGS}
               ${command}
               ${cmdarg}
               )
@@ -652,9 +652,9 @@ endmacro()
 # -----------------------------------------------------------------------------#
 # copy_dll_link_libraries_to_build_dir( target )
 #
-# For Win32 with shared libraries, all dll dependencies must be located in the 
-# PATH or in the application directory.  This cmake function creates POST_BUILD 
-# rules for unit tests and applications to ensure that the most up-to-date 
+# For Win32 with shared libraries, all dll dependencies must be located in the
+# PATH or in the application directory.  This cmake function creates POST_BUILD
+# rules for unit tests and applications to ensure that the most up-to-date
 # versions of all dependencies are in the same directory as the application.
 #------------------------------------------------------------------------------#
 function( copy_dll_link_libraries_to_build_dir target )
@@ -730,7 +730,7 @@ function( copy_dll_link_libraries_to_build_dir target )
           message("lib = ${lib} is NOTFOUND --> remove it from the list")
         endif()
       elseif( "${lib}" MATCHES "[$]<")
-        # We have a generator expression.  This routine does not support this, 
+        # We have a generator expression.  This routine does not support this,
         # so drop it.
         list( REMOVE_ITEM link_libs ${lib} )
         if( lverbose )
@@ -810,7 +810,7 @@ function( copy_dll_link_libraries_to_build_dir target )
               "skip it.")
           endif()
           continue()
-        else()       
+        else()
           set(target_loc "$<TARGET_FILE:${lib}>")
         endif()
         get_target_property(target_gnutoms ${lib} GNUtoMS)
@@ -907,10 +907,10 @@ macro( add_scalar_tests test_sources )
   # ------------------------------------------------------------
   # On some platforms (Trinity, Sierra), even scalar tests must be run
   # underneath MPIEXEC_EXECUTABLE (srun, jsrun, lrun):
-  separate_arguments(MPIEXEC_POSTFLAGS)
+  separate_arguments(MPIEXEC_PREFLAGS)
   if( "${MPIEXEC_EXECUTABLE}" MATCHES "srun" OR
       "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
-    set( RUN_CMD ${MPIEXEC_EXECUTABLE} ${MPIEXEC_POSTFLAGS} -n 1 )
+    set( RUN_CMD ${MPIEXEC_EXECUTABLE} ${MPIEXEC_PREFLAGS} -n 1 )
   else()
     unset( RUN_CMD )
   endif()
@@ -1096,11 +1096,11 @@ macro( add_parallel_tests )
 
   # Override MPI Flags upon user request
   if ( NOT DEFINED addparalleltest_MPIFLAGS )
-    set( MPIRUN_POSTFLAGS ${MPIEXEC_POSTFLAGS} )
+    set( MPIRUN_PREFLAGS ${MPIEXEC_PREFLAGS} )
   else()
-    set( MPIRUN_POSTFLAGS "${addparalleltest_MPIFLAGS}" )
+    set( MPIRUN_PREFLAGS "${addparalleltest_MPIFLAGS}" )
   endif()
-  separate_arguments( MPIRUN_POSTFLAGS )
+  separate_arguments( MPIRUN_PREFLAGS )
 
   # Loop over each test source files:
   # 1. Compile the executable

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -254,7 +254,7 @@ macro( setupOpenMPI )
   endif()
 
   # Setting mpi_paffinity_alone to 0 allows parallel ctest to work correctly.
-  # MPIEXEC_POSTFLAGS only affects MPI-only tests (and not MPI+OpenMP tests).
+  # MPIEXEC_PREFLAGS only affects MPI-only tests (and not MPI+OpenMP tests).
   # . --oversubscribe is only available for openmpi version >= 3.0
   # . -H localhost,localhost,localhost,localhost might work for older versions.
   if( "$ENV{GITLAB_CI}" STREQUAL "true" OR "$ENV{TRAVIS}" STREQUAL "true")
@@ -266,7 +266,7 @@ macro( setupOpenMPI )
 
   # (2017-01-13) Bugs in openmpi-1.10.x are mostly fixed. Remove flags used
   # to work around bugs: '-mca btl self,vader -mca timer_require_monotonic 0'
-  set( MPIEXEC_POSTFLAGS "-bind-to none ${runasroot}" CACHE STRING
+  set( MPIEXEC_PREFLAGS "-bind-to none ${runasroot}" CACHE STRING
     "extra mpirun flags (list)." FORCE)
 
   # Find cores/cpu, cpu/node, hyper-threading
@@ -277,13 +277,13 @@ macro( setupOpenMPI )
   #
   if( NOT APPLE )
     # -bind-to fails on OSX, See #691
-    set( MPIEXEC_OMP_POSTFLAGS
+    set( MPIEXEC_OMP_PREFLAGS
       "--map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings ${runasroot}" )
     # "-bind-to socket --map-by ppr:${MPI_CORES_PER_CPU}:socket
     # --report-bindings ${runasroot}"
   endif()
 
-  set( MPIEXEC_OMP_POSTFLAGS ${MPIEXEC_OMP_POSTFLAGS}
+  set( MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS}
     CACHE STRING "extra mpirun flags (list)." FORCE )
 
   mark_as_advanced( MPI_CPUS_PER_NODE MPI_CORES_PER_CPU
@@ -340,12 +340,12 @@ macro( setupCrayMPI )
   #           simultaneously, this option is required to be set or they will
   #           stomp on the same cores.
 
-  set(postflags " ") # -N 1 --cpu_bind=verbose,cores
-  string(APPEND postflags " --gres=craynetwork:0") # --exclusive
-  set( MPIEXEC_POSTFLAGS ${postflags} CACHE STRING
+  set(preflags " ") # -N 1 --cpu_bind=verbose,cores
+  string(APPEND preflags " --gres=craynetwork:0") # --exclusive
+  set( MPIEXEC_PREFLAGS ${preflags} CACHE STRING
     "extra mpirun flags (list)." FORCE)
 
-  set( MPIEXEC_OMP_POSTFLAGS "${MPIEXEC_POSTFLAGS} -c ${MPI_CORES_PER_CPU}"
+  set( MPIEXEC_OMP_PREFLAGS "${MPIEXEC_PREFLAGS} -c ${MPI_CORES_PER_CPU}"
     CACHE STRING "extra mpirun flags (list)." FORCE)
 
 endmacro()
@@ -383,10 +383,10 @@ macro( setupSpectrumMPI )
   #
 
   if( DEFINED ENV{OMP_NUM_THREADS} )
-    set( MPIEXEC_OMP_POSTFLAGS "-c $ENV{OMP_NUM_THREADS}" )
+    set( MPIEXEC_OMP_PREFLAGS "-c $ENV{OMP_NUM_THREADS}" )
   endif()
 
-  set( MPIEXEC_OMP_POSTFLAGS ${MPIEXEC_OMP_POSTFLAGS}
+  set( MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS}
     CACHE STRING "extra mpirun flags (list)." FORCE )
 
   mark_as_advanced( MPI_CPUS_PER_NODE MPI_CORES_PER_CPU
@@ -487,7 +487,7 @@ The Draco build system doesn't know how to configure the build for
     TYPE RECOMMENDED
     PURPOSE "If not available, all Draco components will be built as scalar applications."  )
 
-  mark_as_advanced( MPIEXEC_OMP_POSTFLAGS MPI_LIBRARIES )
+  mark_as_advanced( MPIEXEC_OMP_PREFLAGS MPI_LIBRARIES )
 
 endmacro()
 
@@ -651,7 +651,7 @@ macro( setupMPILibrariesWindows )
           "Are we using hyper-threading?" FORCE )
       endif()
 
-      set( MPIEXEC_OMP_POSTFLAGS "-exitcodes"
+      set( MPIEXEC_OMP_PREFLAGS "-exitcodes"
         CACHE STRING "extra mpirun flags (list)." FORCE )
     endif()
 
@@ -757,7 +757,7 @@ macro( setupMPILibrariesWindows )
     message(STATUS "Looking for MPI.......not found")
   endif()
 
-  mark_as_advanced( MPI_FLAVOR MPIEXEC_OMP_POSTFLAGS MPI_LIBRARIES )
+  mark_as_advanced( MPI_FLAVOR MPIEXEC_OMP_PREFLAGS MPI_LIBRARIES )
 
 endmacro( setupMPILibrariesWindows )
 


### PR DESCRIPTION
### Background

+ Jae noticed that we were using a CMake variable incorrectly.
+ Proper use is described at https://cmake.org/cmake/help/v3.17/module/FindMPI.html?highlight=mpiexec_preflags#usage-of-mpiexec

### Purpose of Pull Request

* [Fixes Redmine Issue #1856](https://rtt.lanl.gov/redmine/issues/1856)

### Description of changes

*  This PR renames `MPIEXEC_POSTLFAGS` to `MPIEXEC_PRELAGS` to correct the issue.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
