### PR TITLE
Minor fix to tstEnsight_Stream

### DIFF
--- a/src/viz/test/tstEnsight_Stream.cc
+++ b/src/viz/test/tstEnsight_Stream.cc
@@ -71,7 +71,8 @@ void test_simple(rtt_dsxx::UnitTest &ut, bool const binary, bool const geom,
   const int i(20323);
   const string s("dog");
   const double d(112.3);
-  const string file("ensight_stream.out");
+  const string file("ensight_stream_" + std::to_string(rtt_c4::nodes()) +
+                    ".out");
 
   {
     Ensight_Stream f(file, binary, geom, decomposed);
@@ -132,14 +133,18 @@ void test_simple(rtt_dsxx::UnitTest &ut, bool const binary, bool const geom,
 //----------------------------------------------------------------------------//
 int main(int argc, char *argv[]) {
   rtt_c4::ParallelUnitTest ut(argc, argv, rtt_dsxx::release);
-  try {                     // >>> UNIT TESTS
+  try { // >>> UNIT TESTS
     // serial/replicated use test
     if (rtt_c4::node() == 0) {
       test_simple(ut, true, false, false);  // test binary
       test_simple(ut, false, false, false); // test ascii
       test_simple(ut, true, false, false);  // test binary with geom flag
     }
-    // parallel/decomposition tests in decomposition moded
+
+    // Wait for rank 0 to finish serial testing before proceeding:
+    rtt_c4::global_barrier();
+
+    // parallel/decomposition tests in decomposition mode
     test_simple(ut, true, false, true);  // test binary
     test_simple(ut, false, false, true); // test ascii
     test_simple(ut, true, false, true);  // test binary with geom flag


### PR DESCRIPTION
### Background

* TstEnsight_Stream had a couple of small possible issues with resource contention

### Purpose of Pull Request

* Append number of procs to test output to prevent multiple instances of tstEnsight_Stream from writing to the same file simultaneously
* Add a global barrier between "serial" (rank 0 only) and parallel calls to test_simple to let rank 0 finish its write/read before the parallel calls access the same file.

### Description of changes

* see above :)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation