### PR TITLE
Fix TF_ environment for rzansel and sierra

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -21,8 +21,8 @@ export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
 
 # Support building cassio with ccsrad shared deployment repository.
 if [[ -d /usr/workspace/eapdev/eap/users/ccsrad/Cassio.deployment ]]; then
-  export TF_DEPLOYMENT_CLONES=/usr/workspace/eapdev/eap/users/ccsrad/Cassio.deployment
-  export TF_SPACK_INSTANCES=/usr/workspace/eapdev/eap/users/ccsrad/spack_instances
+  export TF_DEPLOYMENT_CLONES=/usr/workspace/dacodes/eap/users/ccsrad/eap.deployment
+  export TF_SPACK_INSTANCES=/usr/workspace/dacodes/eap/users/ccsrad/spack_instances
 fi
 
 #


### PR DESCRIPTION
### Background

* There were some weird permissions issues related _workspace_ locations on rzansel and sierra.  This change fixes those issues.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
