### PR TITLE
Update to diagnostics/qt to reflect new cmake behavior.

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -315,41 +315,15 @@ endmacro()
 macro( setupQt )
   message( STATUS "Looking for Qt SDK...." )
 
-  # The CMake package information should be found in
-  # $QTDIR/lib/cmake/Qt5Widgets/Qt5WidgetsConfig.cmake.  On CCS Linux
-  # machines, QTDIR is set when loading the qt module
-  # (QTDIR=/ccs/codes/radtran/vendors/Qt53/5.3/gcc_64):
-  if( "${QTDIR}notset" STREQUAL "notset" AND EXISTS "$ENV{QTDIR}" )
-    set( QTDIR $ENV{QTDIR} CACHE PATH "This path should include /lib/cmake/Qt5Widgets" )
-  endif()
-  set( CMAKE_PREFIX_PATH_QT "$ENV{QTDIR}/lib/cmake/Qt5Widgets" )
+  # Find the QtWidgets library
+  find_package(Qt5 COMPONENTS Widgets QUIET)
 
-  if( NOT EXISTS ${CMAKE_PREFIX_PATH_QT}/Qt5WidgetsConfig.cmake )
-    # message( FATAL_ERROR "Could not find cQt cmake macros.  Try
-    # setting CMAKE_PREFIX_PATH_QT to the path that contains
-    # Qt5WidgetsConfig.cmake" )
-    message( STATUS "Looking for Qt SDK....not found." )
-  else()
-    file( TO_CMAKE_PATH "${CMAKE_PREFIX_PATH_QT}" CMAKE_PREFIX_PATH_QT )
-    list( APPEND CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH_QT}" )
-    find_package(Qt5Widgets)
-    find_package(Qt5Core)
-    get_target_property(QtCore_location Qt5::Core LOCATION)
-    if( Qt5Widgets_FOUND )
-      set( QT_FOUND 1 )
-      # Instruct CMake to run moc automatically when needed (only for
-      # subdirectories that need Qt)
-      # set(CMAKE_AUTOMOC ON)
-      message( STATUS "Looking for Qt SDK....found ${QTDIR}." )
-    else()
-      set( QT_FOUND "QT-NOTFOUND" )
-      message( STATUS "Looking for Qt SDK....not found." )
-    endif()
-  endif()
-
-  if( QT_FOUND )
+  if( Qt5Core_DIR )
     mark_as_advanced( Qt5Core_DIR Qt5Gui_DIR Qt5Gui_EGL_LIBRARY
       Qt5Widgets_DIR QTDIR)
+    message( STATUS "Looking for Qt SDK....found ${Qt5Core_DIR}" )
+  else()
+    message( STATUS "Looking for Qt SDK....not found." )
   endif()
 
   set_package_properties( Qt PROPERTIES

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -90,7 +90,7 @@ fi
 if [[ ${CRAY_CPU_TARGET} =~ haswell ]] || [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
 
   module use --append ${VENDOR_DIR}-ec/modulefiles
-  dracomodules="git cmake numdiff gsl/2.5 metis eospac/6.4.0 random123 parmetis \
+  dracomodules="git cmake/3.17.0 numdiff gsl/2.5 metis eospac/6.4.0 random123 parmetis \
 superlu-dist/5.4.0 trilinos/12.14.1 clang-format python/3.6-anaconda-5.0.1 quo"
 
   if [[ -d ${VENDOR_DIR}-ec ]]; then
@@ -107,12 +107,13 @@ elif [[ ${CRAY_CPU_TARGET} =~ arm ]]; then
   module use --append ${VENDOR_DIR}-ec/modulefiles-capulin
   comp="gcc-8.3.0"
   mpi="mpt-7.7.10"
-  dracomodules="git/2.20.1 cmake numdiff/5.9.0-${comp} gsl/2.5-${comp} openblas/0.3.6-${comp} metis/5.1.0-${comp} eospac/6.4.0-${comp} random123/1.09-${comp} parmetis/4.0.3-${comp}-${mpi} superlu-dist/5.4.0-${comp}-${mpi}-openblas trilinos/12.14.1-${comp}-${mpi}-openblas cray-python/3.6.5.6 qt"
+  dracomodules="git/2.20.1 cmake numdiff/5.9.0-${comp} gsl/2.5-${comp} openblas/0.3.6-${comp} metis/5.1.0-${comp} eospac/6.4.0-${comp} random123/1.09-${comp} parmetis/4.0.3-${comp}-${mpi} superlu-dist/5.4.0-${comp}-${mpi}-openblas trilinos/12.14.1-${comp}-${mpi}-openblas cray-python/3.6.5.6 qt quo"
 
   if [[ -d ${VENDOR_DIR}-ec ]]; then
     group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`
     if [[ `groups | grep -c $group_for_vendor_ec` != 0 ]]; then
-      dracomodules="$dracomodules csk/0.4.2-${comp} ndi"
+      dracomodules="$dracomodules csk/0.5.0-${comp}"
+      # ndi
     fi
   fi
 

--- a/environment/bashrc/.bashrc_cts1
+++ b/environment/bashrc/.bashrc_cts1
@@ -58,7 +58,7 @@ else
 
   export dracomodules="ack htop clang-format python \
 intel/19.0.4 openmpi/2.1.2 mkl \
-cmake/3.14.6 numdiff git totalview trilinos/12.10.1 \
+cmake/3.17.0 numdiff git totalview trilinos/12.10.1 \
 superlu-dist/5.1.3 metis parmetis random123 eospac/6.4.0 quo"
 
   if [[ -d ${VENDOR_DIR}-ec ]]; then

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for diagnostics.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -76,7 +76,7 @@ add_component_executable(
   PREFIX       Draco
   )
 
-if( QT_FOUND )
+if( Qt5Core_DIR )
   add_subdirectory( qt )
 endif()
 

--- a/src/diagnostics/qt/CMakeLists.txt
+++ b/src/diagnostics/qt/CMakeLists.txt
@@ -3,41 +3,30 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2015 June 26
 # brief  Generate build project files for diagnostics/qt
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
-cmake_minimum_required( VERSION 3.9.0 )
+cmake_minimum_required( VERSION 3.17.0 )
 project( diagnostics_qt CXX )
 
 # ---------------------------------------------------------------------------- #
 # Special options for Qt applications
 # ---------------------------------------------------------------------------- #
 
-# Find generated files in the corresponding build directories:
-# 1. <file>.ui files generate ui_<file>.h headers in the build directory via the
-#    qt5_wrap_ui macro.
-# 2. <file>.qrc files generate qrc_<file>.cpp in the build directory via the
-#    qt5_add_resources macro.
-
 # Instruct CMake to run moc automatically when needed (only for subdirectories
 # that need Qt)
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
 
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
 
-file( GLOB sources   *.cc *.cpp )
-file( GLOB headers   *.hh *.h )
-file( GLOB ui_files  *.ui )
-#file( GLOB resources *.qrc )
-
-# Use moc to convert *.ui files into ui_*.h files:
-qt5_wrap_ui( ui_headers ${ui_files} )
-
-# use rcc to convert *.qrc files into qrc_*.cpp files:
-qt5_add_resources( qrc_sources ${resources} )
-list( APPEND sources ${qrc_sources} )
+file( GLOB sources   main.cc mainwindow.cc diWidget.cc)
+file( GLOB headers   mainwindow.hh diWidget.hh)
+file( GLOB ui_files  mainwindow.ui )
+# file( GLOB resources *.qrc )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
@@ -49,11 +38,10 @@ list( APPEND sources ${qrc_sources} )
 add_component_executable(
   TARGET      Exe_draco_info_gui
   TARGET_DEPS "Lib_diagnostics;Qt5::Widgets"
-  SOURCES     "${sources}"
+  SOURCES     "${sources};${ui_files}"
   PREFIX       Draco
   FOLDER       diagnostics
-  NOCOMMANDWINDOW
-  )
+  NOCOMMANDWINDOW )
 
 # Copy Qt dll files to build directory
 # copy_dll_link_libraries_to_build_dir( Exe_draco_info_gui )

--- a/src/diagnostics/qt/diWidget.cc
+++ b/src/diagnostics/qt/diWidget.cc
@@ -5,11 +5,9 @@
  * \date   Monday, Aug 11, 2016, 17:05 pm
  * \brief  Implementation for draco info widget.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-//----------------------------------------------------------------------------//
 #include "diWidget.hh"
 #include "../draco_info.hh"
 

--- a/src/diagnostics/qt/diWidget.hh
+++ b/src/diagnostics/qt/diWidget.hh
@@ -5,11 +5,9 @@
  * \date   Monday, Aug 11, 2016, 17:05 pm
  * \brief  Declaration of draco info widget.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-//----------------------------------------------------------------------------//
 #ifndef diwidget_hh
 #define diwidget_hh
 
@@ -23,7 +21,15 @@ class diWidget : public QWidget {
 
 public:
   explicit diWidget(QWidget *parent = 0);
-  ~diWidget(){/* empty */};
+  ~diWidget() = default;
+
+  // disable copy/move construction
+  diWidget(diWidget const &rhs) = delete;
+  diWidget(diWidget const &&rhs) = delete;
+
+  // disable assignment and move-assignment
+  diWidget &operator=(diWidget const &rhs) = delete;
+  diWidget &operator=(diWidget const &&rhs) = delete;
 
 private slots:
   /* void on_actionAbout_triggered(); */
@@ -34,12 +40,6 @@ private:
   QGridLayout *layout;
   QLabel *label1;
   QPushButton *pushbutton1;
-
-  // disable copy construction
-  diWidget(diWidget const &rhs);
-
-  // disable assignment
-  diWidget &operator=(diWidget const &rhs);
 };
 
 #endif // diwidget_hh

--- a/src/diagnostics/qt/main.cc
+++ b/src/diagnostics/qt/main.cc
@@ -5,13 +5,13 @@
  * \date   Monday, Aug 11, 2016, 17:05 pm
  * \brief  Main program for Gui version of draco info.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-//----------------------------------------------------------------------------//
 #include "mainwindow.hh"
 #include <QApplication>
+
+//! \example https://github.com/jasondegraw/Qt-CMake-HelloWorld
 
 int main(int argc, char *argv[]) {
   // http://qt-project.org/doc/qt-5/qtwidgets-mainwindows-mainwindow-main-cpp.html

--- a/src/diagnostics/qt/mainwindow.cc
+++ b/src/diagnostics/qt/mainwindow.cc
@@ -5,19 +5,12 @@
  * \date   Monday, Aug 11, 2016, 17:05 pm
  * \brief  Implementation for draco info main Qt window.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-//----------------------------------------------------------------------------//
 #include "mainwindow.hh"
+#include "ui_mainwindow.h"
 #include <QStatusBar>
-//#include "ui_mainwindow.h"
-
-// Compiling with high warning levels will produce this warning:
-// warning: base class 'class Ui_MainWindow' has a non-virtual destructor [-Weffc++]
-//     class MainWindow: public Ui_MainWindow {};
-// This cannot be fixed because ui_mainwindow.h is generated automatically by Qt.
 
 //----------------------------------------------------------------------------//
 //! Constructor

--- a/src/diagnostics/qt/mainwindow.hh
+++ b/src/diagnostics/qt/mainwindow.hh
@@ -5,19 +5,16 @@
  * \date   Monday, Aug 11, 2016, 17:05 pm
  * \brief  Declarations for draco info main Qt window.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-//----------------------------------------------------------------------------//
 #ifndef diagnostics_qt_mainwindow_hh
 #define diagnostics_qt_mainwindow_hh
 
 #include "diWidget.hh"
 #include <QMainWindow>
 
-//namespace Ui
-//{
+//namespace Ui {
 //   class MainWindow;
 //}
 
@@ -26,18 +23,20 @@ class MainWindow : public QMainWindow {
 
 public:
   explicit MainWindow(QWidget *parent = 0);
-  ~MainWindow(){};
+  ~MainWindow() = default;
+
+  // disable copy/move construction
+  MainWindow(MainWindow const &rhs) = delete;
+  MainWindow(MainWindow const &&rhs) = delete;
+
+  // disable assignment and move-assignment
+  MainWindow &operator=(MainWindow const &rhs) = delete;
+  MainWindow &operator=(MainWindow const &&hs) = delete;
 
 private slots:
   // None
 
 private:
-  // disable copy construction
-  MainWindow(MainWindow const &rhs);
-
-  // disable assignment
-  MainWindow &operator=(MainWindow const &rhs);
-
   // Forms
   //Ui::MainWindow *ui;
 


### PR DESCRIPTION
### Background

+ After upgrading to cmake-3.17.0, our one Qt example failed to configure or build. I have updated build system logic to match what cmake-3.17+ expects for Qt applications.

### Purpose of Pull Request

* [Fixes Redmine Issue #1900](https://rtt.lanl.gov/redmine/issues/1900)

### Description of changes

+ Greatly simplify Qt discovery in `vendor_libraries.cmake`, but require Qt5 (disallow Qt3 or Qt4).
+ When building `diagnostics/qt` require cmake-3.17.0+:
  + Begin using `CMAKE_AUTOUIC` and `CMAKE_AUTORCC`.
  + CMake no longer requries the use of the macros `qt5_wrap_ui` or `add_resources`.
  + `.ui` files are now treated like source files.
+ Add code to delete move ctors and move assignment operators.


### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
