### PR TITLE
Provide a new variable for MPIEXEC_PREFLAGS for PERFBENCH.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -342,6 +342,8 @@ macro( setupCrayMPI )
   string(APPEND preflags " --gres=craynetwork:0") # --exclusive
   set( MPIEXEC_PREFLAGS ${preflags} CACHE STRING
     "extra mpirun flags (list)." FORCE)
+  set( MPIEXEC_PREFLAGS_PERFBENCH ${preflags} CACHE STRING
+    "extra mpirun flags (list)." FORCE)
 
   set( MPIEXEC_OMP_PREFLAGS "${MPIEXEC_PREFLAGS} -c ${MPI_CORES_PER_CPU}"
     CACHE STRING "extra mpirun flags (list)." FORCE)

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -260,14 +260,12 @@ macro( setupOpenMPI )
   if( "$ENV{GITLAB_CI}" STREQUAL "true" OR "$ENV{TRAVIS}" STREQUAL "true")
     set(runasroot "--allow-run-as-root --oversubscribe")
   endif()
-
-  # This flag also shows up in jayenne/pkg_tools/run_milagro_test.py and
-  # regress_funcs.py.
-
-  # (2017-01-13) Bugs in openmpi-1.10.x are mostly fixed. Remove flags used
-  # to work around bugs: '-mca btl self,vader -mca timer_require_monotonic 0'
+  # For PERFBENCH that use Quo, we need '--map-by socket:SPAN' instead of
+  # '-bind-to none'.  The 'bind-to none' is required to pack a node.
   set( MPIEXEC_PREFLAGS "-bind-to none ${runasroot}" CACHE STRING
     "extra mpirun flags (list)." FORCE)
+  set( MPIEXEC_PREFLAGS_PERFBENCH "--map-by socket:SPAN ${runasroot}" CACHE
+    STRING "extra mpirun flags (list)." FORCE)
 
   # Find cores/cpu, cpu/node, hyper-threading
   query_topology()


### PR DESCRIPTION
### Background

* _Perfbench_ regressions run one test at a time and when working with _libquo_, we want the work to be spread out across the available sockets.

### Purpose of Pull Request

* [Related to Redmine Issue #1881](https://rtt.lanl.gov/redmine/issues/1881)

### Description of changes

* Provide a new variable `MPIEXEC_PREFLAGS_PERFBENCH` that can be used when registering tests under the `ENABLE_PERFBENCH=ON` regression mode.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
