### PR TITLE
Minor tweak to dev environment.

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -614,7 +614,7 @@ macro( SetupVendorLibrariesUnix )
 
   # Doxygen ------------------------------------------------------------------
   message( STATUS "Looking for Doxygen..." )
-  find_package( Doxygen QUIET OPTIONAL_COMPONENTS dot mscgen dia )
+  find_package( Doxygen QUIET OPTIONAL_COMPONENTS dot mscgen )
   set_package_properties( Doxygen PROPERTIES
     URL "http://www.stack.nl/~dimitri/doxygen"
     DESCRIPTION "Doxygen autodoc generator"
@@ -646,7 +646,7 @@ macro( SetupVendorLibrariesWindows )
 
   # Doxygen ------------------------------------------------------------------
   message( STATUS "Looking for Doxygen..." )
-  find_package( Doxygen QUIET OPTIONAL_COMPONENTS dot mscgen dia )
+  find_package( Doxygen QUIET OPTIONAL_COMPONENTS dot mscgen )
   set_package_properties( Doxygen PROPERTIES
     URL "http://www.stack.nl/~dimitri/doxygen"
     DESCRIPTION "Doxygen autodoc generator"

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -129,7 +129,7 @@ if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
     export https_proxy=$http_proxy
     export HTTP_PROXY=$http_proxy
     export HTTPS_PROXY=$http_proxy
-    export no_proxy=".lanl.gov"
+    export no_proxy=lanl.gov
     export NO_PROXY=$no_proxy
   fi
 


### PR DESCRIPTION
### Description of changes

+ No longer look for `dia` as a tool to be used by `doxygen`.  `dia` is no longer maintained and is incompatible with newer tools like `python3`.
+ Fix an incorrect value for `NO_PROXY` in `.bashrc`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
