### PR TITLE
Constant analytic stopping power model

### DIFF
--- a/src/cdi_CPEloss/Analytic_Constant_Eloss_Model.hh
+++ b/src/cdi_CPEloss/Analytic_Constant_Eloss_Model.hh
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   cdi_CPEloss/Analytic_Constant_Eloss_Model.hh
+ * \author Ben R. Ryan
+ * \date   Feb 21 2020
+ * \brief  Analytic_Constant_Eloss_Model class definition.
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
+ *         All rights reserved. */
+//----------------------------------------------------------------------------//
+
+#ifndef rtt_cdi_CPEloss_Analytic_Constant_Eloss_Model_hh
+#define rtt_cdi_CPEloss_Analytic_Constant_Eloss_Model_hh
+
+#include "Analytic_Eloss_Model.hh"
+#include <algorithm>
+
+namespace rtt_cdi_cpeloss {
+//============================================================================//
+/*!
+ * \class Analytic_Constant_Eloss_Model
+ * \brief Analytic_Constant_Eloss_Model derived class.
+ *
+ * CP energy loss class using constant value provided to constructor.
+ */
+//============================================================================//
+
+class Analytic_Constant_Eloss_Model : public Analytic_Eloss_Model {
+public:
+  //! Constructor
+  Analytic_Constant_Eloss_Model(const rtt_cdi::CParticle &target,
+                                const rtt_cdi::CParticle &projectile,
+                                const double eloss_value_in)
+      : Analytic_Eloss_Model(target, projectile), eloss_value(eloss_value_in) {}
+
+  //! Calculate the eloss rate in units of shk^-1;
+  //! T given in keV, rho in g/cc, v0 in cm/shk
+  double calculate_eloss(const double T, const double rho,
+                         const double v0) const override {
+    return eloss_value;
+  }
+
+private:
+  double eloss_value;
+};
+
+} // namespace rtt_cdi_cpeloss
+
+#endif // rtt_cdi_CPEloss_Analytic_Constant_Eloss_Model_hh
+
+//----------------------------------------------------------------------------//
+// End cdi_CPEloss/Analytic_Constant_Eloss_Model.hh
+//----------------------------------------------------------------------------//

--- a/src/cdi_CPEloss/Analytic_Constant_Eloss_Model.hh
+++ b/src/cdi_CPEloss/Analytic_Constant_Eloss_Model.hh
@@ -4,7 +4,7 @@
  * \author Ben R. Ryan
  * \date   Feb 21 2020
  * \brief  Analytic_Constant_Eloss_Model class definition.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
+ * \note   Copyright (C) 2020 Triad National Security, LLC.
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
@@ -34,8 +34,8 @@ public:
 
   //! Calculate the eloss rate in units of shk^-1;
   //! T given in keV, rho in g/cc, v0 in cm/shk
-  double calculate_eloss(const double T, const double rho,
-                         const double v0) const override {
+  double calculate_eloss(const double /*T*/, const double /*rho*/,
+                         const double /*v0*/) const override {
     return eloss_value;
   }
 

--- a/src/cdi_CPEloss/test/tstAnalytic_CP_Eloss.cc
+++ b/src/cdi_CPEloss/test/tstAnalytic_CP_Eloss.cc
@@ -8,11 +8,12 @@
  *         All rights reserved. */
 //----------------------------------------------------------------------------//
 
+#include "cdi/CDI.hh"
 #include "cdi_CPEloss/Analytic_CP_Eloss.hh"
+#include "cdi_CPEloss/Analytic_Constant_Eloss_Model.hh"
 #include "cdi_CPEloss/Analytic_KP_Alpha_Eloss_Model.hh"
 #include "cdi_CPEloss/Analytic_Spitzer_Eloss_Model.hh"
 #include "cdi_CPEloss/Analytic_TR_Eloss_Model.hh"
-#include "cdi/CDI.hh"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/dbc.hh"
@@ -300,6 +301,45 @@ void TR_test(rtt_dsxx::UnitTest &ut) {
   return;
 }
 
+void Constant_test(rtt_dsxx::UnitTest &ut) {
+
+  // Deuterium:
+  int32_t deuterium_zaid = 1002;
+  double deuterium_mass = 3.34358e-24;
+  rtt_cdi::CParticle target_in(deuterium_zaid, deuterium_mass);
+  // Alpha particle:
+  int32_t alpha_zaid = 2004;
+  double alpha_mass = 6.64424e-24;
+  rtt_cdi::CParticle projectile_in(alpha_zaid, alpha_mass);
+
+  std::shared_ptr<Analytic_Eloss_Model> zero_model_in(
+      new rtt_cdi_cpeloss::Analytic_Constant_Eloss_Model(target_in,
+                                                         projectile_in, 0.));
+  std::shared_ptr<Analytic_Eloss_Model> one_model_in(
+      new rtt_cdi_cpeloss::Analytic_Constant_Eloss_Model(target_in,
+                                                         projectile_in, 1.));
+
+  Analytic_CP_Eloss eloss_zero_mod(zero_model_in, target_in, projectile_in,
+                                   rtt_cdi::CPModelAngleCutoff::NONE);
+  Analytic_CP_Eloss eloss_one_mod(one_model_in, target_in, projectile_in,
+                                  rtt_cdi::CPModelAngleCutoff::NONE);
+
+  // Check that basic accessors return correct result:
+  // Analytic model should match that passed to constructor
+  FAIL_IF_NOT(
+      rtt_dsxx::soft_equiv(eloss_zero_mod.getEloss(1., 2., 3.), 0., 1.0e-3));
+
+  FAIL_IF_NOT(
+      rtt_dsxx::soft_equiv(eloss_one_mod.getEloss(1., 2., 3.), 1., 1.0e-3));
+
+  if (ut.numFails == 0)
+    PASSMSG("Constant CPEloss test passes.");
+  else
+    FAILMSG("Constant CPEloss test fails.");
+
+  return;
+}
+
 //----------------------------------------------------------------------------//
 
 int main(int argc, char *argv[]) {
@@ -308,6 +348,7 @@ int main(int argc, char *argv[]) {
     KP_alpha_test(ut);
     Spitzer_test(ut);
     TR_test(ut);
+    Constant_test(ut);
   }
   UT_EPILOG(ut);
 }


### PR DESCRIPTION
### Background

* It would be nice to have zero and infinite stopping power models for CPT for testing purposes. This has also been requested by other developers to facilitate cross-code comparisons.

### Purpose of Pull Request

* Add a constant analytic stopping power model to be used to construct zero, ~infinite stopping powers.
* [Fixes Redmine Issue #2089](https://rtt.lanl.gov/redmine/issues/2089)

### Description of changes

* Add `cdi_CPEloss/Analytic_Constant_Eloss_Model.hh` which takes a constant stopping power value as an argument in the constructor and returns this value when used to evaluate a stopping power.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
