### PR TITLE
Installed shell scripts need +X permissions.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -58,7 +58,6 @@ write_basic_package_version_file(
 set( file_list
   ${CMake_src}
   ${CMake_in}
-  ${config_helper_sh}
   ${Python_src}
   ${CMAKE_CURRENT_BINARY_DIR}/draco-config.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/draco-config-version.cmake
@@ -66,6 +65,7 @@ set( file_list
 
 install( FILES ${file_list}  DESTINATION cmake )
 install( FILES ${CMake_AFSD} DESTINATION cmake/CMakeAddFortranSubdirectory )
+install( PROGRAMS ${config_helper_sh} DESTINATION cmake )
 
 ##---------------------------------------------------------------------------##
 ## End of config/CMakeLists.txt


### PR DESCRIPTION
### Background

* I'm still working out all of the kinks related to switching from BullseyeCoverage to gcov/lcov coverage reporting. I am hopeful this fixes the the last remaining issue.  The helper script `capture_lcov.sh` did not have execute permission when installed.

### Purpose of Pull Request

* [Related to Redmine Issue #1930](https://rtt.lanl.gov/redmine/issues/1930)

### Description of changes

* When installing shell scripts use `install( PROGRAMS ... )` instead of `install(FILES ... )`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
