### PR TITLE
Fix broken cmake code introduced in PR 865

### DIFF
--- a/config/draco-config-install.cmake.in
+++ b/config/draco-config-install.cmake.in
@@ -99,8 +99,17 @@ set(Draco_TPL_LIST "@Draco_TPL_LIST@")
 
 @Draco_EXPORT_TARGET_PROPERTIES@
 
+#------------------------------------------------------------------------------#
+# Ensure imported targets required by Draco are defined
+# - Optionally we could use 'include(CMakeFindDependencyMacro)'
+#------------------------------------------------------------------------------#
+
+# CMake macros to query the availability of TPLs.
+include( vendor_libraries )
+
+# If DRACO_CALIPER is 1, then this build of Draco requires the CALIPER::caliper
+# target. If the CALIPER::caliper target is not defined, then create it.
 set( DRACO_CALIPER @DRACO_CALIPER@ )
-if( DRACO_CALIPER )
-  include(CMakeFindDependencyMacro)
+if( DRACO_CALIPER AND NOT TARGET CALIPER::caliper)
   setupCaliper()
 endif()


### PR DESCRIPTION
### Background

* PR #865 installed a broken `draco-config.cmake` that broke downstream projects.

### Description of changes

* I chose to call Draco's setup macros to define the import target `CALIPER::caliper`, but I forgot to tell `draco-config-cmake` to `include(vendor_libraries)`.  This is required to bring the `setupCaliper` macro into scope.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
