### PR TITLE
Reorder enumeration of geometry in mesh_element/Geometry.hh

### DIFF
--- a/src/mesh_element/Geometry.hh
+++ b/src/mesh_element/Geometry.hh
@@ -13,11 +13,19 @@
 
 namespace rtt_mesh_element {
 
-//! Enumerates supported geometries.
+/*! Enumerates supported geometries.
+ *
+ * The order of enumerated values is not arbiterary. The corresponding integral
+ * value is the number of suppressed dimensions in the geometry, e.g., axisymmetric
+ * geometry looks 2-D but is actually 3-D (one suppressed dimension) while spherical
+ * geometry looks 1-D but is actually 3-D (two suppressed dimensions.) The number
+ * of suppressed dimensions is used in some formulas in a number of hydrodynamics
+ * codes, so it seems like a good idea for us to adopt this convention as well.
+ */
 enum Geometry {
+  CARTESIAN,    //!< 1D (slab) or 2D (XY) Cartesian geometry
   AXISYMMETRIC, //!< 2D (cylindrical) R-Z
   SPHERICAL,    //!< 1D SPHERICAL
-  CARTESIAN,    //!< 1D (slab) or 2D (XY) Cartesian geometry
   END_GEOMETRY  //!< Sentinel value
 };
 


### PR DESCRIPTION
The new enumeration is consistent with common practice in hydrodynamics codes,
where the enumerated value is the number of suppressed dimensions. See the
expanded description of the enumeration in the modified definition for further
explanation.

By adopting an enumeration that matches many hydrocodes, we avoid having to do as much translation from host code enumeration to our library enumeration, with all the unpleasant surprises that brings.

### Description of changes

* Reorder enumerators without changing their names. The corrensponding integral value for each enumerator then matches the common hydrodynamics code definition.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
