### PR TITLE
Re-teach the build system to install eospac and csk dll files.

### DIFF
--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -35,6 +35,13 @@ add_component_executable(
   SOURCES     ${PROJECT_SOURCE_DIR}/QueryEospac.cc
   PREFIX       Draco )
 
+# Copy necessary dll files to the build directory
+if(WIN32)
+  add_custom_command( TARGET Lib_cdi_eospac POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:EOSPAC::eospac>
+            $<TARGET_FILE_DIR:Lib_cdi_eospac> )
+endif()
+
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #

--- a/src/compton/CMakeLists.txt
+++ b/src/compton/CMakeLists.txt
@@ -39,6 +39,12 @@ if( TARGET COMPTON::compton )
   # generated include directive files (config.h)
   target_include_directories( Lib_compton
     PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
+  # Copy necessary dll files to the build directory
+  if(WIN32)
+    add_custom_command( TARGET Lib_compton POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+              $<TARGET_FILE:COMPTON::compton> $<TARGET_FILE_DIR:Lib_compton> )
+  endif()
 
   # -------------------------------------------------------------------------- #
   # Installation instructions


### PR DESCRIPTION
### Background

+ For cdi_eospac and compton, teach the build system to provide required dlls.
+ After #798, the build system no longer copied the eospac or compton dll to the build tree.  When these files are missing at run time, the tests will fail.

### Purpose of Pull Request

+ This PR fixes issue #802

### Description of changes

+ TPLs provided by the vcpkg package manager know how to install themselves into the build tree.  This is what allowed the simplifications found in #798 to work.  However, eospac and compton are not currently provided by vcpkg, so they must be copied via `POST_BUILD` rules.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
