### PR TITLE
Minor environment cleanup

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -341,6 +341,7 @@ macro( setupCrayMPI )
   string(APPEND preflags " --gres=craynetwork:0") # --exclusive
   set( MPIEXEC_PREFLAGS ${preflags} CACHE STRING
     "extra mpirun flags (list)." FORCE)
+  # consider adding '-m=cyclic'
   set( MPIEXEC_PREFLAGS_PERFBENCH ${preflags} CACHE STRING
     "extra mpirun flags (list)." FORCE)
 

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -57,7 +57,7 @@ case ${-} in
 
     # Attempt to find DRACO
     if ! [[ $DRACO_SRC_DIR ]]; then
-      _BINDIR=$(dirname "${BASH_ARGV[@]:1}")
+      _BINDIR=$(dirname "${BASH_ARGV[0]}")
       DRACO_SRC_DIR=$(cd "$_BINDIR/../.." || exit; pwd)
       export DRACO_SRC_DIR
       export DRACO_ENV_DIR="${DRACO_SRC_DIR}/environment"

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -57,20 +57,23 @@ case ${-} in
 
     # Attempt to find DRACO
     if ! [[ $DRACO_SRC_DIR ]]; then
-      _BINDIR=`dirname "$BASH_ARGV"`
-      export DRACO_SRC_DIR=`(cd $_BINDIR/../..;pwd)`
-      export DRACO_ENV_DIR=${DRACO_SRC_DIR}/environment
+      _BINDIR=$(dirname "${BASH_ARGV[@]:1}")
+      DRACO_SRC_DIR=$(cd "$_BINDIR/../.." || exit; pwd)
+      export DRACO_SRC_DIR
+      export DRACO_ENV_DIR="${DRACO_SRC_DIR}/environment"
     fi
 
     ##------------------------------------------------------------------------##
     ## Common aliases
     ##------------------------------------------------------------------------##
 
-    source ${DRACO_ENV_DIR}/bashrc/bash_aliases.sh
+    # help shellcheck linter.
+    # shellcheck source=/dev/null
+    source "${DRACO_ENV_DIR}/bashrc/bash_aliases.sh"
 
     # If this is an xterm set the title to user@host:dir
     case "$TERM" in
-      xterm*|rxvt*) echo -ne "\033]0;${nodename}\007" ;;
+      xterm*|rxvt*) echo -ne "\033]0;${nodename:-xterm}\007" ;;
       *) ;;
     esac
     ;; # end case 'interactive'
@@ -92,13 +95,16 @@ esac
 if [[ ${INTERACTIVE} ]]; then
 
   # Common bash functions and alias definitions
-  source ${DRACO_ENV_DIR}/bashrc/bash_functions.sh
-  source ${DRACO_ENV_DIR}/../tools/common.sh
+  # shellcheck source=/dev/null
+  source "${DRACO_ENV_DIR}/bashrc/bash_functions.sh"
+  # shellcheck source=/dev/null
+  source "${DRACO_ENV_DIR}/../tools/common.sh"
 
   # aliases and bash functions for working with slurm
-  if !  [[ `which squeue 2>&1 | grep -c "no squeue"` == 1 ]] &&
-    [[ `which squeue | grep -c squeue` -gt 0 ]]; then
-    source ${DRACO_ENV_DIR}/bashrc/bashrc_slurm
+  if !  [[ $(which squeue 2>&1 | grep -c "no squeue") == 1 ]] &&
+    [[ $(which squeue | grep -c squeue) -gt 0 ]]; then
+    # shellcheck source=/dev/null
+    source "${DRACO_ENV_DIR}/bashrc/bashrc_slurm"
   fi
 fi
 
@@ -109,13 +115,13 @@ fi
 if [[ ${INTERACTIVE} == true ]]; then
 
   # Append PATHS (not linux specific, not ccs2 specific).
-  add_to_path ${DRACO_ENV_DIR}/bin
-  add_to_path ${DRACO_SRC_DIR}/tools
+  add_to_path "${DRACO_ENV_DIR}/bin"
+  add_to_path "${DRACO_SRC_DIR}/tools"
 
   # Tell wget to use LANL's www proxy (see
   # trac.lanl.gov/cgi-bin/ctn/trac.cgi/wiki/SelfHelpCenter/ProxyUsage)
   # export http_proxy=http://wpad.lanl.gov/wpad.dat
-  current_domain=`awk '/^domain/ {print $2}' /etc/resolv.conf`
+  current_domain=$(awk '/^domain/ {print $2}' /etc/resolv.conf)
   #  found=`nslookup proxyout.lanl.gov | grep -c Name`
   #  if test ${found} == 1; then
   if [[ ${current_domain} == "lanl.gov" ]]; then
@@ -136,7 +142,7 @@ if [[ ${INTERACTIVE} == true ]]; then
 
   # Parse the setup scripts, but don't actually load any modules.  This allows
   # the developer to run 'dracoenv' or 'rdde' later to load modules.
-  if [[ -z $DRACO_ENV_LOAD ]]; then
+  if [[ -z "$DRACO_ENV_LOAD" ]]; then
     export DRACO_ENV_LOAD=ON
   fi
 
@@ -146,35 +152,40 @@ if [[ ${INTERACTIVE} == true ]]; then
   ##---------------------------------------------------------------------------##
   ## ENVIRONMENTS - machine specific settings
   ##---------------------------------------------------------------------------##
-  target="`uname -n | sed -e s/[.].*//`"
-  arch=`uname -m`
+  target=$(uname -n | sed -e s/[.].*//)
 
   case ${target} in
 
     # Darwin Heterogeneous Cluster (GPU, ARM, P9, etc.)
     # wiki: https://darwin.lanl.gov
     darwin-fe* | cn[0-9]*)
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_darwin_fe ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_darwin_fe" ;;
 
     # Badger | Cyclone | Fire | Grizzly | Ice | Snow
     ba* | cy* | fi* | gr* | ic* | sn* )
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_cts1 ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_cts1" ;;
 
     # wtrw and rfta
     red-wtrw* | rfta* | redcap* )
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_rfta ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_rfta" ;;
 
     # capulin, thunder, trinitite (tt-fey) | trinity (tr-fe)
     cp-login* | th-login* |tt-fey* | tt-login* | tr-fe* | tr-login* | nid* )
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_cray ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_cray" ;;
 
     # LLNL ATS-2
     rzmanta* | rzansel* | sierra* )
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_ats2 ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_ats2" ;;
 
     # LAP Virtual Machine
     vc*)
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_vm ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_vm" ;;
 
     # CCS-NET machines (insufficient space on ccscs5 for vendor+data).
     ccscs5*)
@@ -183,30 +194,16 @@ if [[ ${INTERACTIVE} == true ]]; then
       export NoModules=1
       ;;
     ccscs[1-4]* | ccscs[6-9]*)
-      source ${DRACO_ENV_DIR}/bashrc/.bashrc_linux64 ;;
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_linux64" ;;
 
     # Assume personal workstation
-    *)
-      if [[ -d /ccs/codes/radtran ]]; then
-        # assume this is a CCS LAN machine (64-bit)
-        if test `uname -m` = 'x86_64'; then
-          # draco environment only supports 64-bit linux...
-          source ${DRACO_ENV_DIR}/bashrc/.bashrc_linux64
-        else
-          echo "Draco's environment is not fully supported on 32-bit Linux."
-          echo "Module support may not be available. Email kgt@lanl.gov for more information."
-          # source ${DRACO_ENV_DIR}/bashrc/.bashrc_linux32
-        fi
-      elif [[ -d /usr/projects/draco ]]; then
-        # XCP machine like 'toolbox'?
-        source ${DRACO_ENV_DIR}/bashrc/.bashrc_linux64
-      fi
-      export NoModules=1
-      ;;
+    *) export NoModules=1 ;;
 
   esac
 
-  source ${DRACO_ENV_DIR}/bashrc/bash_functions2.sh
+  # shellcheck source=/dev/null
+  source "${DRACO_ENV_DIR}/bashrc/bash_functions2.sh"
   if [[ "${DRACO_ENV_LOAD:-OFF}" == "ON" ]]; then
     dracoenv
   fi
@@ -215,7 +212,9 @@ fi
 
 # provide some bash functions (dracoenv, rmdracoenv) for non-interactive
 # sessions.
-source ${DRACO_ENV_DIR}/bashrc/bash_functions2.sh
+
+# shellcheck source=/dev/null
+source "${DRACO_ENV_DIR}/bashrc/bash_functions2.sh"
 
 if [[ "${verbose:=false}" == "true" ]]; then
   echo "done with draco/environment/bashrc/.bashrc";

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -106,13 +106,7 @@ fi
 ## ENVIRONMENTS - once per login
 ##---------------------------------------------------------------------------##
 
-# Darwin salloc inherits the user environment, so we need to bypass the
-# "already-done" logic
-if [[ ${SLURM_CLUSTER_NAME} == "darwin" ]]; then
-  export DRACO_BASHRC_DONE=no
-fi
-
-if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
+if [[ ${INTERACTIVE} == true ]]; then
 
   # Append PATHS (not linux specific, not ccs2 specific).
   add_to_path ${DRACO_ENV_DIR}/bin
@@ -216,9 +210,6 @@ if [[ ${DRACO_BASHRC_DONE:-no} == no ]] && [[ ${INTERACTIVE} == true ]]; then
   if [[ "${DRACO_ENV_LOAD:-OFF}" == "ON" ]]; then
     dracoenv
   fi
-
-  # Mark that we have already done this setup
-  export DRACO_BASHRC_DONE=yes
 
 fi
 

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -107,7 +107,7 @@ elif [[ ${CRAY_CPU_TARGET} =~ arm ]]; then
   module use --append ${VENDOR_DIR}-ec/modulefiles-capulin
   comp="gcc-8.3.0"
   mpi="mpt-7.7.10"
-  dracomodules="git/2.20.1 cmake numdiff/5.9.0-${comp} gsl/2.5-${comp} openblas/0.3.6-${comp} metis/5.1.0-${comp} eospac/6.4.0-${comp} random123/1.09-${comp} parmetis/4.0.3-${comp}-${mpi} superlu-dist/5.4.0-${comp}-${mpi}-openblas trilinos/12.14.1-${comp}-${mpi}-openblas cray-python/3.6.5.6 qt quo"
+  dracomodules="git/2.20.1 cmake/3.17.2 numdiff/5.9.0-${comp} gsl/2.5-${comp} openblas/0.3.6-${comp} metis/5.1.0-${comp} eospac/6.4.0-${comp} random123/1.09-${comp} parmetis/4.0.3-${comp}-${mpi} superlu-dist/5.4.0-${comp}-${mpi}-openblas trilinos/12.14.1-${comp}-${mpi}-openblas cray-python/3.6.5.6 qt quo"
 
   if [[ -d ${VENDOR_DIR}-ec ]]; then
     group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`

--- a/tools/ats1-env.sh
+++ b/tools/ats1-env.sh
@@ -142,7 +142,7 @@ case $ddir in
       run "module load intel/17.0.4"
       run "module load cmake/3.17.0 numdiff git"
       run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.14.1 metis parmetis/4.0.3 superlu-dist quo"
+      run "module load trilinos/12.14.1 metis parmetis/4.0.3 superlu-dist" # quo
       run "module use --append ${VENDOR_DIR}-ec/modulefiles"
       run "module load csk"
       run "module list"
@@ -175,7 +175,7 @@ case $ddir in
       run "module load intel/17.0.4"
       run "module load cmake/3.17.0 numdiff git"
       run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.14.1 metis parmetis/4.0.3 superlu-dist quo"
+      run "module load trilinos/12.14.1 metis parmetis/4.0.3 superlu-dist" # quo
       run "module use --append ${VENDOR_DIR}-ec/modulefiles"
       run "module load csk"
       run "module swap craype-haswell craype-mic-knl"

--- a/tools/ats1-env.sh
+++ b/tools/ats1-env.sh
@@ -9,7 +9,7 @@ export VENDOR_DIR=/usr/projects/draco/vendors
 export CRAYPE_LINK_TYPE=dynamic
 
 # Sanity Check (Cray machines have very fragile module systems!)
-if [[ -d $ParMETIS_ROOT_DIR ]]; then
+if [[ -d "${ParMETIS_ROOT_DIR:-false}" ]]; then
   echo "ERROR: This script should be run from a clean environment."
   echo "       Try running 'rmdracoenv'."
   exit 1
@@ -17,7 +17,7 @@ fi
 
 # symlinks will be generated for each machine that point to the correct
 # installation directory.
-if [[ `df | grep yellnfs2 | grep -c jayenne` -gt 0 ]]; then
+if [[ $(df | grep yellnfs2 | grep -c jayenne) -gt 0 ]]; then
   export siblings="trinitite"
 else
   export siblings="trinity"
@@ -30,8 +30,8 @@ environments="intel1904env intel1904env-knl intel1704env intel1704env-knl"
 export CONFIG_BASE+=" -DCMAKE_VERBOSE_MAKEFILE=ON"
 
 # SLURM
-avail_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\|.*access.*\)|.*/\1/' | sed -e 's/|.*//'`
-case $avail_queues in
+avail_queues=$(sacctmgr -np list assoc user="$LOGNAME" | sed -e 's/.*|\(.*dev.*\|.*access.*\)|.*/\1/' | sed -e 's/|.*//')
+case "$avail_queues" in
   *access*) access_queue="-A access --qos=access" ;;
   *dev*) access_queue="--qos=dev" ;;
 esac
@@ -41,12 +41,12 @@ export access_queue
 # Specify environments (modules)
 #------------------------------------------------------------------------------#
 
-if ! [[ $ddir ]] ;then
+if [[ "${ddir:-false}" == false ]] ;then
   echo "FATAL ERROR: Expected ddir to be set in the environment. (ats1-env.sh)"
   exit 1
 fi
 
-case $ddir in
+case "$ddir" in
 
   #------------------------------------------------------------------------------#
   draco-7_5*|draco-7_6*|draco-7_7*)
@@ -55,7 +55,7 @@ case $ddir in
       unset partition
       unset jobnameext
 
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
+      if [[ "${CRAY_CPU_TARGET}" == mic-knl ]]; then
         run "module swap craype-mic-knl craype-haswell"
       fi
       run "module load user_contrib friendly-testing"
@@ -78,10 +78,11 @@ case $ddir in
       run "module use --append ${VENDOR_DIR}-ec/modulefiles"
       run "module load csk"
       run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+      CC=$(which cc)
+      CXX=$(which CC)
+      FC=$(which ftn)
+      export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH":"$LD_LIBRARY_PATH"
+      export CC CXX FC
     }
 
     function intel1904env-knl()
@@ -89,7 +90,7 @@ case $ddir in
       export partition="-p knl"
       export jobnameext="-knl"
 
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
+      if [[ "${CRAY_CPU_TARGET}" == mic-knl ]]; then
         run "module swap craype-mic-knl craype-haswell"
       fi
       run "module load user_contrib friendly-testing"
@@ -113,17 +114,18 @@ case $ddir in
       run "module swap craype-haswell craype-mic-knl"
       run "module list"
       run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+      CC=$(which cc)
+      CXX=$(which CC)
+      FC=$(which ftn)
+      export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH":"$LD_LIBRARY_PATH"
+      export CC CXX FC
     }
     function intel1704env()
     {
       unset partition
       unset jobnameext
 
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
+      if [[ "${CRAY_CPU_TARGET}" == mic-knl ]]; then
         run "module swap craype-mic-knl craype-haswell"
       fi
       run "module load user_contrib friendly-testing"
@@ -146,10 +148,11 @@ case $ddir in
       run "module use --append ${VENDOR_DIR}-ec/modulefiles"
       run "module load csk"
       run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+      CC=$(which cc)
+      CXX=$(which CC)
+      FC=$(which ftn)
+      export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH":"$LD_LIBRARY_PATH"
+      export CC CXX FC
     }
 
     function intel1704env-knl()
@@ -157,7 +160,7 @@ case $ddir in
       export partition="-p knl"
       export jobnameext="-knl"
 
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
+      if [[ "${CRAY_CPU_TARGET}" == mic-knl ]]; then
         run "module swap craype-mic-knl craype-haswell"
       fi
       run "module load user_contrib friendly-testing"
@@ -181,221 +184,11 @@ case $ddir in
       run "module swap craype-haswell craype-mic-knl"
       run "module list"
       run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-    }
-    ;;
-
-#------------------------------------------------------------------------------#
-  draco-7_2* | draco-7_3* | draco-7_4*)
-    function intel1904env()
-    {
-      unset partition
-      unset jobnameext
-
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
-        run "module swap craype-mic-knl craype-haswell"
-      fi
-      run "module load user_contrib friendly-testing"
-      run "module unload cmake numdiff git"
-      run "module unload gsl random123 eospac"
-      run "module unload trilinos ndi quo"
-      run "module unload superlu-dist metis parmetis"
-      run "module unload csk lapack"
-      run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
-      run "module unload lapack "
-      run "module unload intel gcc"
-      run "module unload papi perftools"
-      run "module load PrgEnv-intel"
-      run "module unload intel"
-      run "module unload xt-libsci xt-totalview"
-      run "module unload cray-hugepages2M"
-      run "module load intel/19.0.4"
-      run "module load cmake/3.14.6 numdiff git"
-      run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.10.1 metis parmetis/4.0.3 superlu-dist quo"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk"
-      run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-    }
-    function intel1802env()
-    {
-      unset partition
-      unset jobnameext
-
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
-        run "module swap craype-mic-knl craype-haswell"
-      fi
-      run "module load user_contrib"
-      run "module load friendly-testing"
-      run "module unload cmake numdiff git"
-      run "module unload gsl random123 eospac"
-      run "module unload trilinos ndi quo"
-      run "module unload superlu-dist metis parmetis"
-      run "module unload csk lapack"
-      run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
-      run "module unload lapack "
-      run "module unload intel gcc"
-      run "module unload papi perftools"
-      run "module load PrgEnv-intel"
-      run "module unload intel"
-      run "module unload xt-libsci xt-totalview"
-      run "module unload cray-hugepages2M"
-      run "module load intel/18.0.2"
-      run "module load cmake/3.14.6 numdiff git"
-      run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.14.1 metis parmetis/4.0.3 superlu-dist quo"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk"
-      run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-    }
-    function intel1904env-knl()
-    {
-      export partition="-p knl"
-      export jobnameext="-knl"
-
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
-        run "module swap craype-mic-knl craype-haswell"
-      fi
-      run "module load user_contrib friendly-testing"
-      run "module unload cmake numdiff git"
-      run "module unload gsl random123 eospac"
-      run "module unload trilinos ndi quo"
-      run "module unload superlu-dist metis parmetis"
-      run "module unload csk lapack"
-      run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
-      run "module unload intel gcc"
-      run "module unload papi perftools"
-      run "module load PrgEnv-intel"
-      run "module unload intel"
-      run "module unload xt-libsci xt-totalview"
-      run "module unload cray-hugepages2M"
-      run "module load intel/19.0.4"
-      run "module load cmake/3.14.6 numdiff git"
-      run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.14.1 metis parmetis/4.0.3 superlu-dist quo"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk"
-      run "module swap craype-haswell craype-mic-knl"
-      run "module list"
-      run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-    }
-
-    function intel1802env-knl()
-    {
-      export partition="-p knl"
-      export jobnameext="-knl"
-
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
-        run "module swap craype-mic-knl craype-haswell"
-      fi
-      run "module load user_contrib friendly-testing"
-      run "module unload cmake numdiff git"
-      run "module unload gsl random123 eospac"
-      run "module unload trilinos ndi quo"
-      run "module unload superlu-dist metis parmetis"
-      run "module unload csk lapack"
-      run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
-      run "module unload intel gcc"
-      run "module unload papi perftools"
-      run "module load PrgEnv-intel"
-      run "module unload intel"
-      run "module unload xt-libsci xt-totalview"
-      run "module unload cray-hugepages2M"
-      run "module load intel/18.0.2"
-      run "module load cmake/3.14.6 numdiff git"
-      run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.10.1 metis parmetis/4.0.3 superlu-dist quo"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk"
-      run "module swap craype-haswell craype-mic-knl"
-      run "module list"
-      run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-    }
-    function intel1704env()
-    {
-      unset partition
-      unset jobnameext
-
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
-        run "module swap craype-mic-knl craype-haswell"
-      fi
-      run "module load user_contrib friendly-testing"
-      run "module unload cmake numdiff git"
-      run "module unload gsl random123 eospac"
-      run "module unload trilinos ndi quo"
-      run "module unload superlu-dist metis parmetis"
-      run "module unload csk lapack"
-      run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
-      run "module unload lapack "
-      run "module unload intel gcc"
-      run "module unload papi perftools"
-      run "module load PrgEnv-intel"
-      run "module unload intel"
-      run "module unload xt-libsci xt-totalview"
-      run "module load intel/17.0.4"
-      run "module load cmake/3.14.6 numdiff git"
-      run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.10.1 metis parmetis/4.0.3 superlu-dist quo"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk"
-      run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
-    }
-    function intel1704env-knl()
-    {
-      export partition="-p knl"
-      export jobnameext="-knl"
-
-      if [[ ${CRAY_CPU_TARGET} == mic-knl ]]; then
-        run "module swap craype-mic-knl craype-haswell"
-      fi
-      run "module load user_contrib friendly-testing"
-      run "module unload cmake numdiff git"
-      run "module unload gsl random123 eospac"
-      run "module unload trilinos ndi quo"
-      run "module unload superlu-dist metis parmetis"
-      run "module unload csk lapack"
-      run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
-      run "module unload intel gcc"
-      run "module unload papi perftools"
-      run "module load PrgEnv-intel"
-      run "module unload intel"
-      run "module unload xt-libsci xt-totalview"
-      run "module load intel/17.0.4"
-      run "module load cmake/3.14.6 numdiff git"
-      run "module load gsl random123 eospac/6.4.0 ndi python/3.6-anaconda-5.0.1"
-      run "module load trilinos/12.10.1 metis parmetis/4.0.3 superlu-dist quo"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load csk"
-      run "module swap craype-haswell craype-mic-knl"
-      run "module list"
-      run "module list"
-      CC=`which cc`
-      CXX=`which CC`
-      FC=`which ftn`
-      export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+      CC=$(which cc)
+      CXX=$(which CC)
+      FC=$(which ftn)
+      export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH":"$LD_LIBRARY_PATH"
+      export CC CXX FC
     }
     ;;
 
@@ -414,8 +207,8 @@ esac
 #------------------------------------------------------------------------------#
 
 for env in $environments; do
-  if [[ `fn_exists $env` -gt 0 ]]; then
-    if [[ $verbose ]]; then echo "export -f $env"; fi
+  if [[ $(fn_exists "$env") -gt 0 ]]; then
+    if [[ ${verbose:-false} != false ]]; then echo "export -f $env"; fi
     # exporting these environment is required on CTS-1, but breaks the module
     # system on trinitite.  Ugh.
     # export -f $env

--- a/tools/cts1-env.sh
+++ b/tools/cts1-env.sh
@@ -7,39 +7,41 @@ export VENDOR_DIR=/usr/projects/draco/vendors
 
 # symlinks will be generated for each machine that point to the correct
 # installation directory.
-if [[ `df | grep yellow | grep -c jayenne` -gt 0 ]]; then
+if [[ $(df | grep yellow | grep -c jayenne) -gt 0 ]]; then
   export siblings="snow badger kodiak grizzly"
 else
   export siblings="fire ice cyclone"
 fi
 
 # The following toolchains will be used when releasing code
-export environments="intel1904env intel1704env gcc830env gcc740env"
+environments="intel1904env intel1704env gcc830env gcc740env"
 
 # Extra cmake options
 export CONFIG_BASE+=" -DCMAKE_VERBOSE_MAKEFILE=ON"
 
 # SLURM
-avail_queues=`sacctmgr -np list assoc user=$LOGNAME | sed -e 's/.*|\(.*dev.*\|.*access.*\)|.*/\1/' | sed -e 's/|.*//'`
-case $avail_queues in
+avail_queues=$(sacctmgr -np list assoc user="$LOGNAME" | sed -e 's/.*|\(.*dev.*\|.*access.*\)|.*/\1/' | sed -e 's/|.*//')
+case "$avail_queues" in
   *access*) access_queue="-A access --qos=access" ;;
   *dev*) access_queue="--qos=dev" ;;
 esac
 export access_queue
 
 # Special setup for CTS-1: replace the 'latest' symlink
-(cd /usr/projects/$package; if [[ -L latest ]]; then rm latest; fi; ln -s $source_prefix latest)
+if [[ ${package:-false} == false ]] ; then die "package not defined"; fi
+if [[ ${source_prefix:-false} == false ]] ; then die "source_prefix not defined"; fi
+(cd "/usr/projects/${package:=draco}" || exit; if [[ -L latest ]]; then rm latest; fi; ln -s "${source_prefix:-source_prefix}" latest)
 
 #------------------------------------------------------------------------------#
 # Specify environments (modules)
 #------------------------------------------------------------------------------#
 
-if ! [[ $ddir ]] ;then
+if [[ ${ddir:=false} == false ]] ;then
   echo "FATAL ERROR: Expected ddir to be set in the environment. (cts1-env.sh)"
   exit 1
 fi
 
-case $ddir in
+case "${ddir}" in
 
   #------------------------------------------------------------------------------#
   draco-7_5*|draco-7_6*|draco-7_7*)
@@ -95,63 +97,6 @@ case $ddir in
       run "module load parmetis superlu-dist/5.1.3 trilinos/12.10.1"
       run "module list"
     }
-    export -f $environments
-    ;;
-
-  draco-7_2* | draco-7_3* | draco-7_4*)
-    function intel1904env
-    {
-      run "module purge"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load friendly-testing user_contrib"
-      run "module load cmake git numdiff python/3.6-anaconda-5.0.1"
-      run "module load intel/19.0.4 openmpi/2.1.2"
-      run "unset MPI_ROOT"
-      run "module load random123 eospac/6.4.0 gsl"
-      run "module load mkl metis ndi csk qt quo"
-      run "module load parmetis superlu-dist trilinos"
-      run "module list"
-    }
-    function intel1802env()
-    {
-      run "module purge"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load friendly-testing user_contrib"
-      run "module load cmake git numdiff python/3.6-anaconda-5.0.1"
-      run "module load intel/18.0.2 openmpi/2.1.2"
-      run "unset MPI_ROOT"
-      run "module load random123 eospac/6.4.0 gsl"
-      run "module load mkl metis ndi csk qt quo"
-      run "module load parmetis superlu-dist trilinos"
-      run "module list"
-    }
-    function intel1704env()
-    {
-      run "module purge"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load friendly-testing user_contrib"
-      run "module load cmake git numdiff python/3.6-anaconda-5.0.1"
-      run "module load intel/17.0.4 openmpi/2.1.2"
-      run "unset MPI_ROOT"
-      run "module load random123 eospac/6.4.0 gsl"
-      run "module load mkl metis ndi csk qt quo"
-      run "module load parmetis superlu-dist trilinos"
-      run "module list"
-    }
-    function gcc740env()
-    {
-      run "module purge"
-      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
-      run "module load friendly-testing user_contrib"
-      run "module load cmake git numdiff python/3.6-anaconda-5.0.1"
-      run "module load gcc/7.4.0 openmpi/2.1.2"
-      run "unset MPI_ROOT"
-      run "module load random123 eospac/6.4.0 gsl"
-      run "module load mkl metis ndi csk qt quo"
-      run "module load parmetis superlu-dist trilinos"
-      run "module list"
-    }
-    export -f $environments
     ;;
 
 #------------------------------------------------------------------------------#
@@ -166,10 +111,11 @@ esac
 # Sanity check
 #------------------------------------------------------------------------------#
 
-for env in $environments; do
-  if [[ `fn_exists $env` -gt 0 ]]; then
-    if [[ $verbose ]]; then echo "export -f $env"; fi
-    export -f $env
+for env in ${environments}; do
+  if [[ $(fn_exists "$env") -gt 0 ]]; then
+    if [[ "${verbose:-false}" != false ]]; then echo "export -f $env"; fi
+
+    export -f "${env?}"
   else
     die "Requested environment $env is not defined."
   fi

--- a/tools/cts1-env.sh
+++ b/tools/cts1-env.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # The following toolchains will be used when releasing code
-export environments="intel1904env intel1704env gcc830env"
+export environments="intel1904env intel1704env gcc830env gcc740env"
 
 # Extra cmake options
 export CONFIG_BASE+=" -DCMAKE_VERBOSE_MAKEFILE=ON"
@@ -76,6 +76,19 @@ case $ddir in
       run "module load friendly-testing user_contrib"
       run "module load cmake/3.17.0 git numdiff python/3.6-anaconda-5.0.1"
       run "module load gcc/8.3.0 openmpi/2.1.2"
+      run "unset MPI_ROOT"
+      run "module load random123 eospac/6.4.0 gsl"
+      run "module load mkl metis ndi csk qt quo"
+      run "module load parmetis superlu-dist/5.1.3 trilinos/12.10.1"
+      run "module list"
+    }
+    function gcc740env()
+    {
+      run "module purge"
+      run "module use --append ${VENDOR_DIR}-ec/modulefiles"
+      run "module load friendly-testing user_contrib"
+      run "module load cmake/3.17.2 git numdiff python/3.6-anaconda-5.0.1"
+      run "module load gcc/7.4.0 openmpi/2.1.2"
       run "unset MPI_ROOT"
       run "module load random123 eospac/6.4.0 gsl"
       run "module load mkl metis ndi csk qt quo"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -36,15 +36,17 @@
 
 # switch to group 'ccsrad' or dacodes
 install_group=$USER
-build_group=$USER
-if [[   `groups | grep -c dacodes` -gt 0 ]]; then install_group=dacodes;
-elif [[ `groups | grep -c ccsrad`  -gt 0 ]]; then install_group=ccsrad; fi
-if [[ $(id -gn) != $install_group ]]; then exec sg $install_group "$0 $*"; fi
+if [[   $(groups | grep -c dacodes) -gt 0 ]]; then install_group=dacodes;
+elif [[ $(groups | grep -c ccsrad)  -gt 0 ]]; then install_group=ccsrad; fi
+if [[ $(id -gn) != "$install_group" ]]; then exec sg $install_group "$0 $*"; fi
 umask 0007       # initially no world or group access
 set -m           # Enable job control
 shopt -s extglob # Allow variable as case condition
 install_permissions="g+rwX,o-rwX"
+export install_permissions
+# shellcheck disable=SC2034
 build_permisssions="g-rwX,o-rwX"
+export build_permissions
 
 #----------------------------------------------------------------------#
 # Per release settings go here (edits go here)
@@ -61,11 +63,13 @@ build_permisssions="g-rwX,o-rwX"
 ##---------------------------------------------------------------------------##
 
 draco_script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-draco_script_dir=`echo $draco_script_dir | awk '{ print $1 }'`
-export draco_script_dir=`readlink -f $draco_script_dir`
-if [[ -f $draco_script_dir/common.sh ]]; then
+draco_script_dir=$(echo "$draco_script_dir" | awk '{ print $1 }')
+draco_script_dir=$(readlink -f "$draco_script_dir")
+export draco_script_dir
+if [[ -f "$draco_script_dir/common.sh" ]]; then
   echo "source $draco_script_dir/common.sh"
-  source $draco_script_dir/common.sh
+  # shellcheck source=/dev/null
+  source "$draco_script_dir/common.sh"
 else
   echo " "
   echo "FATAL ERROR: Unable to locate Draco's bash functions: "
@@ -74,26 +78,36 @@ else
   exit 1
 fi
 
-export draco_source_prefix=`readlink -f $draco_script_dir/../..`
-export ddir=`echo $draco_source_prefix | sed -e 's%.*/%%'`
+draco_source_prefix=$(readlink -f "$draco_script_dir/../..")
+# shellcheck disable=SC2001
+ddir=$(echo "$draco_source_prefix" | sed -e 's%.*/%%')
+export draco_source_prefix ddir
 
 # If package is set, use those values, otherwise, setup stuff for draco.
 if ! [[ $package ]]; then
   export source_prefix=$draco_source_prefix
   export script_dir=$draco_script_dir
   export pdir=$ddir
-  export package=`echo $pdir | sed -e 's/-.*//'`
-  if [[ -f $draco_script_dir/draco-cmake-opts.sh ]]; then
+
+  # shellcheck disable=SC2001
+  package=$(echo "$pdir" | sed -e 's/-.*//')
+  export package
+  if [[ -f "$draco_script_dir/draco-cmake-opts.sh" ]]; then
     echo "source $draco_script_dir/draco-cmake-opts.sh"
-    source $draco_script_dir/draco-cmake-opts.sh
+    # shellcheck source=/dev/null
+    source "$draco_script_dir/draco-cmake-opts.sh"
   else
     die "Unable to find environment file draco-cmake-opts.sh"
   fi
   # CMake options that will be included in the configuration step
-  export CONFIG_BASE+=" -DDraco_VERSION_PATCH=`echo $ddir | sed -e 's/.*_//'`"
+
+  # shellcheck disable=SC2001
+  dvp=$(echo "$ddir" | sed -e 's/.*_//')
+  CONFIG_BASE+=" -DDraco_VERSION_PATCH=$dvp"
+  export CONFIG_BASE
 fi
 
-scratchdir=`selectscratchdir`
+scratchdir=$(selectscratchdir)
 
 # hw_threads=`lscpu | grep CPU | head -n 1 | awk '{ print $2 }'`
 # hw_threads_per_core=`lscpu | grep Thread | awk '{ print $4 }'`
@@ -101,10 +115,11 @@ scratchdir=`selectscratchdir`
 # build_pe=`npes_build`
 # test_pe=`npes_test`
 
-machfam=`machineFamily`
-if [[ -f $draco_script_dir/${machfam}-env.sh ]]; then
+machfam=$(machineFamily)
+if [[ -f "$draco_script_dir/${machfam}-env.sh" ]]; then
   echo "source ${draco_script_dir}/${machfam}-env.sh"
-  source $draco_script_dir/${machfam}-env.sh
+  # shellcheck source=/dev/null
+  source "$draco_script_dir/${machfam}-env.sh"
 else
   die "Unable to find environment file ${machfam}-env.sh/"
 fi
@@ -140,7 +155,8 @@ echo " "
 ##---------------------------------------------------------------------------##
 
 jobids=""
-echo -e "\nThe following environments will be processed: $environments\n"
+export jobids
+echo -e "\nThe following environments will be processed: ${environments:-none}\n"
 
 for env in $environments; do
 
@@ -150,12 +166,12 @@ for env in $environments; do
   echo "======================================="
   ${env}
 
-  export buildflavor=`flavor`
+  buildflavor=$(flavor)
+  export buildflavor
   # e.g.: buildflavor=snow-openmpi-1.6.5-intel-15.0.3
 
   export install_prefix="$source_prefix/$buildflavor"
   export build_prefix="$scratchdir/$USER/$pdir/$buildflavor"
-
 
   for (( i=0 ; i < ${#VERSIONS[@]} ; ++i )); do
 
@@ -165,15 +181,16 @@ for env in $environments; do
     echo -e "\nExtra environment setup:\n"
 
     # callback to append extra data to the cmake options.
-    if [[ `fn_exists append_config_base` -gt 0 ]]; then
-      extra=`append_config_base`
+    if [[ $(fn_exists append_config_base) -gt 0 ]]; then
+      extra=$(append_config_base)
       echo "  - CONFIG_EXTRA += ${extra}"
       export CONFIG_EXTRA="$extra $CONFIG_BASE"
     else
       export CONFIG_EXTRA="$CONFIG_BASE"
     fi
 
-    source ${draco_script_dir}/${machfam}-release.sh
+    # shellcheck source=/dev/null
+    source "${draco_script_dir}/${machfam}-release.sh"
 
   done
 done

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -90,7 +90,7 @@ if ! [[ $package ]]; then
     die "Unable to find environment file draco-cmake-opts.sh"
   fi
   # CMake options that will be included in the configuration step
-  export CONFIG_BASE+=" -DDRACO_VERSION_PATCH=`echo $ddir | sed -e 's/.*_//'`"
+  export CONFIG_BASE+=" -DDraco_VERSION_PATCH=`echo $ddir | sed -e 's/.*_//'`"
 fi
 
 scratchdir=`selectscratchdir`


### PR DESCRIPTION
### Background

* During the recent release cycle, @jhchang-lanl and @KineticTheory discovered some developer and release environment settings that needed to be updated.  This change-set fixes those items.

### Description of changes

+ Make the `.bashrc` system more robust on Darwin by always sourcing the setup files.
+ Use `cmake/3.17.2` on Trinitite
+ For releases, disable loading quo when using `intel/17.0.4` on trinitite (it doesn't exist).
+ For releases, also provide a release folder based on `gcc/7.4.0`.
+ Fix script error related to the patch version number printed by `draco_info`.

### WIP

- [x] snow environment is broken

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
