### PR TITLE
Another tweak to help lcov reporting work for client projects.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -12,6 +12,7 @@ project( config )
 include(CMakePackageConfigHelpers)
 
 file( GLOB CMake_src *.cmake )
+file( GLOB config_helper_sh *.sh )
 file( GLOB Python_src *.py )
 set( CMake_in
    cmake_uninstall.cmake.in
@@ -57,6 +58,7 @@ write_basic_package_version_file(
 set( file_list
   ${CMake_src}
   ${CMake_in}
+  ${config_helper_sh}
   ${Python_src}
   ${CMAKE_CURRENT_BINARY_DIR}/draco-config.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/draco-config-version.cmake

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -151,6 +151,11 @@ macro(dbsSetupCompilers)
         foreach( myregex ${CODE_COVERAGE_IGNORE_REGEX} )
           list(APPEND lcov_ignore '${myregex}')
         endforeach()
+        if( EXISTS "${PROJECT_SOURCE_DIR}/config/capture_lcov.sh" )
+          set( captureLcov "${PROJECT_SOURCE_DIR}/config/capture_lcov.sh" )
+        else()
+          set( captureLcov "${DRACO_DIR}/config/capture_lcov.sh" )
+        endif()
         add_custom_command(
           OUTPUT "${PROJECT_BINARY_DIR}/covrep_target_aways_out_of_date.txt"
           BYPRODUCTS
@@ -160,8 +165,9 @@ macro(dbsSetupCompilers)
           COMMAND ${LCOV} ${lcovopts2} --remove coverage.info ${lcov_ignore}
           COMMAND genhtml coverage.info --demangle-cpp --output-directory cov-html
           # COMMAND ${LCOV} ${lcovopts1} --list coverage.info
-          COMMAND "${PROJECT_SOURCE_DIR}/config/capture_lcov.sh" -g "${GCOV}" -l "${LCOV}"
+          COMMAND "${captureLcov}" -g "${GCOV}" -l "${LCOV}"
           )
+        unset( captureLcov )
         add_custom_target( covrep
           DEPENDS "${PROJECT_BINARY_DIR}/covrep_target_aways_out_of_date.txt"
           COMMENT "


### PR DESCRIPTION
### Background

* Coverage reporting is working as desired for draco, but not for client codes like Jayenne.  This update ensures that the new helper shell script is installed and available for client codes to use.

### Purpose of Pull Request

* [Related to Redmine Issue #1903](https://rtt.lanl.gov/redmine/issues/1903)

### Description of changes

+ Install `capture_lcov.sh` so other projects can find and use this helper script.
+ Help client projects find `capture_lcov.sh` to allow the `covrep` build target to function correctly.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
