### PR TITLE
Automatically set NDI_ROOT_DIR if NDI is found.

### DIFF
--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -77,27 +77,21 @@ endif()
 find_path( NDI_INCLUDE_DIR
   NAMES ndi.h
   HINTS ${NDI_ROOT_DIR}/include/ndi
-  #PATH_SUFFIXES Release Debug
   )
-
-# if (APPLE)
-#     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.dylib")
-# endif()
 
 set( NDI_LIBRARY_NAME ndipic ndi)
 
 find_library(NDI_LIBRARY
   NAMES ${NDI_LIBRARY_NAME}
   PATHS ${NDI_ROOT_DIR}/lib
-  #PATH_SUFFIXES Release Debug
   )
-
 # Do we also have debug versions?
 find_library( NDI_LIBRARY_DEBUG
   NAMES ${NDI_LIBRARY_NAME}
   HINTS ${NDI_ROOT_DIR}/lib
   PATH_SUFFIXES Debug
 )
+
 set( NDI_INCLUDE_DIRS ${NDI_INCLUDE_DIR} )
 set( NDI_LIBRARIES ${NDI_LIBRARY} )
 

--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -77,6 +77,7 @@ endif()
 find_path( NDI_INCLUDE_DIR
   NAMES ndi.h
   HINTS ${NDI_ROOT_DIR}/include/ndi
+  PATH_SUFFIXES ndi
   )
 
 set( NDI_LIBRARY_NAME ndipic ndi)
@@ -91,7 +92,6 @@ find_library( NDI_LIBRARY_DEBUG
   HINTS ${NDI_ROOT_DIR}/lib
   PATH_SUFFIXES Debug
 )
-
 set( NDI_INCLUDE_DIRS ${NDI_INCLUDE_DIR} )
 set( NDI_LIBRARIES ${NDI_LIBRARY} )
 

--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -7,15 +7,18 @@
 cmake_minimum_required(VERSION 3.9.0)
 project( cdi_ndi CXX )
 
+# No ndi in the Docker image used by Travis CI.
 if( NDI_FOUND AND NOT DEFINED ENV{TRAVIS} )
 
 if( NOT DEFINED NDI_ROOT_DIR AND DEFINED $ENV{NDI_ROOT_DIR})
   set(NDI_ROOT_DIR $ENV{NDI_ROOT_DIR})
 endif()
+
 if( NOT DEFINED NDI_ROOT_DIR )
-  message(FATAL_ERROR "NDI_ROOT_DIR not set. cdi_ndi requires the variable \
-          NDI_ROOT_DIR to be set in the environment or with the -DNDI_ROOT_DIR \
-          flag if the ndi library is found.")
+  # if not set in the environment (by modulefile?), set NDI_ROOT_DIR to the
+  # prefix_path for NDI
+  get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY)
+  get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY CACHE)
 endif()
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
### Background

+ `cdi_ndi` requires `NDI_ROOT_DIR` to be set, but not all module systems set this variable.  This is also the case for spack-based builds of jayenne that do not use modules for ndi.

### Purpose of Pull Request

* Fixes a spack build failure reported by asc_spackages developers.

### Description of changes

+ If the Draco build system reports that ndi was found, but `NDI_ROOT_DIR` isn't set, then use other known information to extract the correct value and set `NDI_ROOT_DIR`.
+ Prune dead code from `FindNDI.cmake`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
