### PR TITLE
Remove CRAY_PE from the build system.

### DIFF
--- a/config/draco-config-install.cmake.in
+++ b/config/draco-config-install.cmake.in
@@ -38,7 +38,6 @@ set_package_properties( draco PROPERTIES
 
 set( DRACO_LIBRARY_TYPE @DRACO_LIBRARY_TYPE@ )
 set( GCC_ENABLE_GLIBCXX_DEBUG "@GCC_ENABLE_GLIBCXX_DEBUG@" )
-set( CRAY_PE "@CRAY_PE@" )
 
 ## ---------------------------------------------------------------------------
 ## Set library specifications and paths

--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -59,7 +59,7 @@ function(dbs_set_sitename)
 
 endfunction()
 
-if( NOT DEFINED CRAY_PE )
+if( NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
   message("
 Platform Checks...
 ")
@@ -69,61 +69,42 @@ endif()
 #------------------------------------------------------------------------------#
 # Sanity checks for Cray Programming Environments
 #
-# If this is a Cray PE,
-# - Set CRAY_PE = TRUE
 # - Ensure CMAKE_EXE_LINKER_FLAGS contains "-dynamic"
 # - Ensure that the compilers given to cmake are actually Cray compiler
 #   wrappers.
 #------------------------------------------------------------------------------#
 macro( query_craype )
 
-  if( NOT DEFINED CRAY_PE )
-
-    # Is this a Cray machine?
-    message( STATUS "Looking to see if we are building in a Cray Environment...")
-    if( DEFINED ENV{CRAYPE_VERSION} )
-      set( CRAY_PE ON CACHE BOOL
-        "Are we building in a Cray Programming Environment?")
-
-      # We expect developers to use the Cray compiler wrappers (especially in
-      # setupMPI.cmake). See also
-      # https://cmake.org/cmake/help/latest/module/FindMPI.html
-      if( NOT "$ENV{CXX}" MATCHES "$ENV{SPACK_ROOT}/lib/spack/env/" )
-        # skip this check if building from within spack.
-        if( NOT "$ENV{CXX}" MATCHES "CC$" OR
-            NOT "$ENV{CC}" MATCHES "cc$" OR
-            NOT "$ENV{FC}" MATCHES "ftn$" OR
-            NOT "$ENV{CRAYPE_LINK_TYPE}" MATCHES "dynamic$" )
-          message( FATAL_ERROR
-            "The build system requires that the Cray compiler wrappers (CC, cc, ftn) be "
-            " used when configuring this product on a Cray system (CRAY_PE=${CRAY_PE}). The"
-            " development environment must also support dynamic linking.  The build system "
-            " thinks you are trying to use:\n"
-            "  CMAKE_CXX_COMPILER     = ${CMAKE_CXX_COMPILER}\n"
-            "  CMAKE_C_COMPILER       = ${CMAKE_C_COMPILER}\n"
-            "  CMAKE_Fortran_COMPILER = ${CMAKE_Fortran_COMPILER}\n"
-            "  CRAYPE_LINK_TYPE       = $ENV{CRAYPE_LINK_TYPE}\n"
-            "If you are working on a system that runs the Cray Programming Environment, try"
-            " setting the following variables and rerunning cmake from a clean build"
-            " directory:\n"
-            "   export CXX=`which CC`\n"
-            "   export CC=`which cc`\n"
-            "   export FC=`which ftn`\n"
-            "   export CRAYPE_LINK_TYPE=dynamic\n"
-            "Otherwise please email this error message and other related information to"
-            " draco@lanl.gov.\n" )
-        endif()
-      endif()
-      message( STATUS
-        "Looking to see if we are building in a Cray Environment..."
-        "found version $ENV{CRAYPE_VERSION}.")
-    else()
-      set( CRAY_PE OFF CACHE BOOL
-        "Are we building in a Cray Programming Environment?")
-      message( STATUS
-        "Looking to see if we are building in a Cray Environment...no.")
+  # We expect developers to use the Cray compiler wrappers. See also
+  # https://cmake.org/cmake/help/latest/module/FindMPI.html
+  #
+  # Skip this check if building from within spack.
+  if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv AND
+      NOT "$ENV{CXX}" MATCHES "$ENV{SPACK_ROOT}/lib/spack/env/" )
+    if( NOT "$ENV{CXX}" MATCHES "CC$" OR
+        NOT "$ENV{CC}" MATCHES "cc$" OR
+        NOT "$ENV{FC}" MATCHES "ftn$" OR
+        NOT "$ENV{CRAYPE_LINK_TYPE}" MATCHES "dynamic$" )
+      message( FATAL_ERROR
+        "The build system requires that the Cray compiler wrappers (CC, cc, "
+        "ftn) be used when configuring this product on a Cray system "
+        "(CMAKE_CXX_COMPILER_WRAPPER = ${CMAKE_CXX_COMPILER_WRAPPER}). The "
+        "development environment must also support dynamic linking.  The "
+        "build system thinks you are trying to use:\n"
+        "  CMAKE_CXX_COMPILER     = ${CMAKE_CXX_COMPILER}\n"
+        "  CMAKE_C_COMPILER       = ${CMAKE_C_COMPILER}\n"
+        "  CMAKE_Fortran_COMPILER = ${CMAKE_Fortran_COMPILER}\n"
+        "  CRAYPE_LINK_TYPE       = $ENV{CRAYPE_LINK_TYPE}\n"
+        "If you are working on a system that runs the Cray Programming "
+        "Environment, try setting the following variables and rerunning cmake "
+        "from a clean build directory:\n"
+        "   export CXX=`which CC`\n"
+        "   export CC=`which cc`\n"
+        "   export FC=`which ftn`\n"
+        "   export CRAYPE_LINK_TYPE=dynamic\n"
+        "Otherwise please email this error message and other related "
+        "information to draco@lanl.gov.\n" )
     endif()
-
   endif()
 endmacro()
 

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -33,7 +33,7 @@ function( setMPIflavorVer )
 
   # First attempt to determine MPI flavor -- scape flavor from full path
   # (this ususally works for HPC or systems with modules)
-  if( CRAY_PE )
+  if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
     set( MPI_FLAVOR "cray" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "openmpi" OR
       "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" )
@@ -51,7 +51,7 @@ function( setMPIflavorVer )
     set( MPI_FLAVOR "spectrum")
   endif()
 
-  if( CRAY_PE )
+  if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
     if( DEFINED ENV{CRAY_MPICH2_VER} )
       set( MPI_VERSION $ENV{CRAY_MPICH2_VER} )
     endif()
@@ -421,7 +421,7 @@ macro( setupMPILibrariesUnix )
     # If this is a Cray system and the Cray MPI compile wrappers are used, then
     # do some special setup:
 
-    if( CRAY_PE )
+    if(  CMAKE_CXX_COMPILER_WRAPPER MATCHES CrayPrgEnv )
       if( NOT EXISTS ${MPIEXEC_EXECUTABLE} )
         find_program( MPIEXEC_EXECUTABLE srun )
       endif()
@@ -461,9 +461,9 @@ macro( setupMPILibrariesUnix )
     else()
       message( FATAL_ERROR "
 The Draco build system doesn't know how to configure the build for
-  MPIEXEC_EXECUTABLE     = ${MPIEXEC_EXECUTABLE}
-  DBS_MPI_VER = ${DBS_MPI_VER}
-  CRAY_PE     = ${CRAY_PE}")
+  MPIEXEC_EXECUTABLE         = ${MPIEXEC_EXECUTABLE}
+  DBS_MPI_VER                = ${DBS_MPI_VER}
+  CMAKE_CXX_COMPILER_WRAPPER = ${CMAKE_CXX_COMPILER_WRAPPER}")
     endif()
 
     # Mark some of the variables created by the above logic as 'advanced' so

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -140,14 +140,12 @@ if( NOT CXX_FLAGS_INITIALIZED )
     string( APPEND CMAKE_CXX_FLAGS_DEBUG " -fdiagnostics-show-template-tree")
   endif()
 
-  # [2017-04-15 KT] -march=native doesn't seem to work correctly on toolbox
-  # Systems running CRAY_PE use commpile wrappers to specify this option.
+  # Systems running CrayPE use compile wrappers to specify this option.
   site_name( sitename )
   string( REGEX REPLACE "([A-z0-9]+).*" "\\1" sitename ${sitename} )
   if (HAS_MARCH_NATIVE AND
       NOT APPLE AND
-      NOT CRAY_PE AND
-      NOT "${sitename}" MATCHES "toolbox")
+      NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
     string( APPEND CMAKE_C_FLAGS " -march=native" )
   elseif( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
     string( APPEND CMAKE_C_FLAGS " -mcpu=powerpc64le -mtune=powerpc64le" )

--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -90,13 +90,9 @@ set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE
 
 # If this is a Cray, the compile wrappers take care of any xHost flags that are
 # needed.
-if( NOT CRAY_PE )
-# include(CheckCCompilerFlag)
-# check_c_compiler_flag(-xHost HAS_XHOST)
- set( HAS_XHOST TRUE )
- toggle_compiler_flag( HAS_XHOST "-xHost" "C;CXX" "")
-#else()
- # -craype-verbose
+if( NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
+  set( HAS_XHOST TRUE )
+  toggle_compiler_flag( HAS_XHOST "-xHost" "C;CXX" "")
 endif()
 toggle_compiler_flag( OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX" "" )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,7 +171,7 @@ endif()
 message("Library Type: ${DRACO_LIBRARY_TYPE}
 ")
 
-if( CRAY_PE AND ENV{CRAYPE_VERSION} )
+if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
   message("Cray system detected: CC -craype-verbose -V|--version:
 ")
   if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel" OR

--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -57,7 +57,8 @@ if( NOT "${CMAKE_CXX_COMPILER_VERSION}x" STREQUAL "x" )
 endif()
 
 # Is this a KNL
-if( CRAY_PE AND "$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl" )
+if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv AND
+    "$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl" )
   set( draco_isKNL ON )
 endif()
 


### PR DESCRIPTION
### Background

+ CMake now provides a built-in mechanism that tells us if we are using Cray compiler wrappers. The value of `CMAKE_CXX_COMPILER_WRAPPER` will be `CrayPrgEnv`.

### Purpose of Pull Request

* [Fixes Redmine Issue #1661](https://rtt.lanl.gov/redmine/issues/1661)

### Description of changes

+ Remove `CRAY_PE` from the build system and replace the existing logic with `CMAKE_CXX_COMPILER_WRAPPER`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
