### PR TITLE
Begin supporting IBM XL builds on Darwin

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -46,7 +46,8 @@ function( setMPIflavorVer )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mvapich2")
     set( MPI_FLAVOR "mvapich2" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "spectrum-mpi" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
+      "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" OR
+      "${MPIEXEC_EXECUTABLE}" MATCHES "smpi"  )
     set( MPI_FLAVOR "spectrum")
   endif()
 

--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -1,6 +1,6 @@
 #-----------------------------*-cmake-*----------------------------------------#
 # file   config/unix-xl.cmake
-# author Gabriel Rockefeller
+# author Gabriel Rockefeller, Kelly Thompson <kgt@lanl.gov>
 # date   2012 Nov 1
 # brief  Establish flags for Linux64 - IBM XL C++
 # note   Copyright (C) 2016-2020 Triad National Security, LLC.
@@ -22,18 +22,57 @@ query_openmp_availability()
 if( NOT CXX_FLAGS_INITIALIZED )
    set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
-  # On Darwin, we also need this config file:
-  # -F/projects/opt/ppc64le/ibm/xlc-16.1.1.2/xlC/16.1.1/etc/xlc.cfg.rhel.7.5.gcc.7.3.0.cuda.9.2
-  # -qfloat=nomaf -qxlcompatmacros
   set( CMAKE_C_FLAGS             "-g" )
-  # ATS-2
   if( EXISTS /usr/gapps )
+    # ATS-2
     string( APPEND CMAKE_C_FLAGS " --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" )
+  elseif(EXISTS /projects/opt/ppc64le/ibm )
+    # Darwin power9 - extract version from module environment.
+    string(REPLACE ":" ";" modules $ENV{LOADEDMODULES})
+    foreach( module ${modules} )
+      if( ${module} MATCHES "^gcc" )
+        string( REGEX REPLACE
+          "[^0-9]*([0-9]+).([0-9]+).([0-9]+)" "\\1.\\2.\\3"
+          gcc_version  ${module} )
+      elseif( NOT DEFINED xlc_version AND ${module} MATCHES "^ibm/xlc" )
+        string( REGEX REPLACE
+          "[^0-9]*([0-9]+).([0-9]+).([0-9]+).([0-9]+).*" "\\1.\\2.\\3.\\4"
+          xlc_version ${module} )
+        string( REGEX REPLACE "[^0-9]*([0-9]+).([0-9]+).([0-9]+).*" "\\1.\\2.\\3"
+          xlc_version_3 ${xlc_version} )
+#      Only cuda-10.1 is currently supported
+      elseif( ${module} MATCHES "^cuda" )
+        string( REGEX REPLACE
+          "[^0-9]*([0-9]+).([0-9]+)" "\\1.\\2"
+          cuda_version ${module} )
+        if( NOT ${cuda_version} STREQUAL "10.1" )
+          message( FATAL_ERROR "Only cuda/10.1 is currently supported."
+            " Found cuda/${cuda_version} in your environment. Replace your cuda"
+            " module with cuda/10.1 or unload the cuda module.")
+        endif()
+      endif()
+    endforeach()
+    # Only redhat 7.7 is currently supported
+    # file( READ /etc/redhat-release rhr )
+    #string( REGEX REPLACE "[^0-9]*([0-9]+).([0-9]+).*" "\\1.\\2"
+    #   redhat_version  ${rhr} )
+    set( config_file "/projects/opt/ppc64le/ibm/xlc-${xlc_version}/xlC/${xlc_version_3}/etc/xlc.cfg.rhel.7.7.gcc.${gcc_version}.cuda.10.1" )
+    if( EXISTS ${config_file} )
+      string( APPEND CMAKE_C_FLAGS " -F${config_file}" )
+    else()
+      message( FATAL_ERROR
+        "IBM XLC selected (Darwin), but requested config file was not found."
+        "\nconfig_file = ${config_file}" )
+    endif()
+    unset( gcc_version )
+    unset( xl_version )
+    unset( config_file )
   endif()
+
   # 2019-04-03 IBM support asks that we not use '-qcheck' due to compiler issues.
-  set( CMAKE_C_FLAGS_DEBUG          "-O0 -qsmp=omp:noopt -qfullpath -DDEBUG") # -qcheck -qoffload
+  set( CMAKE_C_FLAGS_DEBUG          "-O0 -qsmp=omp:noopt -qfullpath -DDEBUG")
   set( CMAKE_C_FLAGS_RELWITHDEBINFO
-    "-O3 -qhot=novector -qsmp=omp -qstrict=nans:operationprecision" ) # -qsimd=auto
+    "-O3 -qhot=novector -qsmp=omp -qstrict=nans:operationprecision" )
   set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
 

--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -25,7 +25,11 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # On Darwin, we also need this config file:
   # -F/projects/opt/ppc64le/ibm/xlc-16.1.1.2/xlC/16.1.1/etc/xlc.cfg.rhel.7.5.gcc.7.3.0.cuda.9.2
   # -qfloat=nomaf -qxlcompatmacros
-  set( CMAKE_C_FLAGS                "-g --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" ) # -qarch=auto
+  set( CMAKE_C_FLAGS             "-g" )
+  # ATS-2
+  if( EXISTS /usr/gapps )
+    string( APPEND CMAKE_C_FLAGS " --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" )
+  endif()
   # Sequoia
   if( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0 )
     string( APPEND CMAKE_C_FLAGS " -qinfo=all -qflags=i:w -qsuppress=1540-0072")

--- a/environment/bashrc/bashrc_slurm
+++ b/environment/bashrc/bashrc_slurm
@@ -191,9 +191,11 @@ case ${-} in
    target="`uname -n | sed -e s/[.].*//`"
    case $target in
      darwin-fe*)
-       alias salloc='module purge; salloc' ;;
+       alias salloc='module purge; salloc --x11' ;;
      tt*|tr*)
-       alias salloc='salloc --gres=craynetwork:0' ;;
+       alias salloc='salloc --gres=craynetwork:0 --x11' ;;
+     *)
+       alias salloc='salloc --x11' ;;
    esac
 
    if test -n "${verbose}"; then echo "done with draco/environment/bashrc/bashrc_slurm"; fi


### PR DESCRIPTION
### Background

+ It is difficult to debug on ATS-2 machines.  Building and testing on Darwin power9 nodes with the IBM XL compiler and Spectrum MPI provides a similar environment.

### Purpose of Pull Request

* [Fixes Redmine Issue #1948](https://rtt.lanl.gov/redmine/issues/1948)

### Description of changes

+ Provide minor build system updates to support Draco builds for XL on Darwin.
  + The compiler option `--gcc-toolchain` appears to be ATS-2 specific so restrict it to ATS-2 machines.
  + Help the build system identify spectrum-mpi as installed on Darwin.
+ Update the draco developer environment so that X11 is automatically enabled for the salloc alias.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
