### PR TITLE
Enable more gcc debug flags by default.

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -86,8 +86,9 @@ endif()
 
 if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
-
   set( CMAKE_C_FLAGS                "-Wcast-align -Wpointer-arith -Wall -pedantic" )
+  string( APPEND CMAKE_C_FLAGS " -Wfloat-equal -Wunused-macros" )
+  string( APPEND CMAKE_C_FLAGS " -fsanitize=bounds-strict -Wshadow -Wformat=2")
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
     string( APPEND CMAKE_C_FLAGS    " -Wno-expansion-to-defined -Wnarrowing" )
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,11 +14,8 @@ include( component_macros )
 
 # Extra 'draco-only' flags
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
-  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 )
-    toggle_compiler_flag( TRUE "-Wfloat-equal -Wunused-macros" "CXX;C" "DEBUG")
-  endif()
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 )
-    toggle_compiler_flag( TRUE "-fsanitize=bounds-strict -Wconversion -Wdouble-promotion -Wshadow -Wformat=2" "CXX" "DEBUG")
+    toggle_compiler_flag( TRUE "-Wconversion -Wdouble-promotion" "CXX" "DEBUG")
   endif()
 #  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
 #


### PR DESCRIPTION
### Background

* Some flags were only enabled for gcc version > 5.0.  Since we always use version 6+, remove some of the extra logic.  

### Purpose of Pull Request

* Fixes #784

### Description of changes

+ Move some gcc debug flags from `src/CMakeLists.txt` to `config/unix-g++.cmake`.
+ This doesn't change draco, but it does make some new flags the default for Jayenne: `-Wfloat-equal -Wunused-macros -fsanitize=bounds-strict -Wshadow -Wformat=2`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
