### PR TITLE
WIP: Limit concurrent GPU enabled tests

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -759,6 +759,9 @@ macro(dbsSetupCuda)
     # Use this string as a toggle when calling add_component_library or
     # add_scalar_tests to force compiling with nvcc.
     set( COMPILE_WITH_CUDA LINK_LANGUAGE CUDA )
+    # Limit the number of tests that can access the GPU concurrently.  See
+    # component_macros.cmake for more details
+    set( GPU_RESOURCE_LOCK GPU_ENABLED )
 
     # setup flags
     if( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" )

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -92,9 +92,9 @@ if test -n "$MODULESHOME"; then
         cflavor="gcc-7.3.0"
         mflavor="$cflavor-openmpi-3.1.3"
         lflavor="lapack-3.8.0"
-        noflavor="git gcc/7.3.0 cuda/10.1 cmake/3.17.0 random123 numdiff"
+        noflavor="git gcc/7.3.0 cuda/11.0 cmake/3.17.3 random123 numdiff"
         compflavor="eospac/6.4.0-$cflavor gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor metis/5.1.0-$cflavor openmpi/p9/3.1.3-gcc_7.3.0"
-        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-${mflavor}-$lflavor trilinos/12.14.1-${mflavor}-$lflavor"
+        mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.4.0-${mflavor}-$lflavor trilinos/12.14.1-${mflavor}-$lflavor caliper/2.0.1-$mflavor"
         # These aren't built for power architectures?
         ec_mf="csk/0.5.0-$cflavor ndi"
 

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -53,8 +53,8 @@ if test -n "$MODULESHOME"; then
         noflavor="emacs git ack gcc/7.3.0 python/3.5.1"
         if [[ ${SLURM_JOB_PARTITION} =~ "volta" || ${SLURM_JOB_PARTITION} =~ "gpu" ]]; then
           # If we have GPUs on this node, then load the cuda toolkit module by default
-          noflavor+=" cuda/10.1"
-          cudaflavor="-cuda-10.1"
+          noflavor+=" cuda/10.2"
+          cudaflavor="-cuda-10.2"
         fi
         compflavor="cmake/3.17.0 gsl/2.5-$cflavor netlib-lapack/3.8.0-$cflavor numdiff/5.9.0-$cflavor random123/1.09-$cflavor metis/5.1.0-$cflavor eospac/6.4.0-$cflavor openmpi/3.1.3-gcc_7.3.0"
         mpiflavor="libquo/1.3-$mflavor parmetis/4.0.3-$mflavor superlu-dist/5.2.2-$mflavor-$lapackflavor trilinos/12.14.1-$mflavor-$lapackflavor"


### PR DESCRIPTION
### Background

* Limit how many concurrent tests can access the GPU.  This should help reduce the number of tests that fail due to 'out of device memory' errors.

### Description of changes

+ Leverage ctest's `RESOURCE_LOCK` to limit how many tests can be run concurrently that access the GPU.  The default is 10 concurrent jobs (`MAX_TESTS_PER_GPU`).
+ When registering tests, add property `${GPU_RESOURCE_LOCK}`.  This variable has no effect if `USE_CUDA=OFF` or `HAVE_CUDA=OFF`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
