### PR TITLE
Fix clang-format version issue.

### DIFF
--- a/environment/git/pre-commit-clang-format
+++ b/environment/git/pre-commit-clang-format
@@ -28,8 +28,8 @@ if ! test -x "$CLANG_FORMAT"; then
 fi
 
 cf_min_ver=6.0
-cf_ver=`"$CLANG_FORMAT" --version`
-if version_gt $cf_ver_min $cf_min; then
+cf_ver=`"$CLANG_FORMAT" --version | sed 's/[[:alpha:]|(|[:space:]|-]//g'`
+if version_gt $cf_min_ver $cf_ver; then
   echo "ERROR: Your version of clang-format is too old. Expecting v 6.0+."
   echo "       pre-commit-hook disabled."
   exit 0


### PR DESCRIPTION
### Background

* Allow clang-format other than version 6.0 to work as a git commit hook.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
