### PR TITLE
Load no-cuda version of trilinos on darwin.

### DIFF
--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -57,7 +57,7 @@ if test -n "$MODULESHOME"; then
           cudaflavor="-cuda-10.1"
         fi
         compflavor="cmake/3.17.0 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
-        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
         if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
@@ -73,7 +73,7 @@ if test -n "$MODULESHOME"; then
         lapackflavor="lapack-3.8.0"
         noflavor="git random123 cmake gcc/7.3.0"
         compflavor="cmake/3.17.0 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
-        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1${cudaflavor}-$mflavor-$lapackflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1-$mflavor-$lapackflavor"
         ec_mf="ndi csk/0.5.0-$cflavor"
         # Add clang-format (version 6) to the default environment.
         if [[ -x /projects/opt/centos7/clang/6.0.0/bin/clang-format ]]; then
@@ -94,7 +94,7 @@ if test -n "$MODULESHOME"; then
         lflavor="lapack-3.8.0"
         noflavor="git gcc/7.3.0 cuda/10.1 cmake/3.17.0 random123 numdiff"
         compflavor="eospac/6.4.0-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
-        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-cuda-10.1-${mflavor}-$lflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-${mflavor}-$lflavor"
         # These aren't built for power architectures?
         ec_mf="csk/0.5.0-$cflavor ndi"
 


### PR DESCRIPTION
### Background

* Use no-cuda version of trilinos on darwin which is faster.

### Purpose of Pull Request

* [Fixes Redmine Issue #1964](https://rtt.lanl.gov/redmine/issues/1964)

### Description of changes

* Load no-cuda version of trilinos

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
