### PR TITLE
Spectrum-MPI on Darwin works the same as OpenMPI.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -35,7 +35,8 @@ function( setMPIflavorVer )
   # (this ususally works for HPC or systems with modules)
   if( CRAY_PE )
     set( MPI_FLAVOR "cray" )
-  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "openmpi")
+  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "openmpi" OR
+      "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" )
     set( MPI_FLAVOR "openmpi" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mpich" OR
       "${MPI_C_HEADER_DIR}" MATCHES "mpich")
@@ -46,8 +47,7 @@ function( setMPIflavorVer )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mvapich2")
     set( MPI_FLAVOR "mvapich2" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "spectrum-mpi" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "smpi"  )
+      "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
     set( MPI_FLAVOR "spectrum")
   endif()
 


### PR DESCRIPTION
### Background

+ The desired flags provided to Spectrum-MPI's `mpirun` are the same as OpenMPI and different than the options used by Spectrum-MPI on rzansel (via `jsrun`). Tell the build system to configure tests with the correct options.

### Purpose of Pull Request

* [Fixes Redmine Issue #1948](https://rtt.lanl.gov/redmine/issues/1948)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
