### PR TITLE
Change CMake logic for lib cdi_ndi to ensure upstream code can build when NDI is not found

### DIFF
--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -51,9 +51,13 @@ add_component_library(
    LIBRARY_NAME cdi_ndi
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
-target_include_directories( Lib_cdi_ndi PUBLIC ${NDI_INCLUDE_DIR}
+
+target_include_directories( Lib_cdi_ndi
    PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
+if(TARGET NDI::ndi)
+  target_include_directories( Lib_cdi_ndi PUBLIC ${NDI_INCLUDE_DIR} )
+endif()
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
@@ -62,7 +66,7 @@ install( TARGETS Lib_cdi_ndi  EXPORT draco-targets DESTINATION
   ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ndi )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_eospac> DESTINATION ${DBSCFGDIR}lib
+  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ndi> DESTINATION ${DBSCFGDIR}lib
     OPTIONAL)
 endif()
 

--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -7,19 +7,6 @@
 cmake_minimum_required(VERSION 3.9.0)
 project( cdi_ndi CXX )
 
-# No ndi in the Docker image used by Travis CI.
-if( NDI_FOUND AND NOT DEFINED ENV{TRAVIS} )
-
-if( NOT DEFINED NDI_ROOT_DIR AND DEFINED $ENV{NDI_ROOT_DIR})
-  set(NDI_ROOT_DIR $ENV{NDI_ROOT_DIR})
-endif()
-
-if( NOT DEFINED NDI_ROOT_DIR )
-  # if not set in the environment (by modulefile?), set NDI_ROOT_DIR to the
-  # prefix_path for NDI
-  get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY)
-  get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY CACHE)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Generate config.h (only occurs when cmake is run)
@@ -34,13 +21,33 @@ file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( APPEND headers ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
 
+set(deps Lib_cdi Lib_rng Lib_units)
+
+# If NDI is found, set the associated variables. Otherwise, the cdi_ndi lib
+# will be built with stubbed-out routines.
+if(TARGET NDI::ndi)
+  list(APPEND deps NDI::ndi)
+
+  if( NOT DEFINED NDI_ROOT_DIR AND DEFINED $ENV{NDI_ROOT_DIR})
+    set(NDI_ROOT_DIR $ENV{NDI_ROOT_DIR})
+  endif()
+
+  if( NOT DEFINED NDI_ROOT_DIR )
+    # if not set in the environment (by modulefile?), set NDI_ROOT_DIR to the
+    # prefix_path for NDI
+    get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY)
+    get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY CACHE)
+  endif()
+
+endif()
+
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
 
 add_component_library(
    TARGET       Lib_cdi_ndi
-   TARGET_DEPS  "Lib_cdi;Lib_rng;Lib_units;NDI::ndi"
+   TARGET_DEPS  "${deps}"
    LIBRARY_NAME cdi_ndi
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
@@ -53,8 +60,6 @@ target_include_directories( Lib_cdi_ndi PUBLIC ${NDI_INCLUDE_DIR}
 
 install( TARGETS Lib_cdi_ndi  EXPORT draco-targets DESTINATION
   ${DBSCFGDIR}lib )
-#install( TARGETS Exe_QueryNDI EXPORT draco-targets DESTINATION
-#  ${DBSCFGDIR}bin )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ndi )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   install(FILES $<TARGET_PDB_FILE:Lib_cdi_eospac> DESTINATION ${DBSCFGDIR}lib
@@ -72,10 +77,7 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
-
-endif() # NDI_FOUND
 
 # ---------------------------------------------------------------------------- #
 # End cdi_ndi/CMakeLists.txt

--- a/src/cdi_ndi/NDI_AtomicMass.cc
+++ b/src/cdi_ndi/NDI_AtomicMass.cc
@@ -7,10 +7,8 @@
  * \note   Copyright (C) 2020 Triad National Security, LLC.
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
-
 #include "NDI_AtomicMass.hh"
-#include "ndi.h"
-#include "cdi_ndi/config.h"
+#include "cdi_ndi/config.h" // definition of NDI_FOUND
 #include "ds++/Assert.hh"
 #include "ds++/path.hh"
 #include <array>
@@ -20,16 +18,6 @@ namespace rtt_cdi_ndi {
 //----------------------------------------------------------------------------//
 // CONSTRUCTORS
 //----------------------------------------------------------------------------//
-/*!
- * \brief Constructor for NDI atomic mass weight reader, using default path to
- *        NDI gendir file.
- */
-NDI_AtomicMass::NDI_AtomicMass()
-    : gendir_path(rtt_dsxx::getFilenameComponent(
-          std::string(NDI_ROOT_DIR) + "/share/gendir.all",
-          rtt_dsxx::FilenameComponent::FC_NATIVE)) {
-  Require(rtt_dsxx::fileExists(gendir_path));
-}
 
 /*!
  * \brief Constructor for NDI atomic mass weight reader, using custom path to
@@ -40,7 +28,17 @@ NDI_AtomicMass::NDI_AtomicMass(const std::string &gendir_path_in)
     : gendir_path(gendir_path_in) {
   Require(rtt_dsxx::fileExists(gendir_path));
 }
-
+#ifdef NDI_FOUND
+/*!
+ * \brief Constructor for NDI atomic mass weight reader, using default path to
+ *        NDI gendir file.
+ */
+NDI_AtomicMass::NDI_AtomicMass()
+    : gendir_path(rtt_dsxx::getFilenameComponent(
+          std::string(NDI_ROOT_DIR) + "/share/gendir.all",
+          rtt_dsxx::FilenameComponent::FC_NATIVE)) {
+  Require(rtt_dsxx::fileExists(gendir_path));
+}
 //----------------------------------------------------------------------------//
 /*!
  * \brief Get atomic mass weight of an isotope with given ZAID. Use method due
@@ -86,9 +84,23 @@ double NDI_AtomicMass::get_amw(const int zaid) const {
 
   return arr[0] * pc.amu();
 }
+#else
+/*!
+ * \brief When NDI is not available, this constructor throws an assertion.
+ */
+NDI_AtomicMass::NDI_AtomicMass() {
+  Insist(0, "NDI lib must be available to use default gendir path.");
+}
 
+//----------------------------------------------------------------------------//
+/*!
+ * \brief When NDI is not available, this method throws an assertion.
+ */
+double NDI_AtomicMass::get_amw(const int /*zaid*/) const {
+  Insist(0, "NDI lib must be available to retrieve amw.");
+}
+#endif // NDI_FOUND
 } // namespace rtt_cdi_ndi
-
 //----------------------------------------------------------------------------//
 // End cdi_ndi/NDI_AtomicMass.cc
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -101,9 +101,10 @@ NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
 /*!
  * \brief Constructor for generic NDI reader- throws when NDI not available
  */
-NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
-                   const std::string &reaction_in,
-                   const std::vector<double> mg_e_bounds_in) {
+NDI_Base::NDI_Base(const std::string & /*dataset_in*/,
+                   const std::string & /*library_in*/,
+                   const std::string & /*reaction_in*/,
+                   const std::vector<double> /*mg_e_bounds_in*/) {
   Insist(0, "NDI default gendir path only available when NDI is found.");
 }
 #endif

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -16,45 +16,6 @@ namespace rtt_cdi_ndi {
 //----------------------------------------------------------------------------//
 // CONSTRUCTORS
 //----------------------------------------------------------------------------//
-/*!
- * \brief Constructor for generic NDI reader, to be inherited by readers for
- *        specific dataset.
- *
- * This base constructor only sets some data members based on constructor input.
- * For more details on NDI, see
- * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
- *
- * \param[in] dataset_in name of requested dataset (provided by inherited class)
- * \param[in] library_in name of requested NDI data library
- * \param[in] reaction_in name of requested reaction
- * \param[in] mg_e_bounds_in multigroup energy bin boundaries (keV)
- */
-NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
-                   const std::string &reaction_in,
-                   const std::vector<double> mg_e_bounds_in)
-    : gendir(rtt_dsxx::getFilenameComponent(
-          std::string(NDI_ROOT_DIR) + "share/gendir.all",
-          rtt_dsxx::FilenameComponent::FC_NATIVE)),
-      dataset(dataset_in), library(library_in), reaction(reaction_in),
-      mg_e_bounds(mg_e_bounds_in) {
-
-  Require(rtt_dsxx::fileExists(gendir));
-
-  Require(gendir.length() > 0);
-  Require(dataset.length() > 0);
-  Require(library.length() > 0);
-  Require(reaction.length() > 0);
-  Require(mg_e_bounds.size() > 0);
-
-  for (size_t i = 0; i < mg_e_bounds.size(); i++) {
-    mg_e_bounds[i] /= 1000.; // keV -> MeV
-  }
-
-  // Check that mg_e_bounds is monotonically decreasing (NDI requirement)
-  Require(rtt_dsxx::is_strict_monotonic_decreasing(mg_e_bounds.begin(),
-                                                   mg_e_bounds.end()));
-  Require(mg_e_bounds.back() > 0);
-}
 
 /*!
  * \brief Constructor for generic NDI reader, to be inherited by readers for
@@ -95,7 +56,57 @@ NDI_Base::NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
   }
   Insist(mg_e_bounds[mg_e_bounds.size() - 1] > 0, "Negative mg bounds!");
 }
+#ifdef NDI_FOUND
+/*!
+ * \brief Constructor for generic NDI reader, to be inherited by readers for
+ *        specific dataset.
+ *
+ * This base constructor only sets some data members based on constructor input.
+ * For more details on NDI, see
+ * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
+ *
+ * \param[in] dataset_in name of requested dataset (provided by inherited class)
+ * \param[in] library_in name of requested NDI data library
+ * \param[in] reaction_in name of requested reaction
+ * \param[in] mg_e_bounds_in multigroup energy bin boundaries (keV)
+ */
+NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
+                   const std::string &reaction_in,
+                   const std::vector<double> mg_e_bounds_in)
+    : gendir(rtt_dsxx::getFilenameComponent(
+          std::string(NDI_ROOT_DIR) + "share/gendir.all",
+          rtt_dsxx::FilenameComponent::FC_NATIVE)),
+      dataset(dataset_in), library(library_in), reaction(reaction_in),
+      mg_e_bounds(mg_e_bounds_in) {
 
+  Require(rtt_dsxx::fileExists(gendir));
+
+  Require(gendir.length() > 0);
+  Require(dataset.length() > 0);
+  Require(library.length() > 0);
+  Require(reaction.length() > 0);
+  Require(mg_e_bounds.size() > 0);
+
+  for (size_t i = 0; i < mg_e_bounds.size(); i++) {
+    mg_e_bounds[i] /= 1000.; // keV -> MeV
+  }
+
+  // Check that mg_e_bounds is monotonically decreasing (NDI requirement)
+  Require(rtt_dsxx::is_strict_monotonic_decreasing(mg_e_bounds.begin(),
+                                                   mg_e_bounds.end()));
+  Require(mg_e_bounds.back() > 0);
+}
+#else
+
+/*!
+ * \brief Constructor for generic NDI reader- throws when NDI not available
+ */
+NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
+                   const std::string &reaction_in,
+                   const std::vector<double> mg_e_bounds_in) {
+  Insist(0, "NDI default gendir path only available when NDI is found.");
+}
+#endif
 } // namespace rtt_cdi_ndi
 
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_Base.hh
+++ b/src/cdi_ndi/NDI_Base.hh
@@ -11,8 +11,8 @@
 #ifndef cdi_ndi_NDI_Base_hh
 #define cdi_ndi_NDI_Base_hh
 
-#include "ndi.h"
 #include "cdi_ndi/config.h"
+
 #include "ds++/Assert.hh"
 #include "ds++/path.hh"
 #include <algorithm>

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -335,8 +335,9 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
 void NDI_TNReaction::load_ndi() {
   Insist(0, "load_ndi() only available when NDI library is found");
 }
-std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
-                                            const double temperature) const {
+std::vector<double>
+NDI_TNReaction::get_PDF(const int /*product_zaid*/,
+                        const double /*temperature*/) const {
   Insist(0, "get_PDF() only available when NDI library is found");
 }
 #endif // NDI_FOUND

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -8,6 +8,8 @@
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
+#include "cdi_ndi/config.h" // definition of NDI_FOUND
+
 #include "NDI_TNReaction.hh"
 #include <cmath>
 
@@ -50,6 +52,8 @@ NDI_TNReaction::NDI_TNReaction(const std::string &library_in,
   load_ndi();
 }
 
+// Protect actual NDI calls with NDI_FOUND macro:
+#ifdef NDI_FOUND
 //----------------------------------------------------------------------------//
 /*!
  * \brief Load NDI dataset. Split off from constructor to allow for both
@@ -326,7 +330,16 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
 
   return pdf;
 }
+#else
 
+void NDI_TNReaction::load_ndi() {
+  Insist(0, "load_ndi() only available when NDI library is found");
+}
+std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
+                                            const double temperature) const {
+  Insist(0, "get_PDF() only available when NDI library is found");
+}
+#endif // NDI_FOUND
 } // namespace rtt_cdi_ndi
 
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_TNReaction.hh
+++ b/src/cdi_ndi/NDI_TNReaction.hh
@@ -12,7 +12,6 @@
 #define cdi_ndi_NDI_TNReaction_hh
 
 #include "NDI_Base.hh"
-#include "ndi.h"
 #include "ds++/Assert.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <algorithm>

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -16,6 +16,12 @@
 /* NDI_ROOT_DIR location, for accessing gendir.all */
 #cmakedefine NDI_ROOT_DIR "@NDI_ROOT_DIR@"
 
+#cmakedefine NDI_FOUND
+
+#ifdef NDI_FOUND
+ #include "ndi.h"
+#endif
+
 #endif // rtt_cdi_ndi_config_h
 
 /*---------------------------------------------------------------------------*/

--- a/src/cdi_ndi/test/CMakeLists.txt
+++ b/src/cdi_ndi/test/CMakeLists.txt
@@ -23,11 +23,14 @@ set( test_sources
 # Both tests read a local test data file, 'ndi_data'. To avoid resource issues,
 # tell ctest to avoid running these two test at the same time with the keyword
 # RESOURCE_LOCK.
+if(TARGET NDI::ndi)
+
 add_scalar_tests(
   SOURCES "${test_sources}"
   DEPS    "Lib_cdi_ndi"
   RESOURCE_LOCK "ndi_data" )
 
+endif()
 #------------------------------------------------------------------------------#
 # End cdi_ndi/test/CMakeLists.txt
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

* previously, the cdi_ndi library wasn't built *at all* when NDI was not found
* this is fine in theory, but it made things tricky in upstream code; because the NDI_FOUND cmake variable was not available, there was no obvious way to protect against includes of draco cdi_ndi header files that were not installed.

### Purpose of Pull Request

* Instead of omitting the cdi_ndi lib entirely when NDI is not found, stub out the routines that need NDI (have them throw assertions)
* This means that upstream code can be built without protecting cdi_ndi includes in macros -- the calls to cdi_ndi will just throw if it is not found
* This is needed to get a corresponding pull request in gitlab going (I will update the description of that PR shortly)

### Description of changes

* update CMakeLists logic for cdi_ndi - there was previously a confusing "if(NDI_FOUND) and not environment(travis)" statement wrapping the cmake logic. I think it was trying to protect against building the cdi_ndi lib in CI -- but you'd think that would be automatic because NDI_FOUND would be false... (?!)
* Move ndi.h include into config file, and remove from other cdi_ndi files
* Wrap actual calls to ndi routines / references to env. variables in NDI_FOUND macro
* @KineticTheory I am open to other ways to do this in CMake, and also more than willing to explain why I did things this way :)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
