### PR TITLE
Disable OpenMP support if discovered version is too old

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -39,13 +39,12 @@ if( HAVE_PAPI )
     "Provide PAPI hardware counters if available." )
 endif()
 
-##---------------------------------------------------------------------------##
-## Query OpenMP availability
-##
-## This feature is usually compiler specific and a compile flag must be added.
-## For this to work the <platform>-<compiler>.cmake files (eg.  unix-g++.cmake)
-## call this macro.
-## ---------------------------------------------------------------------------##
+#-------------------------------------------------------------------------------------------------#
+# Query OpenMP availability
+#
+# This feature is usually compiler specific and a compile flag must be added. For this to work the
+# <platform>-<compiler>.cmake files (e.g.:  unix-g++.cmake) call this macro.
+#-------------------------------------------------------------------------------------------------#
 macro( query_openmp_availability )
   if( NOT PLATFORM_CHECK_OPENMP_DONE )
     set( PLATFORM_CHECK_OPENMP_DONE TRUE CACHE BOOL "Is check for OpenMP done?")
@@ -53,9 +52,15 @@ macro( query_openmp_availability )
     message( STATUS "Looking for OpenMP...")
     find_package(OpenMP QUIET)
     if( OPENMP_FOUND )
-      message( STATUS "Looking for OpenMP... ${OpenMP_C_FLAGS}")
-      set( OPENMP_FOUND ${OPENMP_FOUND} CACHE BOOL "Is OpenMP availalable?"
-        FORCE )
+        message( STATUS "Looking for OpenMP... ${OpenMP_C_FLAGS} (supporting the "
+          "${OpenMP_C_VERSION} standard)")
+      if( OpenMP_C_VERSION VERSION_LESS 3.0 )
+        message( STATUS "OpenMP standard support is too old (< 3.0). Disabling OpenMP build "
+          "features.")
+        set(OPENMP_FOUND FALSE)
+        set(OpenMP_C_FLAGS "" CACHE BOOL "OpenMP disabled (too old)." FORCE)
+      endif()
+      set( OPENMP_FOUND ${OPENMP_FOUND} CACHE BOOL "Is OpenMP available?" FORCE )
     else()
       message(STATUS "Looking for OpenMP... not found")
     endif()

--- a/src/c4/test/tstOMP_API_on.cc
+++ b/src/c4/test/tstOMP_API_on.cc
@@ -63,7 +63,10 @@ int main(int argc, char **argv) {
 
 /* No OpenMP case handled in tstOMP_API_off */
 int main(int argc, char **argv) {
-  rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_jayenne::release);
+  rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
+  try {
+    PASSMSG("OpenMP disabled. No testing will be done.");
+  }
   UT_EPILOG(ut);
 }
 


### PR DESCRIPTION
### Background

+ If OpenMP is found, but the supported version standard is older than 3.0, disable OpenMP.  This is required because we use newer OMP pragmas.
+ Also fix a bug in the new test `tstOMP_API_on.cc` for  the OpenMP-disabled case.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
