### PR TITLE
On rzansel, do not use the --pack lrun/jsrun option.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -377,7 +377,11 @@ macro( setupSpectrumMPI )
   #                         total
   # - jsrun -a4 -c16 -g2 => 4 tasks, 16 cores, 2 gpus
 
-  set( MPIEXEC_PREFLAGS "--pack --threads=1 --bind=off -v")
+  set( MPIEXEC_PREFLAGS "--threads=1 --bind=off -v")
+  # --pack ==> -c 1 -g 0.  This is actually bad for us. Disable
+  # lrun -n 2 -c 10 --threads=10 --bind=off ==>
+  # jsrun --np 1 --nrs 1 -c ALL_CPUS -g ALL_GPUS -d plane:1 -b rs -X 1
+  # consider: jsrun --np 2 --nrs 1 -c 10 -g 0 -bind none
 
   #
   # Setup for OMP plus MPI
@@ -385,7 +389,7 @@ macro( setupSpectrumMPI )
 
   if( DEFINED ENV{OMP_NUM_THREADS} )
 #    set( MPIEXEC_OMP_PREFLAGS "-c $ENV{OMP_NUM_THREADS}" )
-    set( MPIEXEC_OMP_PREFLAGS "--pack -c $ENV{OMP_NUM_THREADS} --threads=$ENV{OMP_NUM_THREADS} --bind=off -v" )
+    set( MPIEXEC_OMP_PREFLAGS "-c $ENV{OMP_NUM_THREADS} --threads=$ENV{OMP_NUM_THREADS} --bind=off -v" )
   endif()
 
   set( MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS}

--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -17,6 +17,7 @@ ulimit -s unlimited
 # Where is the vendor directory
 export PATH=${VENDOR_DIR:=/usr/gapps/jayenne/vendors}/bin:$PATH
 export VENDOR_DIR
+export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
 
 #
 # MODULES


### PR DESCRIPTION
### Description of changes

+ The `--pack` option assumes tests only use one core and one thread.  This is not appropriate for most Draco tests.
+ Also, set an environment variable to prevent warnings about oversubscribing.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
