### PR TITLE
Clean up clang-tidy warnings that were missed in #869

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,7 @@ add_dir_if_exists( linear )        # needs ds++
 add_dir_if_exists( memory )        # needs ds++
 add_dir_if_exists( mesh_element  ) # needs ds++
 add_dir_if_exists( ode )           # needs ds++
-add_dir_if_exists( units )        # needs ds++
+add_dir_if_exists( units )         # needs ds++
 
 if( NOT CI_CLANG_TIDY )
 add_dir_if_exists( cdi )          # needs ds++

--- a/src/linear/btridag.i.hh
+++ b/src/linear/btridag.i.hh
@@ -5,8 +5,7 @@
  * \date   Wed Sep 15 13:03:41 MDT 2010
  * \brief  Implementation of block tridiagonal solver
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #ifndef linear_btridag_i_hh
@@ -46,8 +45,7 @@ void btridag(FieldVector const &a, FieldVector const &b, FieldVector const &c,
   Require(u.size() == n * m);
 
   using namespace rtt_dsxx;
-
-  typedef typename FieldVector::value_type Field;
+  using Field = typename FieldVector::value_type;
 
   if (n == 0) {
     return;

--- a/src/linear/ludcmp.i.hh
+++ b/src/linear/ludcmp.i.hh
@@ -17,8 +17,6 @@
 
 namespace rtt_linear {
 
-using std::vector;
-
 //----------------------------------------------------------------------------//
 /*!
  * \brief LU-decompose a nonsingular matrix.
@@ -37,12 +35,12 @@ void ludcmp(FieldVector &a, IntVector &indx,
             typename FieldVector::value_type &d) {
   Require(a.size() == indx.size() * indx.size());
 
-  typedef typename FieldVector::value_type Field;
+  using Field = typename FieldVector::value_type;
 
   Check(indx.size() < UINT_MAX);
   auto const n = static_cast<unsigned>(indx.size());
 
-  vector<Field> vv(n);
+  std::vector<Field> vv(n);
 
   d = 1.0;
   for (unsigned i = 0; i < n; ++i) {

--- a/src/linear/ludcmp_pt.cc
+++ b/src/linear/ludcmp_pt.cc
@@ -13,16 +13,15 @@
 
 namespace rtt_linear {
 
-template DLL_PUBLIC_linear void ludcmp(vector<double> &a,
-                                       vector<unsigned> &indx, double &d);
+template void ludcmp(std::vector<double> &a, std::vector<unsigned> &indx,
+                     double &d);
 
-template DLL_PUBLIC_linear void lubksb(vector<double> const &a,
-                                       vector<unsigned> const &indx,
-                                       vector<double> &b);
+template void lubksb(std::vector<double> const &a,
+                     std::vector<unsigned> const &indx, std::vector<double> &b);
 
-template DLL_PUBLIC_linear void
-lubksb(vector<double> const &a, vector<unsigned> const &indx,
-       rtt_dsxx::Slice<vector<double>::iterator> &b);
+template void lubksb(std::vector<double> const &a,
+                     std::vector<unsigned> const &indx,
+                     rtt_dsxx::Slice<std::vector<double>::iterator> &b);
 
 } // end namespace rtt_linear
 

--- a/src/linear/svbksb.i.hh
+++ b/src/linear/svbksb.i.hh
@@ -50,7 +50,7 @@ namespace rtt_linear {
  * \post \c x.size()==n
  * \post \c x satisfies \f$UWVx=b\f$
  */
-template <class RandomContainer>
+template <typename RandomContainer>
 void svbksb(const RandomContainer &u, const RandomContainer &w,
             const RandomContainer &v, const unsigned m, const unsigned n,
             const RandomContainer &b, RandomContainer &x) {
@@ -59,7 +59,7 @@ void svbksb(const RandomContainer &u, const RandomContainer &w,
   Require(b.size() == m);
   Require(v.size() == n * n);
 
-  typedef typename RandomContainer::value_type value_type;
+  using value_type = typename RandomContainer::value_type;
   // minimum representable value
   double const mrv = std::numeric_limits<value_type>::min();
   std::vector<value_type> tmp(n);

--- a/src/linear/tred2.hh
+++ b/src/linear/tred2.hh
@@ -14,7 +14,7 @@
 namespace rtt_linear {
 
 //! Householder-reduce a symmetric matrix
-template <class FieldVector1, class FieldVector2, class FieldVector3>
+template <typename FieldVector1, typename FieldVector2, typename FieldVector3>
 void tred2(FieldVector1 &a, unsigned n, FieldVector2 &d, FieldVector3 &e);
 
 } // end namespace rtt_linear

--- a/src/linear/tred2.i.hh
+++ b/src/linear/tred2.i.hh
@@ -43,15 +43,14 @@ namespace rtt_linear {
  * \post \c d.size()==n
  * \post \c e.size()==n
  */
-template <class FieldVector1, class FieldVector2, class FieldVector3>
+template <typename FieldVector1, typename FieldVector2, typename FieldVector3>
 void tred2(FieldVector1 &a, unsigned n, FieldVector2 &d, FieldVector3 &e) {
   Require(a.size() == n * n);
   // O(N*N)    Require(is_symmetric_matrix(a,n));
   Require(n > 0);
 
   using namespace rtt_dsxx;
-
-  typedef typename FieldVector1::value_type Field;
+  using Field = typename FieldVector1::value_type;
 
   // minimum representable value
   double const mrv = std::numeric_limits<Field>::min();

--- a/src/linear/tred2_pt.cc
+++ b/src/linear/tred2_pt.cc
@@ -14,14 +14,11 @@
 
 namespace rtt_linear {
 
-using std::vector;
-
 //----------------------------------------------------------------------------//
 // T1=T2=T3=vector<double>
 //----------------------------------------------------------------------------//
-
-template DLL_PUBLIC_linear void tred2(vector<double> &a, unsigned n,
-                                      vector<double> &d, vector<double> &e);
+template void tred2(std::vector<double> &a, unsigned n, std::vector<double> &d,
+                    std::vector<double> &e);
 
 } // end namespace rtt_linear
 

--- a/src/ode/CMakeLists.txt
+++ b/src/ode/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for ode.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)

--- a/src/ode/test/CMakeLists.txt
+++ b/src/ode/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for ode/test.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 project( ode_test CXX )
@@ -11,18 +11,15 @@ project( ode_test CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 set( test_lib_sources
    ${PROJECT_SOURCE_DIR}/ode_test.cc
-   ${PROJECT_SOURCE_DIR}/ode_test.hh
-)
+   ${PROJECT_SOURCE_DIR}/ode_test.hh )
 file( GLOB test_sources *.cc )
 list( REMOVE_ITEM test_sources ${test_lib_sources} )
 
 # ---------------------------------------------------------------------------- #
 # Build Unit tests
 # ---------------------------------------------------------------------------- #
-
 add_scalar_tests(
    SOURCES "${test_sources}"
    DEPS    "Lib_dsxx" )

--- a/src/ode/test/tstFunction_Traits.cc
+++ b/src/ode/test/tstFunction_Traits.cc
@@ -3,18 +3,13 @@
  * \file   ode/test/tstFunction_Traits.cc
  * \author Kent Budge
  * \date   Wed Aug 18 10:28:16 2004
- * \brief  
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ode/Function_Traits.hh"
-
 #include <iostream>
 #include <typeinfo>
 
@@ -23,35 +18,24 @@ using namespace rtt_ode;
 using namespace rtt_dsxx;
 
 //----------------------------------------------------------------------------//
-// TESTS
+// Helper class
 //----------------------------------------------------------------------------//
 
 class Test_Functor {
 public:
-  typedef double return_type;
+  using return_type = double;
 };
 
-void tstFunction_Traits(UnitTest &ut) {
-  if (typeid(Function_Traits<double (*)(double)>::return_type) !=
-      typeid(double))
-    ut.failure("return_type NOT correct");
-  else
-    ut.passes("return_type correct");
-
-  if (typeid(Function_Traits<Test_Functor>::return_type) !=
-      typeid(Test_Functor::return_type))
-    ut.failure("return_type NOT correct");
-  else
-    ut.passes("return_type correct");
-  return;
-}
-
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   ScalarUnitTest ut(argc, argv, release);
   try {
-    tstFunction_Traits(ut);
+    UT_MSG(typeid(Function_Traits<double (*)(double)>::return_type) ==
+               typeid(double),
+           "return_type correct");
+    UT_MSG(typeid(Function_Traits<Test_Functor>::return_type) ==
+               typeid(Test_Functor::return_type),
+           "return_type NOT correct");
   }
   UT_EPILOG(ut);
 }

--- a/src/ode/test/tstquad.cc
+++ b/src/ode/test/tstquad.cc
@@ -18,27 +18,25 @@ using namespace rtt_dsxx;
 using namespace rtt_ode;
 
 //----------------------------------------------------------------------------//
-// TESTS
+// Helper function
 //----------------------------------------------------------------------------//
 double foo_exp(double x) { return exp(x); }
 
-void tstquad(UnitTest &ut) {
-  typedef void (*Rule)(vector<double> & y, const vector<double> &dydx,
-                       double &x, const double htry, const double eps,
-                       const vector<double> &yscal, double &hdid, double &hnext,
-                       Quad_To_ODE<double (*)(double)>);
+//----------------------------------------------------------------------------//
+// TESTS
+//----------------------------------------------------------------------------//
 
+void tstquad(UnitTest &ut) {
+  using Rule =
+      void (*)(vector<double> & y, const vector<double> &dydx, double &x,
+               const double htry, const double eps, const vector<double> &yscal,
+               double &hdid, double &hnext, Quad_To_ODE<double (*)(double)>);
   using fpdd = double (*)(double);
   fpdd exp_fpdd = &foo_exp;
-
   double eps = 1.0e-12;
-  double integral = rtt_ode::quad<fpdd, Rule>(exp_fpdd, 0.0, 1.0, eps, &rkqs);
-
-  if (!soft_equiv(integral, exp(1.0) - 1.0, 1.0e-12)) {
-    ut.failure("quad NOT accurate");
-  } else {
-    ut.passes("quad accurate");
-  }
+  double const integral =
+      rtt_ode::quad<fpdd, Rule>(exp_fpdd, 0.0, 1.0, eps, &rkqs);
+  UT_MSG(soft_equiv(integral, exp(1.0) - 1.0, eps), "quad accurate");
 }
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* PR #869 added several more directories to the clang-tidy night regression.  While these packages were mostly free of warnings, 6 new ones were reported.  This follow up PR addresses these new warnings.

### Description of changes

+ Most of these changes are simply replacing `typedef` with `using`.
+ Remove a possible namespace injection.
+ Remove redundant `DLL_PUBLIC_*` decoration.
+ Make use of `UT_MSG` in simple unit tests.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
