### PR TITLE
Update doxygen version in docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
 #  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install:
-  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2019aug
+  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2020may
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
 
 script:
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2020april /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2020may /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
 
 #------------------------------------------------------------------------------#
 # See also:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,19 +6,19 @@ FROM ubuntu:latest
 # This image:
 # 1. cd /D f:\work\docker (copy Dockerfile and packages.yaml to this location).
 # 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
-# 3. docker build --rm --pull --tag draco-ci-2020april:latest . 
-#    OR: docker run -it -v /c/work:/work kinetictheory/draco-ci-2019aug /bin/bash -l
+# 3. docker build --rm --pull --tag draco-ci-2020may:latest . 
+#    OR: docker run -it -v /c/work:/work kinetictheory/draco-ci-2020may /bin/bash -l
 #        apt-get install -y --no-install-recommends [ghostview]
 #        rm -rf /vendors/spack/var/spack/repos/builtin/cmake
 #        cp -r /work/kinetictheory/spack/var/spack/repos/builtin/cmake /vendors/spack/var/spack/repos/builtin/.
 #        spack install cmake@3.17.0
 #        exit
 #        docker ps -a
-#        docker commit -m "added cmake-3.17.0." kind_grothen kinetictheory/draco-ci-2020april:latest 
-#        docker push kinetictheory/draco-ci-2020april:latest
+#        docker commit -m "added cmake-3.17.0." kind_grothen kinetictheory/draco-ci-2020may:latest 
+#        docker push kinetictheory/draco-ci-2020may:latest
 # 4. docker image ls -a ==> find container name (or docker ps)
-# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <hash> kinetictheory/draco-ci-2020april:latest # queues for upload
-# 6. docker push kinetictheory/draco-ci-2020april:latest
+# 5. docker commit -m "added sphinx and mscgen" -a kinetictheory <hash> kinetictheory/draco-ci-2020may:latest # queues for upload
+# 6. docker push kinetictheory/draco-ci-2020may:latest
 # 7. docker system prune -a (remove old dangling data)
 
 MAINTAINER KineticTheory "https://github.com/KineticTheory"
@@ -33,7 +33,7 @@ MAINTAINER KineticTheory "https://github.com/KineticTheory"
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV SPACK_ROOT=/vendors/spack
-ENV DRACO_TPL="cmake@3.17.0 gsl numdiff random123@1.09 openmpi netlib-lapack metis parmetis mscgen libquo eospac@6.4.0 lcov"
+ENV DRACO_TPL="cmake@3.17.0 gsl numdiff random123@1.09 openmpi netlib-lapack metis parmetis mscgen libquo eospac@6.4.0 lcov doxygen@1.8.14"
 ENV FORCE_UNSAFE_CONFIGURE=1
 ENV DISTRO=bionic
 ENV CLANG_FORMAT_VER=6.0


### PR DESCRIPTION
### Background

+ The docker image has a different version of doxygen than the ccs-net machines.  This occasionally results in different nightly regression and CI behavior for the autodoc target.
+ [Fix Redmine 1707](https://rtt.lanl.gov/redmine/issues/1707)

### Description of changes

+ Update doxygen in the docker image to 1.8.14 to match ccs-net.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
