### PR TITLE
Split QueryEnv into Query_Env and SLURM_Task_Info for better reuse.

### DIFF
--- a/config/configureFileOnMake.cmake
+++ b/config/configureFileOnMake.cmake
@@ -56,6 +56,7 @@ endif()
 
 # Decode "---" as " " for variables passed to this function
 string( REPLACE "___" " " project_brief "${project_brief}" )
+string( REPLACE "___" " " DOXYGEN_HTML_DYNAMIC_MENUS ${DOXYGEN_D ../HTML_DYNAMIC_MENUS} )
 
 # Ensure we use native path styles
 file( TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}" PROJECT_SOURCE_DIR )

--- a/config/dracoVersion.cmake
+++ b/config/dracoVersion.cmake
@@ -84,6 +84,8 @@ macro( set_ccs2_software_version PROJNAME )
       "${${PROJNAME}_DATE_STAMP_YEAR}${${PROJNAME}_DATE_STAMP_MONTH}${${PROJNAME}_DATE_STAMP_DAY}"
       )
   endif()
+  set( ${PROJNAME}_VERSION_PATCH ${${PROJNAME}_VERSION_PATCH} CACHE STRING
+    "version info" FORCE )
 
   set( ${PROJNAME}_VERSION "${${PROJNAME}_VERSION_MAJOR}.${${PROJNAME}_VERSION_MINOR}"
     CACHE STRING "${PROJNAME} version information" FORCE)

--- a/src/c4/SLURM_Task_Info.hh
+++ b/src/c4/SLURM_Task_Info.hh
@@ -31,6 +31,8 @@ namespace rtt_c4 {
  *
  * Draco's unit tests don't really make sure that's the case, so if SLURM
  * changes, this may break. */
+//----------------------------------------------------------------------------//
+
 class SLURM_Task_Info {
 public:
   /**\brief Get SLURM_CPUS_PER_TASK */

--- a/src/c4/SLURM_Task_Info.hh
+++ b/src/c4/SLURM_Task_Info.hh
@@ -1,6 +1,6 @@
 //----------------------------------*-C++-*-----------------------------------//
 /*!
- * \file   c4/QueryEnv.hh
+ * \file   c4/SLURM_Task_Info.hh
  * \author Tim Kelley
  * \date   Fri Jun 7 08:06:53 2019
  * \brief  Functions for working with your environment
@@ -8,60 +8,22 @@
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-#ifndef Query_Env_hh
-#define Query_Env_hh
+#ifndef SLURM_Task_Info_hh
+#define SLURM_Task_Info_hh
 
-#include <cstdlib> // getenv, setenv
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <tuple>
-#include <type_traits>
-#include <utility> // pair
+#include "ds++/Query_Env.hh"
 
 namespace rtt_c4 {
 
 //----------------------------------------------------------------------------//
 /*!
- * \brief Get a value from the environment
+ *\brief Basic information about SLURM tasks, and whether that information was
+ *       available.
  *
- * \tparam T: the type of the value, must be default constructible
- *
- * \param key: the key to which you would like the corresponding value
- * \param default_value: a default value to return if key undefined.
- * \return: {whether key was defined, corresponding value}
- *
- * \note Calls POSIX getenv() function, which is not required to be re-entrant.
- * If the key was set in the environment, get_env_val() returns the value
- * converted to type T, that was set in the environment. If the key was not set
- * in the environment, it returns the default_value that the caller
- * provides. The first argument of the pair describes whether the key was
- * defined.
- */
-template <typename T>
-std::pair<bool, T> get_env_val(std::string const &key, T default_value = T{}) {
-  static_assert(std::is_default_constructible<T>::value,
-                "get_env_val only usable with default constructible types");
-  T val{default_value};
-  char *s_val = getenv(key.c_str());
-  bool is_defined(false);
-  if (s_val) {
-    std::stringstream val_str(s_val);
-    val_str >> val;
-    is_defined = true;
-  }
-  return std::make_pair(is_defined, val);
-} // get_env_val
-
-//----------------------------------------------------------------------------//
-/*!
- *\brief Basic information about SLURM tasks, and whether that information
- * was available.
- *
- * \note: values are based on what was in the environment at the time this
- * class is instantiated. This class is likely non-reentrant, so use with care
- * in multithreaded environments. This class relies on SLURM setting the
- * following environment variables:
+ * \note values are based on what was in the environment at the time this class
+ *       is instantiated. This class is likely non-reentrant, so use with care
+ *       in multithreaded environments. This class relies on SLURM setting the
+ *       following environment variables:
  *
  * SLURM_CPUS_PER_TASK  (the argument to -c)
  * SLURM_NTASKS         (the argument to -n)
@@ -86,9 +48,9 @@ public:
   //! Return value of SLURM_NODELIST
   std::string get_nodelist() const { return nodelist_; }
 
-  /* note: these rely on the idea that n_cpus_per_task etc are never
-   * going to be in the realm of 2 billion. On the blessaed day that
-   * comes to pass, Machine Overlords, rethink this (please / thank you). */
+  /* note: these rely on the idea that n_cpus_per_task etc are never going to be
+   * in the realm of 2 billion. On the blessaed day that comes to pass, Machine
+   * Overlords, rethink this (please / thank you). */
 
   /**\brief Was SLURM_CPUS_PER_TASK set? */
   bool is_cpus_per_task_set() const { return def_cpus_per_task_; }
@@ -102,14 +64,15 @@ public:
   // ctor
   SLURM_Task_Info() {
     std::tie(def_cpus_per_task_, cpus_per_task_) =
-        get_env_val<int>("SLURM_CPUS_PER_TASK", cpus_per_task_);
-    std::tie(def_ntasks_, ntasks_) = get_env_val<int>("SLURM_NTASKS", ntasks_);
+        rtt_dsxx::get_env_val<int>("SLURM_CPUS_PER_TASK", cpus_per_task_);
+    std::tie(def_ntasks_, ntasks_) =
+        rtt_dsxx::get_env_val<int>("SLURM_NTASKS", ntasks_);
     std::tie(def_job_num_nodes_, job_num_nodes_) =
-        get_env_val<int>("SLURM_JOB_NUM_NODES", job_num_nodes_);
+        rtt_dsxx::get_env_val<int>("SLURM_JOB_NUM_NODES", job_num_nodes_);
     std::tie(def_cpus_on_node_, cpus_on_node_) =
-        get_env_val<int>("SLURM_CPUS_ON_NODE", job_num_nodes_);
+        rtt_dsxx::get_env_val<int>("SLURM_CPUS_ON_NODE", job_num_nodes_);
     std::tie(def_nodelist_, nodelist_) =
-        get_env_val<std::string>("SLURM_NODELIST");
+        rtt_dsxx::get_env_val<std::string>("SLURM_NODELIST");
   }
 
   // state
@@ -131,8 +94,8 @@ private:
 
 } // namespace rtt_c4
 
-#endif // Query_Env_hh
+#endif // SLURM_Task_Info_hh
 
 //----------------------------------------------------------------------------//
-// end of QueryEnv.hh
+// end of SLURM_Task_Info.hh
 //----------------------------------------------------------------------------//

--- a/src/c4/bin/ythi.cc
+++ b/src/c4/bin/ythi.cc
@@ -26,7 +26,6 @@
 
 #include "c4/bin/ythi.hh"
 #include "c4/C4_Functions.hh"
-#include "c4/QueryEnv.hh"
 #include "c4/xthi_cpuset.hh"
 #include <atomic>
 #include <iomanip>

--- a/src/c4/bin/ythi.hh
+++ b/src/c4/bin/ythi.hh
@@ -15,7 +15,7 @@
 #define rtt_c4_bin_ythi_hh
 
 #include "c4/C4_Functions.hh"
-#include "c4/QueryEnv.hh"
+#include "c4/SLURM_Task_Info.hh"
 #include "c4/xthi_cpuset.hh"
 #include <atomic>
 #include <iomanip>

--- a/src/c4/test/tstQuoWrapper.cc
+++ b/src/c4/test/tstQuoWrapper.cc
@@ -9,8 +9,8 @@
 //----------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
-#include "c4/QueryEnv.hh"
 #include "c4/QuoWrapper.hh"
+#include "c4/SLURM_Task_Info.hh"
 #include "c4/bin/ythi.hh"
 #include "ds++/DracoMath.hh"
 #include "ds++/Release.hh"

--- a/src/c4/test/tstSLURM_Task_Info.cc
+++ b/src/c4/test/tstSLURM_Task_Info.cc
@@ -1,6 +1,6 @@
 //----------------------------------*-C++-*-----------------------------------//
 /*!
- * \file   c4/test/tstQueryEnv.cc
+ * \file   c4/test/tstSLURM_Task_Info.cc
  * \author Tim Kelley
  * \date   Fri Jun 7 08:06:53 2019
  * \note   Copyright (C) 2019-2020 Triad National Security, LLC.

--- a/src/c4/test/tstSLURM_Task_Info.cc
+++ b/src/c4/test/tstSLURM_Task_Info.cc
@@ -7,7 +7,7 @@
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
-#include "c4/QueryEnv.hh"
+#include "c4/SLURM_Task_Info.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/SystemCall.hh"
@@ -36,7 +36,7 @@ env_store_t clean_env() {
     constexpr int a_large_int = 0x0FFFFFFC;
     bool k_defined{false};
     int ival;
-    std::tie(k_defined, ival) = rtt_c4::get_env_val<int>(k, a_large_int);
+    std::tie(k_defined, ival) = rtt_dsxx::get_env_val<int>(k, a_large_int);
     if (k_defined) {
       std::stringstream storestr;
       storestr << ival;
@@ -168,5 +168,5 @@ int main(int argc, char *argv[]) {
 }
 
 //----------------------------------------------------------------------------//
-// end of c4/test/tstQueryEnv.cc
+// end of c4/test/tstSLURM_Task_Info.cc
 //----------------------------------------------------------------------------//

--- a/src/ds++/Query_Env.hh
+++ b/src/ds++/Query_Env.hh
@@ -37,6 +37,8 @@ namespace rtt_dsxx {
  *       not set in the environment, it returns the default_value that the
  *       caller provides. The first argument of the pair describes whether the
  *       key was defined.
+ *
+ * \example ds++/test/tstQuery_Env.cc
  */
 template <typename T>
 std::pair<bool, T> get_env_val(std::string const &key, T default_value = T{}) {

--- a/src/ds++/Query_Env.hh
+++ b/src/ds++/Query_Env.hh
@@ -1,0 +1,63 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   ds++/Query_Env.hh
+ * \author Tim Kelley
+ * \date   Fri Jun 7 08:06:53 2019
+ * \brief  Functions for working with your environment
+ * \note   Copyright (C) 2019-2020 Triad National Security, LLC.
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef Query_Env_hh
+#define Query_Env_hh
+
+#include <cstdlib> // getenv, setenv
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility> // pair
+
+namespace rtt_dsxx {
+
+//----------------------------------------------------------------------------//
+/*!
+ * \brief Get a value from the environment
+ *
+ * \tparam T: the type of the value, must be default constructible
+ *
+ * \param key: the key to which you would like the corresponding value
+ * \param default_value: a default value to return if key undefined.
+ * \return: {whether key was defined, corresponding value}
+ *
+ * \note Calls POSIX getenv() function, which is not required to be re-entrant.
+ *       If the key was set in the environment, get_env_val() returns the value
+ *       converted to type T, that was set in the environment. If the key was
+ *       not set in the environment, it returns the default_value that the
+ *       caller provides. The first argument of the pair describes whether the
+ *       key was defined.
+ */
+template <typename T>
+std::pair<bool, T> get_env_val(std::string const &key, T default_value = T{}) {
+  static_assert(std::is_default_constructible<T>::value,
+                "get_env_val only usable with default constructible types");
+  T val{default_value};
+  char *s_val = getenv(key.c_str());
+  bool is_defined(false);
+  if (s_val) {
+    std::stringstream val_str(s_val);
+    val_str >> val;
+    is_defined = true;
+  }
+  return std::make_pair(is_defined, val);
+
+} // get_env_val
+
+} // namespace rtt_dsxx
+
+#endif // Query_Env
+
+//----------------------------------------------------------------------------//
+// end ds++/Query_Env.hh
+//----------------------------------------------------------------------------//

--- a/src/ds++/test/tstQuery_Env.cc
+++ b/src/ds++/test/tstQuery_Env.cc
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   ds++/test/tstQuery_Env.cc
+ * \author Kent G. Budge
+ * \date   Wed Nov 10 09:35:09 2010
+ * \brief  Test functions defined in ds++/draco_math.hh.
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#include "ds++/Query_Env.hh"
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+
+//----------------------------------------------------------------------------//
+// TESTS
+//----------------------------------------------------------------------------//
+
+void tstgetpath(rtt_dsxx::UnitTest &ut) {
+
+  bool def_path{false};
+  std::string path;
+
+  std::tie(def_path, path) = rtt_dsxx::get_env_val<std::string>("PATH", path);
+
+  if (def_path && path.size() > 0)
+    PASSMSG("PATH was set in the environment.");
+  else
+    FAILMSG("Failed to read the PATH environment variable.");
+
+  return;
+}
+
+//----------------------------------------------------------------------------//
+void tstgetfoobar(rtt_dsxx::UnitTest &ut) {
+
+  bool def_foobar{false};
+  std::string foobar;
+
+  std::tie(def_foobar, foobar) =
+      rtt_dsxx::get_env_val<std::string>("FOOBAR", foobar);
+
+  FAIL_IF(def_foobar);
+  FAIL_IF(foobar.size() > 1);
+
+  return;
+}
+
+//----------------------------------------------------------------------------//
+int main(int argc, char *argv[]) {
+  rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
+  try {
+    tstgetpath(ut);
+    tstgetfoobar(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//----------------------------------------------------------------------------//
+// end of tstQuery_Env.cc
+//----------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* I want to use the `get_env_val` function without including all of the SLURM info.

### Description of changes

+ Pull `gen_env_val` out of `c4/QueryEnv.hh` and into a new file `ds++/Query_Env.hh`.
+ Rename `c4/QueryEnv.hh` to `c4/SLURM_Task_Info.hh`.
+ Add a unit test for `ds++/Query_Env.hh`.
+ Update include directives as needed.
+ I also included two one-line fixes to the build system that I needed during the most recent release.  
  + In `configureFileOnMake.cmake`, use a hack to correctly set `DOXYGEN_HTML_DYNAMIC_MENUS` in `doxygen_config`.  This will eliminate a build warning that occurs for the `make autodoc` rule.
  + In `dracoVersion.cmake`, ensure that the _patch_ version is saved to the `CMakeCache.txt`. This should fix an annoyance related to releases where the patch version is always listed as the build date instead of the actual patch version number.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
