### PR TITLE
Augment Draco developer environment for CTS-1 and ATS-1.

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -19,6 +19,12 @@ export PATH=${VENDOR_DIR:=/usr/gapps/jayenne/vendors}/bin:$PATH
 export VENDOR_DIR
 export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
 
+# Support building cassio with ccsrad shared deployment repository.
+if [[ -d /usr/workspace/eapdev/eap/users/ccsrad/Cassio.deployment ]]; then
+  export TF_DEPLOYMENT_CLONES=/usr/workspace/eapdev/eap/users/ccsrad/Cassio.deployment
+  export TF_SPACK_INSTANCES=/usr/workspace/eapdev/eap/users/ccsrad/spack_instances
+fi
+
 #
 # MODULES
 #

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -67,6 +67,12 @@ elif [[ ${CRAY_CPU_TARGET} =~ knl ]]; then
   export NRANKS_PER_NODE=68
 fi
 
+# Support building cassio with ccsrad shared deployment repository.
+if [[ -d /usr/projects/eap/users/ccsrad/Cassio.deployment ]]; then
+  export TF_DEPLOYMENT_CLONES=/usr/projects/eap/users/ccsrad/Cassio.deployment
+  export TF_SPACK_INSTANCES=/usr/projects/eap/users/ccsrad/spack_instances
+fi
+
 #
 # MODULES
 #

--- a/environment/bashrc/.bashrc_cts1
+++ b/environment/bashrc/.bashrc_cts1
@@ -19,6 +19,12 @@ if [[ ! ${VENDOR_DIR} ]]; then
    fi
 fi
 
+# Support building cassio with ccsrad shared deployment repository.
+if [[ -d /usr/projects/eap/users/ccsrad/Cassio.deployment ]]; then
+  export TF_DEPLOYMENT_CLONES=/usr/projects/eap/users/ccsrad/Cassio.deployment
+  export TF_SPACK_INSTANCES=/usr/projects/eap/users/ccsrad/spack_instances
+fi
+
 # shell options
 # Do not escape $ for bash completion
 shopt -s direxpand


### PR DESCRIPTION
### Description of changes

+ Provide two additional variables that will aid developer who are working on `ccsrad-next` branches.  These variables help us keep a sane spack setup.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
