### PR TITLE
Fix a bug in cdi_ndi related to expected data path.

### DIFF
--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -4,14 +4,8 @@
 # note   Copyright (C) 2020 Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.17.0)
 project( cdi_ndi CXX )
-
-
-# ---------------------------------------------------------------------------- #
-# Generate config.h (only occurs when cmake is run)
-# ---------------------------------------------------------------------------- #
-configure_file( config.h.in ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
 
 # ---------------------------------------------------------------------------- #
 # Source files
@@ -20,11 +14,10 @@ configure_file( config.h.in ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( APPEND headers ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
-
 set(deps Lib_cdi Lib_rng Lib_units)
 
-# If NDI is found, set the associated variables. Otherwise, the cdi_ndi lib
-# will be built with stubbed-out routines.
+# If NDI is found, set the associated variables. Otherwise, the cdi_ndi lib will
+# be built with stubbed-out routines.
 if(TARGET NDI::ndi)
   list(APPEND deps NDI::ndi)
 
@@ -39,12 +32,29 @@ if(TARGET NDI::ndi)
     get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY CACHE)
   endif()
 
+  # Location of gendir and gendir.all files.
+  if( NOT DEFINED NDI_DATA_DIR OR NOT EXISTS "${NDI_DATA_DIR}" )
+    if( DEFINED ENV{NDI_GENDIR_PATH} AND EXISTS "$ENV{NDI_GENDIR_PATH}" )
+      get_filename_component( NDI_DATA_DIR "$ENV{NDI_GENDIR_PATH}" DIRECTORY )
+    elseif( EXISTS "${NDI_ROOT_DIR}/share/gendir" )
+      set( NDI_DATA_DIR "${NDI_ROOT_DIR}/share" )
+    else()
+      message( FATAL_ERROR "Could not find NDI data file gendir.")
+    endif()
+  endif()
+  set( NDI_DATA_DIR "${NDI_DATA_DIR}" CACHE PATH
+    "Location of NDI gendir file." )
+
 endif()
+
+# ---------------------------------------------------------------------------- #
+# Generate config.h (only occurs when cmake is run)
+# ---------------------------------------------------------------------------- #
+configure_file( config.h.in ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_cdi_ndi
    TARGET_DEPS  "${deps}"
@@ -58,6 +68,7 @@ target_include_directories( Lib_cdi_ndi
 if(TARGET NDI::ndi)
   target_include_directories( Lib_cdi_ndi PUBLIC ${NDI_INCLUDE_DIR} )
 endif()
+
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_ndi/NDI_AtomicMass.cc
+++ b/src/cdi_ndi/NDI_AtomicMass.cc
@@ -7,38 +7,47 @@
  * \note   Copyright (C) 2020 Triad National Security, LLC.
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
+
 #include "NDI_AtomicMass.hh"
 #include "cdi_ndi/config.h" // definition of NDI_FOUND
-#include "ds++/Assert.hh"
-#include "ds++/path.hh"
+#include "ds++/SystemCall.hh"
 #include <array>
 
 namespace rtt_cdi_ndi {
 
-//----------------------------------------------------------------------------//
-// CONSTRUCTORS
-//----------------------------------------------------------------------------//
+//============================================================================//
+// Stubbed implementation when NDI is unavailable.
+//============================================================================//
 
-/*!
- * \brief Constructor for NDI atomic mass weight reader, using custom path to
- *        NDI gendir file.
- * \param[in] gendir_path_in path to gendir file
- */
-NDI_AtomicMass::NDI_AtomicMass(const std::string &gendir_path_in)
-    : gendir_path(gendir_path_in) {
-  Require(rtt_dsxx::fileExists(gendir_path));
+#ifndef NDI_FOUND
+
+//! When NDI is not available, this constructor throws an assertion.
+NDI_AtomicMass::NDI_AtomicMass() {
+  Insist(0, "NDI lib must be available to use default gendir path.");
 }
-#ifdef NDI_FOUND
+
+//! When NDI is not available, this method throws an assertion.
+double NDI_AtomicMass::get_amw(const int /*zaid*/) const {
+  Insist(0, "NDI lib must be available to retrieve amw.");
+}
+
+#else
+
+//============================================================================//
+// Normal implementation
+//============================================================================//
+
 /*!
  * \brief Constructor for NDI atomic mass weight reader, using default path to
  *        NDI gendir file.
  */
 NDI_AtomicMass::NDI_AtomicMass()
     : gendir_path(rtt_dsxx::getFilenameComponent(
-          std::string(NDI_ROOT_DIR) + "/share/gendir.all",
+          std::string(NDI_DATA_DIR) + rtt_dsxx::dirSep + "gendir",
           rtt_dsxx::FilenameComponent::FC_NATIVE)) {
   Require(rtt_dsxx::fileExists(gendir_path));
 }
+
 //----------------------------------------------------------------------------//
 /*!
  * \brief Get atomic mass weight of an isotope with given ZAID. Use method due
@@ -84,23 +93,11 @@ double NDI_AtomicMass::get_amw(const int zaid) const {
 
   return arr[0] * pc.amu();
 }
-#else
-/*!
- * \brief When NDI is not available, this constructor throws an assertion.
- */
-NDI_AtomicMass::NDI_AtomicMass() {
-  Insist(0, "NDI lib must be available to use default gendir path.");
-}
 
-//----------------------------------------------------------------------------//
-/*!
- * \brief When NDI is not available, this method throws an assertion.
- */
-double NDI_AtomicMass::get_amw(const int /*zaid*/) const {
-  Insist(0, "NDI lib must be available to retrieve amw.");
-}
-#endif // NDI_FOUND
+#endif
+
 } // namespace rtt_cdi_ndi
+
 //----------------------------------------------------------------------------//
 // End cdi_ndi/NDI_AtomicMass.cc
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_AtomicMass.hh
+++ b/src/cdi_ndi/NDI_AtomicMass.hh
@@ -11,6 +11,8 @@
 #ifndef cdi_ndi_NDI_AtomicMass_hh
 #define cdi_ndi_NDI_AtomicMass_hh
 
+#include "ds++/Assert.hh"
+#include "ds++/path.hh"
 #include "units/PhysicalConstexprs.hh"
 #include <string>
 
@@ -34,8 +36,15 @@ public:
   //! Constructor (default gendir path)
   NDI_AtomicMass();
 
-  //! Constructor (overridden gendir path)
-  NDI_AtomicMass(const std::string &gendir_path_in);
+  /*!
+   * \brief Constructor for NDI atomic mass weight reader, using custom path to
+   *        NDI gendir file.
+   * \param[in] gendir_path_in path to gendir file
+   */
+  NDI_AtomicMass(const std::string &gendir_path_in)
+      : gendir_path(gendir_path_in) {
+    Require(rtt_dsxx::fileExists(gendir_path));
+  }
 
   //! Retrieve atomic mass weight for isotope with given ZAID
   double get_amw(const int zaid) const;

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -9,6 +9,7 @@
 //----------------------------------------------------------------------------//
 
 #include "NDI_Base.hh"
+#include "ds++/SystemCall.hh"
 #include "ds++/dbc.hh"
 
 namespace rtt_cdi_ndi {
@@ -56,7 +57,27 @@ NDI_Base::NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
   }
   Insist(mg_e_bounds[mg_e_bounds.size() - 1] > 0, "Negative mg bounds!");
 }
-#ifdef NDI_FOUND
+
+//============================================================================//
+// Stubbed implementation when NDI is unavailable
+//============================================================================//
+
+#ifndef NDI_FOUND
+
+//! Constructor for generic NDI reader- throws when NDI not available
+NDI_Base::NDI_Base(const std::string & /*dataset_in*/,
+                   const std::string & /*library_in*/,
+                   const std::string & /*reaction_in*/,
+                   const std::vector<double> /*mg_e_bounds_in*/) {
+  Insist(0, "NDI default gendir path only available when NDI is found.");
+}
+
+#else
+
+//============================================================================//
+// Normal implementation
+//============================================================================//
+
 /*!
  * \brief Constructor for generic NDI reader, to be inherited by readers for
  *        specific dataset.
@@ -74,7 +95,7 @@ NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
                    const std::string &reaction_in,
                    const std::vector<double> mg_e_bounds_in)
     : gendir(rtt_dsxx::getFilenameComponent(
-          std::string(NDI_ROOT_DIR) + "share/gendir.all",
+          std::string(NDI_DATA_DIR) + rtt_dsxx::dirSep + "gendir",
           rtt_dsxx::FilenameComponent::FC_NATIVE)),
       dataset(dataset_in), library(library_in), reaction(reaction_in),
       mg_e_bounds(mg_e_bounds_in) {
@@ -96,18 +117,9 @@ NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
                                                    mg_e_bounds.end()));
   Require(mg_e_bounds.back() > 0);
 }
-#else
 
-/*!
- * \brief Constructor for generic NDI reader- throws when NDI not available
- */
-NDI_Base::NDI_Base(const std::string & /*dataset_in*/,
-                   const std::string & /*library_in*/,
-                   const std::string & /*reaction_in*/,
-                   const std::vector<double> /*mg_e_bounds_in*/) {
-  Insist(0, "NDI default gendir path only available when NDI is found.");
-}
 #endif
+
 } // namespace rtt_cdi_ndi
 
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_Base.hh
+++ b/src/cdi_ndi/NDI_Base.hh
@@ -28,16 +28,17 @@ namespace rtt_cdi_ndi {
 /*!
  * \class NDI_Base
  *
- * \brief Base class for wrapping NDI calls to NDI data. Reads data, constructs
- *        internal storage amenable to radiation calculations, and provides
- *        accessors. Instantiated only through a data type-specific derived
- *        class. Energies and temperatures are in units of keV. Velocity-
- *        averaged cross sections are in units of cm^3 sh^-1. Probability
- *        density functions sum to unity. Unit conversions from NDI data are
- *        done when data is initially read in. For more details on NDI, see
- *        https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
- *        Currently only multigroup data is supported, continuous energy data
- *        is probably best added through a refactor.
+ * \brief Base class for wrapping NDI calls to NDI data.
+ *
+ * Reads data, constructs internal storage amenable to radiation calculations,
+ * and provides accessors. Instantiated only through a data type-specific
+ * derived class. Energies and temperatures are in units of keV. Velocity-
+ * averaged cross sections are in units of cm^3 sh^-1. Probability density
+ * functions sum to unity. Unit conversions from NDI data are done when data is
+ * initially read in. For more details on NDI, see
+ * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html Currently only
+ * multigroup data is supported, continuous energy data is probably best added
+ * through a refactor.
  */
 //============================================================================//
 

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -13,11 +13,14 @@
 /* Draco/Cmake build system variables */
 /*---------------------------------------------------------------------------*/
 
-/* NDI_ROOT_DIR location, for accessing gendir.all */
+/* Prefix path for NDI libraries and include files */
+#cmakedefine NDI_DATA_DIR "@NDI_DATA_DIR@"
+
+/* NDI_ROOT_DIR location, for accessing gendir */
 #cmakedefine NDI_ROOT_DIR "@NDI_ROOT_DIR@"
 
+/* Activate NDI calls found in cdi_ndi, otherwise, use code stubs. */
 #cmakedefine NDI_FOUND
-
 #ifdef NDI_FOUND
  #include "ndi.h"
 #endif

--- a/src/cdi_ndi/test/tstNDI_AtomicMass.cc
+++ b/src/cdi_ndi/test/tstNDI_AtomicMass.cc
@@ -13,6 +13,7 @@
 #include "cdi_ndi/config.h"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
+#include "ds++/SystemCall.hh"
 #include "ds++/dbc.hh"
 #include "ds++/path.hh"
 #include <fstream>
@@ -63,6 +64,7 @@ void amw_test(rtt_dsxx::UnitTest &ut) {
   }
 }
 
+//----------------------------------------------------------------------------//
 void amw_default_test(rtt_dsxx::UnitTest &ut) {
 
   NDI_AtomicMass ndi_amw;
@@ -79,20 +81,19 @@ void amw_default_test(rtt_dsxx::UnitTest &ut) {
   FAIL_IF_NOT(soft_equiv(electron_amw, 9.109382909999999302e-28, 1.e-8));
 
   if (ut.numFails == 0) {
-    PASSMSG("NDI_AtomicMass (default gendir.all path) test passes.");
+    PASSMSG("NDI_AtomicMass (default gendir path) test passes.");
   } else {
-    FAILMSG("NDI_AtomicMass (default_gendir.all path) test fails.");
+    FAILMSG("NDI_AtomicMass (default_gendir path) test fails.");
   }
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {
     amw_test(ut);
     std::string gendir_default = rtt_dsxx::getFilenameComponent(
-        std::string(NDI_ROOT_DIR) + "share/gendir.all",
+        std::string(NDI_DATA_DIR) + rtt_dsxx::dirSep + "gendir",
         rtt_dsxx::FilenameComponent::FC_NATIVE);
 
     if (rtt_dsxx::fileExists(gendir_default)) {

--- a/src/cdi_ndi/test/tstNDI_TNReaction.cc
+++ b/src/cdi_ndi/test/tstNDI_TNReaction.cc
@@ -12,6 +12,7 @@
 #include "cdi_ndi/NDI_TNReaction.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
+#include "ds++/SystemCall.hh"
 #include "ds++/dbc.hh"
 #include <fstream>
 #include <iostream>
@@ -129,6 +130,7 @@ void gendir_test(rtt_dsxx::UnitTest &ut) {
   }
 }
 
+//----------------------------------------------------------------------------//
 void gendir_default_test(rtt_dsxx::UnitTest &ut) {
   std::string library_in = "lanl04";
   std::string reaction_in = "d+t->n+a";
@@ -137,20 +139,19 @@ void gendir_default_test(rtt_dsxx::UnitTest &ut) {
   NDI_TNReaction tn(library_in, reaction_in, mg_e_bounds);
 
   if (ut.numFails == 0) {
-    PASSMSG("NDI_TNReaction (default gendir.all path) test passes.");
+    PASSMSG("NDI_TNReaction (default gendir path) test passes.");
   } else {
-    FAILMSG("NDI_TNReaction (default gendir.all path) test fails.");
+    FAILMSG("NDI_TNReaction (default gendir path) test fails.");
   }
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {
     gendir_test(ut);
     std::string gendir_default = rtt_dsxx::getFilenameComponent(
-        std::string(NDI_ROOT_DIR) + "share/gendir.all",
+        std::string(NDI_DATA_DIR) + rtt_dsxx::dirSep + "gendir",
         rtt_dsxx::FilenameComponent::FC_NATIVE);
 
     if (rtt_dsxx::fileExists(gendir_default)) {


### PR DESCRIPTION
### Background

* NDI's data and installation are not always collocated. `NDI_ROOT_DIR` points to the library installation location but not necessarily to the data location.
* `NDI_GENDIR_PATH` should point to the data location.

### Description of changes

* Change `cdi_ndi` by adding a new variable `NDI_DATA_DIR` that helps locate the `gendir*` files. Save this value in `cdi_ndi/config.h` and use it in the library when looking for NDI data.
* Begin using `gendir` instead of `gendir.all` as the default NDI data file for this package. This change is based on new information from the NDI team.  The specialized constructor allows any NDI data file to be used, including `gendir.all`.
* I reworked the formatting of the `.cc` files to make it easier to distinguish between the stubbed-out version and the regular version.
* To improve portability, use `rtt_dsxx:dirSep` instead of `/` as the directory delimiter.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
