### PR TITLE
Add a wait_all call to c4 that returns the source rank ID for MPI comms

### DIFF
--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -429,21 +429,27 @@ void blocking_probe(int source, int tag, int &message_size);
  * \param requests
  * Set of requests to wait on.
  */
-void wait_all(unsigned count, C4_Req *requests);
+void wait_all(const unsigned count, C4_Req *const requests);
 
 //----------------------------------------------------------------------------//
 /*!
  * \brief Wait until every one of a set of posted sends/receives is complete.
  *
- * This version returns source rank information.
+ * This version returns source rank information for RECEIVE REQUESTS ONLY
+ * WARNING: If you call this function with send requests, the source rank ID
+ * might not be set in MPI_STATUS. REPEAT: THE RETURN VALUE IS VALID FOR
+ * RECEIVE REQUESTS ONLY!!!! 
+ *
+ * \pre All requests passed to this function must be receive requests
  *
  * \param count
  * Size of the set of requests to wait on.
  * \param requests
  * Set of requests to wait on.
- * \return A vector containing the source rank IDs for all messages.
+ * \return A vector containing the source rank IDs for received messages.
  */
-std::vector<int> wait_all_with_source(unsigned count, C4_Req *requests);
+std::vector<int> wait_all_with_source(const unsigned count,
+                                      C4_Req *const requests);
 
 //----------------------------------------------------------------------------//
 /*!

--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -433,6 +433,20 @@ void wait_all(unsigned count, C4_Req *requests);
 
 //----------------------------------------------------------------------------//
 /*!
+ * \brief Wait until every one of a set of posted sends/receives is complete.
+ *
+ * This version returns source rank information.
+ *
+ * \param count
+ * Size of the set of requests to wait on.
+ * \param requests
+ * Set of requests to wait on.
+ * \return A vector containing the source rank IDs for all messages.
+ */
+std::vector<int> wait_all_with_source(unsigned count, C4_Req *requests);
+
+//----------------------------------------------------------------------------//
+/*!
  * \brief Wait until one of a set of posted sends/receives is complete.
  *
  * \param count

--- a/src/c4/C4_MPI.cc
+++ b/src/c4/C4_MPI.cc
@@ -167,7 +167,7 @@ void blocking_probe(int source, int tag, int &message_size) {
 }
 
 //----------------------------------------------------------------------------//
-void wait_all(unsigned count, C4_Req *requests) {
+void wait_all(const unsigned count, C4_Req *const requests) {
 
   // Nothing to do if count is zero.
   if (count == 0)
@@ -187,7 +187,8 @@ void wait_all(unsigned count, C4_Req *requests) {
 }
 
 //----------------------------------------------------------------------------//
-std::vector<int> wait_all_with_source(unsigned count, C4_Req *requests) {
+std::vector<int> wait_all_with_source(const unsigned count,
+                                      C4_Req *const requests) {
 
   // Nothing to do if count is zero.
   if (count == 0)

--- a/src/c4/C4_MPI.cc
+++ b/src/c4/C4_MPI.cc
@@ -187,6 +187,36 @@ void wait_all(unsigned count, C4_Req *requests) {
 }
 
 //----------------------------------------------------------------------------//
+std::vector<int> wait_all_with_source(unsigned count, C4_Req *requests) {
+
+  // Nothing to do if count is zero.
+  if (count == 0)
+    return std::vector<int>();
+
+  // Return value -- rank IDs for all message sources.
+  std::vector<int> msg_sources(count);
+
+  std::vector<MPI_Request> array_of_requests(count);
+  // This is needed to obtain the source rank for each message:
+  std::vector<MPI_Status> array_of_statuses(count);
+  for (unsigned i = 0; i < count; ++i) {
+    if (requests[i].inuse())
+      array_of_requests[i] = requests[i].r();
+    else
+      array_of_requests[i] = MPI_REQUEST_NULL;
+  }
+  Remember(int check =)
+      MPI_Waitall(count, &array_of_requests[0], &array_of_statuses[0]);
+  Check(check == MPI_SUCCESS);
+
+  for (unsigned p = 0; p < count; p++) {
+    msg_sources[p] = array_of_statuses[p].MPI_SOURCE;
+  }
+
+  return msg_sources;
+}
+
+//----------------------------------------------------------------------------//
 // ABORT
 //----------------------------------------------------------------------------//
 int abort(int error) {

--- a/src/c4/C4_Req.hh
+++ b/src/c4/C4_Req.hh
@@ -170,6 +170,8 @@ private:
   template <typename T>
   friend void send_is(C4_Req &r, const T *buf, int nels, int dest, int tag);
   friend void wait_all(unsigned count, C4_Req *requests);
+  friend std::vector<int> wait_all_with_source(unsigned count,
+                                               C4_Req *requests);
   friend unsigned wait_any(unsigned count, C4_Req *requests);
   template <typename T>
   friend void global_isum(T &send_buffer, T &recv_buffer, C4_Req &request);

--- a/src/c4/C4_Serial.cc
+++ b/src/c4/C4_Serial.cc
@@ -116,6 +116,12 @@ void wait_all(unsigned /*count*/, C4_Req * /*requests*/) {
   return;
 }
 
+std::vector<int> wait_all_with_source(unsigned /*count*/,
+                                      C4_Req * /*requests*/) {
+  // Insist(false, "no messages expected in serial programs!");
+  return std::vector<int>();
+}
+
 unsigned wait_any(unsigned /*count*/, C4_Req * /*requests*/) {
   Insist(false, "no messages expected in serial programs!");
   return 0;

--- a/src/c4/C4_Serial.cc
+++ b/src/c4/C4_Serial.cc
@@ -111,14 +111,10 @@ void blocking_probe(int /* source */, int /* tag */, int & /* message_size */) {
   Insist(false, "no messages expected in serial programs!");
 }
 
-void wait_all(unsigned /*count*/, C4_Req * /*requests*/) {
-  // Insist(false, "no messages expected in serial programs!");
-  return;
-}
+void wait_all(unsigned /*count*/, C4_Req *const /*requests*/) { return; }
 
 std::vector<int> wait_all_with_source(unsigned /*count*/,
-                                      C4_Req * /*requests*/) {
-  // Insist(false, "no messages expected in serial programs!");
+                                      C4_Req *const /*requests*/) {
   return std::vector<int>();
 }
 

--- a/src/c4/test/tstsend_is.cc
+++ b/src/c4/test/tstsend_is.cc
@@ -146,7 +146,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
                       right);
 
       // wait for all communication to finish
-      rtt_c4::wait_all(static_cast<unsigned>(comm.size()), &comm[0]);
+      vector<int> sources = rtt_c4::wait_all_with_source(
+          static_cast<unsigned>(comm.size()), &comm[0]);
+
+      // Check that the source IDs were returned correctly:
+      FAIL_IF_NOT(sources.size() == 2);
+      // First comm is receive from rank "left":
+      FAIL_IF_NOT(sources[0] == left);
+      // Second comm is send to rank pid:
+      FAIL_IF_NOT(sources[1] == pid);
 
       // expected results
       vector<int> expected(bsize);

--- a/src/c4/test/tstsend_is.cc
+++ b/src/c4/test/tstsend_is.cc
@@ -175,7 +175,12 @@ void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
     }
     // Check assertion flag and size of wait_all_with_source result:
     FAIL_IF(nullreq_failed);
+    // Result will be size zero in the scalar build:
+#ifdef C4_SCALAR
+    FAIL_IF_NOT(result.size() == 0);
+#else
     FAIL_IF_NOT(result.size() == 2);
+#endif
   }
 }
 

--- a/src/c4/test/tstsend_is.cc
+++ b/src/c4/test/tstsend_is.cc
@@ -153,8 +153,11 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(sources.size() == 2);
       // First comm is receive from rank "left":
       FAIL_IF_NOT(sources[0] == left);
+      // NOTE: KPL: the value of MPI_SOURCE for a send
+      // operation does not appear to be set in all implementations.
+      // It is not clear whether this is a bug or intended behavior.
       // Second comm is send to rank pid:
-      FAIL_IF_NOT(sources[1] == pid);
+      //FAIL_IF_NOT(sources[1] == pid);
 
       // expected results
       vector<int> expected(bsize);

--- a/src/c4/test/tstsend_is.cc
+++ b/src/c4/test/tstsend_is.cc
@@ -105,6 +105,81 @@ MPI_Datatype Custom::MPI_Type = MPI_Datatype();
 #endif
 
 //----------------------------------------------------------------------------//
+void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
+
+  using namespace std;
+  int const pid = rtt_c4::node();
+
+  if (pid == 0)
+    cout << "Test wait_all() corner cases..." << endl;
+
+  // Zero count case:
+  {
+    // C4_Req communication handles.
+    rtt_c4::C4_Req *const comm(nullptr);
+    const unsigned count(0);
+
+    // No actual messages to send -- verify that wait_all
+    // and wait_all_with_source correctly return.
+    bool zerocount_failed = false;
+
+    // result output from source version of wait_all:
+    std::vector<int> result;
+
+    try {
+      wait_all(count, comm);
+    } catch (...) {
+      zerocount_failed = true;
+    }
+    // Check assertion flag and size of wait_all_with_source result:
+    FAIL_IF(zerocount_failed);
+
+    // wait_all_with_source version:
+    zerocount_failed = false;
+    try {
+      result = wait_all_with_source(count, comm);
+    } catch (...) {
+      zerocount_failed = true;
+    }
+    // Check assertion flag and size of wait_all_with_source result:
+    FAIL_IF(zerocount_failed);
+    FAIL_IF_NOT(result.size() == 0);
+  }
+
+  // Inactive request case:
+  {
+    // C4_Req communication handles.
+    std::array<rtt_c4::C4_Req, 2> comm;
+
+    // Result from wait_all_with_source call
+    std::vector<int> result;
+
+    // Test a null op -- I didn't actually send anything, so the
+    // MPI requests should be set to MPI_REQUEST_NULL and the wait_all
+    // should return immediately,
+    bool nullreq_failed = false;
+    try {
+      wait_all(comm.size(), &comm[0]);
+    } catch (...) {
+      nullreq_failed = true;
+    }
+    // Check assertion flag:
+    FAIL_IF(nullreq_failed);
+
+    // wait_all_with_source version:
+    nullreq_failed = false;
+    try {
+      result = wait_all_with_source(comm.size(), &comm[0]);
+    } catch (...) {
+      nullreq_failed = true;
+    }
+    // Check assertion flag and size of wait_all_with_source result:
+    FAIL_IF(nullreq_failed);
+    FAIL_IF_NOT(result.size() == 2);
+  }
+}
+
+//----------------------------------------------------------------------------//
 void test_simple(rtt_dsxx::UnitTest &ut) {
   // borrowed from http://mpi.deino.net/mpi_functions/MPI_Issend.html.
   using namespace std;
@@ -154,10 +229,8 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       // First comm is receive from rank "left":
       FAIL_IF_NOT(sources[0] == left);
       // NOTE: KPL: the value of MPI_SOURCE for a send
-      // operation does not appear to be set in all implementations.
-      // It is not clear whether this is a bug or intended behavior.
-      // Second comm is send to rank pid:
-      //FAIL_IF_NOT(sources[1] == pid);
+      // operation does not appear to be set in all implementations, so we don't check
+      // the value for the send operation.
 
       // expected results
       vector<int> expected(bsize);
@@ -1105,6 +1178,7 @@ void test_send_custom(rtt_dsxx::UnitTest &ut) {
 int main(int argc, char *argv[]) {
   rtt_c4::ParallelUnitTest ut(argc, argv, rtt_dsxx::release);
   try {
+    test_zerocount_and_inactive(ut);
     test_simple(ut);
     test_send_custom(ut);
   }


### PR DESCRIPTION
### Background

* In the parMETIS local redecomposition implementation I'm working on, I need to be able to access a list of source ranks that have sent me data. Adding this wait_all_with_source call accomplishes that.

### Purpose of Pull Request

* add needed MPI functionality to c4, including dummy functions for serial case
* Modify MPI send test to exercise the new function

### Description of changes

* see above :)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
