### PR TITLE
Add CUDA flag to allow lambdas in thrust

### DIFF
--- a/config/unix-cuda.cmake
+++ b/config/unix-cuda.cmake
@@ -45,7 +45,8 @@ endif()
 if( NOT CUDA_FLAGS_INITIALIZED )
 
   set( CUDA_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
-  set( CMAKE_CUDA_FLAGS                "${Draco_CUDA_ARCH} -g --expt-relaxed-constexpr")
+  set( CMAKE_CUDA_FLAGS                "${Draco_CUDA_ARCH} -g
+    --expt-relaxed-constexpr --expt-extended-lambda")
   if( CMAKE_CXX_COMPILER_ID MATCHES "XL")
     string(APPEND CMAKE_CUDA_FLAGS " -ccbin xlC -Xcompiler -std=c++14 -Xcompiler --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -Xcompiler -qxflag=disable__cplusplusOverride")
   endif()


### PR DESCRIPTION
### Background

* Thrust makes it very easy to do operations on array-like containers with `for_each` and lambdas. To use trust with device lambdas you need to compile with `--expt-extended-lambda` (https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#options-for-altering-compiler-linker-behavior-extended-lambda). 

### Purpose of Pull Request

* Needed for recent GPU improvement in Jayenne
* Allow more `std::algorithm` like code in CUDA with Thrust and lambdas

### Description of changes

* Add flag for device lambdas

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
