### PR TITLE
Minor update to draco-developer bash files.

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -4,7 +4,7 @@
 ## File  : environment/bashrc/.bashrc
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016-2019, Triad National Security, LLC.
+## Note  : Copyright (C) 2016-2020, Triad National Security, LLC.
 ##         All rights are reserved.
 ##
 ## Bash configuration file upon bash shell startup
@@ -217,7 +217,7 @@ fi
 source "${DRACO_ENV_DIR}/bashrc/bash_functions2.sh"
 
 if [[ "${verbose:=false}" == "true" ]]; then
-  echo "done with draco/environment/bashrc/.bashrc";
+  echo "in draco/environment/bashrc/.bashrc ... done";
 fi
 
 ##---------------------------------------------------------------------------##

--- a/environment/bashrc/.bashrc_ccsnet
+++ b/environment/bashrc/.bashrc_ccsnet
@@ -10,7 +10,7 @@
 ##  Bash configuration file upon bash shell startup
 ##---------------------------------------------------------------------------##
 
-if [[ -n "$verbose" ]]; then echo "In .bashrc_linux64"; fi
+if [[ -n "$verbose" ]]; then echo "In draco/environment/bashrc/.bashrc_ccsnet"; fi
 
 ##---------------------------------------------------------------------------##
 ## ENVIRONMENTS

--- a/environment/bashrc/bash_aliases.sh
+++ b/environment/bashrc/bash_aliases.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 ##-*- Mode: bash -*-
-#------------------------------------------------------------------------------#
-# bashrc_aliases
-#
-# bashrc_aliases is sourced by interactive shells from
-# .bash_profile and .bashrc
-#------------------------------------------------------------------------------#
+##---------------------------------------------------------------------------##
+## File  : environment/bashrc/bashrc_aliases.sh
+## Date  : Tuesday, Sep 01, 2020, 19:01 pm
+## Author: Kelly Thompson <kgt@lanl.gov>
+## Note  : Copyright (C) 2020, Triad National Security, LLC.
+##         All rights are reserved.
+##
+## bashrc_aliases is sourced by interactive shells from .bash_profile and
+## .bashrc
+##---------------------------------------------------------------------------##
 
 #------------------------------------------------------------------------------#
 # Draco Dev Env Customizations
@@ -35,10 +39,15 @@ alias resettermtitle='echo -ne "\033]0;${nodename}\007"'
 # Module related:
 alias moduel='module'
 alias ma='module avail'
+alias mica='module --ignore_cache avail'
 alias mls='module list'
 alias mld='module load'
 alias mul='module unload'
 alias msh='module show'
+
+# machines
+alias sierra='ssh -t redcap ssh sierra.llnl.gov'
+alias rzansel='ssh -t ihpc-gate1.lanl.gov ssh rzansel.llnl.gov'
 
 #------------------------------------------------------------------------------#
 # Color Prompt
@@ -129,5 +138,5 @@ unset color_prompt
 # add_to_path /scratch/vendors/bin PATH
 
 #------------------------------------------------------------------------------#
-# End .bash_aliases
+# End environment/bashrc/bashrc_aliases.sh
 #------------------------------------------------------------------------------#

--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -3,7 +3,7 @@
 ## File  : environment/bashrc/bash_functions.sh
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
 ## Author: Kelly Thompson
-## Note  : Copyright (C) 2016-2019, Triad National Security, LLC.
+## Note  : Copyright (C) 2016-2020, Triad National Security, LLC.
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 ##
@@ -343,7 +343,7 @@ function qrm ()
 export -f qrm
 
 if [[ "${verbose:=false}" ==  "true" ]]; then
-  echo "done with draco/environment/bashrc/bash_functions.sh";
+  echo "in draco/environment/bashrc/bash_functions.sh ... done";
 fi
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
### Description of changes

+ Add alias for connecting to `rzansel` and `sierra`.
+ Add alias `mica` for `module --ignore_cache avail`.  This is useful on CTS-1 as we transition to a new user_contrib stack.
+ Update debug statements and copyright dates.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
