### PR TITLE
Change filename in ofpstream test to be n-rank-dependent

### DIFF
--- a/src/c4/test/tstofpstream.cc
+++ b/src/c4/test/tstofpstream.cc
@@ -24,7 +24,7 @@ using namespace rtt_c4;
 void tstofpstream(UnitTest &ut) {
 
   unsigned const pid = rtt_c4::node();
-  ofpstream out("tstofpstream.txt");
+  ofpstream out("tstofpstream_" + std::to_string(rtt_c4::nodes()) + ".txt");
 
   out << "MPI rank " << pid << " reporting ..." << endl;
   out.send();
@@ -48,9 +48,12 @@ void tstofpstream_bin(UnitTest &ut) {
 
   int pid = rtt_c4::node();
 
+  std::string filename("tstofpstream_" + std::to_string(rtt_c4::nodes()) +
+                       ".bin");
+
   // Binary write rank ids to file using ofpstream:
   {
-    ofpstream out("tstofpstream.bin", std::ofstream::binary);
+    ofpstream out(filename, std::ofstream::binary);
     out.write(reinterpret_cast<const char *>(&pid), sizeof(int));
     out.send();
     out.shrink_to_fit();
@@ -58,7 +61,7 @@ void tstofpstream_bin(UnitTest &ut) {
 
   // Read file on head rank, check for correct conversion and ordering
   if (pid == 0) {
-    ifstream in("tstofpstream.bin", std::ifstream::binary);
+    ifstream in(filename, std::ifstream::binary);
     int this_pid(-42);
     for (int a = 0; a < rtt_c4::nodes(); a++) {
       in.read(reinterpret_cast<char *>(&this_pid), sizeof(int));


### PR DESCRIPTION
### Background

* KT was seeing intermittent failures in the ofpstream test, likely because of file system contention (the 1, 2, and 4-proc variants all wrote to / read from the same test file)

### Purpose of Pull Request

* [Fixes Redmine Issue #1950](https://rtt.lanl.gov/redmine/issues/1950)

### Description of changes

* Change test file name to append the number of procs used by the test.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation