### PR TITLE
Minor compatibility update for MSVC 2019 16.7.0 Preview 4.0

### DIFF
--- a/src/c4/test/tstsend_is.cc
+++ b/src/c4/test/tstsend_is.cc
@@ -119,8 +119,8 @@ void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
     rtt_c4::C4_Req *const comm(nullptr);
     const unsigned count(0);
 
-    // No actual messages to send -- verify that wait_all
-    // and wait_all_with_source correctly return.
+    // No actual messages to send -- verify that wait_all and
+    // wait_all_with_source correctly return.
     bool zerocount_failed = false;
 
     // result output from source version of wait_all:
@@ -154,12 +154,12 @@ void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
     // Result from wait_all_with_source call
     std::vector<int> result;
 
-    // Test a null op -- I didn't actually send anything, so the
-    // MPI requests should be set to MPI_REQUEST_NULL and the wait_all
-    // should return immediately,
+    // Test a null op -- I didn't actually send anything, so the MPI requests
+    // should be set to MPI_REQUEST_NULL and the wait_all should return
+    // immediately,
     bool nullreq_failed = false;
     try {
-      wait_all(comm.size(), &comm[0]);
+      wait_all(static_cast<unsigned>(comm.size()), &comm[0]);
     } catch (...) {
       nullreq_failed = true;
     }
@@ -169,7 +169,8 @@ void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
     // wait_all_with_source version:
     nullreq_failed = false;
     try {
-      result = wait_all_with_source(comm.size(), &comm[0]);
+      result =
+          wait_all_with_source(static_cast<unsigned>(comm.size()), &comm[0]);
     } catch (...) {
       nullreq_failed = true;
     }

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -106,7 +106,9 @@
 /* restrict is valid keyword in C99 but not in C++11.  Protect this define so
  * that it is set only for C++ */
 #ifdef __cplusplus
+#if ! defined(MSVC) || MSVC_VERSION < 1927
 #define restrict @RESTRICT_KEYWORD@
+#endif
 #endif /* __cplusplus */
 
 /* Platform checks for various functions */
@@ -175,10 +177,10 @@
  * \page diagnostics Diagnostics Levels
  *
  * The diagnostics can be turned on in three different levels based on logical
- * bit comparisions.  The following shows the levels:
+ * bit comparisons.  The following shows the levels:
  * - Bit 0, (001), activates Level 1 (negligible performance impact)
  * - Bit 1, (010), activates Level 2 (some performance impact and possible
- *                                    intrusive output, rtt_memory trackin is
+ *                                    intrusive output, rtt_memory tracking is
  *                                    activated.)
  *                 and a stack trace will be added to DbC messages.
  * - Bit 2, (100), activates Level 3 (includes fpe_trap diagnostics)
@@ -197,7 +199,7 @@
  * levels.  The default setting is 0.
  *
  * The intent is to use Level 1 for high-level, low cost diagnostics that are
- * always active (ie. User "Education").  Levels 2 and 3 are for low-level
+ * always active (i.e. User "Education").  Levels 2 and 3 are for low-level
  * diagnostics that could incur a performance penalty.  However, all of these
  * usages are up to the client.
  *
@@ -290,7 +292,7 @@
 /* When using GCC, provide a CPP macro that tells the compiler to
    expect (and not warn) if a variable is defined but not used.
    This warning can be suppressed by marking the variable with a
-   speciall attribute.  See jayenne/src/mc/Constants.hh. */
+   special attribute.  See jayenne/src/mc/Constants.hh. */
 #ifdef __GNUC__
 #define VARIABLE_IS_NOT_USED __attribute__ ((unused))
 #else


### PR DESCRIPTION
### Background

+ The `restrict` keyword behaves a little differently in the latest MSVC.  Make a CPP adjustment to keep builds working.
+ The new MSVC also starting warning on a integral type conversion that I fixed with a `static_cast`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
