### PR TITLE
Attempt to set PYTHONPATH for new superlinter checks.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,7 +2,7 @@
 ###########################
 ###########################
 ## Linter GitHub Actions ##
-## github.com/github/super-linter 
+## github.com/github/super-linter
 ###########################
 ###########################
 name: Lint Code Base
@@ -21,6 +21,9 @@ on:
     branches-ignore:
       - 'master'
       - 'develop'
+
+env:
+  PYTHONPATH: /home/runner/work/Draco/Draco/config
 
 ###############
 # Set the Job #

--- a/src/viz/test/tstEnsight_Translator.py
+++ b/src/viz/test/tstEnsight_Translator.py
@@ -4,7 +4,7 @@
 # date   Wednesday, September 14, 2016, 14:16 pm
 # brief  This is a Python script that is used to check the output from
 #        viz/test/tstEnsight_Translator
-# note   Copyright (C) 2016, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 


### PR DESCRIPTION
### Background

* Python linter checks are failing because some python files are not in python path.
* This may take some trial and error iteration to make it work.

### Description of changes

* Attempt to set PYTHON path for the linter check.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
