### PR TITLE
Update Draco dev environment to support KNL on darwin.

### DIFF
--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -39,8 +39,8 @@ if test -n "$MODULESHOME"; then
         lflavor="lapack-3.8.0"
         noflavor="git gcc/8.2.0"
         compflavor="cmake/3.15.3 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_8.2.0"
-        mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lflavor trilinos/12.14.1-$mflavor-$lflavor"
-        ec_mf="csk/0.5.0-$cflavor" # ndi
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lflavor trilinos/12.14.1-$mflavor-$lflavor"
+        ec_mf="csk/0.5.0-$cflavor ndi/2.1.3-$cflavor"
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
         export OMPI_MCA_btl=^openib
         export UCX_NET_DEVICES=mlx5_0:1
@@ -57,7 +57,7 @@ if test -n "$MODULESHOME"; then
           cudaflavor="-cuda-10.1"
         fi
         compflavor="cmake/3.16.4 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
-        mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
         if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
@@ -66,14 +66,19 @@ if test -n "$MODULESHOME"; then
       ;;
 
       knl)
-        cflavor="gcc-7.1.0"
-        mflavor="$cflavor-openmpi-2.1.0"
-        noflavor="git random123 cmake"
-        compflavor="gcc/7.1.0 gsl/2.4-$cflavor metis/5.1.0-$cflavor \
-numdiff/5.9.0"
-        mpiflavor="openmpi/2.1.0-gcc_7.1.0 parmetis/4.0.3-$mflavor \
-superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
-        ec_mf="ndi eospac/6.3.0"
+        module unuse ${VENDOR_DIR}-ec/Modules/$DRACO_ARCH
+        module use --append ${VENDOR_DIR}-ec/Modules/x86_64
+        cflavor="gcc-7.3.0"
+        mflavor="$cflavor-openmpi-3.1.3"
+        lapackflavor="lapack-3.8.0"
+        noflavor="git random123 cmake gcc/7.3.0"
+        compflavor="cmake/3.16.4 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
+        ec_mf="ndi csk/0.5.0-$cflavor"
+        # Add clang-format (version 6) to the default environment.
+        if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
+          export PATH=$PATH:/projects/opt/centos7/clang/6.0.0/bin
+        fi
         ;;
 #       power8*)
 #         cflavor="gcc-7.1.0"
@@ -89,9 +94,9 @@ superlu-dist/5.2.2-$mflavor trilinos/12.12.1-$mflavor"
         lflavor="lapack-3.8.0"
         noflavor="git gcc/7.3.0 cuda/10.1"
         compflavor="eospac/6.4.0-$cflavor cmake/3.16.4-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
-        mpiflavor="parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
-        ec_mf="csk/0.5.0-$cflavor" # ndi
+        ec_mf="csk/0.5.0-$cflavor ndi"
 
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
         # eliminates warnings: "there are more than one active ports on host"


### PR DESCRIPTION
### Background

* We hadn't updated the developer-environment for KNL nodes on Darwin for quite a long time.  

### Purpose of Pull Request

* [Fixes Redmine Issue #1898](https://rtt.lanl.gov/redmine/issues/1898)

### Description of changes

+ Update module list and point to modules/TPLs built for x86_64.
```bash
export VENDOR_DIR=/usr/projects/draco/vendors
export DRACO_ARCH=x86_64
module use --append ${VENDOR_DIR}/user_contrib
module use --append ${VENDOR_DIR}-ec/Modules/$DRACO_ARCH
module load user_contrib
mflavor="$cflavor-openmpi-3.1.3"
lapackflavor="lapack-3.8.0"
noflavor="git random123 cmake gcc/7.3.0"
compflavor="cmake/3.16.4 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
ec_mf="ndi csk/0.5.0-$cflavor"
export dracomodules="$noflavor $compflavor $mpiflavor $ec_mf"
module load $dracomodules
```
+ I am also providing an alternate set of TPLs for the spec `%intel@19.0.5 ^openmpi@4.0.2`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
