### PR TITLE
Spell out that the base type of Geometry is int.

### DIFF
--- a/src/mesh_element/Geometry.hh
+++ b/src/mesh_element/Geometry.hh
@@ -21,8 +21,10 @@ namespace rtt_mesh_element {
  * geometry looks 1-D but is actually 3-D (two suppressed dimensions.) The number
  * of suppressed dimensions is used in some formulas in a number of hydrodynamics
  * codes, so it seems like a good idea for us to adopt this convention as well.
+ *
+ * We specify the base as int to guarantee better interoperability with FORTRAN codes.
  */
-enum Geometry {
+enum Geometry : int {
   CARTESIAN,    //!< 1D (slab) or 2D (XY) Cartesian geometry
   AXISYMMETRIC, //!< 2D (cylindrical) R-Z
   SPHERICAL,    //!< 1D SPHERICAL


### PR DESCRIPTION
### Background

* The Geometry enumeration has meaningful integer values for its enumerators, based on a common convention in hydrodynamics codes of specifying geometry by the number of suppressed dimensions. This value is actually used in computations in such codes.
* We should go just a bit further, and spell out that the base type of this enumeration is int. This should allow FORTRAN codes using the common convention to safely pass their geometry to C++ codes using iso_c bindings.

### Purpose of Pull Request

* Add base type of int to the Geometry enumeration.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
