### PR TITLE
Apply clang-tidy transformations to parser component.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,12 +80,12 @@ add_dir_if_exists( fit )          # needs linear
 add_dir_if_exists( meshReaders )  # needs c4
 add_dir_if_exists( min )          # needs linear
 add_dir_if_exists( norms )        # needs c4
+add_dir_if_exists( parser )       # needs units, c4, mesh_element
 add_dir_if_exists( roots )        # needs linear
 add_dir_if_exists( VendorChecks ) # needs c4
 
 if( NOT CI_CLANG_TIDY )
 add_dir_if_exists( compton )      # needs c4, CSK
-add_dir_if_exists( parser )       # needs units, c4, mesh_element
 add_dir_if_exists( rng )          # needs ds++, device
 add_dir_if_exists( viz )          # needs c4
 

--- a/src/parser/Abstract_Class_Parser.cc
+++ b/src/parser/Abstract_Class_Parser.cc
@@ -19,7 +19,7 @@ c_string_vector abstract_class_parser_keys;
 //----------------------------------------------------------------------------//
 c_string_vector::~c_string_vector() {
   Check(data.size() < UINT_MAX);
-  unsigned const n = static_cast<unsigned>(data.size());
+  auto const n = static_cast<unsigned>(data.size());
   for (unsigned i = 0; i < n; ++i) {
     delete[] data[i];
   }

--- a/src/parser/Abstract_Class_Parser.hh
+++ b/src/parser/Abstract_Class_Parser.hh
@@ -58,13 +58,13 @@ private:
  * \arg \a get_parse_table A function that returns a reference to the parse
  * table for the abstract class.
  *
- * \arg \a get_parsed_object A function that returns a reference to a
- * storage location for a pointer to the abstract class.
+ * \arg \a get_parsed_object A function that returns a reference to a storage
+ * location for a pointer to the abstract class.
  *
  * The key to this class is the register_child function, which is called for
- * each child class prior to attempting any parsing. It specifies a keyword
- * for selecting each child class and a function that does the actual parsing
- * of the class specification. This assumes an input grammar of the form
+ * each child class prior to attempting any parsing. It specifies a keyword for
+ * selecting each child class and a function that does the actual parsing of the
+ * class specification. This assumes an input grammar of the form
  *
  * \code
  * abstract class keyword
@@ -88,7 +88,7 @@ private:
 template <typename Abstract_Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Abstract_Class> &get_parsed_object(),
           typename Parse_Function =
-	    std::function<std::shared_ptr<Abstract_Class>(Token_Stream &)>>
+              std::function<std::shared_ptr<Abstract_Class>(Token_Stream &)>>
 class Abstract_Class_Parser {
 public:
   // TYPES

--- a/src/parser/Abstract_Class_Parser.i.hh
+++ b/src/parser/Abstract_Class_Parser.i.hh
@@ -38,7 +38,7 @@ operator()(Token_Stream &tokens) const {
 class c_string_vector {
 public:
   ~c_string_vector();
-  c_string_vector(void) : data(0) { /* empty */
+  c_string_vector() : data(0) { /* empty */
   }
   std::vector<char *> data;
 };
@@ -67,7 +67,7 @@ std::vector<Parse_Function> Abstract_Class_Parser<
  * \param keyword Keyword associated with the child class
  *
  * \param parsefunction Parse function that reads a specification from a
- * Token_Stream and returns a corresponding object of the child class.
+ *           Token_Stream and returns a corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
@@ -78,7 +78,7 @@ void Abstract_Class_Parser<
   using namespace rtt_parser;
 
   char *cptr = new char[keyword.size() + 1];
-  std::strcpy(cptr, keyword.c_str());
+  std::strncpy(cptr, keyword.c_str(), keyword.size() + 1);
   abstract_class_parser_keys.data.push_back(cptr);
 
   int const Num = static_cast<int>(map_.size());
@@ -100,7 +100,7 @@ void Abstract_Class_Parser<
  * \param keyword Keyword associated with the child class
  *
  * \param parsefunction Parse function that reads a specification from a
- * Token_Stream and returns a corresponding object of the child class.
+ *           Token_Stream and returns a corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
@@ -112,7 +112,7 @@ void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
   using namespace rtt_parser;
 
   char *cptr = new char[keyword.size() + 1];
-  std::strcpy(cptr, keyword.c_str());
+  std::strncpy(cptr, keyword.c_str(), keyword.size() + 1);
   abstract_class_parser_keys.data.push_back(cptr);
 
   int const Num = static_cast<int>(map_.size());

--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -49,11 +49,11 @@ namespace rtt_parser {
  * indicating that the corresponding parameters have not been parsed yet.  This
  * allows us to detect whether a parameter has been parsed yet.
  *
- * Where possible, the sentinel value should be one that doesn't make
- * sense for the parameter in question, such as 0 for a dimension that
- * must be nonzero, or a negative value for a parameter that must be
- * positive.  This ensures that the sentinel value can be distinguished
- * from any value a user might specify in an input "deck."
+ * Where possible, the sentinel value should be one that doesn't make sense for
+ * the parameter in question, such as 0 for a dimension that must be nonzero, or
+ * a negative value for a parameter that must be positive.  This ensures that
+ * the sentinel value can be distinguished from any value a user might specify
+ * in an input "deck."
  *
  * Since Parse_Table uses static functions to parse the token stream, it is
  * generally necessary to have a static pointer somewhere that points to the
@@ -100,8 +100,8 @@ namespace rtt_parser {
  *
  * Create the object from the parsed fields.  This function should have no
  * preconditions that are not guaranteed by a preceding successful call to
- * check_completeness. create_object will be called only if no errors
- * were detected in the input "deck".
+ * check_completeness. create_object will be called only if no errors were
+ * detected in the input "deck".
  *
  * Note that Class_Parse_Table must define the type Return_Class, which is the
  * class of the object that Class_Parse_Table is designed to parse.
@@ -109,8 +109,7 @@ namespace rtt_parser {
  * For convenience, skeletons for such a class are provided in
  * draco/environment/templates/template__parser.hh,cc
  */
-
-template <class Class> class Class_Parse_Table;
+template <typename Class> class Class_Parse_Table;
 
 //----------------------------------------------------------------------------//
 /*! Template for helper function that produces a class object.
@@ -120,21 +119,20 @@ template <class Class> class Class_Parse_Table;
  * \return A pointer to an object matching the user specification, or NULL if
  * the specification is not valid.
  */
-
-template <class Class_Parse_Table>
+template <typename Class_Parse_Table>
 std::shared_ptr<typename Class_Parse_Table::Return_Class>
 parse_class_from_table(Token_Stream &tokens) {
   using rtt_parser::END;
   using rtt_parser::EXIT;
   using rtt_parser::Token;
 
-  typedef typename Class_Parse_Table::Return_Class Return_Class;
+  using Return_Class = typename Class_Parse_Table::Return_Class;
 
   // Construct the parse object as described above.
   Class_Parse_Table parse_table;
 
-  // Save the old error count, so we can distinguish fresh errors within
-  // this class keyword block from previous errors.
+  // Save the old error count, so we can distinguish fresh errors within this
+  // class keyword block from previous errors.
   unsigned const old_error_count = tokens.error_count();
 
   // Parse the class keyword block and check for completeness
@@ -142,8 +140,8 @@ parse_class_from_table(Token_Stream &tokens) {
   bool allow_exit = parse_table.allow_exit(); // improve code coverage
   std::shared_ptr<Return_Class> Result;
   if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
-  // A class keyword block is expected to end with an END or (if
-  // allow_exit is true) an EXIT.
+  // A class keyword block is expected to end with an END or (if allow_exit is
+  // true) an EXIT.
   {
     parse_table.check_completeness(tokens);
 
@@ -151,8 +149,8 @@ parse_class_from_table(Token_Stream &tokens) {
       // No fresh errors in the class keyword block.  Create the object.
       Result = parse_table.create_object();
     }
-    // else there were errors in the keyword block. Don't try to
-    // create a class object.  Return the null pointer.
+    // else there were errors in the keyword block. Don't try to create a class
+    // object.  Return the null pointer.
   } else {
     tokens.report_syntax_error("missing 'end'?");
   }
@@ -170,7 +168,6 @@ parse_class_from_table(Token_Stream &tokens) {
  * \return A pointer to an object matching the user specification, or NULL if
  * the specification is not valid.
  */
-
 template <typename Class_Parse_Table, typename Context>
 std::shared_ptr<typename Class_Parse_Table::Return_Class>
 parse_class_from_table(Token_Stream &tokens, Context const &context) {
@@ -178,13 +175,13 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
   using rtt_parser::EXIT;
   using rtt_parser::Token;
 
-  typedef typename Class_Parse_Table::Return_Class Return_Class;
+  using Return_Class = typename Class_Parse_Table::Return_Class;
 
   // Construct the parse object as described above.
   Class_Parse_Table parse_table(context);
 
-  // Save the old error count, so we can distinguish fresh errors within
-  // this class keyword block from previous errors.
+  // Save the old error count, so we can distinguish fresh errors within this
+  // class keyword block from previous errors.
   unsigned const old_error_count = tokens.error_count();
 
   // Parse the class keyword block and check for completeness
@@ -192,8 +189,8 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
   bool allow_exit = parse_table.allow_exit(); // improve code coverage
   std::shared_ptr<Return_Class> Result;
   if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
-  // A class keyword block is expected to end with an END or (if
-  // allow_exit is true) an EXIT.
+  // A class keyword block is expected to end with an END or (if allow_exit is
+  // true) an EXIT.
   {
     parse_table.check_completeness(tokens);
 
@@ -201,8 +198,8 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
       // No fresh errors in the class keyword block.  Create the object.
       Result = parse_table.create_object();
     }
-    // else there were errors in the keyword block. Don't try to
-    // create a class object.  Return the null pointer.
+    // else there were errors in the keyword block. Don't try to create a class
+    // object.  Return the null pointer.
   } else {
     tokens.report_syntax_error("missing 'end'?");
   }
@@ -210,11 +207,11 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
   return Result;
 }
 
-//----------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Template for base class for class parser
  *
- * This is to simplify writing a class parser. A specializaton of Class_Parse_Table for a
- * class Class uses this as a base class, as follows:
+ * This is to simplify writing a class parser. A specializaton of
+ * Class_Parse_Table for a class Class uses this as a base class, as follows:
  *
  * Class__parser.hh:
  *
@@ -229,7 +226,8 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
  *      shared_ptr<Sweeper_Creator> create_object();
  *
  *    protected:
- *      // Data to be parsed which will be used to construct the class, for example:
+ *      // Data to be parsed which will be used to construct the class, for
+ *      // example:
  *
  *      Context_Type debug_context;
  *      bool flag;
@@ -285,18 +283,17 @@ parse_class_from_table(Token_Stream &tokens, Context const &context) {
  *        tokens, debug_context);
  * }
  *
- * This introduces all the "boilerplate" and lets the developer focus on the data required
- * for the constructor for Class, the parse functions needed to parse this data, and the
- * check and construct functions.
+ * This introduces all the "boilerplate" and lets the developer focus on the
+ * data required for the constructor for Class, the parse functions needed to
+ * parse this data, and the check and construct functions.
  */
-
-template <class Class, bool allow_an_exit = false>
+template <typename Class, bool allow_an_exit = false>
 class Class_Parse_Table_Base {
 public:
   // TYPEDEFS
 
-  typedef Class Return_Class;
-  typedef unsigned Context_Type;
+  using Return_Class = Class;
+  using Context_type = unsigned;
 
   // MANAGEMENT
 
@@ -320,7 +317,7 @@ private:
 
   friend class Class_Parse_Table<Class>;
 
-  void initialize(Keyword const keywords[], unsigned count) {
+  void initialize(Keyword const *keywords, unsigned count) {
     static bool first_time = true;
     if (first_time) {
       count /= static_cast<unsigned>(sizeof(Keyword));
@@ -334,11 +331,11 @@ private:
   static Parse_Table parse_table_;
 };
 
-template <class Class, bool allow_exit>
+template <typename Class, bool allow_exit>
 /*static*/ Class_Parse_Table<Class>
     *Class_Parse_Table_Base<Class, allow_exit>::current_;
 
-template <class Class, bool allow_exit>
+template <typename Class, bool allow_exit>
 /*static*/ Parse_Table Class_Parse_Table_Base<Class, allow_exit>::parse_table_;
 
 } // end namespace rtt_parser

--- a/src/parser/Class_Parser.i.hh
+++ b/src/parser/Class_Parser.i.hh
@@ -2,7 +2,8 @@
 /*!
  * \file   Class_Parser.i.hh
  * \brief  Definitions of member functions of template Class_Parser
- * \note   Copyright (C) 2016-2019 TRIAD, LLC. All rights reserved */
+ * \note   Copyright (C) 2016-2019 Trian National Security, LLC.
+ *         All rights reserved */
 //----------------------------------------------------------------------------//
 
 #ifndef rtt_Class_Parser_i_hh
@@ -14,8 +15,8 @@ namespace rtt_parser {
 
 //----------------------------------------------------------------------------//
 /*!
- * \param child Reference to the complete child object for which this base
- * is being constructed.
+ * \param child Reference to the complete child object for which this base is
+ *           being constructed.
  *
  * \param raw_table Pointer to an array of keywords.
  *
@@ -26,7 +27,7 @@ namespace rtt_parser {
  * \note See documentation for \c Parse_Table::add for an explanation of the
  *       low-level argument list.
  */
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 Class_Parser_Base<Class, once, allow_exit>::Class_Parser_Base(
     Child &child, Class_Parser_Keyword<Class> const *raw_table,
     unsigned const count)
@@ -48,14 +49,13 @@ Class_Parser_Base<Class, once, allow_exit>::Class_Parser_Base(
  * \param table Array of keywords to be added to the table.
  * \param count Number of valid elements in the array of keywords.
  *
- * \throw invalid_argument If the keyword table is ill-formed or
- * ambiguous.
+ * \throw invalid_argument If the keyword table is ill-formed or ambiguous.
  *
  * \note The argument list reflects the convenience of defining raw keyword
- * tables as static C arrays.  This justifies a low-level interface in place
- * of, say, vector<Keyword>.
+ *       tables as static C arrays.  This justifies a low-level interface in
+ *       place of, say, vector<Keyword>.
  */
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 void Class_Parser_Base<Class, once, allow_exit>::add(
     Keyword const *const table, size_t const count) noexcept(false) {
   Require(count == 0 || table != nullptr);
@@ -85,11 +85,10 @@ void Class_Parser_Base<Class, once, allow_exit>::add(
  *
  * \param table Vector of keywords to be added to the table.
  *
- * \throw invalid_argument If the keyword table is ill-formed or
- * ambiguous.
+ * \throw invalid_argument If the keyword table is ill-formed or ambiguous.
   */
-template <class Class, bool once, bool allow_exit>
-template <class Base>
+template <typename Class, bool once, bool allow_exit>
+template <typename Base>
 void Class_Parser_Base<Class, once, allow_exit>::add(
     std::vector<Class_Parser_Keyword<Base>> const &table) noexcept(false) {
   unsigned const count = table.size();
@@ -116,7 +115,7 @@ void Class_Parser_Base<Class, once, allow_exit>::add(
 
 //----------------------------------------------------------------------------//
 /* private */
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 void Class_Parser_Base<Class, once, allow_exit>::sort_table_() noexcept(
     false) // apparently std::sort can throw
 {
@@ -163,58 +162,55 @@ void Class_Parser_Base<Class, once, allow_exit>::sort_table_() noexcept(
 
 //----------------------------------------------------------------------------//
 /*!
- * Parse the stream of tokens until an END, EXIT, or ERROR token is
- * reached.
+ * Parse the stream of tokens until an END, EXIT, or ERROR token is reached.
  *
- * \param tokens
- * The Token Stream from which to obtain the stream of tokens.
+ * \param tokens The Token Stream from which to obtain the stream of tokens.
  *
  * \return The terminating token: either END, EXIT, or ERROR.
  *
  * \throw rtt_dsxx::assertion If the keyword table is ambiguous.
  */
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 std::shared_ptr<Class>
 Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
 
   using std::vector;
 
-  // Save the old error count, so we can distinguish fresh errors within
-  // this class keyword block from previous errors.
+  // Save the old error count, so we can distinguish fresh errors within this
+  // class keyword block from previous errors.
   unsigned const old_error_count = tokens.error_count();
 
-  // The is_recovering flag is used during error recovery to suppress
-  // additional error messages.  This reduces the likelihood that a single
-  // error in a token stream will generate a large number of error
-  // messages.
+  // The is_recovering flag is used during error recovery to suppress additional
+  // error messages.  This reduces the likelihood that a single error in a token
+  // stream will generate a large number of error messages.
 
   bool is_recovering = false;
 
-  // Create a comparator object that will be used to attempt to match
-  // keywords in the Token_Stream to keywords in the Parse_Table.
+  // Create a comparator object that will be used to attempt to match keywords
+  // in the Token_Stream to keywords in the Parse_Table.
 
   Keyword_Compare_ const comp;
 
-  // Now begin the process of pulling keywords off the input token stream,
-  // and attempting to match these to the keyword table.
+  // Now begin the process of pulling keywords off the input token stream, and
+  // attempting to match these to the keyword table.
 
   for (;;) {
     Token const token = tokens.shift();
 
-    // The END, EXIT, and ERROR tokens are terminating tokens.  EXIT
-    // means the end of the token stream has been reached.  END is used
-    // to flag the end of a nested parse, where the result of matching a
-    // keyword in one parse table is to begin parsing keywords in a
-    // second parse table.  An END indicates that the second parse table
-    // should return control to the first parse table.  ERROR means that
-    // something went very wrong and we're probably hosed, but it allows
-    // some error recovery from within a nested parse table.
+    // The END, EXIT, and ERROR tokens are terminating tokens.  EXIT means the
+    // end of the token stream has been reached.  END is used to flag the end of
+    // a nested parse, where the result of matching a keyword in one parse table
+    // is to begin parsing keywords in a second parse table.  An END indicates
+    // that the second parse table should return control to the first parse
+    // table.  ERROR means that something went very wrong and we're probably
+    // hosed, but it allows some error recovery from within a nested parse
+    // table.
 
     if (token.type() == END || token.type() == EXIT ||
         token.type() == rtt_parser::ERROR) {
       if (token.type() == END || (allow_exit && token.type() == EXIT))
-      // A class keyword block is expected to end with an END or (if
-      // allow_exit is true) an EXIT.
+      // A class keyword block is expected to end with an END or (if allow_exit
+      // is true) an EXIT.
       {
         check_completeness(tokens);
 
@@ -222,8 +218,8 @@ Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
           // No fresh errors in the class keyword block.  Create the object.
           return std::shared_ptr<Class>(create_object());
         } else {
-          // there were errors in the keyword block. Don't try to
-          // create a class object.  Return the null pointer.
+          // there were errors in the keyword block. Don't try to create a class
+          // object.  Return the null pointer.
           return nullptr;
         }
       } else {
@@ -232,40 +228,35 @@ Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
       }
     }
 
-    // A Parse_Table assumes that every construct begins with a keyword.
-    // This keyword is matched to the keyword table, and if a match is
-    // found, control is directed to the associated parse function, which
-    // can be written to accept just about any construct you wish.
-    // However, by the time return controls from a parse function, the
-    // token stream should be pointing either at a terminating token or
-    // the next keyword.
+    // A Parse_Table assumes that every construct begins with a keyword.  This
+    // keyword is matched to the keyword table, and if a match is found, control
+    // is directed to the associated parse function, which can be written to
+    // accept just about any construct you wish.  However, by the time return
+    // controls from a parse function, the token stream should be pointing
+    // either at a terminating token or the next keyword.
 
     if (token.type() == KEYWORD) {
-      // Attempt to match the keyword to the keyword table.  The
-      // following call returns an iterator pointing to the first
-      // keyword in the table whose lexical ordering is greater than or
-      // equal to the keyword token.  The lexical ordering is supplied
-      // by the comp object.
+      // Attempt to match the keyword to the keyword table.  The following call
+      // returns an iterator pointing to the first keyword in the table whose
+      // lexical ordering is greater than or equal to the keyword token.  The
+      // lexical ordering is supplied by the comp object.
 
       auto const match = lower_bound(table_.begin(), table_.end(), token, comp);
 
       if (match == table_.end() ||
           strcmp(match->moniker, token.text().c_str()) != 0) {
-        // The token was not lexically equal to anything in the
-        // keyword table.  In other words, the keyword is
-        // unrecognized by the Parse_Table.  The error recovery
-        // procedure is to generate a diagnostic, then pull
-        // additional tokens off the token stream (without generating
-        // further diagnostics) until one is recognized as either a
-        // keyword or a terminating token.  We implement this
-        // behavior by setting the is_recovering flag when the first
-        // invalid token is encountered, and resetting this flag as
-        // soon as a valid token is encountered.
+        // The token was not lexically equal to anything in the keyword table.
+        // In other words, the keyword is unrecognized by the Parse_Table.  The
+        // error recovery procedure is to generate a diagnostic, then pull
+        // additional tokens off the token stream (without generating further
+        // diagnostics) until one is recognized as either a keyword or a
+        // terminating token.  We implement this behavior by setting the
+        // is_recovering flag when the first invalid token is encountered, and
+        // resetting this flag as soon as a valid token is encountered.
 
         if (!is_recovering) {
-          // We are not recovering from a previous error.  Generate
-          // a diagnostic, and flag that we are now in error
-          // recovery mode.
+          // We are not recovering from a previous error.  Generate a
+          // diagnostic, and flag that we are now in error recovery mode.
 
           tokens.report_semantic_error(token, ": unrecognized keyword: " +
                                                   token.text());
@@ -281,24 +272,22 @@ Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
 
           is_recovering = true;
         }
-        // else we are in recovery mode, and additional diagnostics
-        // are disabled until we see a valid construct.
+        // else we are in recovery mode, and additional diagnostics are disabled
+        // until we see a valid construct.
       } else {
         // We have a valid match.
 
         is_recovering = false;
-        // We successfully processed something, so we are no
-        // longer in recovery mode.
+        // We successfully processed something, so we are no longer in recovery
+        // mode.
 
         try {
-          // Call the parse function associated with the
-          // keyword.
+          // Call the parse function associated with the keyword.
           (child_.*(match->func))(tokens, match->index);
 
           if (once)
-          // Quit after parsing a single keyword. This is
-          // useful for parse tables for selecting one of a
-          // set of short options.
+          // Quit after parsing a single keyword. This is useful for parse
+          // tables for selecting one of a set of short options.
           {
             check_completeness(tokens);
 
@@ -306,51 +295,46 @@ Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
               // No fresh errors in the class keyword block.  Create the object.
               return std::shared_ptr<Class>(create_object());
             } else {
-              // there were errors in the keyword block. Don't try to
-              // create a class object.  Return the null pointer.
+              // there were errors in the keyword block. Don't try to create a
+              // class object.  Return the null pointer.
               return nullptr;
             }
           }
         } catch (const Syntax_Error &) {
-          // If the parse function detects a syntax error, and
-          // if it does not have its own error recovery policy
-          // (or is unable to recover), it should call
-          // tokens.Report_Syntax_Error which generates a
-          // diagnostic and throws a Syntax_Error
-          // exception. This puts the main parser into recovery
-          // mode.
+          // If the parse function detects a syntax error, and if it does not
+          // have its own error recovery policy (or is unable to recover), it
+          // should call tokens.Report_Syntax_Error which generates a diagnostic
+          // and throws a Syntax_Error exception. This puts the main parser into
+          // recovery mode.
 
           is_recovering = true;
         }
       }
     } else if (token.type() == OTHER && token.text() == ";") {
-      // Treat a semicolon token as an empty keyword.  We are no longer
-      // in recovery mode, but we don't actually do anything.
+      // Treat a semicolon token as an empty keyword.  We are no longer in
+      // recovery mode, but we don't actually do anything.
 
       is_recovering = false;
     } else {
-      // The next token in the token stream is not a keyword,
-      // indicating a syntax error. Error recovery consists of
-      // generating a diagnostic message, then continuing to pull
-      // tokens off the token stream (without generating any further
-      // diagnostics) until one is recognized as either a keyword or a
-      // terminating token.  We implement this behavior by setting the
-      // is_recovering flag when the first invalid token is
-      // encountered, and resetting this flag as soon as a valid token
-      // is encountered.
+      // The next token in the token stream is not a keyword, indicating a
+      // syntax error. Error recovery consists of generating a diagnostic
+      // message, then continuing to pull tokens off the token stream (without
+      // generating any further diagnostics) until one is recognized as either a
+      // keyword or a terminating token.  We implement this behavior by setting
+      // the is_recovering flag when the first invalid token is encountered, and
+      // resetting this flag as soon as a valid token is encountered.
 
       if (!is_recovering) {
-        // We are not recovering from a previous error.  Generate a
-        // diagnostic, and flag that we are now in error recovery
-        // mode.
+        // We are not recovering from a previous error.  Generate a diagnostic,
+        // and flag that we are now in error recovery mode.
 
         std::ostringstream msg;
         msg << "expected a keyword, but saw " << token.text();
         tokens.report_semantic_error(token, msg.str());
         is_recovering = true;
       }
-      // else we are in recovery mode, and additional diagnostics are
-      // disabled until we see a valid construct.
+      // else we are in recovery mode, and additional diagnostics are disabled
+      // until we see a valid construct.
     }
   }
 }
@@ -370,12 +354,11 @@ Class_Parser_Base<Class, once, allow_exit>::parse(Token_Stream &tokens) {
  *
  * \return <CODE>strcmp(k1.moniker, k2.moniker)<0 </CODE>
  */
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 bool Class_Parser_Base<Class, once, allow_exit>::Keyword_Compare_::
 operator()(Keyword const &k1, Keyword const &k2) const {
   Require(k1.moniker != nullptr);
   Require(k2.moniker != nullptr);
-
   return strcmp(k1.moniker, k2.moniker) < 0;
 }
 
@@ -383,36 +366,35 @@ operator()(Keyword const &k1, Keyword const &k2) const {
 /*!
  * \brief Comparison function for finding token match in keyword table.
  *
- * This function is used by a Parse_Table to match keywords to identifier
- * tokens using std::lower_bound.
+ * This function is used by a Parse_Table to match keywords to identifier tokens
+ * using std::lower_bound.
  *
  * \param k1 The Keyword to be compared.
  * \param k2 The token to be compared.
  *
- * \return <CODE>strcmp(keyword.moniker,
- *                          token.text().c_str())<0 </CODE>
+ * \return <CODE>strcmp(keyword.moniker, token.text().c_str())<0 </CODE>
  */
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 bool Class_Parser_Base<Class, once, allow_exit>::Keyword_Compare_::
 operator()(Keyword const &k1, Token const &k2) const noexcept {
   Require(k1.moniker != nullptr);
-
   return strcmp(k1.moniker, k2.text().c_str()) < 0;
 }
 
 //----------------------------------------------------------------------------//
 /*!
- * \brief Check whether a keyword satisfies the requirements for use in
- * a Parse_Table.
+ * \brief Check whether a keyword satisfies the requirements for use in a
+ *        Parse_Table.
  *
  * \param key Keyword to be checked.
  *
  * \return \c false unless all the following conditions are met:
- * <ul><li>\c key.moniker must point to a null-terminated string consisting
- * of one or more valid C++ identifiers separated by single spaces.</li>
- * <li>\c key.func must point to a parsing function.</li></ul>
+ *         - \c key.moniker must point to a null-terminated string consisting
+ *           of one  or more valid C++ identifiers separated by single spaces.
+ *         - \c key.func must point to a parsing function.
+ *         .
  */
-template <class Class>
+template <typename Class>
 bool Is_Well_Formed_Keyword(Class_Parser_Keyword<Class> const &key) {
   using namespace std;
 
@@ -420,8 +402,8 @@ bool Is_Well_Formed_Keyword(Class_Parser_Keyword<Class> const &key) {
     return false;
   char const *cptr = key.moniker;
   for (;;) {
-    // Must be at the start of a C identifier, which begins with an
-    // alphabetic character or an underscore.
+    // Must be at the start of a C identifier, which begins with an alphabetic
+    // character or an underscore.
     if (*cptr != '_' && !isalpha(*cptr))
       return false;
 
@@ -430,8 +412,8 @@ bool Is_Well_Formed_Keyword(Class_Parser_Keyword<Class> const &key) {
     while (*cptr == '_' || isalnum(*cptr))
       cptr++;
 
-    // If the identifier is followed by a null, we're finished scanning a
-    // valid keyword.
+    // If the identifier is followed by a null, we're finished scanning a valid
+    // keyword.
     if (*cptr == '\0')
       return true;
 
@@ -440,14 +422,14 @@ bool Is_Well_Formed_Keyword(Class_Parser_Keyword<Class> const &key) {
     if (*cptr != ' ')
       return false;
 
-    // Skip over the space. cptr should now point to the start of the
-    // next C identifier, if this is a valid keyword.
+    // Skip over the space. cptr should now point to the start of the next C
+    // identifier, if this is a valid keyword.
     cptr++;
   }
 }
 
 //----------------------------------------------------------------------------//
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 bool Class_Parser_Base<Class, once, allow_exit>::check_class_invariants()
     const {
   // The keyword table must be well-formed, sorted, and unambiguous.
@@ -464,7 +446,7 @@ bool Class_Parser_Base<Class, once, allow_exit>::check_class_invariants()
 }
 
 //----------------------------------------------------------------------------//
-template <class Class, bool once, bool allow_exit>
+template <typename Class, bool once, bool allow_exit>
 std::vector<typename Class_Parser_Base<Class, once, allow_exit>::Keyword>
     Class_Parser_Base<Class, once, allow_exit>::table_;
 

--- a/src/parser/Console_Token_Stream.cc
+++ b/src/parser/Console_Token_Stream.cc
@@ -18,7 +18,7 @@ using namespace std;
 //! Use the default Text_Token_Stream user-defined whitespace characters.
 Console_Token_Stream::Console_Token_Stream() {
   Ensure(check_class_invariants());
-  Ensure(location_() == "input");
+  Ensure(Console_Token_Stream::location_() == "input");
 }
 
 //----------------------------------------------------------------------------//
@@ -33,7 +33,7 @@ Console_Token_Stream::Console_Token_Stream(set<char> const &ws,
                                            bool const no_nonbreaking_ws)
     : Text_Token_Stream(ws, no_nonbreaking_ws) {
   Ensure(check_class_invariants());
-  Ensure(location_() == "input");
+  Ensure(Console_Token_Stream::location_() == "input");
   Ensure(whitespace() == ws);
   Ensure(this->no_nonbreaking_ws() == no_nonbreaking_ws);
 }

--- a/src/parser/Console_Token_Stream.hh
+++ b/src/parser/Console_Token_Stream.hh
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \brief  Definition of class Console_Token_Stream.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #ifndef rtt_Console_Token_Stream_HH
@@ -25,21 +22,21 @@ using std::string;
  * \brief Console-based token stream
  *
  * Console_Token_Stream represents a text token stream that derives its text
- * stream from the standard console input stream \c cin.  It reports errors
- * to the standard  console error stream \c cerr.
+ * stream from the standard console input stream \c cin.  It reports errors to
+ * the standard console error stream \c cerr.
  *
- * This stream also differs from other streams in that the endline character
- * is converted to the semicolon character.  Parsers for use with console
- * streams typically treat the semicolon as an "end of statement" character
- * by specifying that it is NOT a whitespace character and looking for it as
- * a statement terminator.
+ * This stream also differs from other streams in that the endline character is
+ * converted to the semicolon character.  Parsers for use with console streams
+ * typically treat the semicolon as an "end of statement" character by
+ * specifying that it is NOT a whitespace character and looking for it as a
+ * statement terminator.
  *
  * \note This class is an experimental concept and <i> should not be used in
  * production codes </i>.  In particular, the class cannot readily be tested
  * under our current unit testing system, since it is inherently interactive.
  */
 
-class DLL_PUBLIC_parser Console_Token_Stream : public Text_Token_Stream {
+class Console_Token_Stream : public Text_Token_Stream {
 public:
   // CREATORS
 
@@ -52,31 +49,30 @@ public:
 
   // MANIPULATORS
 
-  void rewind();
+  void rewind() override;
 
-  virtual void report(const Token &token, const string &message);
-
-  virtual void report(const string &message);
-
-  virtual void comment(std::string const &message);
+  void report(const Token &token, const string &message) override;
+  void report(const string &message) override;
+  void comment(std::string const &message) override;
 
 protected:
   // IMPLEMENTATION
 
   //! Return a locator string.
-  virtual string location_() const;
+  string location_() const override;
 
-  virtual void fill_character_buffer_();
-  virtual bool error_() const;
-  virtual bool end_() const;
+  void fill_character_buffer_() override;
+  bool error_() const override;
+  bool end_() const override;
 
-  virtual void push_include(std::string &include_file_name);
-  virtual void pop_include();
+  void push_include(std::string &include_file_name) override;
+  void pop_include() override;
 };
 
 } // namespace rtt_parser
 
 #endif // rtt_Console_Token_Stream_HH
+
 //----------------------------------------------------------------------------//
 // end of Console_Token_Stream.hh
 //----------------------------------------------------------------------------//

--- a/src/parser/Constant_Expression.cc
+++ b/src/parser/Constant_Expression.cc
@@ -45,7 +45,7 @@ void lower(ostream &out, char const *const label, double const power,
       out << '*';
     }
     first = false;
-    unsigned ipower = static_cast<unsigned>(-power);
+    auto ipower = static_cast<unsigned>(-power);
     out << "pow(" << label << "," << ipower << ")";
   }
 }

--- a/src/parser/Constant_Expression.hh
+++ b/src/parser/Constant_Expression.hh
@@ -25,9 +25,6 @@ void write_c(Unit const &units, ostream &out);
  * This is the only concrete type of Expression that is currently available to
  * clients. The need has never arisen to make any other concrete type of
  * Expression directly available.
- *
- * If you need access to another type of concrete Expression, contact the
- * Capsaicin team.
  */
 //============================================================================//
 class Constant_Expression : public Expression {
@@ -57,17 +54,15 @@ public:
 
   // ACCESSORS
 
-  /*virtual*/ bool is_constant() const override { return true; }
+  bool is_constant() const override { return true; }
 
 private:
   // IMPLEMENTATION
 
-  /*virtual*/ double evaluate_(double const *const) const override {
-    return units().conv;
-  }
+  double evaluate_(double const *const) const override { return units().conv; }
 
-  virtual void write_(Precedence const, vector<string> const &,
-                      ostream &out) const override {
+  void write_(Precedence const, vector<string> const &,
+              ostream &out) const override {
     if (is_compatible(units(), dimensionless)) {
       out << units().conv;
     } else {

--- a/src/parser/Expression.cc
+++ b/src/parser/Expression.cc
@@ -14,8 +14,8 @@
 namespace rtt_parser {
 using namespace rtt_dsxx;
 
-typedef std::shared_ptr<Expression> pE;
-typedef map<string, pair<unsigned, Unit>> Variable_Map;
+using pE = std::shared_ptr<Expression>;
+using Variable_Map = map<string, pair<unsigned, Unit>>;
 
 //----------------------------------------------------------------------------//
 /*!
@@ -896,7 +896,7 @@ static pE parse_primary(unsigned const number_of_variables,
     } else
     // a variable or constant name
     {
-      Variable_Map::const_iterator i = variable_map.find(variable.text());
+      auto i = variable_map.find(variable.text());
       if (i != variable_map.end()) {
         retvalue = pE(new Variable_Expression(
             i->second.first, number_of_variables,
@@ -981,7 +981,7 @@ static pE parse_power(unsigned const number_of_variables,
       tokens.report_semantic_error("base of non-constant exponent must"
                                    " be dimensionless");
     } else {
-      Result.reset(new Power_Expression(Result, exponent));
+      Result = std::make_shared<Power_Expression>(Result, exponent);
     }
   }
   return Result;
@@ -1015,13 +1015,13 @@ static pE parse_multiplicative(unsigned const number_of_variables,
   while (tokens.lookahead().text() == "*" || tokens.lookahead().text() == "/") {
     if (tokens.lookahead().text() == "*") {
       tokens.shift();
-      Result.reset(new Product_Expression(
-          Result, parse_unary(number_of_variables, variable_map, tokens)));
+      Result = std::make_shared<Product_Expression>(
+          Result, parse_unary(number_of_variables, variable_map, tokens));
     } else {
       Check(tokens.lookahead().text() == "/");
       tokens.shift();
-      Result.reset(new Quotient_Expression(
-          Result, parse_unary(number_of_variables, variable_map, tokens)));
+      Result = std::make_shared<Quotient_Expression>(
+          Result, parse_unary(number_of_variables, variable_map, tokens));
     }
   }
   return Result;
@@ -1040,7 +1040,7 @@ static pE parse_additive(unsigned const number_of_variables,
       if (!is_compatible(Result->units(), Right->units())) {
         tokens.report_semantic_error("unit incompatibility for + operator");
       } else {
-        Result.reset(new Sum_Expression(Result, Right));
+        Result = std::make_shared<Sum_Expression>(Result, Right);
       }
     } else {
       Check(tokens.lookahead().text() == "-");
@@ -1050,7 +1050,7 @@ static pE parse_additive(unsigned const number_of_variables,
       if (!is_compatible(Result->units(), Right->units())) {
         tokens.report_semantic_error("unit incompatibility for - operator");
       } else {
-        Result.reset(new Difference_Expression(Result, Right));
+        Result = std::make_shared<Difference_Expression>(Result, Right);
       }
     }
   }
@@ -1073,7 +1073,7 @@ static pE parse_relational(unsigned const number_of_variables,
       if (!is_compatible(Result->units(), Right->units())) {
         tokens.report_semantic_error("unit incompatibility for <");
       } else {
-        Result.reset(new Less_Expression(Result, Right));
+        Result = std::make_shared<Less_Expression>(Result, Right);
       }
     } else if (token.text() == "<=") {
       tokens.shift();
@@ -1082,7 +1082,7 @@ static pE parse_relational(unsigned const number_of_variables,
       if (!is_compatible(Result->units(), Right->units())) {
         tokens.report_semantic_error("unit incompatibility for <=");
       } else {
-        Result.reset(new LE_Expression(Result, Right));
+        Result = std::make_shared<LE_Expression>(Result, Right);
       }
     } else if (token.text() == ">") {
       tokens.shift();
@@ -1091,7 +1091,7 @@ static pE parse_relational(unsigned const number_of_variables,
       if (!is_compatible(Result->units(), Right->units())) {
         tokens.report_semantic_error("unit incompatibility for >");
       } else {
-        Result.reset(new Greater_Expression(Result, Right));
+        Result = std::make_shared<Greater_Expression>(Result, Right);
       }
     } else {
       Check(token.text() == ">=");
@@ -1101,7 +1101,7 @@ static pE parse_relational(unsigned const number_of_variables,
       if (!is_compatible(Result->units(), Right->units())) {
         tokens.report_semantic_error("unit incompatibility for >=");
       } else {
-        Result.reset(new GE_Expression(Result, Right));
+        Result = std::make_shared<GE_Expression>(Result, Right);
       }
     }
     token = tokens.lookahead();
@@ -1115,8 +1115,8 @@ static pE parse_and(unsigned const number_of_variables,
   pE Result = parse_relational(number_of_variables, variable_map, tokens);
   while (tokens.lookahead().text() == "&&") {
     tokens.shift();
-    Result.reset(new And_Expression(
-        Result, parse_relational(number_of_variables, variable_map, tokens)));
+    Result = std::make_shared<And_Expression>(
+        Result, parse_relational(number_of_variables, variable_map, tokens));
   }
   return Result;
 }
@@ -1127,8 +1127,8 @@ static pE parse_or(unsigned const number_of_variables,
   pE Result = parse_and(number_of_variables, variable_map, tokens);
   while (tokens.lookahead().text() == "||") {
     tokens.shift();
-    Result.reset(new Or_Expression(
-        Result, parse_and(number_of_variables, variable_map, tokens)));
+    Result = std::make_shared<Or_Expression>(
+        Result, parse_and(number_of_variables, variable_map, tokens));
   }
   return Result;
 }
@@ -1180,8 +1180,8 @@ Expression::parse(unsigned const number_of_variables,
       parse_or(number_of_variables, variable_map, tokens);
   while (tokens.lookahead().text() == "|") {
     tokens.shift();
-    Result.reset(new Or_Expression(
-        Result, parse_or(number_of_variables, variable_map, tokens)));
+    Result = std::make_shared<Or_Expression>(
+        Result, parse_or(number_of_variables, variable_map, tokens));
   }
   return Result;
 }
@@ -1224,8 +1224,8 @@ Expression::parse(unsigned const number_of_variables,
       parse_or(number_of_variables, variable_map, tokens);
   while (tokens.lookahead().text() == "|") {
     tokens.shift();
-    Result.reset(new Or_Expression(
-        Result, parse_or(number_of_variables, variable_map, tokens)));
+    Result = std::make_shared<Or_Expression>(
+        Result, parse_or(number_of_variables, variable_map, tokens));
   }
   if (unit_expressions_are_required() ||
       !is_compatible(Result->units(), dimensionless)) {

--- a/src/parser/Expression.hh
+++ b/src/parser/Expression.hh
@@ -88,7 +88,7 @@ public:
   // CREATORS
 
   //! Destructor.
-  virtual ~Expression() {}
+  virtual ~Expression() = default;
 
   // MANIPULATORS
 

--- a/src/parser/File_Token_Stream.cc
+++ b/src/parser/File_Token_Stream.cc
@@ -17,17 +17,16 @@ using namespace std;
 
 //----------------------------------------------------------------------------//
 /*!
- * Construct a File_Token_Stream that is not yet associated with a file. Use
- * the default Text_Token_Stream user-defined whitespace characters.
+ * Construct a File_Token_Stream that is not yet associated with a file. Use the
+ * default Text_Token_Stream user-defined whitespace characters.
  *
  * This function exists primarily to support construction of arrays of
  * File_Token_Streams.  An example of where this might be useful is in serial
- * code that combines output files produced by each processor in a parallel
- * run.
+ * code that combines output files produced by each processor in a parallel run.
  */
-File_Token_Stream::File_Token_Stream(void) : letters_(), letter_(nullptr) {
+File_Token_Stream::File_Token_Stream() : letters_(), letter_(nullptr) {
   Ensure(check_class_invariants());
-  Ensure(location_() == "<uninitialized>");
+  Ensure(File_Token_Stream::location_() == "<uninitialized>");
 }
 
 //----------------------------------------------------------------------------//
@@ -45,14 +44,14 @@ File_Token_Stream::File_Token_Stream(void) : letters_(), letter_(nullptr) {
 File_Token_Stream::File_Token_Stream(string const &file_name)
     : letters_(), letter_(make_shared<letter>(file_name)) {
   Ensure(check_class_invariants());
-  Ensure(location_() == file_name + ", line 1");
+  Ensure(File_Token_Stream::location_() == file_name + ", line 1");
 }
 
-//-------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- * Construct a File_Token_Stream::letter that derives its text from the specified
- * file. If the file cannot be opened, then \c error() will test true. Use the
- * default Text_Token_Stream user-defined whitespace characters.
+ * Construct a File_Token_Stream::letter that derives its text from the
+ * specified file. If the file cannot be opened, then \c error() will test
+ * true. Use the default Text_Token_Stream user-defined whitespace characters.
  *
  * \param file_name Name of the file from which to extract tokens.
  *
@@ -75,9 +74,8 @@ File_Token_Stream::letter::letter(string const &file_name)
 
 //----------------------------------------------------------------------------//
 /*!
- * \brief Construct a File_Token_Stream that derives its text from the
- *        specified file. If the file cannot be opened, then \c error() will
- *        test true.
+ * \brief Construct a File_Token_Stream that derives its text from the specified
+ *        file. If the file cannot be opened, then \c error() will test true.
  *
  * \param file_name Name of the file from which to extract tokens.
  *
@@ -95,8 +93,8 @@ File_Token_Stream::File_Token_Stream(string const &file_name,
     : Text_Token_Stream(ws, no_nonbreaking_ws), letters_(),
       letter_(make_shared<letter>(file_name)) {
   Ensure(check_class_invariants());
-  Ensure(location_() == file_name + ", line 1");
-  Ensure(whitespace() == ws);
+  Ensure(File_Token_Stream::location_() == file_name + ", line 1");
+  Ensure(File_Token_Stream::whitespace() == ws);
   Ensure(this->no_nonbreaking_ws() == no_nonbreaking_ws);
 }
 
@@ -124,7 +122,7 @@ void File_Token_Stream::letter::open_() {
   Ensure(check_class_invariants());
 }
 
-//---------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Attach the File_Token_Stream to a different file.
  *
@@ -133,7 +131,6 @@ void File_Token_Stream::letter::open_() {
  *
  * \throw invalid_argument If the input stream cannot be opened.
  */
-
 void File_Token_Stream::open(string const &file_name) {
   while (!letters_.empty())
     letters_.pop();
@@ -153,7 +150,6 @@ void File_Token_Stream::open(string const &file_name) {
  *
  * \return A string of the form "filename, line #"
  */
-
 string File_Token_Stream::location_() const {
   ostringstream Result;
   if (letter_ != nullptr) {
@@ -169,7 +165,6 @@ string File_Token_Stream::location_() const {
  * \brief This function moves the next character in the file stream into the
  *         character buffer.
  */
-
 void File_Token_Stream::fill_character_buffer_() {
   if (letter_ != nullptr) {
     char const c = static_cast<char>(letter_->infile_.get());
@@ -192,7 +187,6 @@ void File_Token_Stream::fill_character_buffer_() {
  *
  * \return \c true if an error has occured; \c false otherwise.
  */
-
 bool File_Token_Stream::error_() const {
   return letter_ != nullptr ? letter_->infile_.fail() : false;
 }
@@ -205,7 +199,6 @@ bool File_Token_Stream::error_() const {
  * \return \c true if the end of the text file has been reached; \c false
  * otherwise.
  */
-
 bool File_Token_Stream::end_() const {
   return letter_ != nullptr ? letter_->infile_.eof() : true;
 }
@@ -223,7 +216,6 @@ void File_Token_Stream::report(Token const &token, string const &message) {
  * This function sends a message by writing it to the error console stream.
  * This version assumes that the cursor gives the correct error location.
  */
-
 void File_Token_Stream::report(string const &message) {
   Token const token = lookahead();
   cerr << token.location() << ": " << message << endl;
@@ -236,7 +228,6 @@ void File_Token_Stream::report(string const &message) {
  * This function sends a message by writing it to the error console stream.
  * This version prints no location information.
  */
-
 void File_Token_Stream::comment(string const &message) {
   cerr << message << endl;
 
@@ -245,11 +236,10 @@ void File_Token_Stream::comment(string const &message) {
 
 //----------------------------------------------------------------------------//
 /*!
- * This function rewinds the file stream associated with the file token
- * stream and flushes its internal buffers, so that scanning resumes at
- * the beginning of the file stream. The error count is also reset.
+ * This function rewinds the file stream associated with the file token stream
+ * and flushes its internal buffers, so that scanning resumes at the beginning
+ * of the file stream. The error count is also reset.
  */
-
 void File_Token_Stream::rewind() {
   while (!letters_.empty()) {
     letter_ = letters_.top();
@@ -263,13 +253,12 @@ void File_Token_Stream::rewind() {
   Ensure(check_class_invariants());
 }
 
-//-------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- * This function rewinds the file stream associated with the file token
- * stream and flushes its internal buffers, so that scanning resumes at
- * the beginning of the file stream. The error count is also reset.
+ * This function rewinds the file stream associated with the file token stream
+ * and flushes its internal buffers, so that scanning resumes at the beginning
+ * of the file stream. The error count is also reset.
  */
-
 void File_Token_Stream::letter::rewind() {
   infile_.clear(); // Must clear the error/end flag bits.
   infile_.seekg(0);

--- a/src/parser/File_Token_Stream.hh
+++ b/src/parser/File_Token_Stream.hh
@@ -18,15 +18,15 @@ using std::ifstream;
 using std::set;
 using std::string;
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief File-based token stream
  *
- * File_Token_Stream represents a text token stream that derives its text
- * stream from a file in the file system.  It reports errors to the standard
- * console error stream \c cerr.
+ * File_Token_Stream represents a text token stream that derives its text stream
+ * from a file in the file system.  It reports errors to the standard console
+ * error stream \c cerr.
  */
-class DLL_PUBLIC_parser File_Token_Stream : public Text_Token_Stream {
+class File_Token_Stream : public Text_Token_Stream {
 public:
   // CREATORS
 
@@ -45,25 +45,25 @@ public:
   //! Attach the File_Token_Stream to a file.
   void open(string const &filename);
 
-  virtual void rewind();
+  void rewind() override;
 
-  virtual void report(Token const &token, string const &message);
+  void report(Token const &token, string const &message) override;
 
-  virtual void report(string const &message);
+  void report(string const &message) override;
 
-  virtual void comment(std::string const &message);
+  void comment(std::string const &message) override;
 
 protected:
   // IMPLEMENTATION
 
-  virtual string location_() const;
+  string location_() const override;
 
-  virtual void fill_character_buffer_();
-  virtual bool error_() const;
-  virtual bool end_() const;
+  void fill_character_buffer_() override;
+  bool error_() const override;
+  bool end_() const override;
 
-  virtual void push_include(std::string &file_name);
-  virtual void pop_include();
+  void push_include(std::string &file_name) override;
+  void pop_include() override;
 
 private:
   struct letter {

--- a/src/parser/Parallel_File_Token_Stream.hh
+++ b/src/parser/Parallel_File_Token_Stream.hh
@@ -19,20 +19,18 @@ using std::ifstream;
 using std::set;
 using std::string;
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Parallel file-based token stream
  *
- * \c Parallel_File_Token_Stream is similar to \c File_Token_Stream. However,
- * it assumes an SPMD (Single Program, Multiple Data) run environment. Only
- * the designated I/O processor (normally processor 0) actually reads the
- * file. The characters read are then broadcast to the other processors. The
- * advantage of parallelism at this level is that it avoids the I/O cost of
- * many processors reading one file while communicating data that is still
- * very flat.
+ * \c Parallel_File_Token_Stream is similar to \c File_Token_Stream. However, it
+ * assumes an SPMD (Single Program, Multiple Data) run environment. Only the
+ * designated I/O processor (normally processor 0) actually reads the file. The
+ * characters read are then broadcast to the other processors. The advantage of
+ * parallelism at this level is that it avoids the I/O cost of many processors
+ * reading one file while communicating data that is still very flat.
  */
-
-class DLL_PUBLIC_parser Parallel_File_Token_Stream : public Text_Token_Stream {
+class Parallel_File_Token_Stream : public Text_Token_Stream {
 public:
   // CREATORS
 
@@ -51,16 +49,16 @@ public:
   void open(string const &filename);
 
   //! Rewind the Parallel_File_Token_Stream.
-  virtual void rewind();
+  void rewind() override;
 
   //! Report a condition.
-  virtual void report(Token const &token, string const &message);
+  void report(Token const &token, string const &message) override;
 
   //! Report a condition.
-  virtual void report(string const &message);
+  void report(string const &message) override;
 
   //! Report a comment.
-  virtual void comment(std::string const &message);
+  void comment(std::string const &message) override;
 
   // ACCESSORS
 
@@ -70,15 +68,15 @@ public:
 protected:
   // IMPLEMENTATION
 
-  virtual string location_() const;
+  string location_() const override;
 
-  virtual void fill_character_buffer_();
+  void fill_character_buffer_() override;
 
-  virtual bool error_() const;
-  virtual bool end_() const;
+  bool error_() const override;
+  bool end_() const override;
 
-  virtual void push_include(std::string &include_file_name);
-  virtual void pop_include();
+  void push_include(std::string &include_file_name) override;
+  void pop_include() override;
 
 private:
   // NESTED TYPES
@@ -87,7 +85,7 @@ private:
     // IMPLEMENTATION
 
     //! Constructor
-    letter(string const &file_name);
+    letter(string file_name);
 
     bool check_class_invariants() const;
 

--- a/src/parser/Parse_Table.hh
+++ b/src/parser/Parse_Table.hh
@@ -15,7 +15,7 @@
 #include <vector>
 
 namespace rtt_parser {
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Structure to describe a parser keyword.
  *
@@ -34,12 +34,12 @@ struct Keyword {
   /*! \brief The keyword moniker.
    *
    * The moniker should be a sequence of valid C++ identifiers separated by a
-   * single space.  For example, <CODE>"WORD"</CODE>, <CODE>"First_Word
-   * Second_Word"</CODE>, and <CODE>"B1 T2 T3"</CODE> are all valid Keyword
-   * monikers.  Identifiers beginning with an underscore are permitted but may
-   * be reserved for internal use by frameworks that uses the Parse_Table
-   * services. A Parse_Table attempts to match input to the monikers in its
-   * Keyword table according to a set of rules stored in the Parse_Table (q.v.)
+   * single space.  For example, \c "WORD", <tt>"First_Word Second_Word"</tt>,
+   * and <tt>"B1 T2 T3"</tt> are all valid Keyword monikers.  Identifiers
+   * beginning with an underscore are permitted but may be reserved for internal
+   * use by frameworks that uses the Parse_Table services. A Parse_Table
+   * attempts to match input to the monikers in its Keyword table according to a
+   * set of rules stored in the Parse_Table (q.v.)
    */
   char const *moniker = {nullptr};
 
@@ -76,11 +76,10 @@ struct Keyword {
    * This member is significant only if certain options are set in the
    * Parse_Table.  It is used to support parsing in frameworks that support
    * self-registering modules.  Such modules often need to add keywords to
-   * existing Parse_Tables, and the <CODE>module</CODE> member is useful for
-   * identifying the module from which a particular keyword in a table
-   * originated.  This is particularly important for diagnosing keyword clashes,
-   * where two modules have registered keywords with the same moniker in the
-   * same Parse_Table.
+   * existing Parse_Tables, and the \c module member is useful for identifying
+   * the module from which a particular keyword in a table originated.  This is
+   * particularly important for diagnosing keyword clashes, where two modules
+   * have registered keywords with the same moniker in the same Parse_Table.
    */
   char const *module = {nullptr};
 
@@ -102,7 +101,7 @@ struct Keyword {
         description(description_in) {}
 };
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Simple keyword-matching parse table
  *
@@ -148,7 +147,6 @@ struct Keyword {
  * will never see such a token.  A console stream can choose to convert an
  * endline or other terminator to a semicolon token to force processing.
  */
-
 class Parse_Table {
 public:
   // TYPEDEFS AND ENUMERATIONS
@@ -163,7 +161,7 @@ public:
   // CREATORS
 
   //! Create an empty Parse_Table.
-  Parse_Table() = default;
+  Parse_Table() : vec(0), flags_(0) {} // NOLINT
 
   //! Construct a parse table with the specified keywords.
   Parse_Table(Keyword const *table, size_t count, unsigned flags = 0);
@@ -210,14 +208,13 @@ public:
 private:
   // TYPEDEFS AND ENUMERATIONS
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*!
    * \brief Ordering functor for Keyword
    *
    * Provides an ordering for Keyword compatible with STL sort and search
    * routines.
    */
-
   class Keyword_Compare_ {
   public:
     Keyword_Compare_(unsigned char flags);
@@ -262,7 +259,6 @@ private:
  *      a.index == b.index &&
  *	a.module == b.module </code>
  */
-
 inline bool operator==(Keyword const &a, Keyword const &b) {
   return strcmp(a.moniker, b.moniker) == 0 && a.func == b.func &&
          a.index == b.index && strcmp(a.module, b.module) == 0;
@@ -270,7 +266,6 @@ inline bool operator==(Keyword const &a, Keyword const &b) {
 
 //----------------------------------------------------------------------------//
 //! Check whether a keyword is well-formed.
-
 bool Is_Well_Formed_Keyword(Keyword const &key);
 
 } // namespace rtt_parser

--- a/src/parser/Parse_Table.hh
+++ b/src/parser/Parse_Table.hh
@@ -20,8 +20,7 @@ namespace rtt_parser {
  * \brief Structure to describe a parser keyword.
  *
  * A Keyword describes a keyword in a Parse_Table.  It is a POD struct so that
- * it can be initialized using the low-level C++ initialization construct,
- * e.g.,
+ * it can be initialized using the low-level C++ initialization construct, e.g.,
  *
  * \code
  *   Keyword my_table[] = {{"FIRST",  Parse_First,  0, "TestModule"},
@@ -33,72 +32,68 @@ namespace rtt_parser {
  */
 struct Keyword {
   /*! \brief The keyword moniker.
-     *
-     * The moniker should be a sequence of valid C++ identifiers separated by
-     * a single space.  For example, <CODE>"WORD"</CODE>, <CODE>"First_Word
-     * Second_Word"</CODE>, and <CODE>"B1 T2 T3"</CODE> are all valid Keyword
-     * monikers.  Identifiers beginning with an underscore are permitted but
-     * may be reserved for internal use by frameworks that uses the
-     * Parse_Table services. A Parse_Table attempts to match input to the
-     * monikers in its Keyword table according to a set of rules stored in the
-     * Parse_Table (q.v.)
-     */
-  char const *moniker;
+   *
+   * The moniker should be a sequence of valid C++ identifiers separated by a
+   * single space.  For example, <CODE>"WORD"</CODE>, <CODE>"First_Word
+   * Second_Word"</CODE>, and <CODE>"B1 T2 T3"</CODE> are all valid Keyword
+   * monikers.  Identifiers beginning with an underscore are permitted but may
+   * be reserved for internal use by frameworks that uses the Parse_Table
+   * services. A Parse_Table attempts to match input to the monikers in its
+   * Keyword table according to a set of rules stored in the Parse_Table (q.v.)
+   */
+  char const *moniker = {nullptr};
 
   /*! \brief The keyword parsing function.
-     *
-     * When a Parse_Table finds a match to a moniker in its keyword table, the
-     * corresponding parse function is called. The parse function may read
-     * additional tokens from the input Token_Stream, such as a parameter
-     * value or an entire keyword block, before returning control to the
-     * Parse_Table.
-     *
-     * \param stream
-     * The token stream currently being parsed.
-     *
-     * \param index
-     * An integer argument that optionally allows a single parse function to
-     * handle a set of related keywords. The
-     */
-  void (*func)(Token_Stream &stream, int index);
+   *
+   * When a Parse_Table finds a match to a moniker in its keyword table, the
+   * corresponding parse function is called. The parse function may read
+   * additional tokens from the input Token_Stream, such as a parameter value or
+   * an entire keyword block, before returning control to the Parse_Table.
+   *
+   * \param stream
+   * The token stream currently being parsed.
+   *
+   * \param index
+   * An integer argument that optionally allows a single parse function to
+   * handle a set of related keywords. The
+   */
+  void (*func)(Token_Stream &stream, int index) = {nullptr};
 
   /*! \brief The index argument to the parse function.
-     *
-     * This is the index value that is passed to the parse function when the
-     * Parse_Table finds a match to the keyword moniker. The parse function is
-     * not required to make any use of this argument, but it can be convenient
-     * at times to use the same parse function for closely related keywords
-     * and use the index argument to make the distinction.  For example, an
-     * enumerated or Boolean option may be set using a single parse function
-     * that simply copies the index argument to the option variable.
-     */
-  int index;
+   *
+   * This is the index value that is passed to the parse function when the
+   * Parse_Table finds a match to the keyword moniker. The parse function is not
+   * required to make any use of this argument, but it can be convenient at
+   * times to use the same parse function for closely related keywords and use
+   * the index argument to make the distinction.  For example, an enumerated or
+   * Boolean option may be set using a single parse function that simply copies
+   * the index argument to the option variable.
+   */
+  int index = {0};
 
   /*! Name of the module that supplied the keyword.
-     *
-     * This member is significant only if certain options are set in the
-     * Parse_Table.  It is used to support parsing in frameworks that support
-     * self-registering modules.  Such modules often need to add keywords to
-     * existing Parse_Tables, and the <CODE>module</CODE> member is useful for
-     * identifying the module from which a particular keyword in a table
-     * originated.  This is particularly important for diagnosing keyword
-     * clashes, where two modules have registered keywords with the same
-     * moniker in the same Parse_Table.
-     */
-  char const *module;
+   *
+   * This member is significant only if certain options are set in the
+   * Parse_Table.  It is used to support parsing in frameworks that support
+   * self-registering modules.  Such modules often need to add keywords to
+   * existing Parse_Tables, and the <CODE>module</CODE> member is useful for
+   * identifying the module from which a particular keyword in a table
+   * originated.  This is particularly important for diagnosing keyword clashes,
+   * where two modules have registered keywords with the same moniker in the
+   * same Parse_Table.
+   */
+  char const *module = {nullptr};
 
   /*! Explanation of keyword.
    *
-   * This optional member is a brief description of the keyword. If the
-   * parser sees a keyword in the Token_Stream that it does not recognize,
-   * it will list the recognized keywords and, if a keyword has a non-null
-   * description, it will print that description.
+   * This optional member is a brief description of the keyword. If the parser
+   * sees a keyword in the Token_Stream that it does not recognize, it will list
+   * the recognized keywords and, if a keyword has a non-null description, it
+   * will print that description.
    */
-  char const *description;
+  char const *description = {nullptr};
 
-  Keyword()
-      : moniker(nullptr), func(nullptr), index(0), module(nullptr),
-        description(nullptr) {}
+  Keyword() = default;
 
   Keyword(char const *moniker_in, void (*func_in)(Token_Stream &, int),
           int const index_in, char const *module_in,
@@ -111,56 +106,50 @@ struct Keyword {
 /*!
  * \brief Simple keyword-matching parse table
  *
- * A Parse_Table is a table of keywords and associated parsing functions.
- * It accepts tokens from a Token_Stream, matching the keywords in the
- * Token_Stream to its table and dispatching control to the corresponding
- * parsing functions.  The parsing functions can take additional
- * tokens, such as parameter values, from the Token_Stream prior to
- * returning control to the Parse_Table.
+ * A Parse_Table is a table of keywords and associated parsing functions.  It
+ * accepts tokens from a Token_Stream, matching the keywords in the Token_Stream
+ * to its table and dispatching control to the corresponding parsing functions.
+ * The parsing functions can take additional tokens, such as parameter values,
+ * from the Token_Stream prior to returning control to the Parse_Table.
  *
- * How a Parse_Table determines whether an input keyword token matches a
- * keyword moniker in its Keyword table is determined by a set of flags.
- * By default, a Parse_Table is case-sensitive and requires each
- * identifier in the keyword token to exactly  match the corresponding
- * identifier in the keyword moniker.  However, a Parse_Table may be
- * instructed to ignore case or to accept a partial match on each
- * identifier.  These options are described in more detail in connection with
- * the Set_Flags member function and the Keyword_Compare member functions.
+ * How a Parse_Table determines whether an input keyword token matches a keyword
+ * moniker in its Keyword table is determined by a set of flags.  By default, a
+ * Parse_Table is case-sensitive and requires each identifier in the keyword
+ * token to exactly match the corresponding identifier in the keyword moniker.
+ * However, a Parse_Table may be instructed to ignore case or to accept a
+ * partial match on each identifier.  These options are described in more detail
+ * in connection with the Set_Flags member function and the Keyword_Compare
+ * member functions.
  *
- * When the Parse_Table fails to match an input keyword to its keyword
- * table, or when the input token is not a keyword, END, EXIT,
- * or ERROR, the parse table reports an error, then attempts recovery
- * by reading additional tokens until it encounters either a keyword
- * it recognizes or an END, EXIT, or ERROR.  During this recovery, no
- * additional errors are reported, to avoid swamping the user with
- * additional messages that are unlikely to be helpful.  If recovery
- * is successful (a keyword is recognized in the token stream) parsing
+ * When the Parse_Table fails to match an input keyword to its keyword table, or
+ * when the input token is not a keyword, END, EXIT, or ERROR, the parse table
+ * reports an error, then attempts recovery by reading additional tokens until
+ * it encounters either a keyword it recognizes or an END, EXIT, or ERROR.
+ * During this recovery, no additional errors are reported, to avoid swamping
+ * the user with additional messages that are unlikely to be helpful.  If
+ * recovery is successful (a keyword is recognized in the token stream) parsing
  * resumes as normal.
  *
- * User parse routines may also encounter errors.  These may be reported
- * to the Token_Stream through either the Report_Syntax_Error or
- * Report_Semantic_Error functions.  The former is used when there is
- * an error in the input syntax, as when a keyword is encountered when
- * a numerical value is expected.  In this case, an exception is thrown
- * that is caught by the Parse_Table, which then attempts error recovery
- * as described above.  The Report_Semantic_Error indicates syntactically
- * correct input that is nonetheless unacceptable, as when a numerical
- * value appears where it is expected but violates some constraint, such
- * as positivity.  The error is reported but input processing is not
- * interrupted.
+ * User parse routines may also encounter errors.  These may be reported to the
+ * Token_Stream through either the Report_Syntax_Error or Report_Semantic_Error
+ * functions.  The former is used when there is an error in the input syntax, as
+ * when a keyword is encountered when a numerical value is expected.  In this
+ * case, an exception is thrown that is caught by the Parse_Table, which then
+ * attempts error recovery as described above.  The Report_Semantic_Error
+ * indicates syntactically correct input that is nonetheless unacceptable, as
+ * when a numerical value appears where it is expected but violates some
+ * constraint, such as positivity.  The error is reported but input processing
+ * is not interrupted.
  *
- * For parsers designed to receive input from the console, the default
- * behavior just described is not entirely appropriate. Console parsers are
- * supported by treating any OTHER token whose text character is a semicolon
- * as an empty keyword.  By default, semicolons are treated as whitespace and
- * the parser will never see such a token.  A console stream can choose to
- * convert an endline or other terminator to a semicolon token to force
- * processing.
+ * For parsers designed to receive input from the console, the default behavior
+ * just described is not entirely appropriate. Console parsers are supported by
+ * treating any OTHER token whose text character is a semicolon as an empty
+ * keyword.  By default, semicolons are treated as whitespace and the parser
+ * will never see such a token.  A console stream can choose to convert an
+ * endline or other terminator to a semicolon token to force processing.
  */
 
-class DLL_PUBLIC_parser Parse_Table
-//    : private std::vector<Keyword>
-{
+class Parse_Table {
 public:
   // TYPEDEFS AND ENUMERATIONS
 
@@ -174,15 +163,13 @@ public:
   // CREATORS
 
   //! Create an empty Parse_Table.
-  Parse_Table(void) : vec(0), flags_(0) { /* empty */
-  }
+  Parse_Table() = default;
 
   //! Construct a parse table with the specified keywords.
   Parse_Table(Keyword const *table, size_t count, unsigned flags = 0);
 
   //! This class is meant to be heritable.
-  virtual ~Parse_Table(void) { /* empty */
-  }
+  virtual ~Parse_Table() = default;
 
   // MANIPULATORS
 
@@ -196,7 +183,6 @@ public:
   void remove(char const *);
 
   //! Request a change in capacity.
-  // using std::vector<Keyword>::reserve;
   void reserve(std::vector<Keyword>::size_type n) { vec.reserve(n); }
 
   //! Set parser options.
@@ -205,7 +191,6 @@ public:
   // ACCESSORS
 
   //! Return the number of elements in the vector
-  // using std::vector<Keyword>::size;
   std::vector<Keyword>::size_type size() const { return vec.size(); }
 
   //! Return the current parser options.
@@ -227,11 +212,11 @@ private:
 
   //-----------------------------------------------------------------------//
   /*!
-     * \brief Ordering functor for Keyword
-     *
-     * Provides an ordering for Keyword compatible with STL sort and search
-     * routines.
-     */
+   * \brief Ordering functor for Keyword
+   *
+   * Provides an ordering for Keyword compatible with STL sort and search
+   * routines.
+   */
 
   class Keyword_Compare_ {
   public:
@@ -264,9 +249,8 @@ private:
  * \brief Test equality of Keywords
  *
  * Tests equality of two Keyword structs. Note that this is strict equality,
- * which differs from the comparison offered by the
- * Parse_Table::Keyword_Compare predicate class. It is used primarily for
- * checking assertions.
+ * which differs from the comparison offered by the Parse_Table::Keyword_Compare
+ * predicate class. It is used primarily for checking assertions.
  *
  * \param a
  * First keyword to be compared.
@@ -287,7 +271,7 @@ inline bool operator==(Keyword const &a, Keyword const &b) {
 //----------------------------------------------------------------------------//
 //! Check whether a keyword is well-formed.
 
-DLL_PUBLIC_parser bool Is_Well_Formed_Keyword(Keyword const &key);
+bool Is_Well_Formed_Keyword(Keyword const &key);
 
 } // namespace rtt_parser
 

--- a/src/parser/String_Token_Stream.cc
+++ b/src/parser/String_Token_Stream.cc
@@ -74,7 +74,7 @@ String_Token_Stream::String_Token_Stream(string const &text,
 //----------------------------------------------------------------------------//
 /*!
  * This function constructs and returns a string of the form "near \<text\>"
- * where \<text\> reproduces the region of text where the last token was 
+ * where \<text\> reproduces the region of text where the last token was
  * parsed. This is useful for error reporting in parsers.
  *
  * \return A string of the form "near <text>"
@@ -90,7 +90,7 @@ string String_Token_Stream::location_() const {
     }
   }
   Check(text_.size() < UINT_MAX);
-  unsigned const end = static_cast<unsigned>(text_.size());
+  auto const end = static_cast<unsigned>(text_.size());
   unsigned i;
   for (i = begin; i < end; ++i) {
     char const c = text_[i];

--- a/src/parser/String_Token_Stream.hh
+++ b/src/parser/String_Token_Stream.hh
@@ -4,10 +4,7 @@
  * \author Kent G. Budge
  * \brief  Definition of class String_Token_Stream.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #ifndef rtt_String_Token_Stream_HH
@@ -20,7 +17,7 @@ namespace rtt_parser {
 using std::set;
 using std::string;
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief std::string-based token stream
  *
@@ -28,8 +25,7 @@ using std::string;
  * std::string passed to the constructor. The diagnostic output is directed to
  * an internal string that can be retrieved at will.
  */
-
-class DLL_PUBLIC_parser String_Token_Stream : public Text_Token_Stream {
+class String_Token_Stream : public Text_Token_Stream {
 public:
   // CREATORS
 
@@ -46,16 +42,16 @@ public:
   // MANIPULATORS
 
   // Return to the start of the string.
-  void rewind();
+  void rewind() override;
 
   //! Report a condition.
-  virtual void report(Token const &token, string const &message);
+  void report(Token const &token, string const &message) override;
 
   //! Report a condition.
-  virtual void report(string const &message);
+  void report(string const &message) override;
 
   //! Report a comment.
-  virtual void comment(std::string const &message);
+  void comment(std::string const &message) override;
 
   // ACCESSORS
 
@@ -70,15 +66,15 @@ public:
 
 protected:
   //! Generate a locator string.
-  virtual string location_() const;
+  string location_() const override;
 
-  virtual void fill_character_buffer_();
+  void fill_character_buffer_() override;
 
-  virtual bool error_() const;
-  virtual bool end_() const;
+  bool error_() const override;
+  bool end_() const override;
 
-  virtual void push_include(std::string &include_file_name);
-  virtual void pop_include();
+  void push_include(std::string &include_file_name) override;
+  void pop_include() override;
 
 private:
   // IMPLEMENTATION

--- a/src/parser/Text_Token_Stream.cc
+++ b/src/parser/Text_Token_Stream.cc
@@ -9,8 +9,8 @@
 
 #include "Text_Token_Stream.hh"
 #include "ds++/path.hh"
+#include <cctype>
 #include <cstring>
-#include <ctype.h>
 #include <string>
 
 #if defined(MSVC)
@@ -30,10 +30,7 @@ static string give(string &source) {
 }
 
 //----------------------------------------------------------------------------//
-char const default_ws_string[] = "=:;,";
-
-set<char> const Text_Token_Stream::default_whitespace(
-    default_ws_string, default_ws_string + sizeof(default_ws_string));
+set<char> const Text_Token_Stream::default_whitespace = {'=', ':', ';', ','};
 
 //----------------------------------------------------------------------------//
 /*!
@@ -69,8 +66,7 @@ set<char> const Text_Token_Stream::default_whitespace(
  */
 Text_Token_Stream::Text_Token_Stream(set<char> const &ws,
                                      bool const no_nonbreaking_ws)
-    : buffer_(), whitespace_(ws), line_(1),
-      no_nonbreaking_ws_(no_nonbreaking_ws) {
+    : buffer_(), whitespace_(ws), no_nonbreaking_ws_(no_nonbreaking_ws) {
   Ensure(check_class_invariants());
   Ensure(ws == whitespace());
   Ensure(line() == 1);
@@ -86,9 +82,8 @@ Text_Token_Stream::Text_Token_Stream(set<char> const &ws,
  * The default whitespace characters are contained in the set
  * \c Text_Token_Stream::default_whitespace.
  */
-Text_Token_Stream::Text_Token_Stream(void)
-    : buffer_(), whitespace_(default_whitespace), line_(1),
-      no_nonbreaking_ws_(false) {
+Text_Token_Stream::Text_Token_Stream()
+    : buffer_(), whitespace_(default_whitespace) {
   Ensure(check_class_invariants());
   Ensure(whitespace() == default_whitespace);
   Ensure(line() == 1);
@@ -557,11 +552,8 @@ void Text_Token_Stream::eat_whitespace_() {
  * \param c Character to be pushed onto the back of the character queue.
  */
 void Text_Token_Stream::character_push_back_(char const c) {
-  Remember(unsigned const old_buffer__size =
-               static_cast<unsigned>(buffer_.size()));
-
+  Remember(auto const old_buffer__size = static_cast<unsigned>(buffer_.size()));
   buffer_.push_back(c);
-
   Ensure(check_class_invariants());
   Ensure(buffer_.size() == old_buffer__size + 1);
   Ensure(buffer_.back() == c);
@@ -649,10 +641,10 @@ Token Text_Token_Stream::scan_keyword() {
   Require(isalpha(peek_()) || peek_() == '_');
 
   string token_location = location_();
-  char c = peek_();
+  /*char c =*/peek_();
   unsigned cc = 1;
   unsigned ci = 1;
-  c = peek_(ci);
+  char c = peek_(ci);
   do {
     // Scan a C identifier.
     while (isalnum(c) || c == '_') {

--- a/src/parser/Text_Token_Stream.hh
+++ b/src/parser/Text_Token_Stream.hh
@@ -15,7 +15,7 @@
 #include <stack>
 
 namespace rtt_parser {
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Abstract text-based token stream for simple parsers.
  *
@@ -27,7 +27,7 @@ namespace rtt_parser {
  * Null characters are not permitted in the character stream.  They are used
  * internally to indicate the end of file or an error condition.
  */
-class DLL_PUBLIC_parser Text_Token_Stream : public Token_Stream {
+class Text_Token_Stream : public Token_Stream {
 public:
   // ACCESSORS
 
@@ -47,20 +47,20 @@ public:
 
   // MANIPULATORS
 
-  virtual void rewind() = 0;
+  void rewind() override = 0;
 
   // SERVICES
 
   //! Does the Token_Stream consider \c c to be whitespace?
   bool is_whitespace(char c) const;
 
-  //! Does the Token_Stream consider <i>c</i> to be nonbreaking
+  //! Does the Token_Stream consider \e c to be non-breaking
   bool is_nb_whitespace(char c) const;
 
   // CONST DATA
 
   //! The default whitespace definition
-  static std::set<char> const default_whitespace;
+  DLL_PUBLIC_parser static std::set<char> const default_whitespace;
 
 protected:
   // IMPLEMENTATION
@@ -72,7 +72,7 @@ protected:
   Text_Token_Stream(std::set<char> const &, bool no_nonbreaking_ws = false);
 
   //! Scan the next token.
-  virtual Token fill_();
+  Token fill_() override;
 
   //! Push a character onto the back of the character queue.
   void character_push_back_(char c);
@@ -82,16 +82,16 @@ protected:
   virtual void fill_character_buffer_() = 0;
 
   virtual bool error_() const = 0;
-  virtual bool end_(void) const = 0;
-  virtual std::string location_(void) const = 0;
+  virtual bool end_() const = 0;
+  virtual std::string location_() const = 0;
 
   //! Pop a character off the internal buffer.
-  char pop_char_(void);
+  char pop_char_();
   //! Peek ahead at the internal buffer.
   char peek_(unsigned pos = 0);
 
   //! Skip any whitespace at the cursor position.
-  void eat_whitespace_(void);
+  void eat_whitespace_();
 
   //! Enter a nested file in a include directive.
   virtual void push_include(std::string &include_file_name) = 0;
@@ -99,11 +99,11 @@ protected:
   //! Exit a nested file from a include directive.
   virtual void pop_include() = 0;
 
-  // The following scan_ functions are for numeric scanning.  The names
-  // reflect the context-free grammar given by Stroustrup in appendix A
-  // of _The C++ Programming Language_.  However, we do not presently
-  // recognize type suffixes on either integers or floats.
-  unsigned scan_floating_literal_(void);
+  // The following scan_ functions are for numeric scanning.  The names reflect
+  // the context-free grammar given by Stroustrup in appendix A of _The C++
+  // Programming Language_.  However, we do not presently recognize type
+  // suffixes on either integers or floats.
+  unsigned scan_floating_literal_();
   unsigned scan_digit_sequence_(unsigned &);
   unsigned scan_exponent_part_(unsigned &);
   unsigned scan_fractional_constant_(unsigned &);
@@ -133,16 +133,16 @@ private:
 
   std::stack<unsigned> lines_;
   //!< Stack of current line values for nested input files.
-  unsigned line_;
+  unsigned line_{1};
   //!< Current line in input file.
 
-  bool no_nonbreaking_ws_;
+  bool no_nonbreaking_ws_{false};
   //!< Treat all whitespace as breaking whitespace.
 };
 
 } // namespace rtt_parser
 
 #endif // rtt_Text_Token_Stream_HH
-//--------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of Text_Token_Stream.hh
-//--------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/parser/Token.cc
+++ b/src/parser/Token.cc
@@ -8,28 +8,28 @@
 //----------------------------------------------------------------------------//
 
 #include "Token.hh"
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
-#include <ctype.h>
 
 namespace rtt_parser {
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 //! Is the argument a token type that has no associated text?
 bool Is_Text_Token(Token_Type const type) {
   return type != rtt_parser::ERROR && type != EXIT && type != END;
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * Is the argument a valid OTHER text?
  *
- * \return \c true if the argument points to a string of a single character
- * that does not fit any other token type pattern, or if the argument points
- * to a string of two or three characters from a recognized standard set.
+ * \return \c true if the argument points to a string of a single character that
+ * does not fit any other token type pattern, or if the argument points to a
+ * string of two or three characters from a recognized standard set.
  */
 bool Is_Other_Text(char const *text) {
-  Require(text != NULL);
+  Require(text != nullptr);
 
   if (text[0] == 0) {
     return false;
@@ -46,15 +46,15 @@ bool Is_Other_Text(char const *text) {
   }
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * Is the argument a valid keyword?
  *
- * \return \c true if the argument points to a string consisting of a
- * sequence of  C++ identifiers separated by single spaces.
+ * \return \c true if the argument points to a string consisting of a sequence
+ * of C++ identifiers separated by single spaces.
  */
 bool Is_Keyword_Text(char const *text) {
-  Require(text != NULL);
+  Require(text != nullptr);
 
   char c = *text++;
   while (true) {
@@ -70,15 +70,15 @@ bool Is_Keyword_Text(char const *text) {
   }
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * Is the argument a valid string constant?
  *
- * \return \c true if the argument points to a string consisting of a
- * single C++ string constant, including the delimiting quotes.
+ * \return \c true if the argument points to a string consisting of a single C++
+ * string constant, including the delimiting quotes.
  */
 bool Is_String_Text(char const *text) {
-  Require(text != NULL);
+  Require(text != nullptr);
 
   char c = *text++;
   if (c != '"')
@@ -96,30 +96,30 @@ bool Is_String_Text(char const *text) {
   }
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  *  Is the argument a valid real constant?
  *
- * \return \c true if the argument points to a string consisting of a
- * single C++ floating-point constant.
+ * \return \c true if the argument points to a string consisting of a single C++
+ * floating-point constant.
  */
 bool Is_Real_Text(char const *text) {
-  Require(text != NULL);
+  Require(text != nullptr);
 
   char *endtext;
   strtod(text, &endtext);
   return endtext != text && *endtext == '\0';
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * Is the argument a valid integer constanta?
  *
- * \return \c true if the argument points to a string consisting of a
- * single C++ integer constant.
+ * \return \c true if the argument points to a string consisting of a single C++
+ * integer constant.
  */
 bool Is_Integer_Text(char const *text) {
-  Require(text != NULL);
+  Require(text != nullptr);
 
   char *endtext;
   strtol(text, &endtext, 0);
@@ -141,9 +141,9 @@ bool operator==(Token const &a, Token const &b) {
 //----------------------------------------------------------------------------//
 /*!
  * The invariants all reflect the basic requirement that the token text is
- * consistent with the token type.  For example, if the type is REAL, the
- * text must be a valid C representation of a real number, which can be
- * converted to double using atof.
+ * consistent with the token type.  For example, if the type is REAL, the text
+ * must be a valid C representation of a real number, which can be converted to
+ * double using atof.
  *
  * \return \c true if the invariants are all satisfied; \c false otherwise
  */

--- a/src/parser/Token.hh
+++ b/src/parser/Token.hh
@@ -19,21 +19,20 @@
 namespace rtt_parser {
 using std::string;
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Token types recognized by a Token_Stream.
  */
-
 enum Token_Type {
   END,
-  /*!< The identifier <CODE>end</CODE>, denoting that the Parse_Table
-   *   should return control to its client.  Can be used to implement
-   *   nested parse tables.*/
+  /*!< The identifier <CODE>end</CODE>, denoting that the Parse_Table should
+   *   return control to its client.  Can be used to implement nested parse
+   *   tables.*/
 
   EXIT,
-  /*!< Denotes that the end of the Token_Stream has been reached.
-   *   The Token_Stream will continue to return EXIT indefinitely
-   *   once its end has been reached. */
+  /*!< Denotes that the end of the Token_Stream has been reached.  The
+   *   Token_Stream will continue to return EXIT indefinitely once its end has
+   *   been reached. */
 
   KEYWORD,
   /*!< A sequence of one or more C++ identifiers separated by whitespace. */
@@ -48,25 +47,24 @@ enum Token_Type {
   /*!< A valid C++ string constant. */
 
   ERROR,
-  /*!< The error token, indicating something wrong with the token stream.
-   *   For example, a file-based token stream would return this token if
-   *   the file failed to open. */
+  /*!< The error token, indicating something wrong with the token stream.  For
+   *   example, a file-based token stream would return this token if the file
+   *   failed to open. */
 
   OTHER
-  /*! A single character or sequence of characters (such as "==") that does
-   *  not belong to one of the regular token types described above.
+  /*! A single character or sequence of characters (such as "==") that does not
+   *  belong to one of the regular token types described above.
    */
 };
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Description of a token.
  *
- * This class represents a lexical token, for use in simple parsing systems
- * for analysis codes.  The token is characterized by its type, value, and
- * location.
+ * This class represents a lexical token, for use in simple parsing systems for
+ * analysis codes.  The token is characterized by its type, value, and location.
  */
-class DLL_PUBLIC_parser Token {
+class Token {
 public:
   // CREATORS
 
@@ -83,8 +81,7 @@ public:
   inline Token(Token_Type type, string &&text, string &&location);
 
   //! Default constructor
-  inline Token(/*empty*/) : type_(END), text_(), location_() { /* empty */
-  }
+  inline Token() : text_(), location_(){};
 
   // ACCESSORS
 
@@ -109,23 +106,23 @@ public:
   }
 
 private:
-  Token_Type type_; //!< Type of this token
-  string text_;     //!< Text of this token
-  string location_; //!< Location information (such as file and line)
+  Token_Type type_ = {END}; //!< Type of this token
+  string text_;             //!< Text of this token
+  string location_;         //!< Location information (such as file and line)
 };
 
 // For checking of assertions
-DLL_PUBLIC_parser bool Is_Text_Token(Token_Type type);
-DLL_PUBLIC_parser bool Is_Integer_Text(char const *string);
-DLL_PUBLIC_parser bool Is_Keyword_Text(char const *string);
-DLL_PUBLIC_parser bool Is_Real_Text(char const *string);
-DLL_PUBLIC_parser bool Is_String_Text(char const *string);
-DLL_PUBLIC_parser bool Is_Other_Text(char const *string);
+bool Is_Text_Token(Token_Type type);
+bool Is_Integer_Text(char const *string);
+bool Is_Keyword_Text(char const *string);
+bool Is_Real_Text(char const *string);
+bool Is_String_Text(char const *string);
+bool Is_Other_Text(char const *string);
 
 //! Test equality of two Tokens
-DLL_PUBLIC_parser bool operator==(Token const &, Token const &);
+bool operator==(Token const &, Token const &);
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \param type Type of the Token.
  * \param text Text of the Token.
@@ -147,7 +144,7 @@ inline Token::Token(Token_Type const type, string const &text,
   Ensure(this->location() == location);
 }
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * Move version of previous constructor.
  *
@@ -170,7 +167,7 @@ inline Token::Token(Token_Type const type, string &&text, string &&location)
   Ensure(this->location() == location);
 }
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \param c The token text (a single character)
  * \param location The token location.
@@ -185,7 +182,7 @@ inline Token::Token(char const c, string const &location)
   Ensure(this->location() == location);
 }
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \param type Token type to create; must be one of END, EXIT, or ERROR.
  * \param location The token location
@@ -206,6 +203,6 @@ inline Token::Token(Token_Type const type, string const &location)
 
 #endif // rtt_Token_HH
 
-//--------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of Token.hh
-//--------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/parser/Token_Equivalence.cc
+++ b/src/parser/Token_Equivalence.cc
@@ -4,14 +4,14 @@
  * \author Kelly G. Thompson
  * \date Thu Jul 20 9:27:29 MST 2006
  * \brief Provide services for ApplicationUnitTest framework.
- * \note Copyright (C) 2016-2020 Triad National Security, LLC
- */
+ * \note Copyright (C) 2016-2020 Triad National Security, LLC.
+ *       All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "Token_Equivalence.hh"
 #include "ds++/Soft_Equivalence.hh"
+#include <cstdlib>
 #include <sstream>
-#include <stdlib.h>
 #include <string>
 
 namespace rtt_parser {
@@ -79,7 +79,6 @@ void check_token_keyword_value(String_Token_Stream &tokens,
         msg << "Did not find the token " << keyword
             << " in the String_Token_Stream." << std::endl;
         ut.failure(msg.str());
-        done = true;
       }
 
       // Get the actual value.
@@ -138,7 +137,6 @@ void check_token_keyword_value(String_Token_Stream &tokens,
         msg << "Did not find the token " << keyword
             << " in the String_Token_Stream." << std::endl;
         ut.failure(msg.str());
-        done = true;
       }
 
       // Get the actual value.
@@ -164,6 +162,6 @@ void check_token_keyword_value(String_Token_Stream &tokens,
 
 } // namespace rtt_parser
 
-//--------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 // end of Token_Equivalence.cc
-//--------------------------------------------------------------------//
+//----------------------------------------------------------------------------//

--- a/src/parser/Token_Stream.cc
+++ b/src/parser/Token_Stream.cc
@@ -4,14 +4,11 @@
  * \author Kent G. Budge
  * \brief  Definitions of Token_Stream member functions.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "Token_Stream.hh"
-#include <string.h>
+#include <cstring>
 
 namespace rtt_parser {
 using namespace std;
@@ -21,9 +18,8 @@ Syntax_Error::Syntax_Error() : runtime_error("syntax error") {
   Ensure(!strcmp(what(), "syntax error"));
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- *
  * This function returns the token at the cursor position and advance the
  * cursor. It will, if necessary, fill() the token buffer first.
  *
@@ -39,14 +35,13 @@ Token Token_Stream::shift() {
   deq.pop_front();
 
   Ensure(check_class_invariants());
-  // Ensure the cursor advances one place to the right, discarding the
-  // leftmost token.
+  // Ensure the cursor advances one place to the right, discarding the leftmost
+  // token.
   return Result;
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- *
  * This function looks ahead in the token stream without changing the cursor
  * position.  It will, if necessary, fill_() the token buffer first.  If the
  * requested position is at or past the end of the file, an EXIT token will be
@@ -55,8 +50,7 @@ Token Token_Stream::shift() {
  * \param pos Number of tokens to look ahead, with 0 being the token at the
  * cursor position.
  *
- * \return The token at the specified position relative to the
- * cursor.
+ * \return The token at the specified position relative to the cursor.
  */
 Token const &Token_Stream::lookahead(unsigned const pos) {
   while (deq.size() <= pos) {
@@ -67,11 +61,10 @@ Token const &Token_Stream::lookahead(unsigned const pos) {
   return deq[pos];
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- *
- * This function pushes the specified token onto the front of the token
- * stream, so that it is now the token in the lookahead(0) position.
+ * This function pushes the specified token onto the front of the token stream,
+ * so that it is now the token in the lookahead(0) position.
  */
 void Token_Stream::pushback(Token const &token) {
   deq.push_front(token);
@@ -80,9 +73,8 @@ void Token_Stream::pushback(Token const &token) {
   Ensure(lookahead() == token);
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- *
  * The default implementation of this function passes its message on to
  * Report_Error, then throws a Syntax_Error exception.
  *
@@ -103,9 +95,9 @@ void Token_Stream::report_syntax_error(Token const &token,
     error_count_++;
     report(token, message);
   } catch (...) {
-    // An error at this point really hoses us.  It means something went
-    // sour with the reporting mechanism, and there probably isn't much
-    // we can do about it.
+    // An error at this point really hoses us.  It means something went sour
+    // with the reporting mechanism, and there probably isn't much we can do
+    // about it.
     throw std::bad_exception();
   }
 
@@ -113,14 +105,13 @@ void Token_Stream::report_syntax_error(Token const &token,
   throw Syntax_Error();
 }
 
-//-----------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
+ * The default implementation of this function passes its message on to report,
+ * then throws a Syntax_Error exception.
  *
- * The default implementation of this function passes its message on to
- * report, then throws a Syntax_Error exception.
- *
- * A syntax error is a badly formed construct that requires explicit
- * error recovery (including resynchronization) by the parsing software.
+ * A syntax error is a badly formed construct that requires explicit error
+ * recovery (including resynchronization) by the parsing software.
  *
  * This versiona ssumes that the cursor is the location of the error.
  *
@@ -135,24 +126,23 @@ void Token_Stream::report_syntax_error(string const &message) {
     error_count_++;
     report(message);
   } catch (...) {
-    // An error at this point really hoses us.  It means something went
-    // sour with the reporting mechanism, and there probably isn't much
-    // we can do about it.
+    // An error at this point really hoses us.  It means something went sour
+    // with the reporting mechanism, and there probably isn't much we can do
+    // about it.
     throw std::bad_exception();
   }
 
   throw Syntax_Error();
 }
 
-//--------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
- *
- * The default implementation of this function passes its message on to
- * report, then returns.
+ * The default implementation of this function passes its message on to report,
+ * then returns.
  *
  * A semantic error is a well-formed construct that has a bad value.  Because
- * the construct is well-formed, parsing may be able to continue after the
- * error is reported without any explicit recovery by the parsing software.
+ * the construct is well-formed, parsing may be able to continue after the error
+ * is reported without any explicit recovery by the parsing software.
  *
  * \param token
  * Token at which the error occurred.
@@ -169,13 +159,12 @@ void Token_Stream::report_semantic_error(Token const &token,
 
 //----------------------------------------------------------------------------//
 /*!
- *
- * The default implementation of this function passes its message
- * on to report, then returns.
+ * The default implementation of this function passes its message on to report,
+ * then returns.
  *
  * A semantic error is a well-formed construct that has a bad value.  Because
- * the construct is well-formed, parsing may be able to continue after the
- * error is reported without any explicit recovery by the parsing software.
+ * the construct is well-formed, parsing may be able to continue after the error
+ * is reported without any explicit recovery by the parsing software.
  *
  * This version assumes that the cursor is the error location.
  *
@@ -192,12 +181,12 @@ void Token_Stream::report_semantic_error(string const &message) {
 //----------------------------------------------------------------------------//
 /*!
  *
- * The default implementation of this function passes its message on to
- * report, then returns.
+ * The default implementation of this function passes its message on to report,
+ * then returns.
  *
  * A semantic error is a well-formed construct that has a bad value.  Because
- * the construct is well-formed, parsing may be able to continue after the
- * error is reported without any explicit recovery by the parsing software.
+ * the construct is well-formed, parsing may be able to continue after the error
+ * is reported without any explicit recovery by the parsing software.
  *
  * This version assumes that the cursor is the error location.
  *

--- a/src/parser/Token_Stream.hh
+++ b/src/parser/Token_Stream.hh
@@ -15,7 +15,7 @@
 #include <memory>
 
 namespace rtt_parser {
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Parser exception class
  *
@@ -28,18 +28,18 @@ public:
   Syntax_Error();
 };
 
-//-------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*!
  * \brief Abstract token stream for simple parsers
  *
  * Modern simulation codes require detailed problem specifications, which
  * typically take the form of a human-readable ASCII text input file.  The
- * problem specification language used in such input files has some
- * similarities to a programming language, though it is typically simpler than
- * a high-level language like C++ or Java. The problem specification expressed
- * in this problem specification language must be scanned and parsed by the
- * simulation code in order to load the data structures and control parameters
- * required to run the simulation.
+ * problem specification language used in such input files has some similarities
+ * to a programming language, though it is typically simpler than a high-level
+ * language like C++ or Java. The problem specification expressed in this
+ * problem specification language must be scanned and parsed by the simulation
+ * code in order to load the data structures and control parameters required to
+ * run the simulation.
  *
  * For example, if a fragment of a problem specification text takes the form
  *
@@ -52,14 +52,13 @@ public:
  * followed by a keyword identifying the kind of boundary ("gray source"), and
  * so on.
  *
- * Modern input readers split the task of reading a problem specification taxt
+ * Modern input readers split the task of reading a problem specification text
  * into scanning and parsing. Scanning is the task of converting the raw text
  * into a sequence of \b tokens, which represent the keywords, numerical or
- * string values, and other lowest-level constructs in the problem
- * specification language. This sequence or stream of tokens is then analyzed
- * by a parser that understands the syntax of the problem specification
- * language and can extract the semantic meaning of each part of the problem
- * specification.
+ * string values, and other lowest-level constructs in the problem specification
+ * language. This sequence or stream of tokens is then analyzed by a parser that
+ * understands the syntax of the problem specification language and can extract
+ * the semantic meaning of each part of the problem specification.
  *
  * A Token_Stream is an abstract representation of a stream of tokens that can
  * be presented to a Parse_Table or other parsing client. Each token is
@@ -70,49 +69,53 @@ public:
  * position; but when the cursor advances (via the Shift method) the token it
  * advances over is discarded forever.
  *
- * The actual scanner that does the conversion of raw text to tokens is
- * provided by an implementation of the \c fill function in a child
- * class. This is usually the \c Text_Token_Stream class, whose implementation
- * of the \c fill function converts a stream of ASCII characters to a stream
- * of tokens, but one can imagine unconventional sources of tokens such as an
- * HTML form on a web interface.
+ * The actual scanner that does the conversion of raw text to tokens is provided
+ * by an implementation of the \c fill function in a child class. This is
+ * usually the \c Text_Token_Stream class, whose implementation of the \c fill
+ * function converts a stream of ASCII characters to a stream of tokens, but one
+ * can imagine unconventional sources of tokens such as an HTML form on a web
+ * interface.
  *
  * Because the token stream object is specific to a particular kind of user
- * interface, we find it convenient to allow the parser to report any syntax
- * or semantic errors it discovers in the problem specification to the token
+ * interface, we find it convenient to allow the parser to report any syntax or
+ * semantic errors it discovers in the problem specification to the token
  * stream, which "knows" the best way to convey these to the human client
  * running the program. This style of error reporting also permits the token
- * stream to add additional information to the error message, indicating to
- * the human client where the error occurred. For example, a \c
- * File_Token_Stream can tell the human client the line in the input file
- * where the error was detected.
+ * stream to add additional information to the error message, indicating to the
+ * human client where the error occurred. For example, a \c File_Token_Stream
+ * can tell the human client the line in the input file where the error was
+ * detected.
  */
 
-class DLL_PUBLIC_parser Token_Stream {
+class Token_Stream {
 public:
   // CREATORS
 
-  virtual ~Token_Stream() {}
+  virtual ~Token_Stream() = default;
 
   // MANIPULATORS
 
   //! Return the next token in the stream and advance the cursor.
   Token shift();
 
-  //! Look ahead at tokens.
-  // Lookahead references should remain valid until the referenced token is shifted.
+  /*!
+   * \brief Look ahead at tokens.
+   *
+   * Lookahead references should remain valid until the referenced token is
+   * shifted.
+   */
   Token const &lookahead(unsigned pos = 0);
 
   //! Insert a token into the stream at the cursor position.
   void pushback(Token const &token);
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*!
-     * \brief Reset the stream
-     *
-     * This function resets the token stream to some initial state defined
-     * by the child class.
-     */
+   * \brief Reset the stream
+   *
+   * This function resets the token stream to some initial state defined by the
+   * child class.
+   */
   virtual void rewind() = 0;
 
   //! Report a syntax error to the user.
@@ -132,80 +135,76 @@ public:
   //! Report a semantic error to the user.
   virtual void report_semantic_error(std::exception const &message);
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*!
-     * \brief Report an error to the user.
-     *
-     * This function sends a message to the user in a stream-specific manner.
-     *
-     * \param token
-     * Token that triggered the error.
-     *
-     * \param message
-     * Message to be passed to the user.
-     */
+   * \brief Report an error to the user.
+   *
+   * This function sends a message to the user in a stream-specific manner.
+   *
+   * \param token Token that triggered the error.
+   *
+   * \param message Message to be passed to the user.
+   */
   virtual void report(Token const &token, std::string const &message) = 0;
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*!
-     * \brief Report an error to the user.
-     *
-     * This function sends a message to the user in a stream-specific
-     * manner.  This variant assumes that the cursor gives the correct
-     * location of the error.
-     *
-     * \param message
-     * Message to be passed to the user.
-     */
+   * \brief Report an error to the user.
+   *
+   * This function sends a message to the user in a stream-specific manner. This
+   * variant assumes that the cursor gives the correct location of the error.
+   *
+   * \param message
+   * Message to be passed to the user.
+   */
   virtual void report(std::string const &message) = 0;
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*!
-     * \brief Send a comment, without location information, to the user.
-     *
-     * This function sends a message to the user in a stream-specific manner.
-     * This differs from the report() functions chiefly in that the message
-     * is not preceded by any location information. This is useful for
-     * extended comments, e.g., listing available keywords when the stream
-     * contains an unrecognized keyword.
-     *
-     * \param message
-     * Message to be passed to the user.
-     */
+   * \brief Send a comment, without location information, to the user.
+   *
+   * This function sends a message to the user in a stream-specific manner. This
+   * differs from the report() functions chiefly in that the message is not
+   * preceded by any location information. This is useful for extended comments,
+   * e.g., listing available keywords when the stream contains an unrecognized
+   * keyword.
+   *
+   * \param message
+   * Message to be passed to the user.
+   */
   virtual void comment(std::string const &message) = 0;
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*! Check a syntax condition.
-     *
-     * By putting the check branch here, we improve coverage statistics for
-     * branch coverage. Making the function inline keeps the cost of doing so
-     * negligible.
-     *
-     * \param condition Condition to be checked. If false, the message is
-     * delivered in a stream-dependent manner, the stream's error counter is
-     * incremented, and a syntax exception is thrown.
-     *
-     * \param message Diagnostic message to be delivered if condition tests as
-     * false.
-     */
+   *
+   * By putting the check branch here, we improve coverage statistics for branch
+   * coverage. Making the function inline keeps the cost of doing so negligible.
+   *
+   * \param condition
+   * Condition to be checked. If false, the message is delivered in a
+   * stream-dependent manner, the stream's error counter is incremented, and a
+   * syntax exception is thrown.
+   *
+   * \param message
+   * Diagnostic message to be delivered if condition tests as false.
+   */
   void check_syntax(bool const condition, char const *const message) {
     if (!condition)
       report_syntax_error(message);
   }
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*! Check a semantic condition.
-     *
-     * By putting the check branch here, we improve coverage statistics for
-     * branch coverage. Making the function inline keeps the cost of doing so
-     * negligible.
-     *
-     * \param condition Condition to be checked. If false, the message is
-     * delivered and the stream's error counter is incremented.
-     *
-     * \param message Diagnostic message to be delivered if condition tests as
-     * false.
-     */
+   *
+   * By putting the check branch here, we improve coverage statistics for branch
+   * coverage. Making the function inline keeps the cost of doing so negligible.
+   *
+   * \param condition Condition to be checked. If false, the message is
+   * delivered and the stream's error counter is incremented.
+   *
+   * \param message Diagnostic message to be delivered if condition tests as
+   * false.
+   */
   void check_semantics(bool const condition, char const *const message) {
     if (!condition)
       report_semantic_error(message);
@@ -228,39 +227,36 @@ protected:
   //! Construct a Token_Stream.
   inline Token_Stream();
 
-  //-----------------------------------------------------------------------//
+  //--------------------------------------------------------------------------//
   /*!
-     * \brief Add one or more tokens to the end of the lookahead buffer.
-     *
-     * This function is used by \c shift and \c lookahead to keep the token
-     * stream filled.
-     *
-     * Each call to the function scans the next token from the ultimate token
-     * source (such as a text file or GUI) and returns it to the client. If no
-     * more tokens are available, the function must return an EXIT token.
-     *
-     * \return Next token to put on the token buffer.
-     */
+   * \brief Add one or more tokens to the end of the lookahead buffer.
+   *
+   * This function is used by \c shift and \c lookahead to keep the token stream
+   * filled.
+   *
+   * Each call to the function scans the next token from the ultimate token
+   * source (such as a text file or GUI) and returns it to the client. If no
+   * more tokens are available, the function must return an EXIT token.
+   *
+   * \return Next token to put on the token buffer.
+   */
   virtual Token fill_() = 0;
 
 private:
   // DATA
 
-  //! Number of errors reported to the stream since it was constructed or
-  //! last rewound.
-  unsigned error_count_;
+  //! Number of errors reported to the stream since it was constructed or last
+  //! rewound.
+  unsigned error_count_ = {0};
 
 private:
   // DATA
   std::deque<Token> deq;
 };
 
-//-----------------------------------------------------------------------//
-/*!
- * Construct a Token_Stream and place the cursor at the start of the
- * stream.
- */
-inline Token_Stream::Token_Stream() : error_count_(0), deq() {
+//----------------------------------------------------------------------------//
+//! Construct a Token_Stream and place the cursor at the start of the stream.
+inline Token_Stream::Token_Stream() : deq() {
   Ensure(check_class_invariants());
   Ensure(error_count() == 0);
 }

--- a/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
@@ -26,7 +26,6 @@ using namespace rtt_parser;
  * Declare an abstract class, Parent, for which we wish to write a constructor.
  * The following would typically be declared in a file named Parent.hh
  */
-
 class Parent {
 public:
   explicit Parent(int const magic) : magic_(magic) {}
@@ -35,7 +34,7 @@ public:
 
   int magic() const { return magic_; }
 
-  virtual ~Parent() {}
+  virtual ~Parent() = default;
 
   virtual string name() = 0;
   // Makes this class abstract, and gives us a way to test later which child
@@ -147,7 +146,7 @@ std::shared_ptr<Parent> parse_class(Token_Stream &tokens, int const &context) {
  */
 class Son : public Parent {
 public:
-  virtual string name() { return "son"; }
+  string name() override { return "son"; }
 
   Son(double /*snip_and_snails*/, int const context) : Parent(context) {}
   // "snips and snails" is provided by the parser based on the parsed
@@ -167,7 +166,7 @@ template <> class Class_Parse_Table<Son> : public Class_Parse_Table<Parent> {
 public:
   // TYPEDEFS
 
-  typedef Son Return_Class;
+  using Return_Class = Son;
 
   // MANAGEMENT
 
@@ -178,13 +177,9 @@ public:
       // parse functions needed to parse a specification. This is done once the
       // first time any Class_Parse_Table<Son> object is constructed.
 
-      const Keyword keywords[] = {
-          {"snips and snails", parse_snips_and_snails, 0, ""},
-      };
-
-      const unsigned number_of_keywords = sizeof(keywords) / sizeof(Keyword);
-      parse_table_.add(keywords, number_of_keywords);
-
+      std::array<Keyword, 1> const keywords{
+          Keyword{"snips and snails", parse_snips_and_snails, 0, ""}};
+      parse_table_.add(keywords.data(), keywords.size());
       parse_table_is_initialized_ = true;
     }
 
@@ -267,10 +262,9 @@ std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens,
  * Now define a second child of Parent, which we will (whimsically) call
  * Daughter. The following would typicall be placed in the file Daughter.hh
  */
-
 class Daughter : public Parent {
 public:
-  virtual string name() { return "daughter"; }
+  string name() override { return "daughter"; }
 
   Daughter(double /*sugar_and_spice*/) : Parent(0) {}
   // This child doesn't care about the context, which is perfectly acceptable
@@ -287,18 +281,15 @@ template <> class Class_Parse_Table<Daughter> {
 public:
   // TYPEDEFS
 
-  typedef Daughter Return_Class;
+  using Return_Class = Daughter;
 
   // MANAGEMENT
 
   Class_Parse_Table() {
     if (!parse_table_is_initialized_) {
-      const Keyword keywords[] = {
-          {"sugar and spice", parse_sugar_and_spice, 0, ""},
-      };
-
-      const unsigned number_of_keywords = sizeof(keywords) / sizeof(Keyword);
-      parse_table_.add(keywords, number_of_keywords);
+      std::array<Keyword, 1> const keywords{
+          Keyword{"sugar and spice", parse_sugar_and_spice, 0, ""}};
+      parse_table_.add(keywords.data(), keywords.size());
       parse_table_is_initialized_ = true;
     }
 

--- a/src/parser/test/tstAbstract_Class_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Parser.cc
@@ -26,10 +26,9 @@ using namespace rtt_parser;
  * The following would typically be declared in a file associated with the
  * Parent class.
  */
-
 class Parent {
 public:
-  virtual ~Parent() {}
+  virtual ~Parent() = default;
 
   virtual string name() = 0;
 };
@@ -108,7 +107,7 @@ template <> std::shared_ptr<Parent> parse_class<Parent>(Token_Stream &tokens) {
  */
 class Son : public Parent {
 public:
-  virtual string name() { return "son"; }
+  string name() override { return "son"; }
 
   Son(double /*snip_and_snails*/) {}
 };
@@ -133,19 +132,15 @@ template <> class Class_Parse_Table<Son> {
 public:
   // TYPEDEFS
 
-  typedef Son Return_Class;
+  using Return_Class = Son;
 
   // MANAGEMENT
 
   Class_Parse_Table() {
     if (!parse_table_is_initialized_) {
-      const Keyword keywords[] = {
-          {"snips and snails", parse_snips_and_snails, 0, ""},
-      };
-
-      const unsigned number_of_keywords = sizeof(keywords) / sizeof(Keyword);
-      parse_table_.add(keywords, number_of_keywords);
-
+      std::array<Keyword, 1> const keywords{
+          Keyword{"snips and snails", parse_snips_and_snails, 0, ""}};
+      parse_table_.add(keywords.data(), keywords.size());
       parse_table_is_initialized_ = true;
     }
 
@@ -196,10 +191,9 @@ template <> std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens) {
  * The following is what you would expect to find in a file associated with
  * the Daughter class.
  */
-
 class Daughter : public Parent {
 public:
-  virtual string name() { return "daughter"; }
+  string name() override { return "daughter"; }
 
   Daughter(double /*sugar_and_spice*/) {}
 };
@@ -224,18 +218,15 @@ template <> class Class_Parse_Table<Daughter> {
 public:
   // TYPEDEFS
 
-  typedef Daughter Return_Class;
+  using Return_Class = Daughter;
 
   // MANAGEMENT
 
   Class_Parse_Table() {
     if (!parse_table_is_initialized_) {
-      const Keyword keywords[] = {
-          {"sugar and spice", parse_sugar_and_spice, 0, ""},
-      };
-
-      const unsigned number_of_keywords = sizeof(keywords) / sizeof(Keyword);
-      parse_table_.add(keywords, number_of_keywords);
+      std::array<Keyword, 1> const keywords{
+          Keyword{"sugar and spice", parse_sugar_and_spice, 0, ""}};
+      parse_table_.add(keywords.data(), keywords.size());
       parse_table_is_initialized_ = true;
     }
 
@@ -290,13 +281,9 @@ void parse_parent(Token_Stream &tokens, int) {
   parent = parse_class<Parent>(tokens);
 }
 
-const Keyword top_keywords[] = {
-    {"parent", parse_parent, 0, ""},
-};
-
-const unsigned number_of_top_keywords = sizeof(top_keywords) / sizeof(Keyword);
-
-Parse_Table top_parse_table(top_keywords, number_of_top_keywords);
+std::array<Keyword, 1> const top_keywords{
+    Keyword{"parent", parse_parent, 0, ""}};
+Parse_Table top_parse_table(top_keywords.data(), top_keywords.size());
 
 std::shared_ptr<Parent> parse_son(Token_Stream &tokens) {
   return parse_class<Son>(tokens);
@@ -333,7 +320,6 @@ void test(UnitTest &ut) {
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   ScalarUnitTest ut(argc, argv, release);
   try {

--- a/src/parser/test/tstClass_Parse_Table.cc
+++ b/src/parser/test/tstClass_Parse_Table.cc
@@ -49,7 +49,7 @@ public:
 protected:
   // DATA
 
-  double parsed_insouciance;
+  double parsed_insouciance{-1.0};
   bool context;
 
 private:
@@ -92,12 +92,11 @@ void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
 
 //----------------------------------------------------------------------------//
 Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const context_in)
-    : parsed_insouciance(-1.0), context(context_in) // sentinel value
+    : context(context_in) // sentinel value
 {
-  Keyword const keywords[] = {
-      {"insouciance", parse_insouciance_, 0, ""},
-  };
-  initialize(keywords, sizeof(keywords));
+  std::array<Keyword, 1> const keywords{
+      Keyword{"insouciance", parse_insouciance_, 0, ""}};
+  initialize(keywords.data(), sizeof(keywords));
 }
 
 //----------------------------------------------------------------------------//

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -49,7 +49,7 @@ public:
 protected:
   // DATA
 
-  double parsed_insouciance;
+  double parsed_insouciance{-1.0};
   bool context;
 
 private:
@@ -92,12 +92,12 @@ void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
 
 //----------------------------------------------------------------------------//
 Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const context_in)
-    : parsed_insouciance(-1.0), context(context_in) // sentinel value
+    : context(context_in) // sentinel value
 {
-  Keyword const keywords[] = {
-      {"insouciance", parse_insouciance_, 0, ""},
-  };
-  initialize(keywords, sizeof(keywords));
+  std::array<Keyword, 1> const keywords{
+      Keyword{"insouciance", parse_insouciance_, 0, ""}};
+  // std::cout << "kt ==> sizeof(keywords) " << sizeof(keywords) << std::endl;
+  initialize(keywords.data(), sizeof(keywords));
 }
 
 //----------------------------------------------------------------------------//

--- a/src/parser/test/tstConsole_Token_Stream.cc
+++ b/src/parser/test/tstConsole_Token_Stream.cc
@@ -185,8 +185,8 @@ void tstConsole_Token_Stream(rtt_dsxx::UnitTest &ut) {
       ITFAILS;
 
     token = tokens.shift();
-    if (token.type() != STRING || token.text() != "\"manifest \\\"string\\\"\"")
-      ITFAILS;
+    FAIL_IF(token.type() != STRING ||
+            token.text() != R"("manifest \"string\"")");
 
     token = tokens.shift();
     if (token.type() != OTHER || token.text() != "@")

--- a/src/parser/test/tstExpression.cc
+++ b/src/parser/test/tstExpression.cc
@@ -116,9 +116,11 @@ void tstExpression(UnitTest &ut) {
 #pragma clang diagnostic ignored "-Wliteral-conversion"
 #endif
 
-  if (soft_equiv((*expression)(xs), (((1 && 1.3) || !(y < -1)) / 5. +
-                                     (2 > 1) * r * square(2.7 - 1.1 * z)) *
-                                        t)) {
+  if (soft_equiv((*expression)(xs),
+                 (((1 && 1.3) || !(y < -1)) / 5. +       //NOLINT
+                  (2 > 1) * r * square(2.7 - 1.1 * z)) * //NOLINT
+                     t))                                 // NOLINT
+  {
     PASSMSG("expression successfully evaluated");
   } else {
     FAILMSG("expression NOT successfully evaluated");

--- a/src/parser/test/tstFile_Token_Stream.cc
+++ b/src/parser/test/tstFile_Token_Stream.cc
@@ -231,8 +231,8 @@ void tstFile_Token_Stream(rtt_dsxx::UnitTest &ut) {
       ITFAILS;
 
     token = tokens.shift();
-    if (token.type() != STRING || token.text() != "\"manifest \\\"string\\\"\"")
-      ITFAILS;
+    FAIL_IF(token.type() != STRING ||
+            token.text() != R"("manifest \"string\"")");
 
     token = tokens.shift();
     if (token.type() != OTHER || token.text() != "@")

--- a/src/parser/test/tstParallel_File_Token_Stream.cc
+++ b/src/parser/test/tstParallel_File_Token_Stream.cc
@@ -5,10 +5,7 @@
  * \date   Fri Apr  4 09:34:28 2003
  * \brief  Unit tests for class Parallel_File_Token_Stream
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
@@ -113,137 +110,106 @@ void tstParallel_File_Token_Stream(rtt_dsxx::UnitTest &ut) {
     }
     FAIL_IF_NOT(caught);
 
-    if (tokens.error_count() != 1)
-      ITFAILS;
+    FAIL_IF(tokens.error_count() != 1);
 
     token = tokens.shift();
-    if (token.type() != KEYWORD || token.text() != "COLOR")
-      ITFAILS;
+    FAIL_IF(token.type() != KEYWORD || token.text() != "COLOR");
 
     token = tokens.shift();
-    if (token.type() != OTHER || token.text() != "=")
-      ITFAILS;
+    FAIL_IF(token.type() != OTHER || token.text() != "=");
 
     token = tokens.shift();
-    if (token.type() != KEYWORD || token.text() != "BLACK")
-      ITFAILS;
+    FAIL_IF(token.type() != KEYWORD || token.text() != "BLACK");
 
     token = tokens.shift();
-    if (token.type() != END)
-      ITFAILS;
+    FAIL_IF(token.type() != END);
 
     token = tokens.shift();
-    if (token.type() != OTHER || token.text() != "-")
-      ITFAILS;
+    FAIL_IF(token.type() != OTHER || token.text() != "-");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1.563e+3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1.563e+3");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1.563e+3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1.563e+3");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != ".563e+3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != ".563e+3");
 
     token = tokens.shift();
-    if (token.type() != OTHER || token.text() != ".")
-      ITFAILS;
+    FAIL_IF(token.type() != OTHER || token.text() != ".");
 
     token = tokens.shift();
-    if (token.type() != OTHER || token.text() != "-")
-      ITFAILS;
+    FAIL_IF(token.type() != OTHER || token.text() != "-");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1.")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1.");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1.563")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1.563");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1.e+3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1.e+3");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1.e3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1.e3");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1e+3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1e+3");
 
     token = tokens.shift();
-    if (token.type() != REAL || token.text() != "1e3")
-      ITFAILS;
+    FAIL_IF(token.type() != REAL || token.text() != "1e3");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "19090")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "19090");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "01723")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "01723");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "0x1111a")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "0x1111a");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "0")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "0");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "8123")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "8123");
 
     token = tokens.shift();
-    if (token.type() != STRING || token.text() != "\"manifest string\"")
-      ITFAILS;
+    FAIL_IF(token.type() != STRING || token.text() != "\"manifest string\"");
 
     token = tokens.shift();
-    if (token.type() != STRING || token.text() != "\"manifest \\\"string\\\"\"")
-      ITFAILS;
+    FAIL_IF(token.type() != STRING ||
+            token.text() != R"("manifest \"string\"")");
 
     token = tokens.shift();
-    if (token.type() != OTHER || token.text() != "@")
-      ITFAILS;
+    FAIL_IF(token.type() != OTHER || token.text() != "@");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "1")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "1");
 
     token = tokens.shift();
-    if (token.type() != KEYWORD || token.text() != "e")
-      ITFAILS;
+    FAIL_IF(token.type() != KEYWORD || token.text() != "e");
 
     token = tokens.shift();
-    if (token.type() != INTEGER || token.text() != "0")
-      ITFAILS;
+    FAIL_IF(token.type() != INTEGER || token.text() != "0");
 
     token = tokens.shift();
-    if (token.type() != KEYWORD || token.text() != "x")
-      ITFAILS;
+    FAIL_IF(token.type() != KEYWORD || token.text() != "x");
 
     token = tokens.shift();
-    if (token.type() != EXIT)
-      ITFAILS;
+    FAIL_IF(token.type() != EXIT);
+
     token = tokens.shift();
-    if (token.type() != EXIT)
-      ITFAILS;
+    FAIL_IF(token.type() != EXIT);
 
     tokens.rewind();
     token = tokens.lookahead();
     token = tokens.shift();
-    if (token.type() != KEYWORD || token.text() != "BLUE")
-      ITFAILS;
+    FAIL_IF(token.type() != KEYWORD || token.text() != "BLUE");
 
     // Check invariance even when --with-dbc=0.
-    if (!tokens.check_class_invariants())
-      ITFAILS;
+    FAIL_IF(!tokens.check_class_invariants());
   }
 
   {
@@ -383,7 +349,6 @@ void tstParallel_File_Token_Stream(rtt_dsxx::UnitTest &ut) {
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   rtt_c4::ParallelUnitTest ut(argc, argv, rtt_dsxx::release);
   try {

--- a/src/parser/test/tstString_Token_Stream.cc
+++ b/src/parser/test/tstString_Token_Stream.cc
@@ -216,8 +216,8 @@ void tstString_Token_Stream(UnitTest &ut) {
       ITFAILS;
 
     token = tokens.shift();
-    if (token.type() != STRING || token.text() != "\"manifest \\\"string\\\"\"")
-      ITFAILS;
+    FAIL_IF(token.type() != STRING ||
+            token.text() != R"("manifest \"string\"")");
 
     token = tokens.shift();
     if (token.type() != OTHER || token.text() != "@")

--- a/src/parser/test/tstToken.cc
+++ b/src/parser/test/tstToken.cc
@@ -81,7 +81,7 @@ void token_test(UnitTest &ut) {
     ut.failure(__LINE__);
   if (Is_String_Text("This is a test"))
     ut.failure(__LINE__);
-  if (!Is_String_Text("\"Backslash \\ test\""))
+  if (!Is_String_Text(R"("Backslash \ test")"))
     ut.failure(__LINE__);
   if (Is_String_Text("\"Backslash \\"))
     ut.failure(__LINE__);

--- a/src/parser/test/tstToken_Equivalence.cc
+++ b/src/parser/test/tstToken_Equivalence.cc
@@ -5,10 +5,7 @@
  * \date   Fri Jul 21 09:10:49 2006
  * \brief  Unit test for functions in Token_Equivalence.
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -58,7 +55,6 @@ void tstOne(UnitTest &ut) {
 }
 
 //----------------------------------------------------------------------------//
-
 int main(int argc, char *argv[]) {
   ScalarUnitTest ut(argc, argv, release);
   try {

--- a/src/parser/test/tstutilities.cc
+++ b/src/parser/test/tstutilities.cc
@@ -84,8 +84,8 @@ void tstutilities(UnitTest &ut) {
 
   // Try to read some vectors.
 
-  double v[3];
-  parse_vector(tokens, v);
+  std::array<double, 3> v;
+  parse_vector(tokens, v.data());
   Token token = tokens.shift();
   if (rtt_dsxx::soft_equiv(v[0], 3.0, eps) &&
       rtt_dsxx::soft_equiv(v[1], 0.0, eps) &&
@@ -95,7 +95,7 @@ void tstutilities(UnitTest &ut) {
   else
     FAILMSG("1-D vector NOT successfully parsed");
 
-  parse_vector(tokens, v);
+  parse_vector(tokens, v.data());
   token = tokens.shift();
   if (rtt_dsxx::soft_equiv(v[0], 1.0, eps) &&
       rtt_dsxx::soft_equiv(v[1], 2.0, eps) &&
@@ -105,7 +105,7 @@ void tstutilities(UnitTest &ut) {
   else
     FAILMSG("2-D vector NOT successfully parsed");
 
-  parse_vector(tokens, v);
+  parse_vector(tokens, v.data());
   if (rtt_dsxx::soft_equiv(v[0], 4.0, eps) &&
       rtt_dsxx::soft_equiv(v[1], 3.0, eps) &&
       rtt_dsxx::soft_equiv(v[2], 2.0, eps) && tokens.shift().text() == "stop")
@@ -113,8 +113,8 @@ void tstutilities(UnitTest &ut) {
   else
     FAILMSG("3-D vector NOT successfully parsed");
 
-  unsigned w[3];
-  parse_unsigned_vector(tokens, w, 3);
+  std::array<unsigned, 3> w;
+  parse_unsigned_vector(tokens, w.data(), 3);
   token = tokens.shift();
   if (w[0] == 3 && w[1] == 2 && w[2] == 1 && token.type() == KEYWORD &&
       token.text() == "stop")
@@ -284,7 +284,7 @@ void tstutilities(UnitTest &ut) {
     FAILMSG("cgs energy NOT successfully parsed");
 
   unsigned old_error_count = tokens.error_count();
-  length = parse_quantity(tokens, rtt_parser::m, "length");
+  /* length = */ parse_quantity(tokens, rtt_parser::m, "length");
   if (tokens.error_count() == old_error_count)
     FAILMSG("bad length NOT successfully detected");
   else
@@ -503,8 +503,8 @@ void tstutilities(UnitTest &ut) {
   }
   {
     String_Token_Stream string("1 2 3");
-    unsigned x[4];
-    parse_unsigned_vector(string, x, 4);
+    std::array<unsigned, 4> x;
+    parse_unsigned_vector(string, x.data(), 4);
     if (string.error_count() == 0)
       FAILMSG("did NOT detect too short vector correctly");
     else
@@ -606,7 +606,7 @@ void tstutilities(UnitTest &ut) {
       FAILMSG("did NOT quantity with units to SI correctly");
     quantity_with_units.rewind();
 
-    c = parse_quantity(bare_quantity, m / s, "velocity");
+    /* c = */ parse_quantity(bare_quantity, m / s, "velocity");
     if (bare_quantity.error_count() > 0)
       PASSMSG("correctly flagged missing units in bare quantity");
     else
@@ -641,7 +641,7 @@ void tstutilities(UnitTest &ut) {
       FAILMSG("did NOT quantity with units to cgs correctly");
     quantity_with_units.rewind();
 
-    c = parse_quantity(bare_quantity, m / s, "velocity");
+    /* c = */ parse_quantity(bare_quantity, m / s, "velocity");
     if (bare_quantity.error_count() > 0)
       PASSMSG("correctly flagged missing units in bare quantity");
     else
@@ -684,7 +684,7 @@ void tstutilities(UnitTest &ut) {
       FAILMSG("did NOT parse local_Temp with units to SI correctly");
     quantity_with_units.rewind();
 
-    local_Temp = parse_temperature(bare_quantity);
+    /* local_Temp = */ parse_temperature(bare_quantity);
     if (bare_quantity.error_count() > 0)
       PASSMSG("correctly flagged missing units in bare quantity");
     else
@@ -720,7 +720,7 @@ void tstutilities(UnitTest &ut) {
       FAILMSG("did NOT quantity with units to X4 correctly");
     quantity_with_units.rewind();
 
-    local_Temp = parse_temperature(bare_quantity);
+    /* local_Temp = */ parse_temperature(bare_quantity);
     if (bare_quantity.error_count() > 0)
       PASSMSG("correctly flagged missing units in bare quantity");
     else
@@ -764,7 +764,7 @@ void tstutilities(UnitTest &ut) {
       FAILMSG("did NOT parse local_Temp with units to SI correctly");
     quantity_with_units.rewind();
 
-    local_Temp = parse_temperature(bare_quantity);
+    /* local_Temp = */ parse_temperature(bare_quantity);
     if (bare_quantity.error_count() > 0)
       PASSMSG("correctly flagged missing units in bare quantity");
     else
@@ -799,7 +799,7 @@ void tstutilities(UnitTest &ut) {
       FAILMSG("did NOT quantity with units to X4 correctly");
     quantity_with_units.rewind();
 
-    local_Temp = parse_temperature(bare_quantity);
+    /* local_Temp = */ parse_temperature(bare_quantity);
     if (bare_quantity.error_count() > 0)
       PASSMSG("correctly flagged missing units in bare quantity");
     else

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -11,10 +11,10 @@
 #include "utilities.hh"
 #include "units/PhysicalConstants.hh"
 #include "units/PhysicalConstantsSI.hh"
-#include <ctype.h>
-#include <errno.h>
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
 #include <sstream>
-#include <stdlib.h>
 
 namespace // anonymous
 {
@@ -142,7 +142,7 @@ unsigned parse_unsigned_integer(Token_Stream &tokens) {
                              errno != ERANGE,
                          "integer value overflows");
 
-  Check(endptr != NULL);
+  Check(endptr != nullptr);
   // Check(Result<UINT32_MAX);
   return static_cast<unsigned>(Result);
 }
@@ -185,7 +185,7 @@ int parse_integer(Token_Stream &tokens) {
     if (Result != static_cast<int>(Result) || errno == ERANGE) {
       tokens.report_semantic_error("integer value overflows");
     }
-    Check(endptr != NULL && *endptr == '\0');
+    Check(endptr != nullptr && *endptr == '\0');
     // Check(std::abs(Result)<INT32_MAX);
     return static_cast<int>(Result);
   } else {
@@ -241,7 +241,7 @@ double parse_real(Token_Stream &tokens) {
         tokens.report("note: real value underflows: " + text);
       }
     }
-    Check(endptr != NULL && *endptr == '\0');
+    Check(endptr != nullptr && *endptr == '\0');
     return sign * Result;
   } else {
     tokens.report_syntax_error(token, "expected a real number");
@@ -285,10 +285,10 @@ double parse_nonnegative_real(Token_Stream &tokens) {
 /*!
  * \param tokens Token stream from which to parse the quantity.
  * \param x On return, contains the parsed vector components.
- * \pre \c x!=NULL
+ * \pre \c x!=nullptr
  */
-void parse_vector(Token_Stream &tokens, double x[]) {
-  Require(x != NULL);
+void parse_vector(Token_Stream &tokens, double *x) {
+  Require(x != nullptr);
 
   // At least one component must be present.
   x[0] = parse_real(tokens);
@@ -312,10 +312,10 @@ void parse_vector(Token_Stream &tokens, double x[]) {
  * \param x On return, contains the parsed vector components.
  * \param size size of parameter x.
  *
- * \pre \c x!=NULL
+ * \pre \c x!=nullptr
  */
-void parse_unsigned_vector(Token_Stream &tokens, unsigned x[], unsigned size) {
-  Require(x != NULL);
+void parse_unsigned_vector(Token_Stream &tokens, unsigned *x, unsigned size) {
+  Require(x != nullptr);
 
   for (unsigned i = 0; i < size; ++i) {
     if (at_real(tokens)) {

--- a/src/parser/utilities.hh
+++ b/src/parser/utilities.hh
@@ -41,7 +41,7 @@ bool parse_bool(Token_Stream &);
 
 Unit parse_unit(Token_Stream &);
 
-void parse_vector(Token_Stream &, double[]);
+void parse_vector(Token_Stream &, double *);
 
 //! parser a quote-delimited string, stripping the quotes.
 std::string parse_manifest_string(Token_Stream &tokens);
@@ -49,7 +49,7 @@ std::string parse_manifest_string(Token_Stream &tokens);
 void parse_geometry(Token_Stream &tokens,
                     rtt_mesh_element::Geometry &parsed_geometry);
 
-void parse_unsigned_vector(Token_Stream &, unsigned[], unsigned);
+void parse_unsigned_vector(Token_Stream &, unsigned *, unsigned);
 void set_internal_unit_system(rtt_units::UnitSystem const &units);
 void set_unit_expressions_are_required(bool);
 rtt_units::UnitSystem const &get_internal_unit_system();


### PR DESCRIPTION
### Background

* More clang-tidy updates.

### Description of changes

+ Use `auto` when type is fully specified by RHS.
+ Use `strncpy` instead of `strcpy`.
+ Prefer `using` to `typedef`.
+ Remvove redundant `DLL_PUBLIC` decoration.
+ Use `override` for member functions of derived types.
+ Use `make_shared` instead of `reset` for shared pointers.
+ Use `=default` and `=delete` for trivial or disabled constructors.
+ Reindent and rewrap some comment blocks
+ Replace C-style arrays with `std::array`.
+ Use default initialization for some class member data.
+ Prefer C++ headers to C headers (`<cctype>` vs. `"cytpe.h"`).
+ Use `nullptr` instead of `NULL`
+ Eliminate dead-stores.
+ Make use of `FAIL_IF` in some places.
+ Make use of C++11 string literals to reduce inline escape characters.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
