### PR TITLE
Protect TNReaction constructors in NDI_FOUND to suppress unreachable …

### DIFF
--- a/src/cdi_ndi/NDI_Base.hh
+++ b/src/cdi_ndi/NDI_Base.hh
@@ -11,7 +11,7 @@
 #ifndef cdi_ndi_NDI_Base_hh
 #define cdi_ndi_NDI_Base_hh
 
-#include "cdi_ndi/config.h"
+#include "cdi_ndi/config.h" // Definition of NDI_FOUND
 
 #include "ds++/Assert.hh"
 #include "ds++/path.hh"

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -7,14 +7,13 @@
  * \note   Copyright (C) 2020 Triad National Security, LLC.
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
-
-#include "cdi_ndi/config.h" // definition of NDI_FOUND
-
 #include "NDI_TNReaction.hh"
 #include <cmath>
 
 namespace rtt_cdi_ndi {
 
+// Protect actual NDI calls with NDI_FOUND macro:
+#ifdef NDI_FOUND
 //----------------------------------------------------------------------------//
 // CONSTRUCTORS
 //----------------------------------------------------------------------------//
@@ -35,7 +34,7 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in,
 
   load_ndi();
 }
-
+//----------------------------------------------------------------------------//
 /*!
  * \brief Constructor for NDI reader specific to TN reaction data using default
  *        gendir file.
@@ -51,9 +50,6 @@ NDI_TNReaction::NDI_TNReaction(const std::string &library_in,
 
   load_ndi();
 }
-
-// Protect actual NDI calls with NDI_FOUND macro:
-#ifdef NDI_FOUND
 //----------------------------------------------------------------------------//
 /*!
  * \brief Load NDI dataset. Split off from constructor to allow for both
@@ -331,10 +327,40 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
   return pdf;
 }
 #else
-
-void NDI_TNReaction::load_ndi() {
-  Insist(0, "load_ndi() only available when NDI library is found");
+//----------------------------------------------------------------------------//
+// CONSTRUCTORS
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Constructor for NDI reader -- base class constructor will throw
+ *        because NDI is not available.
+ *
+ * \param[in] gendir_in path to gendir file
+ * \param[in] library_in name of requested NDI data library
+ * \param[in] reaction_in name of requested reaction
+ * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
+ */
+NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in,
+                               const std::string &library_in,
+                               const std::string &reaction_in,
+                               const std::vector<double> mg_e_bounds_in)
+    : NDI_Base(gendir_in, "tn", library_in, reaction_in,
+               mg_e_bounds_in) { /* ... */
 }
+
+/*!
+ * \brief Constructor for NDI reader -- base class constructor will throw
+ *        because NDI is not available.
+ *
+ * \param[in] library_in name of requested NDI data library
+ * \param[in] reaction_in name of requested reaction
+ * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
+ */
+NDI_TNReaction::NDI_TNReaction(const std::string &library_in,
+                               const std::string &reaction_in,
+                               const std::vector<double> mg_e_bounds_in)
+    : NDI_Base("tn", library_in, reaction_in, mg_e_bounds_in) { /* ... */
+}
+
 std::vector<double>
 NDI_TNReaction::get_PDF(const int /*product_zaid*/,
                         const double /*temperature*/) const {

--- a/src/cdi_ndi/NDI_TNReaction.hh
+++ b/src/cdi_ndi/NDI_TNReaction.hh
@@ -55,7 +55,10 @@ public:
                               const double temperature) const;
 
 private:
+// Only implemented if NDI is found
+#ifdef NDI_FOUND
   void load_ndi();
+#endif
 };
 
 } // namespace rtt_cdi_ndi


### PR DESCRIPTION
…code warning in MSVC

### Background

* PR 818 caused a build warning for MSVC in release mode; this attempts to fix it.

### Purpose of Pull Request

* See above -- fixing a build warning in MSVC that I introduced in my last PR

### Description of changes

* Move TNReaction constructors inside NDI_FOUND macro; if !NDI_FOUND, constructors are now stubs, and the base class (NDI_Base) will throw.
* Remove cdi_ndi/config include in derived TNReaction class; it is available through the base class NDI_Base
* only declare load_ndi function when NDI_FOUND

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
