### PR TITLE
Update docker image with cmake-3.17.0 and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2019aug /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2020april /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 #   https://rtt.lanl.gov/redmine/projects/draco/wiki/
 #   https://rtt.lanl.gov/redmine/projects/draco/wiki/Common_Configure_Options
 
-cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
 set(ddesc "An object-oriented component library supporting radiation")
 string(APPEND ddesc " transport applications.")
 project( Draco DESCRIPTION ${ddesc} VERSION 7.6 LANGUAGES CXX C)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,13 +6,19 @@ FROM ubuntu:latest
 # This image:
 # 1. cd /D f:\work\docker (copy Dockerfile and packages.yaml to this location).
 # 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
-# 3. docker build --rm --pull --tag draco-ci-2019june:latest . 
-#    OR: docker run -it kinetictheory/draco-ci-2019june /bin/bash -l
+# 3. docker build --rm --pull --tag draco-ci-2020april:latest . 
+#    OR: docker run -it -v /c/work:/work kinetictheory/draco-ci-2019aug /bin/bash -l
 #        apt-get install -y --no-install-recommends [ghostview]
+#        rm -rf /vendors/spack/var/spack/repos/builtin/cmake
+#        cp -r /work/kinetictheory/spack/var/spack/repos/builtin/cmake /vendors/spack/var/spack/repos/builtin/.
+#        spack install cmake@3.17.0
 #        exit
+#        docker ps -a
+#        docker commit -m "added cmake-3.17.0." kind_grothen kinetictheory/draco-ci-2020april:latest 
+#        docker push kinetictheory/draco-ci-2020april:latest
 # 4. docker image ls -a ==> find container name (or docker ps)
-# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <hash> kinetictheory/draco-ci-2019june:latest # queues for upload
-# 6. docker push kinetictheory/draco-ci-2019june:latest
+# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <hash> kinetictheory/draco-ci-2020april:latest # queues for upload
+# 6. docker push kinetictheory/draco-ci-2020april:latest
 # 7. docker system prune -a (remove old dangling data)
 
 MAINTAINER KineticTheory "https://github.com/KineticTheory"
@@ -27,7 +33,7 @@ MAINTAINER KineticTheory "https://github.com/KineticTheory"
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV SPACK_ROOT=/vendors/spack
-ENV DRACO_TPL="cmake@3.14.4 gsl@2.5 numdiff@5.9.0 random123@1.09 openmpi@3.1.4 netlib-lapack@3.8.0 metis@5.1.0 parmetis@4.0.3 superlu-dist trilinos mscgen"
+ENV DRACO_TPL="cmake@3.17.0 gsl numdiff random123@1.09 openmpi netlib-lapack metis parmetis mscgen libquo eospac@6.4.0 lcov"
 ENV FORCE_UNSAFE_CONFIGURE=1
 ENV DISTRO=bionic
 ENV CLANG_FORMAT_VER=6.0
@@ -66,7 +72,7 @@ RUN if ! test -f /etc/profile.d/modules.sh; then \
 #    apt-get install -y clang-format-${CLANG_FORMAT_VER}; \
 #    export PATH=$PATH:/usr/bin
 RUN  apt-get install -y --no-install-recommends clang-format-${CLANG_FORMAT_VER}; \
-     ln -s /usr/bin/clang-format-6.0 /usr/bin/clang-format; \
+     ln -s /usr/bin/clang-format-${CLANG_FORMAT_VER} /usr/bin/clang-format; \
      export PATH=$PATH:/usr/bin
 
 ## code cov plugin...
@@ -86,11 +92,11 @@ RUN if ! test -d $SPACK_ROOT/opt/spack ; then \
 COPY packages.yaml $SPACK_ROOT/etc/spack/linux
 
 # metis/parmetis downloads are broken right now, use a mirror.
-COPY mirrors.yaml $SPACK_ROOT/etc/spack
-RUN mkdir -p $SPACK_ROOT/spack.mirror/metis
-RUN mkdir -p $SPACK_ROOT/spack.mirror/parmetis
-COPY metis-5.1.0.tar.gz $SPACK_ROOT/spack.mirror/metis
-COPY parmetis-4.0.3.tar.gz $SPACK_ROOT/spack.mirror/parmetis
+#COPY mirrors.yaml $SPACK_ROOT/etc/spack
+#RUN mkdir -p $SPACK_ROOT/spack.mirror/metis
+#RUN mkdir -p $SPACK_ROOT/spack.mirror/parmetis
+#COPY metis-5.1.0.tar.gz $SPACK_ROOT/spack.mirror/metis
+#COPY parmetis-4.0.3.tar.gz $SPACK_ROOT/spack.mirror/parmetis
 
 RUN if ! test -f /etc/profile.d/spack.sh; then \
       echo "source $SPACK_ROOT/share/spack/setup-env.sh" > /etc/profile.d/spack.sh; \

--- a/tools/spack/packages.yaml
+++ b/tools/spack/packages.yaml
@@ -1,0 +1,63 @@
+packages:
+  autoconf:
+    version: [2.69]
+    paths:
+      autoconf@2.69: /usr
+    buildable: False
+  automake:
+    version: [1.15.1]
+    paths:
+      automake@1.15.1: /usr
+    buildable: False
+  bzip2:
+    version: [1.0.6]
+    paths:
+      bzip2@1.0.6: /
+    buildable: False
+  doxygen:
+    variants: [+graphviz]
+  eospac:
+    version: [6.4.0]
+  graphviz:
+    variants: [+pangocairo]
+  hypre:
+    variants: [+mpi~internal-superlu]
+  m4:
+    version: [1.4.18]
+    paths:
+      m4@1.4.18: /usr
+    buildable: False
+  matio:
+    variants: [+hdf5]
+  perl:
+    version: [5.26.1]
+    paths:
+      perl@5.26.1: /usr
+    buildable: False
+  petsc:
+    variants: [+boost+hdf5]
+  qt:
+    variants: [+phonon+dbus]
+  superlu-dist:
+    version: [5.4.0]
+  tar:
+    version: [1.29]
+    paths:
+      tar@1.29: /
+    buildable: False
+  trilinos:
+    variants: [+nox+superlu-dist~alloptpkgs~amesos2~boost~exodus~glm~gtest~hdf5~hypre~ifpack2~kokkos~matio~muelu~mumps~netcdf~suite-sparse~tpetra~zoltan2]
+  xz:
+    version: [5.2.2]
+    paths:
+      xz@5.2.2: /usr
+    buildable: False
+  all:
+    variants: [+mpi build_type=Release]
+    providers:
+      blas: [netlib-lapack]
+      lapack: [netlib-lapack]
+    permissions:
+      read: world
+      write: user
+      

--- a/tools/travis-run-tests.sh
+++ b/tools/travis-run-tests.sh
@@ -59,9 +59,9 @@ else
   done
 
   # Provide a newer lcov that is compatible with gcc-8.
-  run "cp -r ${SOURCE_DIR}/tools/spack/lcov ${SPACK_ROOT}/var/spack/repos/builtin/packages/."
-  run "spack install lcov@1.14"
-  run "spack load lcov"
+  #run "cp -r ${SOURCE_DIR}/tools/spack/lcov ${SPACK_ROOT}/var/spack/repos/builtin/packages/."
+  #run "spack install lcov@1.14"
+  #run "spack load lcov"
 
   if [[ $GCCVER ]]; then
     export CXX=`which g++-${GCCVER}`


### PR DESCRIPTION
### Background

* We are adopting cmake-3.17.0 as the minimum required version.  Update the docker image with this new install.  Also provide libquo, lcov, and eospac.

### Description of changes

* Use updated docker image from dockerhub, `draco-ci-2020april`.
* Set `cmake_minimum_required(VERSION 3.17)`
* Travis script expects to find the following new items in the CI environment:
  * cmake-3.17.0
  * lcov
  * eospac
  * libquo
* The following packages are no longer provided 
  * superlu-dist
  * trilinos

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
