### PR TITLE
Feature Add Caliper

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -503,6 +503,36 @@ endmacro()
 
 
 #------------------------------------------------------------------------------
+# Setup Caliper (https://github.com/LLNL/Caliper)
+#------------------------------------------------------------------------------
+macro( setupCaliper)
+
+  if( NOT TARGET caliper )
+    message( STATUS "Looking for Caliper...")
+
+    find_package( caliper QUIET
+      HINTS $ENV{CALIPER_ROOT_DIR}/share/cmake
+      )
+
+    if(caliper_FOUND)
+      message(STATUS "Looking for Caliper...found")
+    else()
+      message(STATUS "Looking for Caliper...not found")
+    endif()
+
+    if( DEFINED caliper_INCLUDE_DIR )
+      message(STATUS "caliper_INCLUDE_DIR ... defined: ${caliper_INCLUDE_DIR}")
+    else()
+      message(STATUS "caliper_INCLUDE_DIR ... not defined")
+    endif()
+
+  endif()
+
+endmacro()
+
+
+
+#------------------------------------------------------------------------------
 # Setup Eospac (https://laws.lanl.gov/projects/data/eos.html)
 #------------------------------------------------------------------------------
 macro( setupEOSPAC )
@@ -597,6 +627,7 @@ macro( SetupVendorLibrariesUnix )
   setupPython()
   setupQt()
   setupLIBQUO()
+  setupCaliper()
 
   # Grace ------------------------------------------------------------------
   message( STATUS "Looking for Grace...")

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -10,6 +10,16 @@ cmake_minimum_required(VERSION 3.9.0)
 project( diagnostics CXX )
 
 ##---------------------------------------------------------------------------##
+# Is Caliper available? If so, let's use it
+##---------------------------------------------------------------------------##
+if(TARGET caliper)
+  set( DRACO_CALIPER "1")
+else()
+  set( DRACO_CALIPER "0")
+endif()
+
+
+##---------------------------------------------------------------------------##
 # Special options for this component
 ##---------------------------------------------------------------------------##
 
@@ -78,6 +88,15 @@ add_component_executable(
 
 if( Qt5Core_DIR AND NOT "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le" )
   add_subdirectory( qt )
+endif()
+
+if(TARGET caliper)
+  target_include_directories( Lib_diagnostics
+    PUBLIC ${caliper_INCLUDE_DIR}
+    )
+  target_link_libraries(Lib_diagnostics
+    caliper
+    )
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/diagnostics/Timing.hh
+++ b/src/diagnostics/Timing.hh
@@ -215,9 +215,9 @@ private:
 
 #define TIMER(timer)
 
-#define TIMER_START(timer)
+#define TIMER_START(name, timer)
 
-#define TIMER_STOP(timer)
+#define TIMER_STOP(name, timer)
 
 #define TIMER_RECORD(name, timer)
 
@@ -225,6 +225,7 @@ private:
 
 #endif
 
+#ifndef DRACO_CALIPER
 //----------------------------------------------------------------------------//
 /*
  * Turn on basic timing operations.
@@ -244,7 +245,7 @@ private:
 #define TIMER_RECORD(name, timer)                                              \
   rtt_diagnostics::Timing_Diagnostics::update_timer(name, timer.wall_clock())
 
-#endif
+#endif // DRACO_TIMING > 0
 
 //----------------------------------------------------------------------------//
 /*
@@ -261,11 +262,34 @@ private:
           << " seconds.\n"                                                     \
           << std::flush
 
-#else
+#else // DRACO_TIMING > 1
 
 #define TIMER_REPORT(timer, ostream, comment)
 
-#endif
+#endif // DRACO_TIMING > 1
+
+#else // Caliper is available
+#include <caliper/cali.h>
+
+#if DRACO_TIMING > 0
+
+#include "c4/Timer.hh"
+
+#define DRACO_TIMING_ON
+
+#define TIMER(timer)
+
+#define TIMER_START(name, timer) CALI_MARK_BEGIN(name)
+
+#define TIMER_STOP(name, timer) CALI_MARK_END(name)
+
+#define TIMER_RECORD(name, timer)
+
+#define TIMER_REPORT(timer, ostream, comment)
+
+#endif // DRACO_TIMING > 0
+
+#endif // DRACO_CALIPER
 
 #endif // diagnostics_Timing_hh
 

--- a/src/diagnostics/config.h.in
+++ b/src/diagnostics/config.h.in
@@ -17,6 +17,9 @@
 /* USE PROCMON - snapshot in time memory reporting via getrusage */
 #cmakedefine USE_PROCMON @USE_PROCMON@
 
+/* Is the Caliper library available? */
+#cmakedefine DRACO_CALIPER @DRACO_CALIPER@
+
 #endif /* rtt_diagnostics_config_h */
 
 /*---------------------------------------------------------------------------*/

--- a/src/diagnostics/test/tstTiming.cc
+++ b/src/diagnostics/test/tstTiming.cc
@@ -25,7 +25,7 @@ typedef rtt_diagnostics::Timing_Diagnostics D;
 
 void do_A() {
   TIMER(A_timer);
-  TIMER_START(A_timer);
+  TIMER_START("A_iteration", A_timer);
 
   // do a mat-vec multiply
 
@@ -49,7 +49,7 @@ void do_A() {
   b[0] = B * x[0] + C * x[1];
   b[S - 1] = A * x[S - 2] + B * x[S - 1];
 
-  TIMER_STOP(A_timer);
+  TIMER_STOP("A_iteration", A_timer);
   TIMER_RECORD("A_iteration", A_timer);
 }
 
@@ -57,7 +57,7 @@ void do_A() {
 
 void do_B() {
   TIMER(B_timer);
-  TIMER_START(B_timer);
+  TIMER_START("B_iteration", B_timer);
 
   // do a mat-vec multiply
 
@@ -81,7 +81,7 @@ void do_B() {
   b[0] = B * x[0] + C * x[1];
   b[S - 1] = A * x[S - 2] + B * x[S - 1];
 
-  TIMER_STOP(B_timer);
+  TIMER_STOP("B_iteration", B_timer);
   TIMER_RECORD("B_iteration", B_timer);
 }
 
@@ -89,7 +89,7 @@ void do_B() {
 
 void do_C() {
   TIMER(C_timer);
-  TIMER_START(C_timer);
+  TIMER_START("C_iteration", C_timer);
 
   // do a mat-vec multiply
 
@@ -113,7 +113,7 @@ void do_C() {
   b[0] = B * x[0] + C * x[1];
   b[S - 1] = A * x[S - 2] + B * x[S - 1];
 
-  TIMER_STOP(C_timer);
+  TIMER_STOP("C_iteration", C_timer);
   TIMER_RECORD("C_iteration", C_timer);
 }
 
@@ -222,13 +222,13 @@ void test_macros(rtt_dsxx::UnitTest &ut) {
 
   // make timers and do results
   TIMER(outer_timer);
-  TIMER_START(outer_timer);
+  TIMER_START("Outer", outer_timer);
 
   do_A();
   do_B();
   do_C();
 
-  TIMER_STOP(outer_timer);
+  TIMER_STOP("Outer", outer_timer);
   TIMER_RECORD("Outer", outer_timer);
 
   // if the timers are off we get no timing data
@@ -239,6 +239,7 @@ void test_macros(rtt_dsxx::UnitTest &ut) {
   if (D::num_timers() != 0)
     ITFAILS;
 #else
+#ifndef DRACO_CALIPER
   if (keys.size() != 4)
     ITFAILS;
   cout << setw(15) << "Routine" << setw(15) << "Fraction" << endl;
@@ -259,6 +260,7 @@ void test_macros(rtt_dsxx::UnitTest &ut) {
 
   cout << "The total time was " << total << endl;
   cout << endl;
+#endif // DRACO_CALIPER
 #endif
 
   TIMER_REPORT(outer_timer, cout, "Total time");


### PR DESCRIPTION
### Background

* Caliper is a useful timing and diagnostics library

### Purpose of Pull Request

* Change existing Draco timing macros to allow either old-school Draco timing or exciting new Caliper.

### Description of changes

* Add a `find_package` to the build system to find Caliper.
* When Caliper is available, Draco timing macros are switched over to Caliper timing macros.
* When Caliper is not available, Draco timing macros use Draco Timing diagnostics.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
