### PR TITLE
Fix informational code concerning MPIEXEC_PREFLAGS.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,7 +166,7 @@ if( CAFS_Fortran_COMPILER )
 endif()
 if( "${DRACO_C4}" STREQUAL "MPI" )
   hanging_indent( 100 5
-  "mpirun command: ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} N ${MPIEXEC_POSTFLAGS}")
+  "mpirun command: ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} N ${MPIEXEC_PREFLAGS}")
 endif()
 message("Library Type: ${DRACO_LIBRARY_TYPE}
 ")

--- a/src/c4/config.h.in
+++ b/src/c4/config.h.in
@@ -25,7 +25,7 @@
 
 /* Is this OpenMPI */
 #cmakedefine MPIEXEC_EXECUTABLE   "@MPIEXEC_EXECUTABLE@"
-#cmakedefine MPIEXEC_POSTFLAGS    "@MPIEXEC_POSTFLAGS@"
+#cmakedefine MPIEXEC_PREFLAGS     "@MPIEXEC_PREFLAGS@"
 #cmakedefine MPIEXEC_NUMPROC_FLAG "@MPIEXEC_NUMPROC_FLAG@"
 
 /* ---------------------------------------- */

--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -48,8 +48,8 @@ DracoInfo::DracoInfo(void)
   mpi = true;
   mpirun_cmd = std::string(MPIEXEC_EXECUTABLE) + std::string(" ") +
                std::string(MPIEXEC_NUMPROC_FLAG) + std::string(" <N> ");
-#ifdef MPIEXEC_POSTFLAGS
-  mpirun_cmd += std::string(MPIEXEC_POSTFLAGS);
+#ifdef MPIEXEC_PREFLAGS
+  mpirun_cmd += std::string(MPIEXEC_PREFLAGS);
 #endif
 #endif
 #ifdef OPENMP_FOUND


### PR DESCRIPTION
### Background

* I missed updating these three files when I changed Draco to use `MPIEXEC_PREFLAGS` instead of `MPIEXEC_POSTFLAGS`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
