### PR TITLE
Add "USE_CUDA" preprocessor definition to config file

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -319,10 +319,6 @@ macro( add_component_library )
     OUTPUT_NAME ${acl_LIBRARY_NAME_PREFIX}${acl_LIBRARY_NAME}
     FOLDER      ${folder_name}
     WINDOWS_EXPORT_ALL_SYMBOLS ON )
- if("${acl_LINK_LANGUAGE}" STREQUAL "CUDA")
-   set_property( TARGET ${acl_TARGET} APPEND PROPERTY
-     COMPILE_DEFINITIONS "USE_CUDA=ON" )
- endif()
   if( DEFINED DRACO_LINK_OPTIONS AND NOT "${DRACO_LINK_OPTIONS}x" STREQUAL "x")
     set_property( TARGET ${acl_TARGET} APPEND PROPERTY
       LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
@@ -605,10 +601,6 @@ macro( add_scalar_tests test_sources )
       COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"" )
     set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
       COMPILE_DEFINITIONS "PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\"" )
-    if("${addscalartest_LINK_LANGUAGE}" STREQUAL "CUDA")
-      set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-        COMPILE_DEFINITIONS "USE_CUDA=ON" )
-    endif()
     if( DEFINED DRACO_LINK_OPTIONS AND
         NOT "${DRACO_LINK_OPTIONS}x" STREQUAL "x")
       set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY

--- a/src/device/config.h.in
+++ b/src/device/config.h.in
@@ -19,7 +19,7 @@
 /*----------------------------------------------------------------------------*/
 /* Mark functions for compilation on host and device */
 
-#if defined HAVE_CUDA && defined USE_CUDA
+#if defined __NVCC__ && defined USE_CUDA
 #define HOST_AND_DEVICE_FUNCTION __host__ __device__
 #define GPU_HOST_DEVICE __host__ __device__
 #define GPU_KERNEL __global__

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -198,7 +198,7 @@ void show_cookies(std::string const &cond, std::string const &file,
 [[noreturn]] void insist_ptr(char const *const cond, char const *const msg,
                              char const *const file, int const line);
 
-#if defined HAVE_CUDA && defined USE_CUDA
+#if defined __NVCC__ && defined USE_CUDA
 
 /*! \brief A special version of insist that does not throw.  Useful for GPU
  *         code. \sa device/config.h.in */
@@ -286,8 +286,8 @@ std::string verbose_error(std::string const &message);
  *
  * Special code for CUDA.
  *
- * If HAVE_CUDA=ON and USE_CUDA=ON, then alter the behavior of the DbC macros
- * because cuda code cannot throw.
+ * If __NVCC__  (processing with nvcc) and USE_CUDA=ON, then alter the behavior
+ * of the DbC macros because cuda code cannot throw.
  */
 /*!
  * \def Require(condition)
@@ -337,16 +337,16 @@ std::string verbose_error(std::string const &message);
  * disable DBC.
  */
 //----------------------------------------------------------------------------//
-#if ( DBC & 8 ) || ( defined HAVE_CUDA && defined USE_CUDA )
+#if ( DBC & 8 ) || ( defined __NVCC__ && defined USE_CUDA )
 
-#if ( DBC & 1 ) && !( defined HAVE_CUDA && defined USE_CUDA )
+#if ( DBC & 1 ) && !( defined __NVCC__ && defined USE_CUDA )
 #define REQUIRE_ON
 #define Require(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
 #else
 #define Require(c)
 #endif
 
-#if ( DBC & 2 ) && !( defined HAVE_CUDA && defined USE_CUDA )
+#if ( DBC & 2 ) && !( defined __NVCC__ && defined USE_CUDA )
 #define CHECK_ON
 #define Check(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
 #define Assert(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
@@ -355,7 +355,7 @@ std::string verbose_error(std::string const &message);
 #define Assert(c)
 #endif
 
-#if ( DBC & 4 ) && !( defined HAVE_CUDA && defined USE_CUDA )
+#if ( DBC & 4 ) && !( defined __NVCC__ && defined USE_CUDA )
 #define ENSURE_ON
 #define Ensure(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
 #else
@@ -365,7 +365,7 @@ std::string verbose_error(std::string const &message);
 //----------------------------------------------------------------------------//
 // Always on
 //----------------------------------------------------------------------------//
-#if ( defined HAVE_CUDA && defined USE_CUDA )
+#if ( defined __NVCC__  && defined USE_CUDA )
 #define Insist(c, m) if(!(c)) rtt_dsxx::no_exception_insist( #c, m, __FILE__, __LINE__)
 #else
 #define Insist(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
@@ -459,7 +459,7 @@ std::string verbose_error(std::string const &message);
 // If any of DBC is on, then make the remember macro active and the NOEXCEPT
 // inactive.
 //----------------------------------------------------------------------------//
-#if DBC && !( defined HAVE_CUDA && defined USE_CUDA )
+#if DBC && !( defined USE_CUDA && defined __NVCC__ )
 #define REMEMBER_ON
 #define Remember(c) c
 #define NOEXCEPT

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -69,7 +69,7 @@
 #cmakedefine draco_is64bit
 #cmakedefine DRACO_UNAME @DRACO_UNAME@
 #cmakedefine HAVE_CUDA @HAVE_CUDA@
-/* #cmakedefine USE_CUDA @USE_CUDA@ */
+#cmakedefine USE_CUDA @USE_CUDA@
 /* Eg: project(foo CXX ${CUDA_DBS_STRING}) */
 #cmakedefine CUDA_DBS_STRING @CUDA_DBS_STRING@
 #cmakedefine APPLE @APPLE@

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -61,7 +61,7 @@ add_scalar_tests(
 target_include_directories( Ut_rng_ut_uniform_exe
   PRIVATE $<BUILD_INTERFACE:${rng_SOURCE_DIR}> )
 
- if( HAVE_CUDA )
+ if( USE_CUDA )
 
   set( test_sources_cuda
      ${PROJECT_SOURCE_DIR}/kat_cuda.cu)


### PR DESCRIPTION
### Background

* Code compiled on the GPU currently sees the preprocessor variable `USE_CUDA` but CPU code that sees GPU code or conditionally calls GPU code also needs to see if `USE_CUDA` is set. To this end, I've added `USE_CUDA` back to the config files in draco. I've also hid a few DBC macros that are used on the GPU behind an `if defined(USE_CUDA) && defined(__NVCC__)` instead of just a `USE_CUDA` check. This makes sure that the CPU does not end up with GPU versions of the DBC calls.

### Purpose of Pull Request

* Needed to get `mcgrid` tests passing with GPUs in Jayenne

### Description of changes

* Remove CMake commands that add "USE_CUDA" to compile line
* Wrap some macros in "__NVCC__" to ensure they are only processed by the NVCC compiler

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
