### PR TITLE
Update darwin p9 environment and spectrum-mpi args.

### DIFF
--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -92,9 +92,9 @@ if test -n "$MODULESHOME"; then
         cflavor="gcc-7.3.0"
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
-        noflavor="git gcc/7.3.0 cuda/10.1 cmake/3.17.0 random123 numdiff"
+        noflavor="git gcc/7.3.0 cuda/11.0 cmake/3.17.3 random123 numdiff"
         compflavor="eospac/6.4.0-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
-        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-${mflavor}-$lflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.4.0-${mflavor}-$lflavor trilinos/12.14.1-${mflavor}-$lflavor caliper/2.0.1-$mflavor"
         # These aren't built for power architectures?
         ec_mf="csk/0.5.0-$cflavor ndi"
 


### PR DESCRIPTION
### Background

* TPLs on darwin were updated. Some TPL versions were advanced.
* Add more options to the Spectrum-MPI `mpirun` command.

### Description of changes

+ For the gcc environment, bump to `cuda/11`, `cmake/3.17.3`, and `superlu-dist/5.4.0`. Add caliper.
+ Rework spectrum-mpi arguments and associated cmake logic.
+ For SMPI on darwin, use options `-intra sm -aff off --reort-bindings`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=`1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
