### PR TITLE
Fix timing macros for Draco diagnostics timing case.

### DIFF
--- a/src/diagnostics/Timing.hh
+++ b/src/diagnostics/Timing.hh
@@ -161,7 +161,7 @@ private:
  */
 
 /*!
- * \def TIMER_START(segmant_name, timer_name)
+ * \def TIMER_START(segment_name, timer_name)
  *
  * If DRACO_TIMING > 0 and DRACO_CALIPER is false
  * TIMER_START(segment_name, timer_name) expands to:
@@ -186,6 +186,7 @@ private:
  * \code
  *     timer_name.stop()
  * \endcode
+ * (Note that the segment_name is ignored.)
  * If DRACO_TIMING > 0 and DRACO_CALIPER is true, then
  * TIMER_STOP(segment_name, timer_name) expands to:
  * \code


### PR DESCRIPTION
## Background

* In adding Caliper capability, neglected to update the case where DRACO_TIMING is on but Caliper is not used.

### Purpose of Pull Request

* Update macros for the case where DRACO_TIMING is on but Caliper is not used.

### Description of changes

* Add argument (unused) to `TIMER_START` and `TIMER_END` so signatures are consistent in all cases.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
