### PR TITLE
Fix a CrayPrg + spack configuration logic issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ dbsConfigInfo()
 # Platform Checks: Is HOST_NAME_MAX defined?  Is WinSock2.h available?  Is
 # gethostname() available?
 include( platform_checks )
-query_craype()
 set_draco_uname()
 query_have_gethostname()
 query_have_maxpathlen()

--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -64,48 +64,6 @@ Platform Checks...
 ")
 dbs_set_sitename()
 
-#--------------------------------------------------------------------------------------------------#
-# Sanity checks for Cray Programming Environments
-#
-# - Ensure CMAKE_EXE_LINKER_FLAGS contains "-dynamic"
-# - Ensure that the compilers given to cmake are actually Cray compiler
-#   wrappers.
-#--------------------------------------------------------------------------------------------------#
-macro( query_craype )
-
-  # We expect developers to use the Cray compiler wrappers. See also
-  # https://cmake.org/cmake/help/latest/module/FindMPI.html
-  #
-  # Skip this check if building from within spack.
-  if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv AND
-      NOT "$ENV{CXX}" MATCHES "$ENV{SPACK_ROOT}/lib/spack/env/" )
-    if( NOT "$ENV{CXX}" MATCHES "CC$" OR
-        NOT "$ENV{CC}" MATCHES "cc$" OR
-        NOT "$ENV{FC}" MATCHES "ftn$" OR
-        NOT "$ENV{CRAYPE_LINK_TYPE}" MATCHES "dynamic$" )
-      message( FATAL_ERROR
-        "The build system requires that the Cray compiler wrappers (CC, cc, "
-        "ftn) be used when configuring this product on a Cray system "
-        "(CMAKE_CXX_COMPILER_WRAPPER = ${CMAKE_CXX_COMPILER_WRAPPER}). The "
-        "development environment must also support dynamic linking.  The "
-        "build system thinks you are trying to use:\n"
-        "  CMAKE_CXX_COMPILER     = ${CMAKE_CXX_COMPILER}\n"
-        "  CMAKE_C_COMPILER       = ${CMAKE_C_COMPILER}\n"
-        "  CMAKE_Fortran_COMPILER = ${CMAKE_Fortran_COMPILER}\n"
-        "  CRAYPE_LINK_TYPE       = $ENV{CRAYPE_LINK_TYPE}\n"
-        "If you are working on a system that runs the Cray Programming "
-        "Environment, try setting the following variables and rerunning cmake "
-        "from a clean build directory:\n"
-        "   export CXX=`which CC`\n"
-        "   export CC=`which cc`\n"
-        "   export FC=`which ftn`\n"
-        "   export CRAYPE_LINK_TYPE=dynamic\n"
-        "Otherwise please email this error message and other related "
-        "information to draco@lanl.gov.\n" )
-    endif()
-  endif()
-endmacro()
-
 ##---------------------------------------------------------------------------##
 ## Determine System Type and System Names
 ##

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -803,7 +803,6 @@ Looking for Draco...\")
 
   # CMake macros that check the system for features like 'gethostname', etc.
   include( platform_checks )
-  query_craype()
 
   # Set compiler options
   include( compilerEnv )


### PR DESCRIPTION
### Background

* A logic error related to discovery of Cray compile wrappers in `platform_checks.cmake` could lead to a configuration failure when building under spack.

### Purpose of Pull Request

* Fixes #900 

### Description of changes

* ~~Convert `SPACK_ROOT` to canonical form.~~
* Remove `query_craype` check as superfluous.
  * This check was helpful we we were still learning how to build and run on Cray machines, but isn't really that helpful now and gets in the way when building TRT codes via spack.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
