### PR TITLE
Clean up testing environment for rzansel with XL.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -47,7 +47,7 @@ function( setMPIflavorVer )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mvapich2")
     set( MPI_FLAVOR "mvapich2" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "spectrum-mpi" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
+      "${MPIEXEC_EXECUTABLE}" MATCHES "lrun" )
     set( MPI_FLAVOR "spectrum")
   endif()
 
@@ -278,8 +278,6 @@ macro( setupOpenMPI )
     # -bind-to fails on OSX, See #691
     set( MPIEXEC_OMP_PREFLAGS
       "--map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings ${runasroot}" )
-    # "-bind-to socket --map-by ppr:${MPI_CORES_PER_CPU}:socket
-    # --report-bindings ${runasroot}"
   endif()
 
   set( MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS}
@@ -379,12 +377,15 @@ macro( setupSpectrumMPI )
   #                         total
   # - jsrun -a4 -c16 -g2 => 4 tasks, 16 cores, 2 gpus
 
+  set( MPIEXEC_PREFLAGS "--pack --threads=1 --bind=off -v")
+
   #
   # Setup for OMP plus MPI
   #
 
   if( DEFINED ENV{OMP_NUM_THREADS} )
-    set( MPIEXEC_OMP_PREFLAGS "-c $ENV{OMP_NUM_THREADS}" )
+#    set( MPIEXEC_OMP_PREFLAGS "-c $ENV{OMP_NUM_THREADS}" )
+    set( MPIEXEC_OMP_PREFLAGS "--pack -c $ENV{OMP_NUM_THREADS} --threads=$ENV{OMP_NUM_THREADS} --bind=off -v" )
   endif()
 
   set( MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS}
@@ -431,7 +432,7 @@ macro( setupMPILibrariesUnix )
     elseif( DEFINED ENV{SYS_TYPE} AND
         "$ENV{SYS_TYPE}" MATCHES "ppc64le_ib_p9" ) # ATS-2
       if( NOT EXISTS ${MPIEXEC_EXECUTABLE} )
-        find_program( MPIEXEC_EXECUTABLE jsrun )
+        find_program( MPIEXEC_EXECUTABLE lrun )
       endif()
       set( MPIEXEC_EXECUTABLE ${MPIEXEC_EXECUTABLE} CACHE STRING
         "Program to execute MPI parallel programs." FORCE )

--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -22,7 +22,7 @@ query_openmp_availability()
 if( NOT CXX_FLAGS_INITIALIZED )
    set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
-  set( CMAKE_C_FLAGS             "-g" )
+  set( CMAKE_C_FLAGS             "-g -qflttrap")
   if( EXISTS /usr/gapps )
     # ATS-2
     string( APPEND CMAKE_C_FLAGS " --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" )

--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -22,7 +22,7 @@ query_openmp_availability()
 if( NOT CXX_FLAGS_INITIALIZED )
    set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
-  set( CMAKE_C_FLAGS             "-g -qflttrap")
+  set( CMAKE_C_FLAGS             "-qflttrap")
   if( EXISTS /usr/gapps )
     # ATS-2
     string( APPEND CMAKE_C_FLAGS " --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" )
@@ -69,11 +69,11 @@ if( NOT CXX_FLAGS_INITIALIZED )
     unset( config_file )
   endif()
 
-  # 2019-04-03 IBM support asks that we not use '-qcheck' due to compiler issues.
-  set( CMAKE_C_FLAGS_DEBUG          "-O0 -qsmp=omp:noopt -qfullpath -DDEBUG")
+  set( CMAKE_C_FLAGS_DEBUG          "-g -O0 -qsmp=omp:noopt -qfullpath -DDEBUG")
   set( CMAKE_C_FLAGS_RELWITHDEBINFO
-    "-O3 -qhot=novector -qsmp=omp -qstrict=nans:operationprecision" )
-  set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DNDEBUG" )
+    "-g -O2 -qsmp=omp -qstrict=nans:operationprecision -qmaxmem=-1" )
+  set( CMAKE_C_FLAGS_RELEASE
+    "-O2 -qsmp=omp -qstrict=nans:operationprecision -qmaxmem=-1 -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
 
   if( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")

--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -66,7 +66,7 @@ function dracoenv()
   export CXX=`which g++`
   export CC=`which gcc`
   export FC=`which gfortran`
-  export MPIRUN="jsrun"
+  export MPIRUN="lrun"
   export OMP_NUM_THREADS=10
 }
 

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -577,10 +577,10 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature,
 
     if (ordinate_set->ordinates().size() >= 2) {
       PASSMSG(string("Ordinate count is plausible. N = " +
-                     to_string(ordinate_set->ordinates().size()) ));
+                     to_string(ordinate_set->ordinates().size())));
     } else {
       FAILMSG(string("Ordinate count is NOT plausible. N = ") +
-              to_string(ordinate_set->ordinates().size()) );
+              to_string(ordinate_set->ordinates().size()));
     }
 
     if (soft_equiv(ordinate_set->norm(), 1.0)) {

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -13,6 +13,7 @@
 #include <iomanip>
 #include <iostream>
 #include <numeric>
+#include <string>
 
 namespace rtt_quadrature {
 using namespace std;
@@ -575,15 +576,18 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature,
                                        Ordinate_Set::LEVEL_ORDERED);
 
     if (ordinate_set->ordinates().size() >= 2) {
-      PASSMSG("Ordinate count is plausible");
+      PASSMSG(string("Ordinate count is plausible. N = " +
+                     to_string(ordinate_set->ordinates().size()) ));
     } else {
-      FAILMSG("Ordinate count is NOT plausible");
+      FAILMSG(string("Ordinate count is NOT plausible. N = ") +
+              to_string(ordinate_set->ordinates().size()) );
     }
 
     if (soft_equiv(ordinate_set->norm(), 1.0)) {
       PASSMSG("Ordinate norm is correct");
     } else {
-      FAILMSG("Ordinate norm is NOT correct");
+      FAILMSG(string("Ordinate norm is NOT correct.  Found norm = ") +
+              to_string(ordinate_set->norm()));
     }
 
     ordinate_set->display();


### PR DESCRIPTION
### Background

* When building optimized builds with IBM XL, the quadrature unit tests and `dsxx_fpe_trap_2` fail.  Some tests launched with `jsrun` would report warnings.

### Purpose of Pull Request

* Fixes #830 
* [Fixes Redmine 1949](https://rtt.lanl.gov/redmine/issues/1949)
* Might fix test failures reported by XL-based regressions on Darwin.

### Description of changes

**Changes for test registration:**

+ For _rzansel_, switch from using `jsrun` to `lrun`.  This fixes an issue where  `jsrun` was complaining about the requested number of threads being greater than the 4 hardware threads provided by each power9 core.
+ For rzansel, update the `MPIEXEC_PREFLAGS` so they work with `lrun`.
  - `MPIEXEC_PREFLAGS="--pack --threads=1 --bind=off -v"`
  - `MPIEXEC_OMP_PREFLAGS="--pack -c $ENV{OMP_NUM_THREADS} --threads=$ENV{OMP_NUM_THREADS} --bind=off -v"`
  - `MPIEXEC_NUMPROC_FLAG="-n"`
  - `MPIRUN=lrun`

**Changes to XL compiler flags:**

+ Only use `-g` for _Debug_ builds.
+ Add `-qflttrap` for all builds to mimic the default floating point exception behavior used by Intel, Gnu, Microsoft, and LLVM.
+ Reduce the _Release_ build optimization to `-O2 -qmaxmem=-1`. Enabling `-O3` produces inaccurate results in quadrature.

**Other:**

+ Make output from `quadrature_test.cc` a bit more verbose.


### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
