### PR TITLE
Replace deprecated std::pointer_to_unary_function with std::function.

### DIFF
--- a/src/parser/Abstract_Class_Parser.hh
+++ b/src/parser/Abstract_Class_Parser.hh
@@ -15,9 +15,6 @@
 #include <iostream>
 
 namespace rtt_parser {
-using std::pointer_to_unary_function;
-using std::string;
-using std::vector;
 
 //============================================================================//
 /*!
@@ -90,8 +87,8 @@ private:
 //============================================================================//
 template <typename Abstract_Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Abstract_Class> &get_parsed_object(),
-          typename Parse_Function = pointer_to_unary_function<
-              Token_Stream &, std::shared_ptr<Abstract_Class>>>
+          typename Parse_Function =
+	    std::function<std::shared_ptr<Abstract_Class>(Token_Stream &)>>
 class Abstract_Class_Parser {
 public:
   // TYPES
@@ -99,12 +96,12 @@ public:
   // STATIC members
 
   //! Register children of the abstract class
-  static void register_child(string const &keyword,
+  static void register_child(std::string const &keyword,
                              Parse_Function parse_function);
 
   //! Register children of the abstract class
   static void register_child(
-      string const &keyword,
+      std::string const &keyword,
       std::shared_ptr<Abstract_Class> parse_function(Token_Stream &));
 
   //! Check the class invariants
@@ -119,7 +116,7 @@ private:
   // DATA
 
   //! Map of child keywords to child creation functions
-  static vector<Parse_Function> map_;
+  static std::vector<Parse_Function> map_;
 };
 
 #include "Abstract_Class_Parser.i.hh"

--- a/src/parser/Abstract_Class_Parser.i.hh
+++ b/src/parser/Abstract_Class_Parser.i.hh
@@ -40,7 +40,7 @@ public:
   ~c_string_vector();
   c_string_vector(void) : data(0) { /* empty */
   }
-  vector<char *> data;
+  std::vector<char *> data;
 };
 DLL_PUBLIC_parser extern c_string_vector abstract_class_parser_keys;
 
@@ -56,7 +56,7 @@ DLL_PUBLIC_parser extern c_string_vector abstract_class_parser_keys;
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
-vector<Parse_Function> Abstract_Class_Parser<
+std::vector<Parse_Function> Abstract_Class_Parser<
     Class, get_parse_table, get_parsed_object, Parse_Function>::map_;
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* The Abstract_Class_Parser uses std::pointer_to_unary_function, which is deprecated in C++11 in favor of std::function and dropped completely in C++17. std::pointer_to_unary function dates back to before the introduction of variable template argument lists, which allow std::function to represent all kinds of functions.

### Purpose of Pull Request

* Replace uses of std::pointer_to_unary_function with std::function.
* [Fixes Redmine Issue #775](https://rtt.lanl.gov/redmine/issues/775)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
