### PR TITLE
Check availability of eos data before registering tests.

### DIFF
--- a/src/cdi_eospac/test/CMakeLists.txt
+++ b/src/cdi_eospac/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for cdi_eospac/test.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 project( cdi_eospac_test CXX )
@@ -11,40 +11,40 @@ project( cdi_eospac_test CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 set( test_sources
-   ${PROJECT_SOURCE_DIR}/tEospac.cc
-   ${PROJECT_SOURCE_DIR}/tEospacWithCDI.cc
-)
+  ${PROJECT_SOURCE_DIR}/tEospac.cc
+  ${PROJECT_SOURCE_DIR}/tEospacWithCDI.cc )
 
 # ---------------------------------------------------------------------------- #
 # Build Unit tests
 # ---------------------------------------------------------------------------- #
+if( (DEFINED ENV{SESAMEPATH} AND EXISTS "$ENV{SESAMEPATH}") OR
+    (DEFINED ENV{SESPATHU}   AND EXISTS "$ENV{SESPATHU}" ) )
 
-add_scalar_tests(
-   SOURCES "${test_sources}"
-   DEPS    "Lib_cdi_eospac"
-   )
+  # These tests require a datafile to be defined in the environment.
 
-include( ApplicationUnitTest )
+  add_scalar_tests(
+    SOURCES "${test_sources}"
+    DEPS    "Lib_cdi_eospac" )
 
-# Run the QueryEospac executable reading interactive commands directly from the
-# file QueryEospacInput.dat.  Save the output to QueryEospacInput.out and
-# compare this to the gold file.
-add_app_unit_test(
-  DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/tQueryEospac.cmake
-  APP    $<TARGET_FILE_DIR:Exe_QueryEospac>/$<TARGET_FILE_NAME:Exe_QueryEospac>
-  STDINFILE ${PROJECT_SOURCE_DIR}/QueryEospacInput.dat
-  GOLDFILE  ${PROJECT_SOURCE_DIR}/QueryEospac.gold
-)
+  include( ApplicationUnitTest )
+
+  # Run the QueryEospac executable reading interactive commands directly from
+  # the file QueryEospacInput.dat.  Save the output to QueryEospacInput.out and
+  # compare this to the gold file.
+  add_app_unit_test(
+    DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/tQueryEospac.cmake
+    APP    $<TARGET_FILE_DIR:Exe_QueryEospac>/$<TARGET_FILE_NAME:Exe_QueryEospac>
+    STDINFILE ${PROJECT_SOURCE_DIR}/QueryEospacInput.dat
+    GOLDFILE  ${PROJECT_SOURCE_DIR}/QueryEospac.gold )
+endif()
 
 # Run the QueryEospac executable with options '--version' and '--help' to ensure
 # these options print the expected output.
 add_app_unit_test(
   DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/tQueryEospac.cmake
   APP    $<TARGET_FILE_DIR:Exe_QueryEospac>/$<TARGET_FILE_NAME:Exe_QueryEospac>
-  TEST_ARGS "--version;--help"
-)
+  TEST_ARGS "--version;--help" )
 
 # ---------------------------------------------------------------------------- #
 # End cdi_eospac/test/CMakeLists.txt


### PR DESCRIPTION
### Background

* There are build environments where the Eospac libraries are installed but the data files are not available.

### Description of changes

* If the Eospac libraries are found, always build the `cdi_eospac` library and some of the tests.
* Do not build are register `cdi_eospac` tests that require the eos data files, when those files are not available.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
