### PR TITLE
Mark functions defined in header inline to change to internal linkage

### DIFF
--- a/src/c4/xthi_cpuset.hh
+++ b/src/c4/xthi_cpuset.hh
@@ -91,7 +91,8 @@ static inline bool CPU_ISSET(int num, cpu_set_t *cs) {
   return (cs->count & teh_bit) != 0;
 }
 
-int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/, cpu_set_t *cpu_set) {
+inline int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/,
+                             cpu_set_t *cpu_set) {
   int64_t core_count = 0;
   size_t len = sizeof(core_count);
   int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);
@@ -112,7 +113,7 @@ int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/, cpu_set_t *cpu_set) {
 #ifdef WIN32
 
 //! \param[in] num_cpu Number of CPU's per node.
-std::string cpuset_to_string(unsigned const num_cpu) {
+inline std::string cpuset_to_string(unsigned const num_cpu) {
 
   // return value;
   std::ostringstream cpuset;
@@ -151,7 +152,7 @@ std::string cpuset_to_string(unsigned const num_cpu) {
 
 #else
 
-std::string cpuset_to_string(unsigned const /*num_cpu*/) {
+inline std::string cpuset_to_string(unsigned const /*num_cpu*/) {
 
   // return value;
   std::ostringstream cpuset;


### PR DESCRIPTION
### Background

* Some functions in c4/xthi_cpuset.hh have external linkage; this leads to multiple definition errors.

### Purpose of Pull Request

* make functions have internal linkage
* [Fixes Redmine Issue #2127](https://rtt.lanl.gov/redmine/issues/2127)

### Description of changes

* mark function definitions `inline`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
