### PR TITLE
Apply clang-tidy recommendations in a few more places

### DIFF
--- a/src/cdi_CPEloss/Analytic_CP_Eloss.cc
+++ b/src/cdi_CPEloss/Analytic_CP_Eloss.cc
@@ -34,7 +34,7 @@ namespace rtt_cdi_cpeloss {
  *                 scattering
  */
 Analytic_CP_Eloss::Analytic_CP_Eloss(
-    SP_Analytic_Model model_in, rtt_cdi::CParticle target_in,
+    SP_Analytic_Model model_in, rtt_cdi::CParticle target_in, // NOLINT
     rtt_cdi::CParticle projectile_in,
     rtt_cdi::CPModelAngleCutoff model_angle_cutoff_in)
     : rtt_cdi::CPEloss(target_in, projectile_in,

--- a/src/cdi_eospac/test/tEospac.cc
+++ b/src/cdi_eospac/test/tEospac.cc
@@ -107,8 +107,8 @@ void cdi_eospac_test(rtt_dsxx::UnitTest &ut) {
   // Try to instantiate the new Eospac object.  Simultaneously, we are
   // assigned material IDs to more SesameTable values.
 
-  spEospac.reset(
-      new rtt_cdi_eospac::Eospac(AlSt.Ue_DT(Al3717).Zfc_DT(Al23714)));
+  spEospac = std::make_shared<rtt_cdi_eospac::Eospac>(
+      AlSt.Ue_DT(Al3717).Zfc_DT(Al23714));
 
   if (spEospac) {
     PASSMSG("shared_ptr to new Eospac object created.");

--- a/src/diagnostics/qt/diWidget.cc
+++ b/src/diagnostics/qt/diWidget.cc
@@ -12,7 +12,7 @@
 #include "../draco_info.hh"
 
 diWidget::diWidget(QWidget *parent)
-    : QWidget(parent), layout(new QGridLayout(this)), label1(NULL),
+    : QWidget(parent), layout(new QGridLayout(this)), label1(nullptr),
       pushbutton1(new QPushButton("&Ok")) {
   // Set the window title.
   setWindowTitle("draco_info-gui");

--- a/src/diagnostics/qt/diWidget.hh
+++ b/src/diagnostics/qt/diWidget.hh
@@ -20,8 +20,8 @@ class diWidget : public QWidget {
   Q_OBJECT
 
 public:
-  explicit diWidget(QWidget *parent = 0);
-  ~diWidget() = default;
+  explicit diWidget(QWidget *parent = nullptr);
+  ~diWidget() override = default;
 
   // disable copy/move construction
   diWidget(diWidget const &rhs) = delete;
@@ -38,7 +38,7 @@ private slots:
 
 private:
   QGridLayout *layout;
-  QLabel *label1;
+  QLabel *label1{nullptr};
   QPushButton *pushbutton1;
 };
 

--- a/src/diagnostics/qt/main.cc
+++ b/src/diagnostics/qt/main.cc
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
   app.setApplicationName("draco_info-gui");
   app.setOrganizationName("LANL CCS-2");
-  MainWindow *mainWin = new MainWindow;
+  auto *mainWin = new MainWindow;
   mainWin->show();
   return app.exec();
 }

--- a/src/diagnostics/qt/mainwindow.hh
+++ b/src/diagnostics/qt/mainwindow.hh
@@ -22,8 +22,8 @@ class MainWindow : public QMainWindow {
   Q_OBJECT
 
 public:
-  explicit MainWindow(QWidget *parent = 0);
-  ~MainWindow() = default;
+  explicit MainWindow(QWidget *parent = nullptr);
+  ~MainWindow() override = default;
 
   // disable copy/move construction
   MainWindow(MainWindow const &rhs) = delete;

--- a/src/diagnostics/test/tstTiming.cc
+++ b/src/diagnostics/test/tstTiming.cc
@@ -17,7 +17,7 @@
 
 using namespace std;
 using rtt_dsxx::soft_equiv;
-typedef rtt_diagnostics::Timing_Diagnostics D;
+using D = rtt_diagnostics::Timing_Diagnostics;
 
 //----------------------------------------------------------------------------//
 // TEST HELPERS

--- a/src/meshReaders/Hex_Mesh_Reader.cc
+++ b/src/meshReaders/Hex_Mesh_Reader.cc
@@ -118,7 +118,7 @@ Hex_Mesh_Reader::Hex_Mesh_Reader(std::string filename)
   std::set<unsigned> stmp;
   for (unsigned i = 0; i < npoints; ++i)
     stmp.insert(i);
-  typedef std::map<std::string, std::set<unsigned>> resultT;
+  using resultT = std::map<std::string, std::set<unsigned>>;
   node_sets.insert(resultT::value_type("Interior", stmp));
 
   // Check the results

--- a/src/min/test/tstmrqmin.cc
+++ b/src/min/test/tstmrqmin.cc
@@ -22,8 +22,10 @@ using namespace rtt_min;
 // TESTS
 //----------------------------------------------------------------------------//
 
-typedef void Model(vector<double> const &x, vector<double> const &a, double &y,
+using Model = void(vector<double> const &x, vector<double> const &a, double &y,
                    vector<double> &dyda);
+// typedef void Model(vector<double> const &x, vector<double> const &a, double &y,
+//                    vector<double> &dyda);
 
 void model(vector<double> const &x, vector<double> const &a, double &y,
            vector<double> &dyda) {

--- a/src/min/test/tstmrqmin.cc
+++ b/src/min/test/tstmrqmin.cc
@@ -24,8 +24,6 @@ using namespace rtt_min;
 
 using Model = void(vector<double> const &x, vector<double> const &a, double &y,
                    vector<double> &dyda);
-// typedef void Model(vector<double> const &x, vector<double> const &a, double &y,
-//                    vector<double> &dyda);
 
 void model(vector<double> const &x, vector<double> const &a, double &y,
            vector<double> &dyda) {

--- a/src/parser/Parse_Table.hh
+++ b/src/parser/Parse_Table.hh
@@ -238,7 +238,7 @@ private:
   // DATA
 
   std::vector<Keyword> vec;
-  unsigned char flags_; //!< Option flags for this parse table.
+  unsigned char flags_{0}; //!< Option flags for this parse table.
 };
 
 //----------------------------------------------------------------------------//

--- a/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
@@ -56,7 +56,7 @@ template <> class Class_Parse_Table<Parent> {
 public:
   // TYPEDEFS
 
-  typedef Parent Return_Class;
+  using Return_Class = Parent;
 
   // MANAGEMENT
 

--- a/src/parser/test/tstAbstract_Class_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Parser.cc
@@ -39,7 +39,7 @@ template <> class Class_Parse_Table<Parent> {
 public:
   // TYPEDEFS
 
-  typedef Parent Return_Class;
+  using Return_Class = Parent;
 
   // MANAGEMENT
 
@@ -102,8 +102,8 @@ template <> std::shared_ptr<Parent> parse_class<Parent>(Token_Stream &tokens) {
 
 //----------------------------------------------------------------------------//
 /*
- * The following is what you would expect to find in a file associated with
- * the Son class.
+ * The following is what you would expect to find in a file associated with the
+ * Son class.
  */
 class Son : public Parent {
 public:
@@ -188,8 +188,8 @@ template <> std::shared_ptr<Son> parse_class<Son>(Token_Stream &tokens) {
 
 //----------------------------------------------------------------------------//
 /*
- * The following is what you would expect to find in a file associated with
- * the Daughter class.
+ * The following is what you would expect to find in a file associated with the
+ * Daughter class.
  */
 class Daughter : public Parent {
 public:

--- a/src/parser/test/tstExpression.cc
+++ b/src/parser/test/tstExpression.cc
@@ -30,7 +30,7 @@ void tstExpression(UnitTest &ut) {
 
   String_Token_Stream tokens(expression_text);
 
-  typedef pair<unsigned, Unit> vd;
+  using vd = pair<unsigned, Unit>;
   map<string, vd> variable_map;
 
   variable_map["r"] = vd(0, m);

--- a/src/roots/test/tstzbrac.cc
+++ b/src/roots/test/tstzbrac.cc
@@ -5,10 +5,7 @@
  * \date   Tue Aug 17 15:24:48 2004
  * \brief  Test the zbrac function template
  * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//----------------------------------------------------------------------------//
-
+ *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -47,7 +44,7 @@ void tstzbrac(UnitTest &ut) {
   double x1 = 0.1, x2 = 10.0;
 
   // Help out the compiler by defining function pointer signature.
-  typedef double (*fpdd)(double);
+  using fpdd = double (*)(double);
   fpdd log_fpdd = &foo;
 
   zbrac<fpdd>(log_fpdd, x1, x2);

--- a/src/roots/test/tstzbrent.cc
+++ b/src/roots/test/tstzbrent.cc
@@ -41,7 +41,7 @@ void tstzbrent(UnitTest &ut) {
   //    zbrac<double (*)(double)>(log, x1, x2);
 
   // Help out the compiler by defining function pointer signature.
-  typedef double (*fpdd)(double);
+  using fpdd = double (*)(double);
   fpdd log_fpdd = &foo;
   zbrac<fpdd>(log_fpdd, x1, x2);
 


### PR DESCRIPTION
### Background

+ The clang-tidy builds on my local machine report a slightly different set of issues compared the CI system. Fix the items that are still reporting warnings.
+ Note: the `diagnostics/qt` sources weren't checked previously.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
