### PR TITLE
Add two macros for GPU builds

### DIFF
--- a/src/device/config.h.in
+++ b/src/device/config.h.in
@@ -22,11 +22,15 @@
 #if defined __NVCC__ && defined USE_CUDA
 #define HOST_AND_DEVICE_FUNCTION __host__ __device__
 #define GPU_HOST_DEVICE __host__ __device__
+#define GPU_DEVICE __device__
 #define GPU_KERNEL __global__
+#define CONSTANT __constant__
 #else
 #define HOST_AND_DEVICE_FUNCTION
 #define GPU_HOST_DEVICE
+#define GPU_DEVICE
 #define GPU_KERNEL
+#define CONSTANT constexpr
 #endif
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
### Background

* I'm using CUDA constant memory for our random walk data tables in the Jayenne GPU port (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#constant).  This requires the `__constant__` decorator for arrays that will be placed in constant device memory. This PR adds a macro that returns `__constant__` when compiling for the GPU and `constexpr` for the CPU. Functions that use constant memory generate a warning if the function is marked `__host__` `__device__` which is what I've used for all functions thus far so I added a macro for just the `__device__` decorator.

### Purpose of Pull Request

* Allow use of CUDA constant memory

### Description of changes

* Add GPU_DEVICE macro for `__device__` only decorator in GPU builds
* Add CONSTANT macro for `__constant__` memory decorator in GPU builds
* Use `constexpr` for CONSTANT in host code

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
