### PR TITLE
Synchronize logic for enabling xthi and associated unit test.

### DIFF
--- a/src/c4/bin/CMakeLists.txt
+++ b/src/c4/bin/CMakeLists.txt
@@ -13,13 +13,13 @@ project( c4_bin CXX )
 
 # xthi depends on OpenMP, don't attempt to build it if we don't have it
 if(OPENMP_FOUND)
-add_component_executable(
-  TARGET      Exe_xthi
-  TARGET_DEPS Lib_c4
-  SOURCES     ${PROJECT_SOURCE_DIR}/xthi.cc
-  PREFIX       Draco )
-install( TARGETS Exe_xthi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
-endif(OPENMP_FOUND)
+  add_component_executable(
+    TARGET      Exe_xthi
+    TARGET_DEPS Lib_c4
+    SOURCES     ${PROJECT_SOURCE_DIR}/xthi.cc
+    PREFIX       Draco )
+  install( TARGETS Exe_xthi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
+endif()
 
 add_component_executable(
   TARGET      Exe_ythi
@@ -30,7 +30,6 @@ add_component_executable(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
 install( TARGETS Exe_ythi EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 
 # ---------------------------------------------------------------------------- #

--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -11,7 +11,6 @@ project( c4_test CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB test_sources *.cc )
 
 # ---------------------------------------------------------------------------- #
@@ -31,8 +30,7 @@ add_parallel_tests(
    PE_LIST   "1;2;4"
    TEST_ARGS "hello"
    PASS_REGEX "Hello"
-   FAIL_REGEX "cruel"
-   )
+   FAIL_REGEX "cruel" )
 list( REMOVE_ITEM test_sources ${special_test} )
 
 # This tests runs with extra arguments
@@ -42,27 +40,21 @@ add_parallel_tests(
    DEPS      Lib_c4
    PE_LIST   "1;2;4"
    TEST_ARGS "--version;--dummy; "
-   PASS_REGEX "tstParallelUnitTest[.ex]*: version"
-   )
+   PASS_REGEX "tstParallelUnitTest[.ex]*: version" )
 list( REMOVE_ITEM test_sources ${special_test} )
 
 # This test uses MPI+OMP:
 # - Bullseye doesn't like some OMP directives.
-# - Timing tests are broken if the test has to be pushed to a virtual
-#   machine (aprun).
+# - Timing tests are broken if the test has to be pushed to a virtual machine 
+#   (aprun).
 set( special_test ${PROJECT_SOURCE_DIR}/tstOMP.cc )
 list( REMOVE_ITEM test_sources ${special_test} )
-if( NOT OPENMP_FOUND )
-   # no-op
-elseif( DBS_CXX_IS_BULLSEYE )
-   # no-op
-else()
+if( OPENMP_FOUND AND NOT DBS_CXX_IS_BULLSEYE )
    add_parallel_tests(
       SOURCES   "${special_test}"
       DEPS      Lib_c4
       PE_LIST   "1;2"
-      MPI_PLUS_OMP
-      )
+      MPI_PLUS_OMP )
 endif()
 
 # Tests that expect exactly 2 PE (omit for DRACO_C4=SCALAR builds):
@@ -73,8 +65,7 @@ if( NOT ${DRACO_C4} STREQUAL "SCALAR" )
   add_parallel_tests(
     SOURCES   "${two_pe_tests}"
     DEPS      Lib_c4
-    PE_LIST   "2"
-    )
+    PE_LIST   "2" )
 endif()
 
 # Tests that expect exactly 4 PE (omit for DRACO_C4=SCALAR builds):
@@ -89,7 +80,7 @@ if( NOT ${DRACO_C4} STREQUAL "SCALAR" )
   if( NOT DEFINED MPI_MAX_NUMPROCS_PHYSICAL )
     message(FATAL_ERROR "need max procs in c4/tests/CMakeLists.txt")
   endif()
-  # Over-ride PROCESSORS propety.  Use 'mpirun -np 4 ...' but reserve all cores.
+  # Override PROCESSORS property.  Use 'mpirun -np 4 ...' but reserve all cores.
   set_tests_properties( c4_tstQuoWrapper_4 PROPERTIES
     PROCESSORS "${MPI_MAX_NUMPROCS_PHYSICAL}" )
 endif()
@@ -97,38 +88,36 @@ endif()
 # Exclude tstTime from valgrind checks.
 set( nomemcheck_tests
   ${PROJECT_SOURCE_DIR}/tstTime.cc
-  ${PROJECT_SOURCE_DIR}/tstGlobalTimer.cc
-  )
+  ${PROJECT_SOURCE_DIR}/tstGlobalTimer.cc )
 list( REMOVE_ITEM test_sources ${nomemcheck_tests} )
 add_parallel_tests(
   SOURCES   "${nomemcheck_tests}"
   DEPS      Lib_c4
   PE_LIST   "1;2;4"
-  LABEL     "nomemcheck"
-  )
+  LABEL     "nomemcheck" )
 
 # The remainder of the tests
 add_parallel_tests(
    SOURCES   "${test_sources}"
    DEPS      Lib_c4
-   PE_LIST   "1;2;4"
-   )
+   PE_LIST   "1;2;4" )
 
 #------------------------------------------------------------------------------#
 # Python based test runners
 #------------------------------------------------------------------------------#
-if( NOT APPLE )
-  include( ApplicationUnitTest )
+include( ApplicationUnitTest )
+if(OPENMP_FOUND)
+  # xthi depends on OpenMP.  If OpenMP is not found, xthi will not be compiled.
   add_app_unit_test(
     DRIVER    ${CMAKE_CURRENT_SOURCE_DIR}/tstXthi.py
     APP       $<TARGET_FILE_DIR:Exe_xthi>/$<TARGET_FILE_NAME:Exe_xthi>
     PE_LIST   "1;2" )
-  add_app_unit_test(
-    DRIVER    ${CMAKE_CURRENT_SOURCE_DIR}/tstYthi.py
-    APP       $<TARGET_FILE_DIR:Exe_ythi>/$<TARGET_FILE_NAME:Exe_ythi>
-    TEST_ARGS 2
-    PE_LIST   "1;2" )
 endif()
+add_app_unit_test(
+  DRIVER    ${CMAKE_CURRENT_SOURCE_DIR}/tstYthi.py
+  APP       $<TARGET_FILE_DIR:Exe_ythi>/$<TARGET_FILE_NAME:Exe_ythi>
+  TEST_ARGS 2
+  PE_LIST   "1;2" )
 
 #------------------------------------------------------------------------------#
 # End src/c4/test/CMakeLists.txt


### PR DESCRIPTION
### Background

+ I ran across this issue while trying to use clang under Visual Studio.  The toolchain appears to behave similarly to apple-clang for OSX.  That is, `clang` doesn't support OpenMP.
+ The logic used to enable building `xthi` should match the logic used to enable `tstXthi.py`. 

### Purpose of Pull Request

* Related to #779

### Description of changes

+ Update `src/c4/test/CMakeLists.txt` to make the enable/disable logic for `xthi` and `tstXthi.py` the same.
+ Update indentation, spacing, more more to cleanup these two `CMakeLists.txt`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
