### PR TITLE
Fix test registration for trinitite (perfbench)

### DIFF
--- a/config/buildEnv.cmake
+++ b/config/buildEnv.cmake
@@ -210,23 +210,6 @@ macro( dbsConfigInfo )
          set( DBS_OPERATING_SYSTEM_VER "${redhat_version} (${CMAKE_SYSTEM})" )
       endif( EXISTS "/etc/redhat-release" )
 
-      # How many local cores
-      if( EXISTS "/proc/cpuinfo" )
-         file( READ "/proc/cpuinfo" cpuinfo )
-         # string( STRIP "${cpuinfo}" cpuinfo )
-         # convert one big string into a set of strings, one per line
-         string( REGEX REPLACE "\n" ";" cpuinfo ${cpuinfo} )
-         set( proc_ids "" )
-         foreach( line ${cpuinfo} )
-            if( ${line} MATCHES "processor" )
-               list( APPEND proc_ids ${line} )
-            endif()
-         endforeach()
-         list( LENGTH proc_ids DRACO_NUM_CORES )
-         set( MPIEXEC_MAX_NUMPROCS ${DRACO_NUM_CORES} CACHE STRING
-            "Number of cores on the local machine." )
-      endif()
-
    elseif() # WIN32
 
       # OS version information

--- a/config/dracoTesting.cmake
+++ b/config/dracoTesting.cmake
@@ -12,43 +12,10 @@ option( BUILD_TESTING "Should we compile the tests?" ON )
 add_feature_info( BUILD_TESTING BUILD_TESTING
    "Turn off to prevent the compilation of unit tests (ctest).")
 
-# how many cores on the local system?
-if( UNIX )
-  if( EXISTS "/proc/cpuinfo" )
-    file( READ "/proc/cpuinfo" cpuinfo )
-    # convert one big string into a set of strings, one per line
-    string( REGEX REPLACE "\n" ";" cpuinfo ${cpuinfo} )
-    set( proc_ids "" )
-    foreach( line ${cpuinfo} )
-       if( ${line} MATCHES "processor" )
-          list( APPEND proc_ids ${line} )
-       endif()
-    endforeach()
-    list( LENGTH proc_ids DRACO_NUM_CORES )
-    set( MPIEXEC_MAX_NUMPROCS ${DRACO_NUM_CORES} CACHE STRING
-       "Number of cores on the local machine." )
-  endif()
-endif()
-
 # enable ctest funcitons and run ctest in parallel if we have multiple cores.
 if( BUILD_TESTING )
   include(CTest)
   enable_testing()
-  # by default do not use parallel build flags (e.g.: -j16)
-  cmake_host_system_information( RESULT logical_cores QUERY NUMBER_OF_LOGICAL_CORES )
-  set( pbuildtestflags "" )
-  if( NOT WIN32 ) # stick with scalar builds for now.
-     set( pbuildtestflags "-j${logical_cores}" )
-  endif()
-  if( ${CMAKE_GENERATOR} MATCHES Ninja )
-    add_custom_target( check
-      COMMAND "${CMAKE_COMMAND}" --build "${Draco_BINARY_DIR}" -- ${pbuildtestflags}
-      COMMAND ${CMAKE_CTEST_COMMAND} ${pbuildtestflags} $$(ARGS) )
-  else()
-    add_custom_target( check
-      COMMAND "${CMAKE_COMMAND}" --build "${Draco_BINARY_DIR}" -- ${pbuildtestflags}
-      COMMAND ${CMAKE_CTEST_COMMAND} ${pbuildtestflags} $(ARGS) )
-  endif()
 endif()
 
 #------------------------------------------------------------------------------#

--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -59,12 +59,10 @@ function(dbs_set_sitename)
 
 endfunction()
 
-if( NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
-  message("
+message("
 Platform Checks...
 ")
-  dbs_set_sitename()
-endif()
+dbs_set_sitename()
 
 #------------------------------------------------------------------------------#
 # Sanity checks for Cray Programming Environments


### PR DESCRIPTION
### Background

+ Perfbench tests have been failing recently and the issue was traced back to defects in the build system that are fixed by this PR.

### Purpose of Pull Request

* [Fixes Redmine Issue #2002](https://rtt.lanl.gov/redmine/issues/2002)

### Description of changes

+ The value of `MPIEXEC_MAX_NUMPROCS` was set in several places in the build system.  Consolidate logic into a single location.
+ Eliminate the rarely used build target `check`.
+ Similar changes were also provided to the regression system.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
