### PR TITLE
Rzansel: point to new spack instance for dev TPLs.

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -43,12 +43,16 @@ if [[ ! ${modcmd} ]]; then
   echo "ERROR: The module command was not found. No modules will be loaded."
 else
 
-  #module use /usr/gapps/user_contrib/spack.20190314/share/spack/lmod/linux-rhel7-ppc64le/Core
-  module use /usr/gapps/jayenne/vendors-ec/spack.20190616/share/spack/lmod/linux-rhel7-ppc64le/Core
+  #module use
+  #module use /usr/gapps/jayenne/vendors-ec/spack.20190616/share/spack/lmod/linux-rhel7-ppc64le/Core
+  module use /usr/gapps/user_contrib/spack.20200402/share/spack/lmod/linux-rhel7-ppc64le/Core
+
+  module unuse /usr/share/lmod/lmod/modulefiles/Core
+  module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
 
 # StdEnv
 
-  export dracomodules="python/3.7.2 gcc/7.3.1 spectrum-mpi/2019.06.24 cmake/3.14.5 git gsl numdiff random123 metis netlib-lapack eospac/6.4.0 parmetis superlu-dist trilinos csk ack htop libquo"
+  export dracomodules="cuda python/3.7.2 ack htop gsl numdiff git random123 gcc/8.3.1 cmake/3.17.0 metis netlib-lapack eospac/6.4.0 spectrum-mpi/2019.06.24 parmetis superlu-dist trilinos libquo csk ndi"
 
 fi
 

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -76,7 +76,7 @@ add_component_executable(
   PREFIX       Draco
   )
 
-if( Qt5Core_DIR )
+if( Qt5Core_DIR AND NOT "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le" )
   add_subdirectory( qt )
 endif()
 


### PR DESCRIPTION
### Background

+ I was finally able to build `trilnos % xl ^spectrum-mpi` on rznsel with spack.  But this requires a newer version of spack that we were using for the last two releases.

### Description of changes

+ Update `.bashrc_ats2` to point to the new spack and load all relevant modulefiles.  This includes *trilinos*, *libquo* and *ndi* that were missing from the last spack instance.
* Also, don't attempt to build Qt-based applications from PPC.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
