### PR TITLE
Fix quo test failure by treating std::thread as upper resource bound

### DIFF
--- a/src/c4/test/tstQuoWrapper.cc
+++ b/src/c4/test/tstQuoWrapper.cc
@@ -53,12 +53,14 @@ void quo_hw_report(rtt_dsxx::UnitTest &ut) {
   // Generic checks.
   FAIL_IF_NOT(rtt_c4::QuoWrapper::num_nodes() > 0);
   FAIL_IF_NOT(rtt_c4::QuoWrapper::num_cores() > 0);
-  /*! \todo This check fails on ATS-2 (rzansel, sierra); need to investigate
-   *        See Redmine #1879.
-   *
-   * FAIL_IF_NOT(rtt_c4::QuoWrapper::num_hw_threads() ==
-   *             thread::hardware_concurrency());
-   */
+
+  // Qup will give the available system resources in the num_hw_threads call
+  // and std::thread::hardware_concurency  will give the total system resources
+  // (not respecting what has been reserved for the OS). Use std::thread as an
+  // upper bound check
+  FAIL_IF_NOT(rtt_c4::QuoWrapper::num_hw_threads() <=
+              thread::hardware_concurrency());
+
   FAIL_IF_NOT(rtt_c4::QuoWrapper::num_sockets_per_node() > 0);
   FAIL_IF_NOT(rtt_c4::QuoWrapper::num_numanodes_per_node() > 0);
   FAIL_IF_NOT(rtt_c4::QuoWrapper::num_mpi_ranks_per_node() > 0);


### PR DESCRIPTION
### Background

* A Quo test was failing on RZ Ansel that checked to see if number of available hardware threads that Quo sees matched the value of `std::thread::hardware_concurrency` (https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency). This difference is because Quo uses an hwloc command that gets the number of cores that are available for use (as set by the system admins) where as std::thread seems to just see the total number of cores on the machine (I don't know exactly how it gets this but its number matches the value in /proc/cpuinfo). We would like to only use the available cores and thus go with the answer Quo gives. I've modified the test to treat the `std::thread::hardware_concurrency` value as an upper bound.

### Purpose of Pull Request

* [Fixes Redmine Issue #1879](https://rtt.lanl.gov/redmine/issues/1879)

### Description of changes

* Uncomment test line checking hardware thread counts.
* Add description of quo and std::thread behavior for detecting hardware thread numbers

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation