### PR TITLE
Add jerk, sh==shake as unit names in unit parser.

### DIFF
--- a/src/parser/test/tstutilities.cc
+++ b/src/parser/test/tstutilities.cc
@@ -262,6 +262,18 @@ void tstutilities(UnitTest &ut) {
   else
     PASSMSG("sr definition checks out");
 
+  left = parse_unit(tokens);
+  if (left != W * 1e17)
+    FAILMSG("jerk and shake definitions did NOT check out");
+  else
+    PASSMSG("jerk and shake definition checks out");
+
+  left = parse_unit(tokens);
+  if (left != s * 1e-8)
+    FAILMSG("sh definitions did NOT check out");
+  else
+    PASSMSG("sh definition checks out");
+
   // Now see if we catch a bogus unit expression.
   try {
     left = parse_unit(tokens);

--- a/src/parser/test/utilities.inp
+++ b/src/parser/test/utilities.inp
@@ -35,6 +35,8 @@ kg-m^2-s^-2
 kg-m^2-s^-2-lx^0
 K
 sr
+jerk/shake
+sh
 
 kg/stone
 

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -405,6 +405,9 @@ bool at_unit_term(Token_Stream &tokens, unsigned position) {
     case 'i':
       return (token.text() == "inch");
 
+    case 'j':
+      return (token.text() == "jerk");
+
     case 'k':
       return (token.text() == "kg" || token.text() == "keV");
 
@@ -424,7 +427,8 @@ bool at_unit_term(Token_Stream &tokens, unsigned position) {
       return (token.text() == "rad");
 
     case 's':
-      return (u.size() == 1 || token.text() == "sr");
+      return (u.size() == 1 || token.text() == "sr" || token.text() == "sh" ||
+              token.text() == "shake");
 
     default:
       return false;
@@ -589,6 +593,13 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         tokens.report_syntax_error("expected a unit");
       break;
 
+    case 'j':
+      if (token.text() == "jerk")
+        retval = J * 1e9;
+      else
+        tokens.report_syntax_error("expected a unit");
+      break;
+
     case 'k':
       if (token.text() == "kg")
         retval = kg;
@@ -642,6 +653,8 @@ static Unit parse_unit_name(Token_Stream &tokens) {
         retval = s;
       else if (token.text() == "sr")
         retval = sr;
+      else if (token.text() == "sh" || token.text() == "shake")
+        retval = 1.0e-8 * s;
       else
         tokens.report_syntax_error("expected a unit");
       break;


### PR DESCRIPTION
### Background

* We occasionally see jerk = 1 gigajoule and shake = sh = 10 nanoseconds as units. It would be nice to support these in the Draco unit parser.

### Purpose of Pull Request

* Add sh, shake, and jerk as recognized units in unit parser.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
