### PR TITLE
Fix build warning reported by gcc-9.2.0.

### DIFF
--- a/src/ds++/SortPermutation.hh
+++ b/src/ds++/SortPermutation.hh
@@ -102,7 +102,7 @@ private:
   public:
     Proxy(SortPermutation::value_type pos_, const std::vector<IT> &iters_)
         : pos(pos_), iters(iters_) {}
-    Proxy(Proxy const &rhs) : pos(rhs.pos), iters(rhs.iters){};
+    Proxy(Proxy const &rhs) noexcept : pos(rhs.pos), iters(rhs.iters){};
     Proxy &operator=(Proxy const &rhs) {
       pos = rhs.pos;
       return *this;


### PR DESCRIPTION
### Background

* A recent change to `SortPermutation.hh` to fix LLVM build issues, introduced a gcc build warning.

### Purpose of Pull Request

* fixes #828 

### Description of changes

* Add  `noexcept` to the copy constructor.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
