### PR TITLE
DevEnv, build, export improvements for Caliper.

### DIFF
--- a/config/FindCaliper.cmake
+++ b/config/FindCaliper.cmake
@@ -75,8 +75,8 @@ endif()
 # lib/i386-linux-gnu (Debian)).
 
 find_path( CALIPER_INCLUDE_DIR
-  NAMES Caliper.h
-  HINTS ${CALIPER_ROOT_DIR}/include/caliper
+  NAMES caliper/Caliper.h
+  HINTS ${CALIPER_ROOT_DIR}/include
   PATH_SUFFIXES caliper
   )
 

--- a/config/FindCaliper.cmake
+++ b/config/FindCaliper.cmake
@@ -1,0 +1,189 @@
+#-----------------------------*-cmake-*----------------------------------------#
+# file   config/FindCaliper.cmake
+# date   Tuesday, Jun 30, 2020, 08:11 am
+# brief  Instructions for discovering the Caliper vendor libraries.
+# note   Copyright (C) 2016-2020 Triad National Security, LLC.
+#        All rights reserved.
+#------------------------------------------------------------------------------#
+
+#.rst:
+# FindCaliper
+# ---------
+#
+# Find the LLNL Caliper library and header files.
+#
+# Caliper: A Performance Analysis Toolbox in a Library,
+# https://github.com/llnl/Caliper
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# If Caliper is found, this module defines the following :prop_tgt:`IMPORTED`
+# targets::
+#
+#  CALIPER::caliper        - The Caliper target
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project::
+#
+#  CALIPER_FOUND          - True if Caliper found on the local system
+#  CALIPER_INCLUDE_DIRS   - Location of Caliper header files.
+#  CALIPER_LIBRARIES      - The Caliper libraries.
+#  CALIPER_VERSION        - The version of the discovered Caliper install.
+#
+# Hints
+# ^^^^^
+#
+# Set ``CALIPER_ROOT_DIR`` to a directory that contains a Caliper installation.
+#
+# This script expects to find libraries at ``$Caliper_ROOT_DIR/lib`` and the
+# Caliper headers at ``$CALIPER_ROOT_DIR/include``.  The library directory may
+# optionally provide Release and Debug folders.
+#
+# Cache Variables
+# ^^^^^^^^^^^^^^^
+#
+# This module may set the following variables depending on platform and type of
+# Caliper installation discovered.  These variables may optionally be set to
+# help this module find the correct files::
+#
+#  CALIPER_LIBRARY        - Location of the Caliper library.
+#  CALIPER_LIBRARY_DEBUG  - Location of the debug Caliper library (if any).
+#
+#------------------------------------------------------------------------------#
+
+# Include these modules to handle the QUIETLY and REQUIRED arguments.
+include(FindPackageHandleStandardArgs)
+
+#=============================================================================
+# If the user has provided ``CALIPER_ROOT_DIR``, use it!  Choose items found
+# at this location over system locations.
+if( EXISTS "$ENV{CALIPER_ROOT_DIR}" )
+  file( TO_CMAKE_PATH "$ENV{CALIPER_ROOT_DIR}" CALIPER_ROOT_DIR )
+  set( CALIPER_ROOT_DIR "${CALIPER_ROOT_DIR}" CACHE PATH
+    "Prefix for Caliper installation." )
+endif()
+
+#=============================================================================
+# Set CALIPER_INCLUDE_DIRS and CALIPER_LIBRARIES. Try to find the libraries at
+# $CALIPER_ROOT_DIR (if provided) or in standard system locations.  These
+# find_library and find_path calls will prefer custom locations over standard
+# locations (HINTS).  If the requested file is not found at the HINTS location,
+# standard system locations will be still be searched (/usr/lib64 (Redhat),
+# lib/i386-linux-gnu (Debian)).
+
+find_path( CALIPER_INCLUDE_DIR
+  NAMES Caliper.h
+  HINTS ${CALIPER_ROOT_DIR}/include/caliper
+  PATH_SUFFIXES caliper
+  )
+
+set( CALIPER_LIBRARY_NAME caliper )
+
+find_library(CALIPER_LIBRARY
+  NAMES ${CALIPER_LIBRARY_NAME}
+  PATHS ${CALIPER_ROOT_DIR}/lib64
+  )
+# Do we also have debug versions?
+find_library( CALIPER_LIBRARY_DEBUG
+  NAMES ${CALIPER_LIBRARY_NAME}
+  HINTS ${CALIPER_ROOT_DIR}/lib64
+  PATH_SUFFIXES Debug
+)
+set( CALIPER_INCLUDE_DIRS ${CALIPER_INCLUDE_DIR} )
+set( CALIPER_LIBRARIES ${CALIPER_LIBRARY} )
+
+#=============================================================================
+# handle the QUIETLY and REQUIRED arguments and set CALIPER_FOUND to TRUE if
+# all listed variables are TRUE.
+find_package_handle_standard_args( Caliper
+  FOUND_VAR
+    CALIPER_FOUND
+  REQUIRED_VARS
+    CALIPER_INCLUDE_DIR
+    CALIPER_LIBRARY
+  VERSION_VAR
+    CALIPER_VERSION
+    )
+
+mark_as_advanced( CALIPER_ROOT_DIR CALIPER_VERSION CALIPER_LIBRARY
+  CALIPER_INCLUDE_DIR CALIPER_LIBRARY_DEBUG CALIPER_USE_PKGCONFIG
+  CALIPER_CONFIG )
+
+#=============================================================================
+# Register imported libraries:
+# 1. If we can find a Windows .dll file (or if we can find both Debug and
+#    Release libraries), we will set appropriate target properties for these.
+# 2. However, for most systems, we will only register the import location and
+#    include directory.
+
+# Look for dlls, or Release and Debug libraries.
+if(WIN32)
+  string( REPLACE ".lib" ".dll" CALIPER_LIBRARY_DLL
+    "${CALIPER_LIBRARY}" )
+  string( REPLACE ".lib" ".dll" CALIPER_LIBRARY_DEBUG_DLL
+    "${CALIPER_LIBRARY_DEBUG}" )
+endif()
+
+if( CALIPER_FOUND AND NOT TARGET CALIPER::caliper )
+  if( WIN32 )
+    if( EXISTS "${CALIPER_LIBRARY_DLL}" )
+
+      # Windows systems with dll libraries.
+      add_library( CALIPER::caliper SHARED IMPORTED )
+
+      # Windows with dlls, but only Release libraries.
+      set_target_properties( CALIPER::caliper PROPERTIES
+        IMPORTED_LOCATION_RELEASE         "${CALIPER_LIBRARY_DLL}"
+        IMPORTED_IMPLIB                   "${CALIPER_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES     "${CALIPER_INCLUDE_DIRS}"
+        IMPORTED_CONFIGURATIONS           Release
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+
+      # If we have both Debug and Release libraries
+      if( EXISTS "${CALIPER_LIBRARY_DEBUG_DLL}" )
+        set_property( TARGET CALIPER::caliper APPEND PROPERTY
+          IMPORTED_CONFIGURATIONS Debug )
+        set_target_properties( CALIPER::caliper PROPERTIES
+          IMPORTED_LOCATION_DEBUG           "${CALIPER_LIBRARY_DEBUG_DLL}"
+          IMPORTED_IMPLIB_DEBUG             "${CALIPER_LIBRARY_DEBUG}" )
+      endif()
+
+    else()
+      # Windows systems with static lib libraries.
+      add_library( CALIPER::caliper SHARED IMPORTED )
+
+      # Windows with dlls, but only Release libraries.
+      set_target_properties( CALIPER::caliper PROPERTIES
+        IMPORTED_LOCATION_RELEASE         "${CALIPER_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES     "${CALIPER_INCLUDE_DIRS}"
+        IMPORTED_CONFIGURATIONS           Release
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+
+      # If we have both Debug and Release libraries
+      if( EXISTS "${CALIPER_LIBRARY_DEBUG}" )
+        set_property( TARGET CALIPER::caliper APPEND PROPERTY
+          IMPORTED_CONFIGURATIONS Debug )
+        set_target_properties( CALIPER::caliper PROPERTIES
+          IMPORTED_LOCATION_DEBUG           "${CALIPER_LIBRARY_DEBUG}" )
+      endif()
+
+    endif()
+
+  else()
+
+    # For all other environments (ones without dll libraries), create the
+    # imported library targets.
+    add_library( CALIPER::caliper    UNKNOWN IMPORTED )
+    set_target_properties( CALIPER::caliper PROPERTIES
+      IMPORTED_LOCATION                 "${CALIPER_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${CALIPER_INCLUDE_DIRS}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+  endif()
+endif()
+
+#------------------------------------------------------------------------------#
+# End FindCaliper.cmake
+#------------------------------------------------------------------------------#

--- a/config/draco-config-install.cmake.in
+++ b/config/draco-config-install.cmake.in
@@ -98,3 +98,9 @@ set(Draco_TPL_LIST "@Draco_TPL_LIST@")
 ## ---------------------------------------------------------------------------
 
 @Draco_EXPORT_TARGET_PROPERTIES@
+
+set( DRACO_CALIPER @DRACO_CALIPER@ )
+if( DRACO_CALIPER )
+  include(CMakeFindDependencyMacro)
+  setupCaliper()
+endif()

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -501,36 +501,23 @@ macro( setupLIBQUO )
 
 endmacro()
 
-
 #------------------------------------------------------------------------------
 # Setup Caliper (https://github.com/LLNL/Caliper)
 #------------------------------------------------------------------------------
 macro( setupCaliper)
 
-  if( NOT TARGET caliper )
+  if( NOT TARGET CALIPER::caliper )
     message( STATUS "Looking for Caliper...")
-
-    find_package( caliper QUIET
-      HINTS $ENV{CALIPER_ROOT_DIR}/share/cmake
-      )
-
-    if(caliper_FOUND)
-      message(STATUS "Looking for Caliper...found")
+    find_package( Caliper QUIET
+      HINTS $ENV{CALIPER_ROOT_DIR}/share/cmake )
+    if(CALIPER_FOUND)
+      message(STATUS "Looking for Caliper...${CALIPER_LIBRARY}")
     else()
       message(STATUS "Looking for Caliper...not found")
     endif()
-
-    if( DEFINED caliper_INCLUDE_DIR )
-      message(STATUS "caliper_INCLUDE_DIR ... defined: ${caliper_INCLUDE_DIR}")
-    else()
-      message(STATUS "caliper_INCLUDE_DIR ... not defined")
-    endif()
-
   endif()
 
 endmacro()
-
-
 
 #------------------------------------------------------------------------------
 # Setup Eospac (https://laws.lanl.gov/projects/data/eos.html)

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -508,8 +508,7 @@ macro( setupCaliper)
 
   if( NOT TARGET CALIPER::caliper )
     message( STATUS "Looking for Caliper...")
-    find_package( Caliper QUIET
-      HINTS $ENV{CALIPER_ROOT_DIR}/share/cmake )
+    find_package( Caliper QUIET )
     if(CALIPER_FOUND)
       message(STATUS "Looking for Caliper...${CALIPER_LIBRARY}")
     else()

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -91,7 +91,7 @@ if [[ ${CRAY_CPU_TARGET} =~ haswell ]] || [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
 
   module use --append ${VENDOR_DIR}-ec/modulefiles
   dracomodules="git cmake/3.17.2 numdiff gsl/2.5 metis eospac/6.4.0 random123 parmetis \
-superlu-dist/5.4.0 trilinos/12.14.1 clang-format python/3.6-anaconda-5.0.1 quo"
+superlu-dist/5.4.0 trilinos/12.14.1 clang-format python/3.6-anaconda-5.0.1 quo caliper"
 
   if [[ -d ${VENDOR_DIR}-ec ]]; then
     group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`

--- a/environment/bashrc/.bashrc_cts1
+++ b/environment/bashrc/.bashrc_cts1
@@ -59,7 +59,7 @@ else
   export dracomodules="ack htop clang-format python \
 intel/19.0.4 openmpi/2.1.2 mkl \
 cmake/3.17.2 numdiff git totalview trilinos/12.10.1 \
-superlu-dist/5.1.3 metis parmetis random123 eospac/6.4.0 quo"
+superlu-dist/5.1.3 metis parmetis random123 eospac/6.4.0 quo caliper"
 
   if [[ -d ${VENDOR_DIR}-ec ]]; then
     group_for_vendor_ec=`\ls -aFld ${VENDOR_DIR}-ec | awk '{ print $4 }'`

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -12,12 +12,13 @@ project( diagnostics CXX )
 ##---------------------------------------------------------------------------##
 # Is Caliper available? If so, let's use it
 ##---------------------------------------------------------------------------##
-if(TARGET caliper)
+if(TARGET CALIPER::caliper)
   set( DRACO_CALIPER "1")
 else()
   set( DRACO_CALIPER "0")
 endif()
-
+set( DRACO_CALIPER ${DRACO_CALIPER} CACHE BOOL
+  "Does Draco require the Caliper library?" FORCE)
 
 ##---------------------------------------------------------------------------##
 # Special options for this component
@@ -46,13 +47,11 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Generate config.h (only occurs when cmake is run)
 # ---------------------------------------------------------------------------- #
-
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/diagnostics/config.h )
 
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( APPEND headers ${PROJECT_BINARY_DIR}/diagnostics/config.h )
@@ -66,9 +65,14 @@ endif()
 # Build package library
 # ---------------------------------------------------------------------------- #
 
+set(deps Lib_c4)
+if(TARGET CALIPER::caliper)
+  list(APPEND deps CALIPER::caliper)
+endif()
+
 add_component_library(
   TARGET       Lib_diagnostics
-  TARGET_DEPS  "Lib_c4"
+  TARGET_DEPS  "${deps}"
   LIBRARY_NAME ${PROJECT_NAME}
   SOURCES      "${sources}"
   HEADERS      "${headers}"
@@ -90,14 +94,6 @@ if( Qt5Core_DIR AND NOT "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le" )
   add_subdirectory( qt )
 endif()
 
-if(TARGET caliper)
-  target_include_directories( Lib_diagnostics
-    PUBLIC ${caliper_INCLUDE_DIR}
-    )
-  target_link_libraries(Lib_diagnostics
-    caliper
-    )
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions


### PR DESCRIPTION
### Background

+ We recently added optional support for using LLNL's Caliper library. There were a few unexpected issues related to exporting the new dependency.  This PR addresses this issue and provides other related cleanup.

### Description of changes

+ Provide a new cmake `find_package` helper `FindCaliper.cmake`.  This allows us to create a `CALIPER::caliper` cmake target that knows about library and include file locations for the vendor.
+ Use the new `FindCaliper.cmake` features to simplify code in `vendor_libraries.cmake` and in `diagnostics/CMakeLists.txt`.
+ For LANL HPC machines, load caliper as part of Draco's default developer environment.
+ When generating the export targets (e.g.: `draco-config.cmake`), ensure that client projects find and define the imported target `CALIPER::caliper` correctly.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
