### PR TITLE
Make type conversions explicit when testing large ints

### DIFF
--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -1276,7 +1276,8 @@ void test_array_prefix_sum(rtt_dsxx::UnitTest &ut) {
   // handled correctly in the calls)
   vector<uint32_t> xuint(array_size, 0);
   for (int32_t i = 0; i < array_size; ++i)
-    xuint[i] = std::numeric_limits<int>::max() + rtt_c4::node() * 10 + i;
+    xuint[i] = static_cast<uint32_t>(std::numeric_limits<int>::max()) +
+               rtt_c4::node() * 10 + i;
 
   prefix_sum(&xuint[0], array_size);
 
@@ -1284,7 +1285,8 @@ void test_array_prefix_sum(rtt_dsxx::UnitTest &ut) {
   for (int32_t i = 0; i < array_size; ++i) {
     for (int32_t r = 0; r < rtt_c4::nodes(); ++r) {
       if (r <= rtt_c4::node())
-        uint_answer[i] += std::numeric_limits<int>::max() + r * 10 + i;
+        uint_answer[i] +=
+            static_cast<uint32_t>(std::numeric_limits<int>::max()) + r * 10 + i;
     }
   }
 
@@ -1322,7 +1324,8 @@ void test_array_prefix_sum(rtt_dsxx::UnitTest &ut) {
   // types are handled correctly in the calls)
   vector<uint64_t> xulong(array_size, 0);
   for (int32_t i = 0; i < array_size; ++i)
-    xulong[i] = std::numeric_limits<int64_t>::max() + rtt_c4::node() * 10 + i;
+    xulong[i] = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) +
+                rtt_c4::node() * 10 + i;
 
   prefix_sum(&xulong[0], array_size);
 
@@ -1330,7 +1333,9 @@ void test_array_prefix_sum(rtt_dsxx::UnitTest &ut) {
   for (int32_t i = 0; i < array_size; ++i) {
     for (int32_t r = 0; r < rtt_c4::nodes(); ++r) {
       if (r <= rtt_c4::node())
-        ulong_answer[i] += std::numeric_limits<int64_t>::max() + r * 10 + i;
+        ulong_answer[i] +=
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) +
+            r * 10 + i;
     }
   }
 


### PR DESCRIPTION
### Background

* Fixes a test that started diffing with `gcc/9.3.0`. The behavior of gcc/9.3.0 is not what I'd expect but I don't care to look into it further.

### Purpose of Pull Request

* Fixes failing tests (https://rtt.lanl.gov/cdash/viewTest.php?onlyfailed&buildid=68633)

### Description of changes

* Static cast the `std::numeric_limits<int>::max()` to a uint32_t type to avoid unexpected behavior
* Static cast the `std::numeric_limits<int64_t>::max()` to a uint64_t type to avoid unexpected behavior

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
