### PR TITLE
New vendor locations for ccs-net

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -195,7 +195,7 @@ if [[ ${INTERACTIVE} == true ]]; then
       ;;
     ccscs[1-4]* | ccscs[6-9]*)
       # shellcheck source=/dev/null
-      source "${DRACO_ENV_DIR}/bashrc/.bashrc_linux64" ;;
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_ccsnet" ;;
 
     # Assume personal workstation
     *) export NoModules=1 ;;

--- a/environment/bashrc/.bashrc_ccsnet
+++ b/environment/bashrc/.bashrc_ccsnet
@@ -1,10 +1,10 @@
 #!/bin/bash
 ##-*- Mode: bash -*-
 ##---------------------------------------------------------------------------##
-## File  : environment/bashrc/.bashrc_linux64
-## Date  : Tuesday, May 31, 2016, 14:48 pm
-## Author: Kelly Thompson
-## Note  : Copyright (C) 2016-2019, Triad National Security, LLC.
+## File  : environment/bashrc/.bashrc_ccsnet
+## Date  : Friday, Aug 28, 2020, 16:10 pm
+## Author: Kelly Thompson <kgt@lanl.gov>
+## Note  : Copyright (C) 2020, Triad National Security, LLC.
 ##         All rights are reserved.
 ##
 ##  Bash configuration file upon bash shell startup
@@ -37,33 +37,19 @@ add_to_path ${VENDOR_DIR}/bin PATH
 target=`uname -n`
 case $target in
   ccscs[1-9]*)
-    # Add /scratch/vendors/Modules.lmod (totalview, ddt, etc.)
-    # Add /scratch/vendors/Modules.core (spack generated modules).
     if [[ "${MODULEPATH}x" == "x" ]]; then
       export MODULEPATH=/ccs/opt/modulefiles
     fi
     module load user_contrib/2020.04
     module use --append /ccs/codes/radtran/Modules
     module load draco/gcc930
-#     dm_core="ack dia doxygen git graphviz htop mscgen numdiff python random123 \
-# tk totalview"
-#     dm_gcc="gcc cmake eospac/6.3.1_r20161202150449 gsl metis netlib-lapack qt"
-#     dm_openmpi="openmpi parmetis superlu-dist trilinos"
-#     if [[ `groups | grep -c ccsrad` != 0 ]]; then
-#       dm_openmpi="$dm_openmpi csk ndi"
-#     fi
-#     export dracomodules="$dm_core $dm_gcc $dm_openmpi"
     ;;
   ccsnet[23]*|rtt*)
     module load user_contrib/2020.04
     module use --append /ccs/codes/radtran/Modules
     ;;
 *)
-    #setup_tcl_modules
-    #module use /ccs/codes/radtran/vendors/Modules
-    #export dracomodules="gcc openmpi emacs/24.4 totalview cmake \
-#lapack random123 eospac dracoscripts git svn dia graphviz doxygen \
-#metis parmetis superlu-dist trilinos ndi csk"
+    die "I don't know how to setup modules for $target"
     ;;
 esac
 
@@ -73,5 +59,5 @@ add_to_path ${DRACO_SRC_DIR}/environment/bibtex BSTINPUTS
 add_to_path ${DRACO_SRC_DIR}/environment/bibfiles BIBINPUTS
 
 ##---------------------------------------------------------------------------##
-## end of .bashrc_linux64
+## end of .bashrc_ccsnet
 ##---------------------------------------------------------------------------##

--- a/environment/bashrc/.bashrc_ccsnet
+++ b/environment/bashrc/.bashrc_ccsnet
@@ -1,0 +1,77 @@
+#!/bin/bash
+##-*- Mode: bash -*-
+##---------------------------------------------------------------------------##
+## File  : environment/bashrc/.bashrc_linux64
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016-2019, Triad National Security, LLC.
+##         All rights are reserved.
+##
+##  Bash configuration file upon bash shell startup
+##---------------------------------------------------------------------------##
+
+if [[ -n "$verbose" ]]; then echo "In .bashrc_linux64"; fi
+
+##---------------------------------------------------------------------------##
+## ENVIRONMENTS
+##---------------------------------------------------------------------------##
+
+# Vendor (Third party libraries) location:
+if ! [[ ${VENDOR_DIR} ]]; then
+  target=`uname -n`
+  case $target in
+    ccscs[1-9]* | ccsnet* ) export VENDOR_DIR=/scratch/vendors ;;
+    *)
+      if [[ -d /ccs/codes/radtran/vendors ]]; then
+        export VENDOR_DIR=/ccs/codes/radtran/vendors
+      fi
+      ;;
+  esac
+fi
+
+add_to_path ${VENDOR_DIR}/bin PATH
+
+#------------------------------------------------------------------------------#
+# Setup Modules
+
+target=`uname -n`
+case $target in
+  ccscs[1-9]*)
+    # Add /scratch/vendors/Modules.lmod (totalview, ddt, etc.)
+    # Add /scratch/vendors/Modules.core (spack generated modules).
+    if [[ "${MODULEPATH}x" == "x" ]]; then
+      export MODULEPATH=/ccs/opt/modulefiles
+    fi
+    module load user_contrib/2020.04
+    module use --append /ccs/codes/radtran/Modules
+    module load draco/gcc930
+#     dm_core="ack dia doxygen git graphviz htop mscgen numdiff python random123 \
+# tk totalview"
+#     dm_gcc="gcc cmake eospac/6.3.1_r20161202150449 gsl metis netlib-lapack qt"
+#     dm_openmpi="openmpi parmetis superlu-dist trilinos"
+#     if [[ `groups | grep -c ccsrad` != 0 ]]; then
+#       dm_openmpi="$dm_openmpi csk ndi"
+#     fi
+#     export dracomodules="$dm_core $dm_gcc $dm_openmpi"
+    ;;
+  ccsnet[23]*|rtt*)
+    module load user_contrib/2020.04
+    module use --append /ccs/codes/radtran/Modules
+    ;;
+*)
+    #setup_tcl_modules
+    #module use /ccs/codes/radtran/vendors/Modules
+    #export dracomodules="gcc openmpi emacs/24.4 totalview cmake \
+#lapack random123 eospac dracoscripts git svn dia graphviz doxygen \
+#metis parmetis superlu-dist trilinos ndi csk"
+    ;;
+esac
+
+#LaTeX
+add_to_path ${DRACO_SRC_DIR}/environment/latex TEXINPUTS
+add_to_path ${DRACO_SRC_DIR}/environment/bibtex BSTINPUTS
+add_to_path ${DRACO_SRC_DIR}/environment/bibfiles BIBINPUTS
+
+##---------------------------------------------------------------------------##
+## end of .bashrc_linux64
+##---------------------------------------------------------------------------##


### PR DESCRIPTION
### Background

* move to new spack provided TPL installations and modules.

### Details

* Update the `.bashrc` for ccs-net machines so that modules and vendors located at `/ccs/opt/vendors/spack.20200429`
* Provide and use new 'super'-modules that live at `/ccs/codes/radtran/draco`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
