### PR TITLE
Tweak XL compiler flags.

### DIFF
--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -26,17 +26,16 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # -F/projects/opt/ppc64le/ibm/xlc-16.1.1.2/xlC/16.1.1/etc/xlc.cfg.rhel.7.5.gcc.7.3.0.cuda.9.2
   # -qfloat=nomaf -qxlcompatmacros
   set( CMAKE_C_FLAGS                "-g --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" ) # -qarch=auto
-  # Sequoia
-  if( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0 )
-    string( APPEND CMAKE_C_FLAGS " -qinfo=all -qflags=i:w -qsuppress=1540-0072")
-    string( APPEND CMAKE_C_FLAGS " -qsuppress=1506-1197" )
-  endif()
   # 2019-04-03 IBM support asks that we not use '-qcheck' due to compiler issues.
   set( CMAKE_C_FLAGS_DEBUG          "-O0 -qsmp=omp:noopt -qfullpath -DDEBUG") # -qcheck -qoffload
   set( CMAKE_C_FLAGS_RELWITHDEBINFO
     "-O3 -qhot=novector -qsmp=omp -qstrict=nans:operationprecision" ) # -qsimd=auto
   set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
+
+  if( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
+    string( APPEND CMAKE_C_FLAGS " -qarch=pwr9 -qtune=pwr9" )
+  endif()
 
    # Email from Roy Musselman <roymuss@us.ibm.com, 2019-03-21:
    # For C++14, add -qxflag=disable__cplusplusOverride
@@ -45,10 +44,6 @@ if( NOT CXX_FLAGS_INITIALIZED )
    set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
    set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
    set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
-
-  if( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
-    string( APPEND CMAKE_C_FLAGS " -qarch=pwr9 -qtune=pwr9" )
-  endif()
 
 endif()
 

--- a/src/c4/test/tstTime.cc
+++ b/src/c4/test/tstTime.cc
@@ -86,7 +86,7 @@ void wall_clock_test(rtt_dsxx::UnitTest &ut) {
   // error is less than 10% for this very short time interval.
   double const prec(20.0 * t.posix_err());
 #else
-  double const prec(2.0 * t.posix_err());
+  double const prec(4.0 * t.posix_err());
 #endif
   double begin(rtt_c4::wall_clock_time());
 


### PR DESCRIPTION
### Background

* While working with McKay yesterday on XL build issues, I revisited our XL compiler flags. A couple of tweaks are worth making. 
* Also, try to make tstTime a little more robust.

### Description of changes

+ No need to support very old XL.  Delete these from the settings.
+ Move the location of setting power9 specific options so that C++ flags also get these options.
+ Loosen tolerance for `tstTime`.  This test has never been stable, but I don't want to toss it because it is good to know that the code doesn't crash, even if the results are a little uncertain (its just a coverage test).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
