### PR TITLE
More updates to support testing and regression on ATS-2.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -383,7 +383,7 @@ macro( setupSpectrumMPI )
     # 1 resource set; 1 thread; no gpu; no binding --nrs 1
     set( MPIEXEC_PREFLAGS "-c 1 -g 0 --bind none")
   elseif( MPIEXEC_EXECUTABLE MATCHES lrun )
-    set( MPIEXEC_PREFLAGS "--threads=1 --bind=off -v")
+    set( MPIEXEC_PREFLAGS "--pack --threads=1 -v") # --bind=off
   endif()
   # --pack ==> -c 1 -g 0.  This is actually bad for us. Disable
   # lrun -n 2 -c 10 --threads=10 --bind=off ==>
@@ -399,7 +399,12 @@ macro( setupSpectrumMPI )
       # 1 resource set; OMP_NUM_THREADS tasks; no gpu; no binding
       set( MPIEXEC_OMP_PREFLAGS "--nrs 1 -c $ENV{OMP_NUM_THREADS} -g 0 --bind none")
     elseif( MPIEXEC_EXECUTABLE MATCHES lrun )
-      set( MPIEXEC_OMP_PREFLAGS "-c $ENV{OMP_NUM_THREADS} --threads=$ENV{OMP_NUM_THREADS} --bind=off -v" )
+      if( DEFINED ENV{OMP_NUM_THREADS} )
+        # --bind=off
+        set( MPIEXEC_OMP_PREFLAGS "--pack --threads=$ENV{OMP_NUM_THREADS} -c$ENV{OMP_NUM_THREADS} -v" )
+      else()
+        set( MPIEXEC_OMP_PREFLAGS "--pack --threads=4 -c 4 -v" )
+      endif()
     endif()
   endif()
 
@@ -447,7 +452,7 @@ macro( setupMPILibrariesUnix )
     elseif( DEFINED ENV{SYS_TYPE} AND
         "$ENV{SYS_TYPE}" MATCHES "ppc64le_ib_p9" ) # ATS-2
       if( NOT EXISTS ${MPIEXEC_EXECUTABLE} )
-        find_program( MPIEXEC_EXECUTABLE jsrun )
+        find_program( MPIEXEC_EXECUTABLE lrun )
       endif()
       set( MPIEXEC_EXECUTABLE ${MPIEXEC_EXECUTABLE} CACHE STRING
         "Program to execute MPI parallel programs." FORCE )

--- a/config/unix-cuda.cmake
+++ b/config/unix-cuda.cmake
@@ -59,7 +59,7 @@ if( NOT CUDA_FLAGS_INITIALIZED )
     endif()
   endif()
   set( CMAKE_CUDA_FLAGS_DEBUG          "-G -O0 -Xcudafe --display_error_number -Xcudafe --diag_suppress=1427")
-  set( CMAKE_CUDA_FLAGS_RELEASE        "-O2")
+  set( CMAKE_CUDA_FLAGS_RELEASE        "-O2") # -dipo
   set( CMAKE_CUDA_FLAGS_MINSIZEREL     "-O2")
   set( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-O2 --generate-line-info")
 

--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -56,7 +56,7 @@ else
 
 # StdEnv
 
-  export dracomodules="cuda/11.0.182 python/3.7.2 ack htop gsl numdiff git random123 gcc/8.3.1 cmake/3.17.0 metis netlib-lapack eospac/6.4.0 spectrum-mpi/2019.06.24 parmetis superlu-dist trilinos libquo csk ndi caliper"
+  export dracomodules="cuda/11.0.2 python/3.7.2 ack htop gsl numdiff git random123 gcc/8.3.1 cmake/3.17.0 metis netlib-lapack eospac/6.4.0 spectrum-mpi/2019.06.24 parmetis superlu-dist trilinos libquo csk ndi caliper"
 
 fi
 
@@ -64,7 +64,7 @@ fi
 
 function dracoenv()
 {
-  module purge
+  module --force purge
   module load StdEnv
   module unload spectrum-mpi xl cuda
   for m in $dracomodules; do
@@ -74,8 +74,8 @@ function dracoenv()
   export CXX=`which g++`
   export CC=`which gcc`
   export FC=`which gfortran`
-  export MPIRUN="jsrun"
-#  export OMP_NUM_THREADS=10
+  export MPIRUN="lrun"
+  export OMP_NUM_THREADS=10
 }
 
 function rmdracoenv()

--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -43,6 +43,7 @@ case $target in
       export MODULEPATH=/etc/modulefiles:/usr/share/modulefiles:/ccs/opt/modulefiles
     fi
     module load user_contrib
+    module unuse /etc/modulefiles
     if [[ -d $HOME/privatemodules ]]; then
       module use --append $HOME/privatemodules
     fi

--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -53,16 +53,23 @@ set( special_tests
   ${PROJECT_SOURCE_DIR}/tstOMP_API_off.cc
   ${PROJECT_SOURCE_DIR}/tstOMP_API_on.cc
 )
+if( DEFINED ENV{TRAVIS} )
+  # TRAVIS has severe limits on number of ranks/threads
+  set( omp_test_pe_list "1" )
+else()
+  set( omp_test_pe_list "1;2" )
+endif()
 foreach( omptest ${special_tests})
   list( REMOVE_ITEM test_sources ${omptest} )
   if( OPENMP_FOUND )
     add_parallel_tests(
       SOURCES   "${omptest}"
       DEPS      Lib_c4
-      PE_LIST   "1;2;4"
+      PE_LIST   "${omp_test_pe_list}"
       MPI_PLUS_OMP )
   endif()
 endforeach()
+unset( omp_test_pe_list )
 
 # Tests that expect exactly 2 PE (omit for DRACO_C4=SCALAR builds):
 set( two_pe_tests ${PROJECT_SOURCE_DIR}/tstPingPong.cc )

--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -13,7 +13,7 @@ project( c4_test CXX )
 # ---------------------------------------------------------------------------- #
 file( GLOB test_sources *.cc )
 
-# Remove some tests from the generic list. These will be process individually 
+# Remove some tests from the generic list. These will be process individually
 # with custom build options
 list( REMOVE_ITEM test_sources ${PROJECT_SOURCE_DIR}/tstfc4_hw.cc )
 
@@ -48,15 +48,21 @@ add_parallel_tests(
 list( REMOVE_ITEM test_sources ${special_test} )
 
 # This test uses MPI+OMP:
-set( special_test ${PROJECT_SOURCE_DIR}/tstOMP.cc )
-list( REMOVE_ITEM test_sources ${special_test} )
-if( OPENMP_FOUND )
-   add_parallel_tests(
-      SOURCES   "${special_test}"
+set( special_tests
+  ${PROJECT_SOURCE_DIR}/tstOMP.cc
+  ${PROJECT_SOURCE_DIR}/tstOMP_API_off.cc
+  ${PROJECT_SOURCE_DIR}/tstOMP_API_on.cc
+)
+foreach( omptest ${special_tests})
+  list( REMOVE_ITEM test_sources ${omptest} )
+  if( OPENMP_FOUND )
+    add_parallel_tests(
+      SOURCES   "${omptest}"
       DEPS      Lib_c4
-      PE_LIST   "1;2"
+      PE_LIST   "1;2;4"
       MPI_PLUS_OMP )
-endif()
+  endif()
+endforeach()
 
 # Tests that expect exactly 2 PE (omit for DRACO_C4=SCALAR builds):
 set( two_pe_tests ${PROJECT_SOURCE_DIR}/tstPingPong.cc )
@@ -124,14 +130,14 @@ if( TARGET Exe_ythi)
     TEST_ARGS 2
     PE_LIST   "1;2" )
 endif()
-  
+
 #------------------------------------------------------------------------------#
 # Wrap f90 tests
 #------------------------------------------------------------------------------#
 if( HAVE_Fortran AND DRACO_C4 STREQUAL MPI )
   add_parallel_tests(
     SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/tstfc4_hw.cc"
-    DEPS    "Lib_c4_ftest;Lib_c4_fc4;Lib_c4;Lib_dsxx" 
+    DEPS    "Lib_c4_ftest;Lib_c4_fc4;Lib_c4;Lib_dsxx"
     PE_LIST "1;2")
 endif()
 

--- a/src/c4/test/tstOMP_API_on.cc
+++ b/src/c4/test/tstOMP_API_on.cc
@@ -25,12 +25,12 @@ using rtt_dsxx::UnitTest;
 //----------------------------------------------------------------------------//
 void check_set_get(UnitTest &ut) {
   int const init_n = get_omp_num_threads();
-  set_omp_num_threads(51);
+  set_omp_num_threads(39);
   // use the direct OMP interface to check number of threads was set correctly
   int const new_max{omp_get_max_threads()};
-  FAIL_IF_NOT(51 == new_max);
+  FAIL_IF_NOT(39 == new_max);
   int const new_max_us(get_omp_max_threads());
-  FAIL_IF_NOT(51 == new_max_us);
+  FAIL_IF_NOT(39 == new_max_us);
   // now reset to the previous number of threads
   set_omp_num_threads(init_n);
   int const final_n{get_omp_num_threads()};


### PR DESCRIPTION
### Background

* Tests were running about 100X too slow on rzansel because the test launcher wasn't configured correctly.

### Purpose of Pull Request

* [Fixes Redmine Issue #1945](https://rtt.lanl.gov/redmine/issues/1945)
* [Fixes Redmine Issue #1933](https://rtt.lanl.gov/redmine/issues/1933)

### Description of changes

+ Switch back to `lrun --pack` for launching jobs on ATS-2.
+ Set lrun as the default launcher for ATS-2.
+ In the Draco developer environment for ATS-2, make `cuda/11.0.2` the default.
+ Ensure that the c4 tests `tstOMP_API_off` and `tstOMP_API_on` are registered as having OpenMP enabled. In the `_on` test, change the test to use 39 OpenMP threads instead of 51.  ATS-2 throws an error if more than 40 threads are requested.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
