### PR TITLE
Update to support LLVM version 10.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
   PATH: c:\projects\win32-vs16-tools\bin;$(PATH);c:\msys64\mingw64\bin
   VCPKGDIR: C:\Tools\vcpkg
   GENERATOR: "Visual Studio 16 2019"
-  CMAKE_OPTIONS: "-DCMAKE_TOOLCHAIN_FILE=%VENDOR_DIR%\\vs2019-toolchain.cmake" 
+  CMAKE_OPTIONS: "-DCMAKE_TOOLCHAIN_FILE=%VENDOR_DIR%\\vs2019-toolchain.cmake"
   #-DCMAKE_VERBOSE_MAKEFILE=ON"
   #QTDIR: c:\Qt\5.14.0
   #PATH+=c:\Qt\5.14.0\bin
@@ -43,6 +43,7 @@ install:
   #   . The vs2019-toolchain.cmake file used by this script.
   - cd \projects
   - curl -L -o win32-vs16-tools.zip https://github.com/KineticTheory/ci-demo/releases/download/vendors-201809/win32-vs16-tools.zip
+  - dir win32-vs16-tools.zip
   - 7z.exe -y x win32-vs16-tools.zip
   - xcopy %VENDOR_DIR%\ports\* %VCPKGDIR%\ports /E /Y /I /Q
   - xcopy %VENDOR_DIR%\installed\* %VCPKGDIR%\installed /E /Y /I /Q

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -39,6 +39,9 @@ case $target in
   ccscs[1-9]*)
     # Add /scratch/vendors/Modules.lmod (totalview, ddt, etc.)
     # Add /scratch/vendors/Modules.core (spack generated modules).
+    if [[ "${MODULEPATH}x" == "x" ]]; then
+      export MODULEPATH=/etc/modulefiles:/usr/share/modulefiles:/ccs/opt/modulefiles
+    fi
     module load user_contrib
     if [[ -d $HOME/privatemodules ]]; then
       module use --append $HOME/privatemodules

--- a/src/ds++/SortPermutation.hh
+++ b/src/ds++/SortPermutation.hh
@@ -101,9 +101,8 @@ private:
 
   public:
     Proxy(SortPermutation::value_type pos_, const std::vector<IT> &iters_)
-        : pos(pos_), iters(iters_) { }
-    Proxy( Proxy const& rhs )
-      : pos(rhs.pos), iters(rhs.iters) {};
+        : pos(pos_), iters(iters_) {}
+    Proxy(Proxy const &rhs) : pos(rhs.pos), iters(rhs.iters){};
     Proxy &operator=(Proxy const &rhs) {
       pos = rhs.pos;
       return *this;

--- a/src/ds++/SortPermutation.hh
+++ b/src/ds++/SortPermutation.hh
@@ -76,11 +76,11 @@ private:
   typedef std::vector<value_type> InternalRep; // NOLINT
 
 public:
-  // A SortPermutation can not be modified; therefor,
-  // always use a const_iterator.
+  // A SortPermutation can not be modified; therefor, always use a
+  // const_iterator.
 
   typedef InternalRep::const_iterator iterator;       // NOLINT
-  typedef InternalRep::const_iterator const_iterator; //NOLINT
+  typedef InternalRep::const_iterator const_iterator; // NOLINT
 
 private:
   // Forward Declarations
@@ -101,11 +101,10 @@ private:
 
   public:
     Proxy(SortPermutation::value_type pos_, const std::vector<IT> &iters_)
-        : pos(pos_), iters(iters_) { /* empty */
-    }
-
+        : pos(pos_), iters(iters_) { }
+    Proxy( Proxy const& rhs )
+      : pos(rhs.pos), iters(rhs.iters) {};
     Proxy &operator=(Proxy const &rhs) {
-      // std::cout << "assigning " << pos << "=" << rhs.pos << std::endl;
       pos = rhs.pos;
       return *this;
     }
@@ -136,8 +135,6 @@ private:
 public:
   // CREATORS
 
-  //    SortPermutation() { /* empty */ }
-
   template <typename IT, class COMP>
   SortPermutation(IT first, IT last, const COMP &comp)
       : indexTable_m(std::distance(first, last)),
@@ -152,13 +149,6 @@ public:
     typedef typename std::iterator_traits<IT>::value_type vtype; // NOLINT
     createPermutation(first, last, std::less<vtype>());
   }
-
-  //Defaulted: SortPermutation(const SortPermutation &rhs);
-  //Defaulted: ~SortPermutation();
-
-  // MANIPULATORS
-
-  //Defaulted: SortPermutation& operator=(const SortPermutation &rhs);
 
   // ACCESSORS
 


### PR DESCRIPTION
### Background

* While exploring the option to build with LLVM version 10, I found a bug in one Draco file.

### Changes

* Add a copy constructor.
* Also,
  * Add a debug print to the appveyor script. I was having trouble getting some extra regression environment tools to install correctly.
  * Add a robustness check to `.bashrc_linux64` to ensure that a basic module environment is available on ccs-net machines.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
