### PR TITLE
Update darwin bashrc to load cmake 3.17.0.

### DIFF
--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -38,7 +38,7 @@ if test -n "$MODULESHOME"; then
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
         noflavor="git gcc/8.2.0"
-        compflavor="cmake/3.15.3 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_8.2.0"
+        compflavor="cmake/3.17.0 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_8.2.0"
         mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lflavor trilinos/12.14.1-$mflavor-$lflavor"
         ec_mf="csk/0.5.0-$cflavor ndi/2.1.3-$cflavor"
         # work around for known openmpi issues: https://rtt.lanl.gov/redmine/issues/1229
@@ -50,13 +50,13 @@ if test -n "$MODULESHOME"; then
         cflavor="gcc-7.3.0"
         mflavor="$cflavor-openmpi-3.1.3"
         lapackflavor="lapack-3.8.0"
-        noflavor="emacs git ack gcc/7.3.0"
+        noflavor="emacs git ack gcc/7.3.0 python/3.5.1"
         if [[ ${SLURM_JOB_PARTITION} =~ "volta" || ${SLURM_JOB_PARTITION} =~ "gpu" ]]; then
           # If we have GPUs on this node, then load the cuda toolkit module by default
           noflavor+=" cuda/10.1"
           cudaflavor="-cuda-10.1"
         fi
-        compflavor="cmake/3.16.4 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
+        compflavor="cmake/3.17.0 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
         mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
@@ -72,7 +72,7 @@ if test -n "$MODULESHOME"; then
         mflavor="$cflavor-openmpi-3.1.3"
         lapackflavor="lapack-3.8.0"
         noflavor="git random123 cmake gcc/7.3.0"
-        compflavor="cmake/3.16.4 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
+        compflavor="cmake/3.17.0 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
         mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
@@ -92,8 +92,8 @@ if test -n "$MODULESHOME"; then
         cflavor="gcc-7.3.0"
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
-        noflavor="git gcc/7.3.0 cuda/10.1"
-        compflavor="eospac/6.4.0-$cflavor cmake/3.16.4-$cflavor random123 numdiff gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
+        noflavor="git gcc/7.3.0 cuda/10.1 cmake/3.17.0 random123 numdiff"
+        compflavor="eospac/6.4.0-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
         mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
         ec_mf="csk/0.5.0-$cflavor ndi"


### PR DESCRIPTION
### Background

* Manually sourcing .bashrc on Darwin still loads earlier cmake version than 3.17.0.
* It looks like all partitions that .bashrc_darwin_fe checks for have cmake 3.17.0

### Purpose of Pull Request

* Update .bashrc_darwin_fe to load cmake 3.17 module, consistent with min version required.

### Description of changes

* Update .bashrc_darwin_fe to load cmake 3.17.0 module.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
