### PR TITLE
Fix minor errors on Apple

### DIFF
--- a/src/c4/xthi_cpuset.hh
+++ b/src/c4/xthi_cpuset.hh
@@ -91,7 +91,7 @@ static inline bool CPU_ISSET(int num, cpu_set_t *cs) {
   return (cs->count & teh_bit) != 0;
 }
 
-int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t *cpu_set) {
+int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/, cpu_set_t *cpu_set) {
   int64_t core_count = 0;
   size_t len = sizeof(core_count);
   int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);

--- a/src/cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
@@ -135,11 +135,11 @@ void multigroup_test(rtt_dsxx::UnitTest &ut) {
 
   // scalar density/temperature + vector density/temperature
   vector<double> data_field(3, 2.0);
-  vector<vector<double>> sig_test = opacity.getOpacity(data_field, 3.0);
+  vector<vector<double>> sigma_total = opacity.getOpacity(data_field, 3.0);
   vector<vector<double>> sig_rho = opacity.getOpacity(2.0, data_field);
 
   for (int i = 0; i < 3; i++) {
-    vector<double> &test = sig_test[i];
+    vector<double> &test = sigma_total[i];
 
     if (soft_equiv(test.begin(), test.end(), ref.begin(), ref.end())) {
       ostringstream message;

--- a/src/cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
+++ b/src/cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc
@@ -135,11 +135,11 @@ void multigroup_test(rtt_dsxx::UnitTest &ut) {
 
   // scalar density/temperature + vector density/temperature
   vector<double> data_field(3, 2.0);
-  vector<vector<double>> sig_t = opacity.getOpacity(data_field, 3.0);
+  vector<vector<double>> sig_test = opacity.getOpacity(data_field, 3.0);
   vector<vector<double>> sig_rho = opacity.getOpacity(2.0, data_field);
 
   for (int i = 0; i < 3; i++) {
-    vector<double> &test = sig_t[i];
+    vector<double> &test = sig_test[i];
 
     if (soft_equiv(test.begin(), test.end(), ref.begin(), ref.end())) {
       ostringstream message;


### PR DESCRIPTION
### Background

* Found two minor bugs on Mac builds that result in compilation errors 

### Purpose of Pull Request

* Fix those bugs

### Description of changes

* In `c4/xthi_cpuset.hh`, comment out parameters that are not used in the Apple implementation of sched_getaffinity.
* In `cdi_analytic/test/tstCompound_Analytic_MultigroupOpacity.cc`, rename `sig_t` to `sig_test`, since the former conflicts with a typedef in Apple's `sys/signal.h`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
