### PR TITLE
Fix USE_CUDA=OFF logic so that Cuda is actually disabled.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -746,6 +746,16 @@ macro(dbsSetupCuda)
     # User option to disable Cuda, even when it is available.
     option(USE_CUDA "Use Cuda?" ON)
 
+  endif()
+
+  # Save the results
+  set( HAVE_CUDA ${HAVE_CUDA} CACHE BOOL
+    "Should we build CUDA portions of this project?" FORCE )
+  if( HAVE_CUDA AND USE_CUDA )
+    # Use this string in 'project(foo ${CUDA_DBS_STRING})' commands to enable
+    # cuda per project.
+    set( CUDA_DBS_STRING "CUDA" CACHE STRING
+      "If CUDA is available, this variable is 'CUDA'")
     # Use this string as a toggle when calling add_component_library or
     # add_scalar_tests to force compiling with nvcc.
     set( COMPILE_WITH_CUDA LINK_LANGUAGE CUDA )
@@ -757,14 +767,7 @@ macro(dbsSetupCuda)
       message(FATAL_ERROR "Build system does not support "
         "CUDACXX=${CMAKE_CUDA_COMPILER}")
     endif()
-  endif()
 
-  # Save the results
-  set( HAVE_CUDA ${HAVE_CUDA} CACHE BOOL
-    "Should we build CUDA portions of this project?" FORCE )
-  if( ${HAVE_CUDA} )
-    set( CUDA_DBS_STRING "CUDA" CACHE STRING
-      "If CUDA is available, this variable is 'CUDA'")
   endif()
 
 endmacro()


### PR DESCRIPTION
### Background

* We need the ability to disable compilation with CUDA even when _nvcc_ is found in the build environment.

### Purpose of Pull Request

* [Fixes Redmine Issue #2083](https://rtt.lanl.gov/redmine/issues/2083)

### Description of changes

* Do not set `CUDA_DBS_STRING`  or `COMPILE_WITH_CUDA` cmake variables unless `(HAVE_CUDA AND USE_CUDA)` is true.
* No need to set CUDA compiler flags if cuda is disabled.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
