### PR TITLE
Eliminate compile warning from Intel.

### DIFF
--- a/src/diagnostics/qt/CMakeLists.txt
+++ b/src/diagnostics/qt/CMakeLists.txt
@@ -43,6 +43,14 @@ add_component_executable(
   FOLDER       diagnostics
   NOCOMMANDWINDOW )
 
+# Disable IPO for appliations that link to Qt SDK, as this causes compile
+# warnings for the Intel compiler (and it refuses to run IPO for this
+# application anyway).
+if( CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+  set_target_properties( Exe_draco_info_gui PROPERTIES
+    INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF )
+endif()
+
 # Copy Qt dll files to build directory
 # copy_dll_link_libraries_to_build_dir( Exe_draco_info_gui )
 if (WIN32)


### PR DESCRIPTION
### Background

+ The Intel compiler generates warnings about disabling IPO when linking to Qt run time libraries.  To eliminate the warning, disable IPO when linking to Qt run time libraries.

### Purpose of Pull Request

* [Fixes Redmine Issue #1904](https://rtt.lanl.gov/redmine/issues/1904)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
