### PR TITLE
Provide clang-tidy recommended changes

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -129,7 +129,7 @@ if [[ ${INTERACTIVE} == true ]]; then
     export https_proxy=$http_proxy
     export HTTP_PROXY=$http_proxy
     export HTTPS_PROXY=$http_proxy
-    export no_proxy=lanl.gov
+    export no_proxy=".lanl.gov,127.0.0.1,localhost"
     export NO_PROXY=$no_proxy
   fi
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,12 +50,19 @@ message(" ")
 message( STATUS "Configuring Level 1 packages --" )
 add_dir_if_exists( ds++ )
 
-# Only test ds++ if CI_CLANG_TIDY is running
+# Only test selected componenets if CI_CLANG_TIDY is running
 
 # Level 2
 message(" ")
 message( STATUS "Configuring Level 2 packages --" )
-add_dir_if_exists( c4 )           # needs ds++
+add_dir_if_exists( c4 )            # needs ds++
+add_dir_if_exists( FortranChecks ) # needs ds++
+add_dir_if_exists( lapack_wrap )   # needs ds++
+add_dir_if_exists( linear )        # needs ds++
+add_dir_if_exists( memory )        # needs ds++
+add_dir_if_exists( mesh_element  ) # needs ds++
+add_dir_if_exists( ode )           # needs ds++
+add_dir_if_exists( units )        # needs ds++
 
 if( NOT CI_CLANG_TIDY )
 add_dir_if_exists( cdi )          # needs ds++
@@ -63,14 +70,7 @@ add_dir_if_exists( device )       # needs ds++
 if( USE_MDSPAN )
   add_dir_if_exists( experimental ) # only the tests need ds++
 endif()
-add_dir_if_exists( FortranChecks ) # needs ds++
-add_dir_if_exists( lapack_wrap )  # needs ds++
-add_dir_if_exists( linear )       # needs ds++
-add_dir_if_exists( memory )       # needs ds++
-add_dir_if_exists( mesh_element ) # needs ds++
-add_dir_if_exists( ode )          # needs ds++
 add_dir_if_exists( plot2D )
-add_dir_if_exists( units )        # needs ds++
 
 # Level 3
 message(" ")

--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -44,7 +44,8 @@ if(TARGET NDI::ndi)
   endif()
   set( NDI_DATA_DIR "${NDI_DATA_DIR}" CACHE PATH
     "Location of NDI gendir file." )
-
+else()
+  set(NDI_DATA_DIR "notfound")
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_ndi/NDI_AtomicMass.hh
+++ b/src/cdi_ndi/NDI_AtomicMass.hh
@@ -11,6 +11,7 @@
 #ifndef cdi_ndi_NDI_AtomicMass_hh
 #define cdi_ndi_NDI_AtomicMass_hh
 
+#include "cdi_ndi/config.h" // definition of NDI_FOUND
 #include "ds++/Assert.hh"
 #include "ds++/path.hh"
 #include "units/PhysicalConstexprs.hh"
@@ -31,19 +32,20 @@ namespace rtt_cdi_ndi {
  */
 //============================================================================//
 class NDI_AtomicMass {
-
 public:
-  //! Constructor (default gendir path)
-  NDI_AtomicMass();
-
   /*!
    * \brief Constructor for NDI atomic mass weight reader, using custom path to
    *        NDI gendir file.
    * \param[in] gendir_path_in path to gendir file
    */
-  NDI_AtomicMass(const std::string &gendir_path_in)
-      : gendir_path(gendir_path_in) {
-    Require(rtt_dsxx::fileExists(gendir_path));
+  explicit NDI_AtomicMass(
+      std::string gendir_path_in = rtt_dsxx::getFilenameComponent(
+          std::string(NDI_DATA_DIR) + rtt_dsxx::dirSep + "gendir",
+          rtt_dsxx::FilenameComponent::FC_NATIVE))
+      : gendir_path(std::move(gendir_path_in)), pc() {
+    Insist(rtt_dsxx::fileExists(gendir_path),
+           "Specified NDI library is not available. gendir_path = " +
+               gendir_path);
   }
 
   //! Retrieve atomic mass weight for isotope with given ZAID
@@ -51,10 +53,10 @@ public:
 
 private:
   //! Path to gendir file
-  std::string gendir_path;
+  std::string const gendir_path;
 
   //! Unit system
-  const rtt_units::PhysicalConstexprs<rtt_units::CGS> pc;
+  rtt_units::PhysicalConstexprs<rtt_units::CGS> const pc;
 };
 
 } // namespace rtt_cdi_ndi

--- a/src/ds++/Index_Set.hh
+++ b/src/ds++/Index_Set.hh
@@ -34,14 +34,10 @@ public:
   Index_Set() = default;
 
   //! Construct with pointer to sizes
-  explicit Index_Set(unsigned const *const dimensions) : m_array_size(0) {
-    set_size(dimensions);
-  }
+  explicit Index_Set(unsigned const *const dimensions) { set_size(dimensions); }
 
   //! Construct with all dimensions equal
-  explicit Index_Set(const unsigned dimension) : m_array_size(0) {
-    set_size(dimension);
-  }
+  explicit Index_Set(const unsigned dimension) { set_size(dimension); }
 
   //! Destructor
   virtual ~Index_Set() = default;

--- a/src/linear/gaussj.i.hh
+++ b/src/linear/gaussj.i.hh
@@ -28,7 +28,7 @@ using std::sqrt;
 template <class DoubleRandomContainer>
 bool is_square(DoubleRandomContainer const &A) {
   Check(A.size() < UINT_MAX);
-  unsigned const n = static_cast<unsigned>(A.size());
+  auto const n = static_cast<unsigned>(A.size());
   for (unsigned i = 0; i < n; ++i) {
     if (A[i].size() != n)
       return false;
@@ -146,7 +146,7 @@ void gaussj(DoubleRandomContainer &A, RandomContainer &b) {
   double const mrv =
       std::numeric_limits<typename RandomContainer::value_type>::min();
   Check(A.size() < UINT_MAX);
-  unsigned const n = static_cast<unsigned>(A.size());
+  auto const n = static_cast<unsigned>(A.size());
 
   vector<int> indxc(n);
   vector<int> indxr(n);

--- a/src/linear/ludcmp.i.hh
+++ b/src/linear/ludcmp.i.hh
@@ -40,7 +40,7 @@ void ludcmp(FieldVector &a, IntVector &indx,
   typedef typename FieldVector::value_type Field;
 
   Check(indx.size() < UINT_MAX);
-  unsigned const n = static_cast<unsigned>(indx.size());
+  auto const n = static_cast<unsigned>(indx.size());
 
   vector<Field> vv(n);
 
@@ -121,12 +121,12 @@ void lubksb(FieldVector1 const &a, IntVector const &indx, FieldVector2 &b) {
   Require(a.size() == indx.size() * indx.size());
   Require(b.size() == indx.size());
 
-  typedef typename FieldVector2::value_type Field;
+  using Field = typename FieldVector2::value_type;
 
   // minimum representable value
   double const mrv = std::numeric_limits<Field>::min();
   Check(indx.size() < UINT_MAX);
-  unsigned const n = static_cast<unsigned>(indx.size());
+  auto const n = static_cast<unsigned>(indx.size());
 
   unsigned ii = 0;
 

--- a/src/linear/qrdcmp.i.hh
+++ b/src/linear/qrdcmp.i.hh
@@ -15,7 +15,6 @@
 #include "ds++/Assert.hh"
 #include "ds++/DracoMath.hh"
 #include <cmath>
-#include <math.h>
 
 namespace rtt_linear {
 

--- a/src/linear/test/tstqrdcmp.cc
+++ b/src/linear/test/tstqrdcmp.cc
@@ -3,22 +3,18 @@
  * \file   linear/test/tstqrdcmp.cc
  * \author Kent Budge
  * \date   Mon Aug  9 13:39:20 2004
- * \brief  
+ * \brief  Unit teests for qrdcmp
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
-
-//----------------------------------------------------------------------------//
-
-#include <iostream>
-#include <vector>
-
-#include "ds++/ScalarUnitTest.hh"
-#include "ds++/Soft_Equivalence.hh"
 
 #include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include "ds++/Soft_Equivalence.hh"
 #include "linear/qrdcmp.hh"
+#include <array>
+#include <iostream>
+#include <vector>
 
 using namespace std;
 using namespace rtt_dsxx;
@@ -40,16 +36,16 @@ void tstqrdcmp(UnitTest &ut) {
   qrdcmp(A, 2, C, D);
 
   // Compute QR to verify
-  double uj[2];
+  array<double, 2> uj;
   uj[0] = A[0 + 2 * 0];
   uj[1] = A[1 + 2 * 0];
-  double Qj[4];
+  array<double, 4> Qj;
   Qj[0 + 2 * 0] = 1 - uj[0] * uj[0] / C[0];
   Qj[0 + 2 * 1] = -uj[0] * uj[1] / C[0];
   Qj[1 + 2 * 0] = -uj[1] * uj[0] / C[0];
   Qj[1 + 2 * 1] = 1 - uj[1] * uj[1] / C[0];
 
-  double QR[4];
+  array<double, 4> QR;
   QR[0 + 2 * 0] = Qj[0 + 2 * 0] * D[0];
   QR[0 + 2 * 1] = Qj[0 + 2 * 0] * A[0 + 2 * 1] + Qj[0 + 2 * 1] * D[1];
   QR[1 + 2 * 0] = Qj[1 + 2 * 0] * D[0];
@@ -78,20 +74,12 @@ void tstqrdcmp(UnitTest &ut) {
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
+  ScalarUnitTest ut(argc, argv, release);
   try {
-    ScalarUnitTest ut(argc, argv, release);
     tstqrdcmp(ut);
-  } catch (exception &err) {
-    cout << "ERROR: While testing tstqrdcmp, " << err.what() << endl;
-    return 1;
-  } catch (...) {
-    cout << "ERROR: While testing tstqrdcmp, an unknown exception was thrown."
-         << endl;
-    return 1;
   }
-  return 0;
+  UT_EPILOG(ut);
 }
 
 //----------------------------------------------------------------------------//

--- a/src/linear/test/tstqrupdt.cc
+++ b/src/linear/test/tstqrupdt.cc
@@ -4,10 +4,7 @@
  * \author Kent Budge
  * \date   Mon Aug  9 13:39:20 2004
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -16,6 +13,7 @@
 #include "linear/qr_unpack.hh"
 #include "linear/qrdcmp.hh"
 #include "linear/qrupdt.hh"
+#include <array>
 
 using namespace std;
 using namespace rtt_dsxx;
@@ -57,7 +55,7 @@ void tstqrupdt(UnitTest &ut) {
 
   // Check the update
 
-  double QR[2 * 2];
+  std::array<double, 2 * 2> QR;
   QR[0 + 2 * 0] = QT[0 + 2 * 0] * A[0 + 2 * 0] + QT[0 + 2 * 1] * A[1 + 2 * 0];
   QR[0 + 2 * 1] = QT[0 + 2 * 0] * A[0 + 2 * 1] + QT[0 + 2 * 1] * A[1 + 2 * 1];
   QR[1 + 2 * 0] = QT[1 + 2 * 0] * A[0 + 2 * 0] + QT[1 + 2 * 1] * A[1 + 2 * 0];

--- a/src/linear/test/tstsvdcmp.cc
+++ b/src/linear/test/tstsvdcmp.cc
@@ -4,16 +4,14 @@
  * \author Kent Budge
  * \date   Mon Aug  9 13:39:20 2004
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include "linear/svdcmp.hh"
+#include <array>
 
 using namespace std;
 using namespace rtt_dsxx;
@@ -36,13 +34,13 @@ void tstsvdcmp(UnitTest &ut) {
 
   // Compute U*W*Tr(V) to verify
 
-  double WV[9];
+  array<double, 9> WV;
   WV[0 + 2 * 0] = W[0] * V[0 + 2 * 0];
   WV[0 + 2 * 1] = W[0] * V[1 + 2 * 0];
   WV[1 + 2 * 0] = W[1] * V[0 + 2 * 1];
   WV[1 + 2 * 1] = W[1] * V[1 + 2 * 1];
 
-  double UWV[6];
+  array<double, 6> UWV;
   UWV[0 + 3 * 0] = U[0 + 3 * 0] * WV[0 + 2 * 0] + U[0 + 3 * 1] * WV[1 + 2 * 0];
   UWV[0 + 3 * 1] = U[0 + 3 * 0] * WV[0 + 2 * 1] + U[0 + 3 * 1] * WV[1 + 2 * 1];
   UWV[1 + 3 * 0] = U[1 + 3 * 0] * WV[0 + 2 * 0] + U[1 + 3 * 1] * WV[1 + 2 * 0];

--- a/src/memory/memory.cc
+++ b/src/memory/memory.cc
@@ -282,7 +282,7 @@ void operator delete(void *ptr, size_t) throw() { operator delete(ptr); }
  *
  * \bug untested
  */
-void rtt_memory::out_of_memory_handler(void) {
+void rtt_memory::out_of_memory_handler() {
   std::set_new_handler(nullptr);
   std::cerr << "Unable to allocate requested memory.\n"
             << rtt_dsxx::print_stacktrace("bad_alloc");

--- a/src/memory/memory.hh
+++ b/src/memory/memory.hh
@@ -30,7 +30,7 @@ uint64_t largest_allocation();
 void report_leaks(std::ostream &);
 
 //! Register rtt_dsxx::print_stacktrace() as the respose to std::bad_alloc.
-void out_of_memory_handler(void);
+void out_of_memory_handler();
 
 } // namespace rtt_memory
 

--- a/src/memory/test/tstmemory.cc
+++ b/src/memory/test/tstmemory.cc
@@ -41,9 +41,8 @@ void tst_memory(rtt_dsxx::UnitTest &ut) {
 
   set_memory_checking(true);
 
-  double *array = new double[20];
-
-  double *array2 = new double[30];
+  auto *array = new double[20];
+  auto *array2 = new double[30];
 
 #if DRACO_DIAGNOSTICS & 2
   if (total_allocation() == 50 * sizeof(double)) {

--- a/src/mesh_element/Element_Definition.cc
+++ b/src/mesh_element/Element_Definition.cc
@@ -101,13 +101,14 @@ Element_Definition::Element_Definition(
       dimension(dimension_), number_of_nodes(number_of_nodes_),
       number_of_sides(number_of_sides_), elem_defs(elem_defs_),
       side_type(side_type_), side_nodes(side_nodes_) {
-  //--------------------------------------------------------------------------//
+
   // Check input first, before any modifications
   Require(number_of_nodes_ > 0);
 
-  for (const auto &elem_def : elem_defs_) {
+#ifdef REQUIRE_ON
+  for (const auto &elem_def : elem_defs_)
     Require(elem_def.get_dimension() + 1 == dimension_);
-  }
+#endif
   Require(side_type_.size() == number_of_sides_);
   for (unsigned i = 0; i < number_of_sides_; ++i) {
     Require(static_cast<unsigned>(side_type_[i]) < elem_defs_.size());
@@ -116,10 +117,10 @@ Element_Definition::Element_Definition(
   for (unsigned i = 0; i < number_of_sides_; ++i) {
     Require(side_nodes_[i].size() ==
             elem_defs_[side_type_[i]].get_number_of_nodes());
-
-    for (unsigned const side_node : side_nodes_[i]) {
+#ifdef REQUIRE_ON
+    for (unsigned const side_node : side_nodes_[i])
       Require(side_node < number_of_nodes_);
-    }
+#endif
   }
 
   // Only time this constructor should be called

--- a/src/mesh_element/Element_Definition.hh
+++ b/src/mesh_element/Element_Definition.hh
@@ -275,8 +275,7 @@ public:
    * This destructor is virtual, implying that Element_Definition is extensible
    * by inheritance.
    */
-  virtual ~Element_Definition(void) { /*empty*/
-  }
+  virtual ~Element_Definition() = default;
 
   // ACCESSORS
 
@@ -284,26 +283,26 @@ public:
    * \brief Returns the name of an element.
    * \return Returns the element name as a string.
    */
-  std::string get_name(void) const { return name; }
+  std::string get_name() const { return name; }
 
   /*!
    * \brief Returns the type of an element.
    * \return Returns the element type.
    */
-  Element_Type get_type(void) const { return type; }
+  Element_Type get_type() const { return type; }
 
   /*!
    * \brief Returns the total number of nodes in an element.
    * \return Total number of nodes in an element.
    */
-  unsigned get_number_of_nodes(void) const { return number_of_nodes; }
+  unsigned get_number_of_nodes() const { return number_of_nodes; }
   /*!
    * \brief Returns the dimension of an element. i.e. nodes return 0, lines
    *        return 1, quads return 2, hexahedra return 3.
    *
    * \return The element dimension (0, 1, 2, or 3).
    */
-  unsigned get_dimension(void) const { return dimension; }
+  unsigned get_dimension() const { return dimension; }
   /*!
    * \brief Returns the number of sides on an element.
    *
@@ -311,7 +310,7 @@ public:
    *         dimensional element. i.e. nodes return 0, lines return 2, quads
    *         return 4, hexahedra return 6.
    */
-  unsigned get_number_of_sides(void) const { return number_of_sides; }
+  unsigned get_number_of_sides() const { return number_of_sides; }
 
   /*!
    * \brief Returns the type (i.e. quad, tri, etc.) of a specified element side.

--- a/src/mesh_element/test/TestElementDefinition.cc
+++ b/src/mesh_element/test/TestElementDefinition.cc
@@ -4,13 +4,14 @@
  * \author Thomas M. Evans
  * \date   Tue Mar 26 16:06:55 2002
  * \brief  Test Element Definitions.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC. 
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
  *         All rights reserved.  */
 //----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "mesh_element/Element_Definition.hh"
+#include <array>
 #include <list>
 #include <sstream>
 
@@ -71,6 +72,12 @@ bool test_hexa_27(rtt_dsxx::UnitTest &ut,
 
 } // end namespace rtt_mesh_element_test
 
+//----------------------------------------------------------------------------//
+template <std::size_t N> std::vector<unsigned> makeuv(std::array<int, N> s) {
+  return std::vector<unsigned>(s.begin(), s.end());
+}
+
+//----------------------------------------------------------------------------//
 void runTest(rtt_dsxx::UnitTest &ut) {
   using rtt_mesh_element::Element_Definition;
 
@@ -101,11 +108,11 @@ void runTest(rtt_dsxx::UnitTest &ut) {
   type_list.push_back(Element_Definition::HEXA_20);
   type_list.push_back(Element_Definition::HEXA_27);
 
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   cout << endl << "Building Elements for Test ---" << endl << endl;
   list<Element_Definition> elem_defs;
   for (size_t i = 0; i < type_list.size(); i++) {
-    elem_defs.push_back(Element_Definition(type_list[i]));
+    elem_defs.emplace_back(type_list[i]);
     cout << elem_defs.back();
     if (!elem_defs.back().invariant_satisfied()) {
       ostringstream msg;
@@ -114,7 +121,7 @@ void runTest(rtt_dsxx::UnitTest &ut) {
       FAILMSG(msg.str());
     }
   }
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   cout << "\nChecking Elements ---\n" << endl;
 
   // CAREFUL HERE -- the order of the function calls must match the type_list
@@ -167,14 +174,14 @@ void runTest(rtt_dsxx::UnitTest &ut) {
   rtt_mesh_element_test::test_hexa_27(ut, elem_defs.front());
   elem_defs.pop_front();
 
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   // Test the POLYGON element.
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
 
   cout << "\nBuilding POLYGON Element ---\n" << endl;
 
   vector<Element_Definition> polyg_elem_defs;
-  polyg_elem_defs.push_back(Element_Definition(Element_Definition::BAR_2));
+  polyg_elem_defs.emplace_back(Element_Definition::BAR_2);
 
   vector<unsigned> polyg_side_type(8,  // number of sides
                                    0); // index into elem_defs
@@ -191,9 +198,9 @@ void runTest(rtt_dsxx::UnitTest &ut) {
                            8,       // number_of_sides
                            polyg_elem_defs, polyg_side_type, polyg_side_nodes);
 
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   // Test the POLYHEDRON element.
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
 
   cout << "\nBuilding POLYHEDRON Element ---\n" << endl;
 
@@ -202,13 +209,13 @@ void runTest(rtt_dsxx::UnitTest &ut) {
   vector<vector<unsigned>> polyh_side_nodes;
 
   // First side is QUAD_4
-  polyh_elem_defs.push_back(Element_Definition(Element_Definition::QUAD_4));
+  polyh_elem_defs.emplace_back(Element_Definition::QUAD_4);
   polyh_side_type.push_back(0);
   vector<unsigned> side0_nodes = {0, 1, 5, 4};
   polyh_side_nodes.push_back(side0_nodes);
 
   // Next four sides are QUAD_5
-  polyh_elem_defs.push_back(Element_Definition(Element_Definition::QUAD_5));
+  polyh_elem_defs.emplace_back(Element_Definition::QUAD_5);
 
   polyh_side_type.push_back(1);
   vector<unsigned> side1_nodes = {1, 0, 3, 2, 11};
@@ -227,7 +234,7 @@ void runTest(rtt_dsxx::UnitTest &ut) {
   polyh_side_nodes.push_back(side4_nodes);
 
   // Last (sixth) side is QUAD_9
-  polyh_elem_defs.push_back(Element_Definition(Element_Definition::QUAD_9));
+  polyh_elem_defs.emplace_back(Element_Definition::QUAD_9);
   polyh_side_type.push_back(2);
   vector<unsigned> side5_nodes = {3, 7, 6, 2, 8, 9, 10, 11, 12};
   polyh_side_nodes.push_back(side5_nodes);
@@ -238,7 +245,7 @@ void runTest(rtt_dsxx::UnitTest &ut) {
                            6,             // number_of_sides
                            polyh_elem_defs, polyh_side_type, polyh_side_nodes);
 
-  //----------------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   // Merely attempting construction, with DBC active, will invoke a slew of
   // precondition, postcondition, and consistency checks.  We perform no
   // other explicit checks here.
@@ -291,13 +298,11 @@ bool test_bar_2(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 1;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 1;
-  const int size = 1;
-  int s0[size] = {0};
-  int s1[size] = {1};
-  ldum =
-      ldum && (elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size));
-  ldum =
-      ldum && (elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size));
+  constexpr int size = 1;
+  std::array<int, size> s0 = {0};
+  std::array<int, size> s1 = {1};
+  ldum = ldum && (elem_def.get_side_nodes(0) == makeuv(s0));
+  ldum = ldum && (elem_def.get_side_nodes(1) == makeuv(s1));
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -324,13 +329,11 @@ bool test_bar_3(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 1;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 1;
-  const int size = 1;
-  int s0[size] = {0};
-  int s1[size] = {1};
-  ldum =
-      ldum && (elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size));
-  ldum =
-      ldum && (elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size));
+  constexpr int size = 1;
+  std::array<int, size> s0 = {0};
+  std::array<int, size> s1 = {1};
+  ldum = ldum && (elem_def.get_side_nodes(0) == makeuv(s0));
+  ldum = ldum && (elem_def.get_side_nodes(1) == makeuv(s1));
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -358,13 +361,13 @@ bool test_tri_3(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 2;
-  const int size = 2;
-  int s0[size] = {0, 1};
-  int s1[size] = {1, 2};
-  int s2[size] = {2, 0};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
+  constexpr int size = 2;
+  std::array<int, size> s0 = {0, 1};
+  std::array<int, size> s1 = {1, 2};
+  std::array<int, size> s2 = {2, 0};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -392,13 +395,13 @@ bool test_tri_6(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
-  const int size = 3;
-  int s0[size] = {0, 1, 3};
-  int s1[size] = {1, 2, 4};
-  int s2[size] = {2, 0, 5};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
+  constexpr int size = 3;
+  std::array<int, size> s0 = {0, 1, 3};
+  std::array<int, size> s1 = {1, 2, 4};
+  std::array<int, size> s2 = {2, 0, 5};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -427,15 +430,15 @@ bool test_quad_4(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 2;
-  const int size = 2;
-  int s0[size] = {0, 1};
-  int s1[size] = {1, 2};
-  int s2[size] = {2, 3};
-  int s3[size] = {3, 0};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
+  constexpr int size = 2;
+  std::array<int, size> s0 = {0, 1};
+  std::array<int, size> s1 = {1, 2};
+  std::array<int, size> s2 = {2, 3};
+  std::array<int, size> s3 = {3, 0};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -468,14 +471,14 @@ bool test_quad_5(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 2;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
 
-  int s0[2] = {0, 1};
-  int s1[3] = {1, 2};
-  int s2[3] = {2, 3};
-  int s3[3] = {3, 0, 4};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + 2);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + 2);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + 2);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + 3);
+  std::array<int, 2> s0 = {0, 1};
+  std::array<int, 2> s1 = {1, 2};
+  std::array<int, 2> s2 = {2, 3};
+  std::array<int, 3> s3 = {3, 0, 4};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
 
   if (ldum) {
     ostringstream message;
@@ -515,14 +518,14 @@ bool test_quad_6(rtt_dsxx::UnitTest &ut,
     ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
     ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
 
-    int s0[2] = {0, 1};
-    int s1[2] = {1, 2};
-    int s2[3] = {2, 3, 4};
-    int s3[3] = {3, 0, 5};
-    ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + 2);
-    ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + 2);
-    ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + 3);
-    ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + 3);
+    std::array<int, 2> s0 = {0, 1};
+    std::array<int, 2> s1 = {1, 2};
+    std::array<int, 3> s2 = {2, 3, 4};
+    std::array<int, 3> s3 = {3, 0, 5};
+    ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+    ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+    ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+    ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   } else {
     string ename = "QUAD_6o";
     ldum = ldum && elem_def.get_name() == ename;
@@ -538,14 +541,14 @@ bool test_quad_6(rtt_dsxx::UnitTest &ut,
     ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 2;
     ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
 
-    int s0[2] = {0, 1};
-    int s1[3] = {1, 2, 4};
-    int s2[2] = {2, 3};
-    int s3[3] = {3, 0, 5};
-    ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + 2);
-    ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + 3);
-    ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + 2);
-    ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + 3);
+    std::array<int, 2> s0 = {0, 1};
+    std::array<int, 3> s1 = {1, 2, 4};
+    std::array<int, 2> s2 = {2, 3};
+    std::array<int, 3> s3 = {3, 0, 5};
+    ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+    ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+    ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+    ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   }
 
   if (ldum) {
@@ -580,14 +583,14 @@ bool test_quad_7(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
 
-  int s0[2] = {0, 1};
-  int s1[3] = {1, 2, 4};
-  int s2[3] = {2, 3, 5};
-  int s3[3] = {3, 0, 6};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + 2);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + 3);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + 3);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + 3);
+  std::array<int, 2> s0 = {0, 1};
+  std::array<int, 3> s1 = {1, 2, 4};
+  std::array<int, 3> s2 = {2, 3, 5};
+  std::array<int, 3> s3 = {3, 0, 6};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
 
   if (ldum) {
     ostringstream message;
@@ -617,15 +620,15 @@ bool test_quad_8(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
-  const int size = 3;
-  int s0[size] = {0, 1, 4};
-  int s1[size] = {1, 2, 5};
-  int s2[size] = {2, 3, 6};
-  int s3[size] = {3, 0, 7};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
+  constexpr int size = 3;
+  std::array<int, size> s0 = {0, 1, 4};
+  std::array<int, size> s1 = {1, 2, 5};
+  std::array<int, size> s2 = {2, 3, 6};
+  std::array<int, size> s3 = {3, 0, 7};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -654,15 +657,15 @@ bool test_quad_9(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
-  const int size = 3;
-  int s0[size] = {0, 1, 4};
-  int s1[size] = {1, 2, 5};
-  int s2[size] = {2, 3, 6};
-  int s3[size] = {3, 0, 7};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
+  constexpr int size = 3;
+  array<int, size> s0 = {0, 1, 4};
+  array<int, size> s1 = {1, 2, 5};
+  array<int, size> s2 = {2, 3, 6};
+  array<int, size> s3 = {3, 0, 7};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -691,15 +694,15 @@ bool test_tetra_4(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
-  const int size = 3;
-  int s0[size] = {0, 2, 1};
-  int s1[size] = {0, 1, 3};
-  int s2[size] = {1, 2, 3};
-  int s3[size] = {2, 0, 3};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
+  constexpr int size = 3;
+  array<int, size> s0 = {0, 2, 1};
+  array<int, size> s1 = {0, 1, 3};
+  array<int, size> s2 = {1, 2, 3};
+  array<int, size> s3 = {2, 0, 3};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -728,15 +731,15 @@ bool test_tetra_10(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 6;
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 6;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 6;
-  const int size = 6;
-  int s0[size] = {0, 2, 1, 6, 5, 4};
-  int s1[size] = {0, 1, 3, 4, 8, 7};
-  int s2[size] = {1, 2, 3, 5, 9, 8};
-  int s3[size] = {2, 0, 3, 6, 7, 9};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
+  constexpr int size = 6;
+  array<int, size> s0 = {0, 2, 1, 6, 5, 4};
+  array<int, size> s1 = {0, 1, 3, 4, 8, 7};
+  array<int, size> s2 = {1, 2, 3, 5, 9, 8};
+  array<int, size> s3 = {2, 0, 3, 6, 7, 9};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -768,18 +771,18 @@ bool test_pyra_5(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[2] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 3;
   ldum = ldum && elem_def.get_number_of_face_nodes()[4] == 3;
-  const int sizeq = 4;
-  int s0[sizeq] = {0, 3, 2, 1};
-  const int sizet = 3;
-  int s1[sizet] = {0, 1, 4};
-  int s2[sizet] = {1, 2, 4};
-  int s3[sizet] = {2, 3, 4};
-  int s4[sizet] = {3, 0, 4};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + sizet);
+  constexpr int sizeq = 4;
+  array<int, sizeq> s0 = {0, 3, 2, 1};
+  constexpr int sizet = 3;
+  array<int, sizet> s1 = {0, 1, 4};
+  array<int, sizet> s2 = {1, 2, 4};
+  array<int, sizet> s3 = {2, 3, 4};
+  array<int, sizet> s4 = {3, 0, 4};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
   if (ldum) {
     ostringstream message;
     message << ename << " Element OK." << endl;
@@ -805,18 +808,18 @@ bool test_pyra_14(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_sides() == 5;
   ldum = ldum &&
          elem_def.get_side_type(0).get_type() == Element_Definition::QUAD_8;
-  const int sizeq = 8;
-  int s0[sizeq] = {0, 3, 2, 1, 8, 7, 6, 5};
-  const int sizet = 6;
-  int s1[sizet] = {0, 1, 4, 5, 10, 9};
-  int s2[sizet] = {1, 2, 4, 6, 11, 10};
-  int s3[sizet] = {2, 3, 4, 7, 12, 11};
-  int s4[sizet] = {3, 0, 4, 8, 9, 12};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + sizet);
+  constexpr int sizeq = 8;
+  array<int, sizeq> s0 = {0, 3, 2, 1, 8, 7, 6, 5};
+  constexpr int sizet = 6;
+  array<int, sizet> s1 = {0, 1, 4, 5, 10, 9};
+  array<int, sizet> s2 = {1, 2, 4, 6, 11, 10};
+  array<int, sizet> s3 = {2, 3, 4, 7, 12, 11};
+  array<int, sizet> s4 = {3, 0, 4, 8, 9, 12};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 5;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 8;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 6;
@@ -852,18 +855,18 @@ bool test_penta_6(rtt_dsxx::UnitTest &ut,
   for (int j = 3; j < 5; ++j)
     ldum = ldum &&
            elem_def.get_side_type(j).get_type() == Element_Definition::TRI_3;
-  const int sizeq = 4;
-  int s0[sizeq] = {0, 1, 4, 3};
-  int s1[sizeq] = {1, 2, 5, 4};
-  int s2[sizeq] = {2, 0, 3, 5};
-  const int sizet = 3;
-  int s3[sizet] = {0, 2, 1};
-  int s4[sizet] = {3, 4, 5};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + sizet);
+  constexpr int sizeq = 4;
+  array<int, sizeq> s0 = {0, 1, 4, 3};
+  array<int, sizeq> s1 = {1, 2, 5, 4};
+  array<int, sizeq> s2 = {2, 0, 3, 5};
+  constexpr int sizet = 3;
+  array<int, sizet> s3 = {0, 2, 1};
+  array<int, sizet> s4 = {3, 4, 5};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 5;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 4;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 4;
@@ -899,18 +902,18 @@ bool test_penta_15(rtt_dsxx::UnitTest &ut,
   for (int j = 3; j < 5; ++j)
     ldum = ldum &&
            elem_def.get_side_type(j).get_type() == Element_Definition::TRI_6;
-  const int sizeq = 8;
-  int s0[sizeq] = {0, 1, 4, 3, 6, 10, 12, 9};
-  int s1[sizeq] = {1, 2, 5, 4, 7, 11, 13, 10};
-  int s2[sizeq] = {2, 0, 3, 5, 8, 9, 14, 11};
-  const int sizet = 6;
-  int s3[sizet] = {0, 2, 1, 8, 7, 6};
-  int s4[sizet] = {3, 4, 5, 12, 13, 14};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + sizet);
+  constexpr int sizeq = 8;
+  array<int, sizeq> s0 = {0, 1, 4, 3, 6, 10, 12, 9};
+  array<int, sizeq> s1 = {1, 2, 5, 4, 7, 11, 13, 10};
+  array<int, sizeq> s2 = {2, 0, 3, 5, 8, 9, 14, 11};
+  constexpr int sizet = 6;
+  array<int, sizet> s3 = {0, 2, 1, 8, 7, 6};
+  array<int, sizet> s4 = {3, 4, 5, 12, 13, 14};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 5;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 8;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 8;
@@ -946,18 +949,18 @@ bool test_penta_18(rtt_dsxx::UnitTest &ut,
   for (int j = 3; j < 5; ++j)
     ldum = ldum &&
            elem_def.get_side_type(j).get_type() == Element_Definition::TRI_6;
-  const int sizeq = 9;
-  int s0[sizeq] = {0, 1, 4, 3, 6, 10, 12, 9, 15};
-  int s1[sizeq] = {1, 2, 5, 4, 7, 11, 13, 10, 16};
-  int s2[sizeq] = {2, 0, 3, 5, 8, 9, 14, 11, 17};
-  const int sizet = 6;
-  int s3[sizet] = {0, 2, 1, 8, 7, 6};
-  int s4[sizet] = {3, 4, 5, 12, 13, 14};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + sizeq);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + sizet);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + sizet);
+  constexpr int sizeq = 9;
+  array<int, sizeq> s0 = {0, 1, 4, 3, 6, 10, 12, 9, 15};
+  array<int, sizeq> s1 = {1, 2, 5, 4, 7, 11, 13, 10, 16};
+  array<int, sizeq> s2 = {2, 0, 3, 5, 8, 9, 14, 11, 17};
+  constexpr int sizet = 6;
+  array<int, sizet> s3 = {0, 2, 1, 8, 7, 6};
+  array<int, sizet> s4 = {3, 4, 5, 12, 13, 14};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 5;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 9;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 9;
@@ -991,19 +994,19 @@ bool test_hexa_8(rtt_dsxx::UnitTest &ut,
   for (int j = 0; j < 6; ++j)
     ldum = ldum &&
            elem_def.get_side_type(j).get_type() == Element_Definition::QUAD_4;
-  const int size = 4;
-  int s0[size] = {0, 3, 2, 1};
-  int s1[size] = {0, 4, 7, 3};
-  int s2[size] = {2, 3, 7, 6};
-  int s3[size] = {1, 2, 6, 5};
-  int s4[size] = {0, 1, 5, 4};
-  int s5[size] = {4, 5, 6, 7};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + size);
-  ldum = ldum && elem_def.get_side_nodes(5) == vector<unsigned>(s5, s5 + size);
+  constexpr int size = 4;
+  array<int, size> s0 = {0, 3, 2, 1};
+  array<int, size> s1 = {0, 4, 7, 3};
+  array<int, size> s2 = {2, 3, 7, 6};
+  array<int, size> s3 = {1, 2, 6, 5};
+  array<int, size> s4 = {0, 1, 5, 4};
+  array<int, size> s5 = {4, 5, 6, 7};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
+  ldum = ldum && elem_def.get_side_nodes(5) == makeuv(s5);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 6;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 4;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 4;
@@ -1037,19 +1040,19 @@ bool test_hexa_20(rtt_dsxx::UnitTest &ut,
   for (int j = 0; j < 6; ++j)
     ldum = ldum &&
            elem_def.get_side_type(j).get_type() == Element_Definition::QUAD_8;
-  const int size = 8;
-  int s0[size] = {0, 3, 2, 1, 11, 10, 9, 8};
-  int s1[size] = {0, 4, 7, 3, 12, 19, 15, 11};
-  int s2[size] = {2, 3, 7, 6, 10, 15, 18, 14};
-  int s3[size] = {1, 2, 6, 5, 9, 14, 17, 13};
-  int s4[size] = {0, 1, 5, 4, 8, 13, 16, 12};
-  int s5[size] = {4, 5, 6, 7, 16, 17, 18, 19};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + size);
-  ldum = ldum && elem_def.get_side_nodes(5) == vector<unsigned>(s5, s5 + size);
+  constexpr int size = 8;
+  array<int, size> s0 = {0, 3, 2, 1, 11, 10, 9, 8};
+  array<int, size> s1 = {0, 4, 7, 3, 12, 19, 15, 11};
+  array<int, size> s2 = {2, 3, 7, 6, 10, 15, 18, 14};
+  array<int, size> s3 = {1, 2, 6, 5, 9, 14, 17, 13};
+  array<int, size> s4 = {0, 1, 5, 4, 8, 13, 16, 12};
+  array<int, size> s5 = {4, 5, 6, 7, 16, 17, 18, 19};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
+  ldum = ldum && elem_def.get_side_nodes(5) == makeuv(s5);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 6;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 8;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 8;
@@ -1084,19 +1087,19 @@ bool test_hexa_27(rtt_dsxx::UnitTest &ut,
   for (int j = 0; j < 6; ++j)
     ldum = ldum &&
            elem_def.get_side_type(j).get_type() == Element_Definition::QUAD_9;
-  const int size = 9;
-  int s0[size] = {0, 3, 2, 1, 11, 10, 9, 8, 20};
-  int s1[size] = {0, 4, 7, 3, 12, 19, 15, 11, 21};
-  int s2[size] = {2, 3, 7, 6, 10, 15, 18, 14, 22};
-  int s3[size] = {1, 2, 6, 5, 9, 14, 17, 13, 23};
-  int s4[size] = {0, 1, 5, 4, 8, 13, 16, 12, 24};
-  int s5[size] = {4, 5, 6, 7, 16, 17, 18, 19, 25};
-  ldum = ldum && elem_def.get_side_nodes(0) == vector<unsigned>(s0, s0 + size);
-  ldum = ldum && elem_def.get_side_nodes(1) == vector<unsigned>(s1, s1 + size);
-  ldum = ldum && elem_def.get_side_nodes(2) == vector<unsigned>(s2, s2 + size);
-  ldum = ldum && elem_def.get_side_nodes(3) == vector<unsigned>(s3, s3 + size);
-  ldum = ldum && elem_def.get_side_nodes(4) == vector<unsigned>(s4, s4 + size);
-  ldum = ldum && elem_def.get_side_nodes(5) == vector<unsigned>(s5, s5 + size);
+  constexpr int size = 9;
+  array<int, size> s0 = {0, 3, 2, 1, 11, 10, 9, 8, 20};
+  array<int, size> s1 = {0, 4, 7, 3, 12, 19, 15, 11, 21};
+  array<int, size> s2 = {2, 3, 7, 6, 10, 15, 18, 14, 22};
+  array<int, size> s3 = {1, 2, 6, 5, 9, 14, 17, 13, 23};
+  array<int, size> s4 = {0, 1, 5, 4, 8, 13, 16, 12, 24};
+  array<int, size> s5 = {4, 5, 6, 7, 16, 17, 18, 19, 25};
+  ldum = ldum && elem_def.get_side_nodes(0) == makeuv(s0);
+  ldum = ldum && elem_def.get_side_nodes(1) == makeuv(s1);
+  ldum = ldum && elem_def.get_side_nodes(2) == makeuv(s2);
+  ldum = ldum && elem_def.get_side_nodes(3) == makeuv(s3);
+  ldum = ldum && elem_def.get_side_nodes(4) == makeuv(s4);
+  ldum = ldum && elem_def.get_side_nodes(5) == makeuv(s5);
   ldum = ldum && elem_def.get_number_of_face_nodes().size() == 6;
   ldum = ldum && elem_def.get_number_of_face_nodes()[0] == 9;
   ldum = ldum && elem_def.get_number_of_face_nodes()[1] == 9;
@@ -1104,17 +1107,22 @@ bool test_hexa_27(rtt_dsxx::UnitTest &ut,
   ldum = ldum && elem_def.get_number_of_face_nodes()[3] == 9;
   ldum = ldum && elem_def.get_number_of_face_nodes()[4] == 9;
   ldum = ldum && elem_def.get_number_of_face_nodes()[5] == 9;
+  FAIL_IF_NOT(ldum);
 
+#ifndef __clang_analyzer__
+  // clang-analyze sees the throw and warns that 'ldum=false' is 'deadcode'.
   try {
     elem_def.get_side_type(6);
     ldum = false;
   } catch (...) {
   }
+
   try {
     elem_def.get_side_nodes(6);
     ldum = false;
   } catch (...) {
   }
+#endif
 
   if (ldum) {
     ostringstream message;

--- a/src/ode/Function_Traits.hh
+++ b/src/ode/Function_Traits.hh
@@ -5,10 +5,7 @@
  * \date   Wed Aug 18 10:31:24 2004
  * \brief  Definition of class template Function_Traits
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #ifndef ode_Function_Traits_hh
@@ -26,15 +23,14 @@ namespace rtt_ode {
  *
  * The Function category includes all types that behave like a function of a
  * single value that returns a value.  Examples include <code> double
- * (*)(double)</code>, <code> double (*)(int)</code>, or <code>
- * complex<double> (*)(double)</code>. Many functor classes are also included
- * in this category.
+ * (*)(double)</code>, <code> double (*)(int)</code>, or <code> complex<double>
+ * (*)(double)</code>. Many functor classes are also included in this category.
  *
  * The default implementation takes its traits from the Function type itself.
  * Specializations must be defined for built-in types.  There are
  * specializations in rtt_ode for <code>double (*)(double)</code> and
  * <code>complex<double> (*)(double)</code>.
- * 
+ *
  * \arg \a Function A function type.
  */
 //============================================================================//
@@ -44,27 +40,26 @@ public:
   // The following traits must be defined for all Function types:
 
   //! Type returned by Function::operator()
-  typedef typename Function::return_type return_type;
+  using return_type = typename Function::return_type;
 };
 
 //----------------------------------------------------------------------------//
 //! Traits for ordinary function mapping double to double
 template <> class Function_Traits<double (*)(double)> {
 public:
-  typedef double return_type;
+  using return_type = double;
 };
 
 #ifdef draco_isAIX
 //----------------------------------------------------------------------------//
 /*! Traits for ordinary function mapping const double to double
  *
- * AIX considers top const qualifiers significant in function
- * signatures. Everyone else, including the ISO standard, disregards top const
- * qualifiers.
+ * AIX considers top const qualifiers significant in function signatures.
+ * Everyone else, including the ISO standard, disregards top const qualifiers.
  */
 template <> class Function_Traits<double (*)(double const)> {
 public:
-  typedef double return_type;
+  using return_type = double;
 };
 #endif
 
@@ -72,7 +67,7 @@ public:
 //! Traits for ordinary function mapping double to complex
 template <> class Function_Traits<std::complex<double> (*)(double)> {
 public:
-  typedef std::complex<double> return_type;
+  using return_type = std::complex<double>;
 };
 
 } // end namespace rtt_ode

--- a/src/ode/quad.i.hh
+++ b/src/ode/quad.i.hh
@@ -5,10 +5,7 @@
  * \date   Mon Sep 20 15:30:05 2004
  * \brief  Adaptive quadrature of a function over a specified interval.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #ifndef ode_quad_i_hh
@@ -17,19 +14,17 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
-
-//#include "quad.hh"
 #include "ds++/Assert.hh"
 
 namespace rtt_ode {
 //----------------------------------------------------------------------------//
-/*! 
+/*!
  * \brief Adaptive quadrature of a function over a specified interval.
- * 
+ *
  * \arg \a Function Function type representing the function to be integrated.
  * \arg \a Rule Function type representing the rule for performing the
- * quadrature. This function type must be compatible with the signature of
- * rtt_ode::rkqs.
+ *         quadrature. This function type must be compatible with the signature
+ *         of rtt_ode::rkqs.
  *
  * \param[in] func
  * Function to be integrated
@@ -38,8 +33,8 @@ namespace rtt_ode {
  * \param[in,out] eps On entry, contains the desired accuracy.  On return,
  * contains the accuracy actually achieved.
  * \param[in] rule
- * Ordinary differential equation solver to use to integrate the function,
- * such as \c bsstep or \c rkqs.
+ * Ordinary differential equation solver to use to integrate the function, such
+ * as \c bsstep or \c rkqs.
  *
  * \return Definite integral of the function over the specified interval.
  *
@@ -58,7 +53,7 @@ quad(Function func, double x1, double x2, double &eps, Rule rule) {
 
   Quad_To_ODE<Function> derivs(func);
 
-  typedef typename Function_Traits<Function>::return_type Field;
+  using Field = typename Function_Traits<Function>::return_type;
 
   double x = x1;
   double h = x2 - x1;

--- a/src/ode/rkqs.i.hh
+++ b/src/ode/rkqs.i.hh
@@ -63,7 +63,7 @@ void rkck(std::vector<Field> const &y, std::vector<Field> const &dydx, double x,
                       dc6 = c6 - 0.25;
 
   Check(y.size() < UINT_MAX);
-  const unsigned n = static_cast<unsigned>(y.size());
+  const auto n = static_cast<unsigned>(y.size());
 
   yout.resize(n);
   yerr.resize(n);
@@ -155,7 +155,7 @@ void rkqs(std::vector<Field> &y, std::vector<Field> const &dydx, double &x,
   using std::vector;
 
   Check(y.size() < UINT_MAX);
-  const unsigned n = static_cast<unsigned>(y.size());
+  const auto n = static_cast<unsigned>(y.size());
 
   double const SAFETY = 0.9;
   double const PSHRNK = -0.25;

--- a/src/ode/test/tstquad.cc
+++ b/src/ode/test/tstquad.cc
@@ -28,7 +28,7 @@ void tstquad(UnitTest &ut) {
                        const vector<double> &yscal, double &hdid, double &hnext,
                        Quad_To_ODE<double (*)(double)>);
 
-  typedef double (*fpdd)(double);
+  using fpdd = double (*)(double);
   fpdd exp_fpdd = &foo_exp;
 
   double eps = 1.0e-12;

--- a/src/units/PhysicalConstexprs.hh
+++ b/src/units/PhysicalConstexprs.hh
@@ -64,8 +64,6 @@ struct CGSH {
 //==============================================================================
 template <typename UNITS> class PhysicalConstexprs {
 public:
-  //! Default constructor
-  constexpr PhysicalConstexprs() {}
 
   //! accesses Avogadro's number
   constexpr double avogadro() const { return d_avogadro; }

--- a/src/units/UnitSystemEnums.hh
+++ b/src/units/UnitSystemEnums.hh
@@ -12,6 +12,7 @@
 #define rtt_units_UnitSystemEnums_hh
 
 #include "ds++/config.h"
+#include <array>
 #include <string>
 
 namespace rtt_units {
@@ -27,9 +28,10 @@ enum Ltype {
 };
 
 int constexpr num_Ltype = 3;
-double constexpr L_cf[] = {0.0, 1.0, 100.0};
-char constexpr L_labels[] = "NA,m,cm";
-char constexpr L_long_labels[] = "no length unit specified,meter,centimeter";
+constexpr std::array<double, num_Ltype> L_cf = {0.0, 1.0, 100.0};
+constexpr char const *L_labels = "NA,m,cm";
+constexpr char const *L_long_labels =
+    "no length unit specified,meter,centimeter";
 
 //========================================//
 // ENUMERATED MASS TYPES
@@ -42,9 +44,9 @@ enum Mtype {
 };
 
 int constexpr num_Mtype = 3;
-double constexpr M_cf[] = {0.0, 1.0, 1000.0};
-char constexpr M_labels[] = "NA,kg,g";
-char constexpr M_long_labels[] = "no mass unit specified,kilogram,gram";
+constexpr std::array<double, num_Mtype> M_cf = {0.0, 1.0, 1000.0};
+constexpr char const *M_labels = "NA,kg,g";
+constexpr char const *M_long_labels = "no mass unit specified,kilogram,gram";
 
 //========================================//
 // ENUMERATED TIME TYPES
@@ -60,9 +62,10 @@ enum ttype {
 };
 
 int constexpr num_ttype = 6;
-double constexpr t_cf[] = {0.0, 1.0, 1.0e3, 1.0e6, 1.0e8, 1.0e9};
-char constexpr t_labels[] = "NA,s,ms,us,sh,ns";
-char constexpr t_long_labels[] =
+constexpr std::array<double, num_ttype> t_cf = {0.0,   1.0,   1.0e3,
+                                                1.0e6, 1.0e8, 1.0e9};
+constexpr char const *t_labels = "NA,s,ms,us,sh,ns";
+constexpr char const *t_long_labels =
     "no time unit specified,second,milisecond,microsecond,shake,nanosecond";
 
 //========================================//
@@ -72,16 +75,16 @@ char constexpr t_long_labels[] =
 enum Ttype {
   T_null, //!< no temperature type
   T_K,    //!< Kelvin
-  T_keV, //!< keV     (1 K = 8.61733238496e-8 keV or 1 keV = 1.1604519302808940e7 K)
-  // This conversion factor between K and keV must agree with the value
-  // given in PhysicalConstants.hh.
-  T_eV //!< eV      (1 K = 8.61733238496e-5 keV or 1 eV = 11604.519302808940 K)
+  T_keV,  //!< keV (1 K=8.61733238496e-8 keV or 1 keV=1.1604519302808940e7 K)
+          //!< This conversion factor between K and keV must agree with the
+          //!< value given in PhysicalConstants.hh.
+  T_eV    //!< eV (1 K = 8.61733238496e-5 keV or 1 eV = 11604.519302808940 K)
 };
 
 int constexpr num_Ttype = 4;
-double constexpr T_cf[] = {0.0, 1.0, 1.0 / 1.1604519302808940e7,
-                           1.0 / 1.1604519302808940e4};
-char constexpr T_labels[] = "NA,K,keV,eV";
+constexpr std::array<double, num_Ttype> T_cf = {
+    0.0, 1.0, 1.0 / 1.1604519302808940e7, 1.0 / 1.1604519302808940e4};
+constexpr char const *T_labels = "NA,K,keV,eV";
 
 //========================================//
 // ENUMERATED CURRENT TYPES
@@ -93,8 +96,8 @@ enum Itype {
 };
 
 int constexpr num_Itype = 2;
-double constexpr I_cf[] = {0.0, 1.0};
-char constexpr I_labels[] = "NA,Amp";
+constexpr std::array<double, num_Itype> I_cf = {0.0, 1.0};
+constexpr char const *I_labels = "NA,Amp";
 
 //========================================//
 // ENUMERATED ANGLE TYPES
@@ -107,8 +110,8 @@ enum Atype {
 };
 
 int constexpr num_Atype = 3;
-double constexpr A_cf[] = {0.0, 1.0, 57.295779512896171};
-char constexpr A_labels[] = "NA,rad,deg";
+constexpr std::array<double, num_Atype> A_cf = {0.0, 1.0, 57.295779512896171};
+constexpr char const *A_labels = "NA,rad,deg";
 
 //========================================//
 // ENUMERATED QUANTITY TYPES
@@ -120,8 +123,8 @@ enum Qtype {
 };
 
 int constexpr num_Qtype = 2;
-double constexpr Q_cf[] = {0.0, 1.0};
-char constexpr Q_labels[] = "NA,mol";
+constexpr std::array<double, num_Qtype> Q_cf = {0.0, 1.0};
+constexpr char const *Q_labels = "NA,mol";
 
 //----------------------------------------------------------------------------//
 // HELPER FUNCTIONS

--- a/src/units/UnitSystemType.cc
+++ b/src/units/UnitSystemType.cc
@@ -14,25 +14,25 @@ namespace rtt_units {
 
 //! default constructor
 UnitSystemType::UnitSystemType()
-    : d_L(FundUnit<Ltype>(L_null, L_cf, L_labels)),
-      d_M(FundUnit<Mtype>(M_null, M_cf, M_labels)),
-      d_t(FundUnit<ttype>(t_null, t_cf, t_labels)),
-      d_T(FundUnit<Ttype>(T_null, T_cf, T_labels)),
-      d_I(FundUnit<Itype>(I_null, I_cf, I_labels)),
-      d_A(FundUnit<Atype>(A_null, A_cf, A_labels)),
-      d_Q(FundUnit<Qtype>(Q_null, Q_cf, Q_labels)) { /* empty */
+    : d_L(FundUnit<Ltype>(L_null, L_cf.data(), L_labels)),
+      d_M(FundUnit<Mtype>(M_null, M_cf.data(), M_labels)),
+      d_t(FundUnit<ttype>(t_null, t_cf.data(), t_labels)),
+      d_T(FundUnit<Ttype>(T_null, T_cf.data(), T_labels)),
+      d_I(FundUnit<Itype>(I_null, I_cf.data(), I_labels)),
+      d_A(FundUnit<Atype>(A_null, A_cf.data(), A_labels)),
+      d_Q(FundUnit<Qtype>(Q_null, Q_cf.data(), Q_labels)) { /* empty */
 }
 
 //! fully qualified constructor
 UnitSystemType::UnitSystemType(Ltype myL, Mtype myM, ttype myt, Ttype myT,
                                Itype myI, Atype myA, Qtype myQ)
-    : d_L(FundUnit<Ltype>(myL, L_cf, L_labels)),
-      d_M(FundUnit<Mtype>(myM, M_cf, M_labels)),
-      d_t(FundUnit<ttype>(myt, t_cf, t_labels)),
-      d_T(FundUnit<Ttype>(myT, T_cf, T_labels)),
-      d_I(FundUnit<Itype>(myI, I_cf, I_labels)),
-      d_A(FundUnit<Atype>(myA, A_cf, A_labels)),
-      d_Q(FundUnit<Qtype>(myQ, Q_cf, Q_labels)) { /* empty */
+    : d_L(FundUnit<Ltype>(myL, L_cf.data(), L_labels)),
+      d_M(FundUnit<Mtype>(myM, M_cf.data(), M_labels)),
+      d_t(FundUnit<ttype>(myt, t_cf.data(), t_labels)),
+      d_T(FundUnit<Ttype>(myT, T_cf.data(), T_labels)),
+      d_I(FundUnit<Itype>(myI, I_cf.data(), I_labels)),
+      d_A(FundUnit<Atype>(myA, A_cf.data(), A_labels)),
+      d_Q(FundUnit<Qtype>(myQ, Q_cf.data(), Q_labels)) { /* empty */
 }
 
 //! Copy constructor

--- a/src/units/UnitSystemType.hh
+++ b/src/units/UnitSystemType.hh
@@ -76,19 +76,19 @@ public:
 
   //! Set a FundUnit type for this UnitSystem
 
-  UnitSystemType &L(Ltype myType, double const *cf = L_cf,
+  UnitSystemType &L(Ltype myType, double const *cf = L_cf.data(),
                     std::string const &labels = L_labels);
-  UnitSystemType &M(Mtype myType, double const *cf = M_cf,
+  UnitSystemType &M(Mtype myType, double const *cf = M_cf.data(),
                     std::string const &labels = M_labels);
-  UnitSystemType &t(ttype myType, double const *cf = t_cf,
+  UnitSystemType &t(ttype myType, double const *cf = t_cf.data(),
                     std::string const &labels = t_labels);
-  UnitSystemType &T(Ttype myType, double const *cf = T_cf,
+  UnitSystemType &T(Ttype myType, double const *cf = T_cf.data(),
                     std::string const &labels = T_labels);
-  UnitSystemType &I(Itype myType, double const *cf = I_cf,
+  UnitSystemType &I(Itype myType, double const *cf = I_cf.data(),
                     std::string const &labels = I_labels);
-  UnitSystemType &A(Atype myType, double const *cf = A_cf,
+  UnitSystemType &A(Atype myType, double const *cf = A_cf.data(),
                     std::string const &labels = A_labels);
-  UnitSystemType &Q(Qtype myType, double const *cf = Q_cf,
+  UnitSystemType &Q(Qtype myType, double const *cf = Q_cf.data(),
                     std::string const &labels = Q_labels);
 
   // ACCESSORS

--- a/src/units/test/tstFundUnit.cc
+++ b/src/units/test/tstFundUnit.cc
@@ -30,7 +30,7 @@ void test_construction(rtt_dsxx::UnitTest &ut) {
   using std::ostringstream;
   using std::string;
 
-  FundUnit<Ltype> myLength(L_null, L_cf, L_labels);
+  FundUnit<Ltype> myLength(L_null, L_cf.data(), L_labels);
 
   // Is the enum value correct?
   if (myLength.enumVal() == L_null) {
@@ -58,7 +58,7 @@ void test_construction(rtt_dsxx::UnitTest &ut) {
   } else {
     ostringstream msg;
     msg << "Unit label was not set correctly "
-        << "(\"" << myLength.label() << "\" != \"NA\")" << endl;
+        << "(\"" << myLength.label() << R"(" != "NA"))" << endl; // " fix emacs
     FAILMSG(msg.str());
   }
 
@@ -66,7 +66,7 @@ void test_construction(rtt_dsxx::UnitTest &ut) {
 
   // Use "long labels" string...
 
-  FundUnit<Ltype> myLength2(rtt_units::L_cm, rtt_units::L_cf,
+  FundUnit<Ltype> myLength2(rtt_units::L_cm, rtt_units::L_cf.data(),
                             rtt_units::L_long_labels);
 
   // Is the label correct?

--- a/src/units/test/tstUnitSystem.cc
+++ b/src/units/test/tstUnitSystem.cc
@@ -647,19 +647,18 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
   }
 
   // Create a faulty UnitSystem (negative cf)
-  double const my_cf[2] = {0.0, -1.0};
+  constexpr std::array<double, 2> my_cf = {0.0, -1.0};
 
   // Fail with L.
   {
     bool with_dbc(true);
     bool found_assert(false);
-    // If DRACO_DBC_LEVE=7, a rtt_dsxx:assertion will be fired when myus
-    // is constructed.  If not, we must test the validUnits() member
-    // funtion explicitly.
+    // If DRACO_DBC_LEVE=7, a rtt_dsxx:assertion will be fired when myus is
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().L(rtt_units::L_m, my_cf));
-      // If DRACO_DBC_LEVE=0 we will get here so call validUnits by
-      // manually.
+      UnitSystem myus(UnitSystemType().L(rtt_units::L_m, my_cf.data()));
+      // If DRACO_DBC_LEVE=0 we will get here so call validUnits by manually.
       with_dbc = false;
       if (!myus.validUnits()) {
         ostringstream msg;
@@ -692,10 +691,10 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
     bool with_dbc(true);
     bool found_assert(false);
     // If DRACO_DBC_LEVEL=7 a rtt_dsxx:assertion will be fired when myus is
-    // constructed.   If not, we must test the validUnits() member
-    // funtion explicitly.
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().M(rtt_units::M_kg, my_cf));
+      UnitSystem myus(UnitSystemType().M(rtt_units::M_kg, my_cf.data()));
       // If DRACO_DBC_LEVEL == 0 we will get here so call validUnits by
       // manually.
       with_dbc = false;
@@ -729,10 +728,10 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
     bool with_dbc(true);
     bool found_assert(false);
     // If DRACO_DBC_LEVEL=7 a rtt_dsxx:assertion will be fired when myus is
-    // constructed.   If not, we must test the validUnits() member
-    // funtion explicitly.
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().t(rtt_units::t_s, my_cf));
+      UnitSystem myus(UnitSystemType().t(rtt_units::t_s, my_cf.data()));
       // If DRACO_DBC_LEVEL == 0 we will get here so call validUnits by
       // manually.
       with_dbc = false;
@@ -763,10 +762,10 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
     bool with_dbc(true);
     bool found_assert(false);
     // If DRACO_DBC_LEVEL=7 a rtt_dsxx:assertion will be fired when myus is
-    // constructed.   If not, we must test the validUnits() member
-    // funtion explicitly.
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().T(rtt_units::T_K, my_cf));
+      UnitSystem myus(UnitSystemType().T(rtt_units::T_K, my_cf.data()));
       // If DRACO_DBC_LEVEL == 0 we will get here so call validUnits by
       // manually.
       with_dbc = false;
@@ -797,10 +796,10 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
     bool with_dbc(true);
     bool found_assert(false);
     // If DRACO_DBC_LEVEL=7 a rtt_dsxx:assertion will be fired when myus is
-    // constructed.   If not, we must test the validUnits() member
-    // funtion explicitly.
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().I(rtt_units::I_amp, my_cf));
+      UnitSystem myus(UnitSystemType().I(rtt_units::I_amp, my_cf.data()));
       // If DRACO_DBC_LEVEL == 0 we will get here so call validUnits by
       // manually.
       with_dbc = false;
@@ -831,10 +830,10 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
     bool with_dbc(true);
     bool found_assert(false);
     // If DRACO_DBC_LEVEL=7 a rtt_dsxx:assertion will be fired when myus is
-    // constructed.   If not, we must test the validUnits() member
-    // funtion explicitly.
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().A(rtt_units::A_rad, my_cf));
+      UnitSystem myus(UnitSystemType().A(rtt_units::A_rad, my_cf.data()));
       // If DRACO_DBC_LEVEL == 0 we will get here so call validUnits by
       // manually.
       with_dbc = false;
@@ -865,10 +864,10 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
     bool with_dbc(true);
     bool found_assert(false);
     // If DRACO_DBC_LEVEL=7 a rtt_dsxx:assertion will be fired when myus is
-    // constructed.   If not, we must test the validUnits() member
-    // funtion explicitly.
+    // constructed.  If not, we must test the validUnits() member function
+    // explicitly.
     try {
-      UnitSystem myus(UnitSystemType().Q(rtt_units::Q_mol, my_cf));
+      UnitSystem myus(UnitSystemType().Q(rtt_units::Q_mol, my_cf.data()));
       // If DRACO_DBC_LEVEL == 0 we will get here so call validUnits by
       // manually.
       with_dbc = false;
@@ -898,7 +897,6 @@ void test_valid_units(rtt_dsxx::UnitTest &ut) {
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {

--- a/src/units/test/tstUnitSystemEnums.cc
+++ b/src/units/test/tstUnitSystemEnums.cc
@@ -3,7 +3,7 @@
  * \file   units/test/tstUnitSystemEnums.cc
  * \author Kelly Thompson
  * \date   Wed Oct  8 13:50:19 2003
- * \brief
+ * \brief  Unit tests for units/UnitSystemEnum class
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
@@ -24,16 +24,16 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
   using std::string;
 
   {
-    int const iSenVal(3);
-    double const adSenVal[iSenVal] = {0.0, 1.0, 100.0};
+    int constexpr iSenVal(3);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0, 1.0, 100.0};
     string const sSenVal("NA,m,cm");
     string const sSenVal2("no length unit specified,meter,centimeter");
 
     constexpr bool is_iSenVal = rtt_units::num_Ltype == iSenVal;
     UT_MSG(is_iSenVal, "num_Ltype has the expected value.");
 
-    UT_MSG(soft_equiv(rtt_units::L_cf, rtt_units::L_cf + iSenVal, adSenVal,
-                      adSenVal + iSenVal),
+    UT_MSG(soft_equiv(rtt_units::L_cf.begin(), rtt_units::L_cf.end(),
+                      adSenVal.begin(), adSenVal.end()),
            "L_cf has the expected values.");
 
     UT_MSG(rtt_units::L_labels == sSenVal, "L_labels has the expected values.");
@@ -44,16 +44,16 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
 
   //--------------------------------------------------------------------------//
   {
-    int const iSenVal(3);
-    double const adSenVal[iSenVal] = {0.0, 1.0, 1000.0};
+    int constexpr iSenVal(3);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0, 1.0, 1000.0};
     string const sSenVal("NA,kg,g");
     string const sSenVal2("no mass unit specified,kilogram,gram");
 
     constexpr bool is_iSenVal = rtt_units::num_Mtype == iSenVal;
     UT_MSG(is_iSenVal, "num_Mtype has the expected value.");
 
-    if (soft_equiv(rtt_units::M_cf, rtt_units::M_cf + iSenVal, adSenVal,
-                   adSenVal + iSenVal))
+    if (soft_equiv(rtt_units::M_cf.begin(), rtt_units::M_cf.end(),
+                   adSenVal.begin(), adSenVal.end()))
       PASSMSG("M_cf has the expected values.");
     else
       FAILMSG("M_cf does not have the expected values.");
@@ -70,8 +70,9 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
   }
   //--------------------------------------------------------------------------//
   {
-    int const iSenVal(6);
-    double const adSenVal[iSenVal] = {0.0, 1.0, 1000.0, 1.0e6, 1.0e8, 1.0e9};
+    int constexpr iSenVal(6);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0,   1.0,   1000.0,
+                                                      1.0e6, 1.0e8, 1.0e9};
     string const sSenVal("NA,s,ms,us,sh,ns");
     string const sSenVal2("no time unit "
                           "specified,second,milisecond,microsecond,shake,"
@@ -80,8 +81,8 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
     constexpr bool is_iSenVal = rtt_units::num_ttype == iSenVal;
     UT_MSG(is_iSenVal, "num_ttype has the expected value.");
 
-    if (soft_equiv(rtt_units::t_cf, rtt_units::t_cf + iSenVal, adSenVal,
-                   adSenVal + iSenVal))
+    if (soft_equiv(rtt_units::t_cf.begin(), rtt_units::t_cf.end(),
+                   adSenVal.begin(), adSenVal.end()))
       PASSMSG("t_cf has the expected values.");
     else
       FAILMSG("t_cf does not have the expected values.");
@@ -98,16 +99,17 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
   }
   //--------------------------------------------------------------------------//
   {
-    double const keV2K(1.16045193028089e7);
-    int const iSenVal(4);
-    double adSenVal[iSenVal] = {0.0, 1.0, 1.0 / keV2K, 1.0e3 / keV2K};
+    double constexpr keV2K(1.16045193028089e7);
+    int constexpr iSenVal(4);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0, 1.0, 1.0 / keV2K,
+                                                      1.0e3 / keV2K};
     string const sSenVal("NA,K,keV,eV");
 
     constexpr bool is_iSenVal = rtt_units::num_Ttype == iSenVal;
     UT_MSG(is_iSenVal, "num_Ttype has the expected value.");
 
-    if (soft_equiv(rtt_units::T_cf, rtt_units::T_cf + iSenVal, adSenVal,
-                   adSenVal + iSenVal)) {
+    if (soft_equiv(rtt_units::T_cf.begin(), rtt_units::T_cf.end(),
+                   adSenVal.begin(), adSenVal.end())) {
       PASSMSG("T_cf has the expected values.");
     } else {
       std::ostringstream msg;
@@ -125,15 +127,15 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
   }
   //--------------------------------------------------------------------------//
   {
-    int const iSenVal(2);
-    double const adSenVal[iSenVal] = {0.0, 1.0};
+    int constexpr iSenVal(2);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0, 1.0};
     string const sSenVal("NA,Amp");
 
     constexpr bool is_iSenVal = rtt_units::num_Itype == iSenVal;
     UT_MSG(is_iSenVal, "num_Itype has the expected value.");
 
-    if (soft_equiv(rtt_units::I_cf, rtt_units::I_cf + iSenVal, adSenVal,
-                   adSenVal + iSenVal))
+    if (soft_equiv(rtt_units::I_cf.begin(), rtt_units::I_cf.end(),
+                   adSenVal.begin(), adSenVal.end()))
       PASSMSG("I_cf has the expected values.");
     else
       FAILMSG("I_cf does not have the expected values.");
@@ -145,15 +147,16 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
   }
   //--------------------------------------------------------------------------//
   {
-    int const iSenVal(3);
-    double const adSenVal[iSenVal] = {0.0, 1.0, 57.295779512896171};
+    int constexpr iSenVal(3);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0, 1.0,
+                                                      57.295779512896171};
     string const sSenVal("NA,rad,deg");
 
     constexpr bool is_iSenVal = rtt_units::num_Atype == iSenVal;
     UT_MSG(is_iSenVal, "num_Atype has the expected value.");
 
-    if (soft_equiv(rtt_units::A_cf, rtt_units::A_cf + iSenVal, adSenVal,
-                   adSenVal + iSenVal))
+    if (soft_equiv(rtt_units::A_cf.begin(), rtt_units::A_cf.end(),
+                   adSenVal.begin(), adSenVal.end()))
       PASSMSG("A_cf has the expected values.");
     else
       FAILMSG("A_cf does not have the expected values.");
@@ -165,15 +168,15 @@ void test_enumValues(rtt_dsxx::UnitTest &ut) {
   }
   //--------------------------------------------------------------------------//
   {
-    int const iSenVal(2);
-    double const adSenVal[iSenVal] = {0.0, 1.0};
+    int constexpr iSenVal(2);
+    constexpr std::array<double, iSenVal> adSenVal = {0.0, 1.0};
     string const sSenVal("NA,mol");
 
     constexpr bool is_iSenVal = rtt_units::num_Qtype == iSenVal;
     UT_MSG(is_iSenVal, "num_Qtype has the expected value.");
 
-    if (soft_equiv(rtt_units::Q_cf, rtt_units::Q_cf + iSenVal, adSenVal,
-                   adSenVal + iSenVal))
+    if (soft_equiv(rtt_units::Q_cf.begin(), rtt_units::Q_cf.end(),
+                   adSenVal.begin(), adSenVal.end()))
       PASSMSG("Q_cf has the expected values.");
     else
       FAILMSG("Q_cf does not have the expected values.");

--- a/src/units/test/tstUnitSystemType.cc
+++ b/src/units/test/tstUnitSystemType.cc
@@ -57,8 +57,8 @@ void test_default_ctor(rtt_dsxx::UnitTest &ut) {
     FAILMSG(msg.str());
   }
 
-  // Establish a fundamental unit for the length, mass and Temperature
-  // portions of UnitSystemType...
+  // Establish a fundamental unit for the length, mass and Temperature portions
+  // of UnitSystemType...
   ust.L(rtt_units::L_m).M(rtt_units::M_kg).T(rtt_units::T_K);
 
   // Check that the object was updated...
@@ -131,7 +131,7 @@ void test_default_ctor(rtt_dsxx::UnitTest &ut) {
   ust.Q(rtt_units::Q_mol)
       .A(rtt_units::A_rad)
       .I(rtt_units::I_amp)
-      .t(rtt_units::t_sh, rtt_units::t_cf, rtt_units::t_long_labels);
+      .t(rtt_units::t_sh, rtt_units::t_cf.data(), rtt_units::t_long_labels);
 
   //---------------------------------------------------------------------//
 
@@ -159,8 +159,9 @@ void test_default_ctor(rtt_dsxx::UnitTest &ut) {
   } else {
     ostringstream msg;
     msg << "UnitSystemType container does not have "
-        << "Q().label() == \"mol\".  Instead the value returned was: \""
+        << R"(Q().label() == "mol".  Instead the value returned was: ")"
         << ust.Q().label() << "\"" << endl;
+    // " fix emacs font-lock issue with odd number of quotes.
     FAILMSG(msg.str());
   }
   //---------------------------------------------------------------------//
@@ -255,7 +256,6 @@ void test_default_ctor(rtt_dsxx::UnitTest &ut) {
 }
 
 //------------------------------------------------------------------------//
-
 void test_qualified_ctor(rtt_dsxx::UnitTest &ut) {
   using rtt_dsxx::soft_equiv;
   using rtt_units::UnitSystemType;


### PR DESCRIPTION
### Background

* Process four additional components with _clang-tidy_ code transformation recommendations and add these packages to the nightly regression that processes _clang-tidy_.

### Description of changes

* Provide updates for mesh_element, ode, linear, and memory components.
* Transform `typedef` to `using` commands.
* Make use of `auto` when the data type is specified on the RHS with a `static_cast`.
* Use `<cmath>` instead of `<math.h>`
* Use `std::array` instead of C-style arrays. 
  * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-stack
  * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#slcon1-prefer-using-stl-array-or-vector-instead-of-a-c-array
* When possible, use C++14 style range-based for-loops.
* Big changes in mesh_element take advantage of new C++14 capabilities to reduce the amount of code.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
