### PR TITLE
Help clang-tidy find correct STL headers.

### DIFF
--- a/src/ds++/test/CMakeLists.txt
+++ b/src/ds++/test/CMakeLists.txt
@@ -66,8 +66,8 @@ add_executable( Exe_do_exception ${PROJECT_SOURCE_DIR}/do_exception.cc )
 target_link_libraries( Exe_do_exception Lib_dsxx )
 set_target_properties( Exe_do_exception PROPERTIES
   FOLDER dsxx_test
-  OUTPUT_NAME do_exception
-  ${Draco_std_target_props_CXX})
+  OUTPUT_NAME do_exception )
+dbs_std_tgt_props( Exe_do_exception )
 
 include( ApplicationUnitTest )
 add_app_unit_test(


### PR DESCRIPTION
### Background

* The clang-tidy build was still complaining about not finding `<stdexcept>`.

### Purpose of Pull Request

* [Fixes Redmine Issue #1889](https://rtt.lanl.gov/redmine/issues/1889)

### Description of changes

* The error message only appeared for the test `do_exception`.  This is a special test that is configured in `ds++/test/CMakeLists.txt` and didn't use the normal macros from `config/component_macros.cmake`.  Test registration was missing the following required property that helps clang-tidy find the correct STL headers:
```cmake                                                 |
set_source_files_properties( ${tgt_sources} 
  PROPERTIES 
    INCLUDE_DIRECTORIES  ${CLANG_TODY_IPATH} 
)      
```

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
