### PR TITLE
WIP: Implement a CMake object libraries capability.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,6 @@ build_script:
   - cd \projects
   - mkdir build
   - cd build
-# no MPI installed so force scalar builds.
   - echo cmake -G "%GENERATOR%" -A x64 %CMAKE_OPTIONS% -DDRACO_C4=%C4_OPTS% %APPVEYOR_BUILD_FOLDER%
   - cmake -G "%GENERATOR%" -A x64 %CMAKE_OPTIONS% -DDRACO_C4=%C4_OPTS% %APPVEYOR_BUILD_FOLDER%
   - echo cmake --build . --config %BUILD_TYPE% -j %NUMBER_OF_PROCESSORS%

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -325,7 +325,6 @@ macro( add_component_library )
   if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Generate an object library.  This can be used instead of the regular library for better
     # interprocedural optimization at link time.
-    message(FATAL_ERROR "should not get here")
     if( "${acl_TARGET}" MATCHES "Lib_" )
       string( REPLACE "Lib_" "Objlib_" acl_objlib_TARGET ${acl_TARGET} )
     else()

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -271,7 +271,7 @@ macro( add_component_library )
     acl
     "NOEXPORT"
     "PREFIX;TARGET;LIBRARY_NAME;LIBRARY_NAME_PREFIX;LIBRARY_TYPE;LINK_LANGUAGE"
-    "HEADERS;SOURCES;TARGET_DEPS;VENDOR_LIST;VENDOR_LIBS;VENDOR_INCLUDE_DIRS"
+    "HEADERS;SOURCES;INCLUDE_DIRS;TARGET_DEPS;VENDOR_LIST;VENDOR_LIBS;VENDOR_INCLUDE_DIRS"
     ${ARGV} )
 
   #
@@ -324,11 +324,25 @@ macro( add_component_library )
       LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
   endif()
 
+  # Generate an object library.  This can be used instead of the regular library for better
+  # interprocedural optimization at link time.
+  if( "${acl_TARGET}" MATCHES "Lib_" )
+    string( REPLACE "Lib_" "Objlib_" acl_objlib_TARGET ${acl_TARGET} )
+  else()
+    string( CONCAT acl_objlib_TARGET "Objlib_" "${acl_TARGET}" )
+  endif()
+  add_library( ${acl_objlib_TARGET} OBJECT ${acl_SOURCES} )
+
   #
   # Generate properties related to library dependencies
   #
-  if( NOT "${acl_TARGET_DEPS}x" STREQUAL "x" )
+  if( DEFINED acl_TARGET_DEPS )
     target_link_libraries( ${acl_TARGET} ${acl_TARGET_DEPS} )
+    target_link_libraries( ${acl_objlib_TARGET} ${acl_TARGET_DEPS} )
+  endif()
+  if( DEFINED acl_INCLUDE_DIRS )
+    target_include_directories( ${acl_TARGET} ${acl_INCLUDE_DIRS} )
+    target_include_directories( ${acl_objlib_TARGET} ${acl_INCLUDE_DIRS} )
   endif()
   if( NOT "${acl_VENDOR_LIBS}x" STREQUAL "x" )
     target_link_libraries( ${acl_TARGET} ${acl_VENDOR_LIBS} )

--- a/src/RTT_Format_Reader/CMakeLists.txt
+++ b/src/RTT_Format_Reader/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for RTT_Format_Reader.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,14 +12,12 @@ project( RTT_Format_Reader CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_RTT_Format_Reader
    TARGET_DEPS  Lib_meshReaders
@@ -31,19 +29,16 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_RTT_Format_Reader EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
+install( TARGETS Lib_RTT_Format_Reader Objlib_RTT_Format_Reader EXPORT draco-targets
+  DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/RTT_Format_Reader )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_RTT_Format_Reader>
-    DESTINATION ${DBSCFGDIR}lib  OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_RTT_Format_Reader> DESTINATION ${DBSCFGDIR}lib  OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -51,7 +46,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/RTT_Format_Reader/CMakeLists.txt
+++ b/src/RTT_Format_Reader/CMakeLists.txt
@@ -29,12 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_RTT_Format_Reader Objlib_RTT_Format_Reader EXPORT draco-targets
-  DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/RTT_Format_Reader )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_RTT_Format_Reader> DESTINATION ${DBSCFGDIR}lib  OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/VendorChecks/CMakeLists.txt
+++ b/src/VendorChecks/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2016 May 11
 # brief  Small test of Vendors libraries (if found)
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)

--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -113,12 +113,7 @@ add_subdirectory( bin )
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_c4 Objlib_c4 EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/c4 )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_c4> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/c4/CMakeLists.txt
+++ b/src/c4/CMakeLists.txt
@@ -47,13 +47,11 @@ endif()
 add_component_library(
    TARGET       Lib_c4
    TARGET_DEPS  ${target_deps}
+   INCLUDE_DIRS "PUBLIC;$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
    LIBRARY_NAME c4
    SOURCES      "${sources}"
    HEADERS      "${headers}"
-   ${c4_extra_VENDORS}
-   )
-target_include_directories( Lib_c4
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
+   ${c4_extra_VENDORS}  )
 
 # ---------------------------------------------------------------------------- #
 # Fortran-based MPI wrapper
@@ -115,7 +113,7 @@ add_subdirectory( bin )
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_c4 EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_c4 Objlib_c4 EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/c4 )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   install(FILES $<TARGET_PDB_FILE:Lib_c4> DESTINATION ${DBSCFGDIR}lib

--- a/src/c4/fc4/CMakeLists.txt
+++ b/src/c4/fc4/CMakeLists.txt
@@ -42,9 +42,8 @@ add_component_library(
   LIBRARY_NAME fc4
   SOURCES      "${f90sources}"
   LINK_LANGUAGE Fortran
-  TARGET_DEPS   "${target_deps}")
-target_include_directories( Lib_c4_fc4 PUBLIC
-    $<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}/fc4> )
+  TARGET_DEPS   "${target_deps}"
+  INCLUDE_DIRS  "PUBLIC;$<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}/fc4>")
 if( WIN32 )
   # The library must be installed in the master project's RUNTIME_OUTPUT_DIR
   set_target_properties( Lib_c4_fc4 PROPERTIES
@@ -54,7 +53,7 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Install
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_c4_fc4 EXPORT draco-targets
+install( TARGETS Lib_c4_fc4 Objlib_c4_fc4 EXPORT draco-targets
   LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
   ARCHIVE DESTINATION "${DBSCFGDIR}lib"
   RUNTIME DESTINATION "${DBSCFGDIR}bin"

--- a/src/c4/fc4/CMakeLists.txt
+++ b/src/c4/fc4/CMakeLists.txt
@@ -53,7 +53,14 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Install
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_c4_fc4 Objlib_c4_fc4 EXPORT draco-targets
+if(TARGET Objlib_c4_fc4)
+  install( TARGETS Objlib_c4_fc4 EXPORT draco-targets
+    LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
+    ARCHIVE DESTINATION "${DBSCFGDIR}lib"
+    RUNTIME DESTINATION "${DBSCFGDIR}bin"
+    PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/fc4" )
+endif()
+install( TARGETS Lib_c4_fc4 EXPORT draco-targets
   LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
   ARCHIVE DESTINATION "${DBSCFGDIR}lib"
   RUNTIME DESTINATION "${DBSCFGDIR}bin"

--- a/src/c4/fc4/CMakeLists.txt
+++ b/src/c4/fc4/CMakeLists.txt
@@ -43,7 +43,8 @@ add_component_library(
   SOURCES      "${f90sources}"
   LINK_LANGUAGE Fortran
   TARGET_DEPS   "${target_deps}"
-  INCLUDE_DIRS  "PUBLIC;$<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}/fc4>")
+  INCLUDE_DIRS  "PUBLIC;$<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}/fc4>"
+  EXPORT_NAME   skip )
 if( WIN32 )
   # The library must be installed in the master project's RUNTIME_OUTPUT_DIR
   set_target_properties( Lib_c4_fc4 PROPERTIES

--- a/src/c4/ftest/CMakeLists.txt
+++ b/src/c4/ftest/CMakeLists.txt
@@ -37,16 +37,17 @@ set( f90sources
 # Build library for test directory
 # ---------------------------------------------------------------------------- #
 set(target_deps Lib_c4_fc4 Lib_c4 Lib_dsxx )
+set(include_dirs PUBLIC
+  "$<BUILD_INTERFACE:${c4_ftest_BINARY_DIR}>"
+  "$<BUILD_INTERFACE:${fc4_BINARY_DIR}>")
 add_component_library(
   TARGET        Lib_c4_ftest
   LIBRARY_NAME  c4_ftest
   SOURCES       "${f90sources}"
   LINK_LANGUAGE Fortran
   TARGET_DEPS   "${target_deps}"
+  INCLUDE_DIRS  "${include_dirs}"
   NOEXPORT )
-target_include_directories( Lib_c4_ftest PUBLIC
-  "$<BUILD_INTERFACE:${c4_ftest_BINARY_DIR}>"
-  "$<BUILD_INTERFACE:${fc4_BINARY_DIR}>")
 
 #------------------------------------------------------------------------------#
 # End c4/ftest/CMakeLists.txt

--- a/src/cdi/CMakeLists.txt
+++ b/src/cdi/CMakeLists.txt
@@ -29,12 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_cdi Objlib_cdi EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/cdi/CMakeLists.txt
+++ b/src/cdi/CMakeLists.txt
@@ -12,7 +12,6 @@ project( cdi CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
@@ -20,7 +19,6 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_cdi
    TARGET_DEPS  Lib_dsxx
@@ -31,8 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_cdi EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_cdi Objlib_cdi EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   install(FILES $<TARGET_PDB_FILE:Lib_cdi> DESTINATION ${DBSCFGDIR}lib
@@ -42,7 +39,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -50,5 +46,8 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
+
+#--------------------------------------------------------------------------------------------------#
+# End cdi/CMakeLists.txt
+#--------------------------------------------------------------------------------------------------#

--- a/src/cdi_CPEloss/CMakeLists.txt
+++ b/src/cdi_CPEloss/CMakeLists.txt
@@ -28,8 +28,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_cdi_CPEloss Objlib_cdi_CPEloss EXPORT draco-targets
-  DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_CPEloss )
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_CPEloss/CMakeLists.txt
+++ b/src/cdi_CPEloss/CMakeLists.txt
@@ -12,14 +12,12 @@ project( cdi_CPEloss CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_cdi_CPEloss
    TARGET_DEPS  "Lib_cdi;Lib_units"
@@ -30,15 +28,13 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_cdi_CPEloss  EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
+install( TARGETS Lib_cdi_CPEloss Objlib_cdi_CPEloss EXPORT draco-targets
+  DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_CPEloss )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
   add_subdirectory( test )
 endif()
@@ -46,7 +42,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_analytic/CMakeLists.txt
+++ b/src/cdi_analytic/CMakeLists.txt
@@ -12,14 +12,12 @@ project( cdi_analytic CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_cdi_analytic
    TARGET_DEPS  "Lib_parser;Lib_roots;Lib_cdi"
@@ -30,19 +28,16 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_cdi_analytic EXPORT draco-targets DESTINATION
+install( TARGETS Lib_cdi_analytic Objlib_cdi_analytic EXPORT draco-targets DESTINATION
   ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_analytic )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_analytic> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_cdi_analytic> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -50,7 +45,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/cdi_analytic/CMakeLists.txt
+++ b/src/cdi_analytic/CMakeLists.txt
@@ -28,12 +28,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_cdi_analytic Objlib_cdi_analytic EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_analytic )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_analytic> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -12,7 +12,6 @@ if( EOSPAC_FOUND AND NOT DEFINED ENV{TRAVIS} )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( REMOVE_ITEM sources ${PROJECT_SOURCE_DIR}/QueryEospac.cc )
@@ -20,14 +19,13 @@ list( REMOVE_ITEM sources ${PROJECT_SOURCE_DIR}/QueryEospac.cc )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_cdi_eospac
    TARGET_DEPS  "Lib_cdi;EOSPAC::eospac"
+   INCLUDE_DIRS "PUBLIC;${EOSPAC_INCLUDE_DIR}"
    LIBRARY_NAME cdi_eospac
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
-target_include_directories( Lib_cdi_eospac PUBLIC ${EOSPAC_INCLUDE_DIR} )
 
 add_component_executable(
   TARGET      Exe_QueryEospac
@@ -45,15 +43,11 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_cdi_eospac  EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
-install( TARGETS Exe_QueryEospac EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}bin )
+install( TARGETS Lib_cdi_eospac Objlib_cdi_eospac EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Exe_QueryEospac EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_eospac )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_eospac> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_cdi_eospac> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_eospac/CMakeLists.txt
+++ b/src/cdi_eospac/CMakeLists.txt
@@ -43,12 +43,8 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_cdi_eospac Objlib_cdi_eospac EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( TARGETS Exe_QueryEospac EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_eospac )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_eospac> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/cdi_ipcress/CMakeLists.txt
+++ b/src/cdi_ipcress/CMakeLists.txt
@@ -12,26 +12,22 @@ project( cdi_ipcress CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 set( sources
    IpcressFile.cc
    IpcressDataTable.cc
    IpcressGrayOpacity.cc
-   IpcressMultigroupOpacity.cc
-)
+   IpcressMultigroupOpacity.cc )
 set( headers
    IpcressFile.hh
    IpcressMaterial.hh
    IpcressFile.t.hh
    IpcressDataTable.hh
    IpcressGrayOpacity.hh
-   IpcressMultigroupOpacity.hh
-)
+   IpcressMultigroupOpacity.hh )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
   TARGET       Lib_cdi_ipcress
   TARGET_DEPS  "Lib_cdi"
@@ -49,18 +45,14 @@ add_component_executable(
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 set( CMAKE_INSTALL_DO_STRIP NO )
-install( TARGETS Lib_cdi_ipcress EXPORT draco-targets
+install( TARGETS Lib_cdi_ipcress Objlib_cdi_ipcress EXPORT draco-targets
   DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ipcress )
-install( TARGETS Exe_Ipcress_Interpreter EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}bin )
+install( TARGETS Exe_Ipcress_Interpreter EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ipcress> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ipcress> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
-install( FILES python/ipcress_reader.py python/plot_ipcress_opacity.py
-  DESTINATION ${DBSCFGDIR}bin )
-
+install( FILES python/ipcress_reader.py python/plot_ipcress_opacity.py DESTINATION ${DBSCFGDIR}bin )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/cdi_ipcress/CMakeLists.txt
+++ b/src/cdi_ipcress/CMakeLists.txt
@@ -8,6 +8,7 @@
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
 project( cdi_ipcress CXX )
+set( CMAKE_INSTALL_DO_STRIP NO )
 
 # ---------------------------------------------------------------------------- #
 # Source files
@@ -44,14 +45,9 @@ add_component_executable(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-set( CMAKE_INSTALL_DO_STRIP NO )
-install( TARGETS Lib_cdi_ipcress Objlib_cdi_ipcress EXPORT draco-targets
-  DESTINATION ${DBSCFGDIR}lib )
+
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ipcress )
 install( TARGETS Exe_Ipcress_Interpreter EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ipcress> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 install( FILES python/ipcress_reader.py python/plot_ipcress_opacity.py DESTINATION ${DBSCFGDIR}bin )
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -10,7 +10,6 @@ project( cdi_ndi CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 list( APPEND headers ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
@@ -41,29 +40,25 @@ configure_file( config.h.in ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
+set( include_dirs PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
+if(TARGET NDI::ndi)
+  list(APPEND include_dirs ${NDI_INCLUDE_DIR} )
+endif()
 add_component_library(
    TARGET       Lib_cdi_ndi
    TARGET_DEPS  "${deps}"
+   INCLUDE_DIRS "${include_dirs}"
    LIBRARY_NAME cdi_ndi
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
 
-target_include_directories( Lib_cdi_ndi
-   PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
-
-if(TARGET NDI::ndi)
-  target_include_directories( Lib_cdi_ndi PUBLIC ${NDI_INCLUDE_DIR} )
-endif()
-
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_cdi_ndi  EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
+install( TARGETS Lib_cdi_ndi Objlib_cdi_ndi EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ndi )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ndi> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ndi> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -55,11 +55,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_cdi_ndi Objlib_cdi_ndi EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ndi )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_cdi_ndi> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/compton/CMakeLists.txt
+++ b/src/compton/CMakeLists.txt
@@ -47,11 +47,7 @@ if( TARGET COMPTON::compton )
   # -------------------------------------------------------------------------- #
   # Installation instructions
   # -------------------------------------------------------------------------- #
-  install( TARGETS Lib_compton Objlib_compton EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
   install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/compton )
-  if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    install(FILES $<TARGET_PDB_FILE:Lib_compton> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-  endif()
 
   # -------------------------------------------------------------------------- #
   # Unit tests

--- a/src/compton/CMakeLists.txt
+++ b/src/compton/CMakeLists.txt
@@ -16,7 +16,6 @@ project( compton CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/compton/config.h )
 
 set( sources "${PROJECT_SOURCE_DIR}/Compton.cc" )
@@ -33,36 +32,30 @@ if( TARGET COMPTON::compton )
   add_component_library(
     TARGET       Lib_compton
     TARGET_DEPS  "Lib_c4;COMPTON::compton"
+    INCLUDE_DIRS "PUBLIC;$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
     LIBRARY_NAME compton
     SOURCES      "${sources}"
     HEADERS      "${headers}" )
-  # generated include directive files (config.h)
-  target_include_directories( Lib_compton
-    PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
   # Copy necessary dll files to the build directory
   if( MSVC AND DRACO_LIBRARY_TYPE STREQUAL SHARED )
     add_custom_command( TARGET Lib_compton POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
               $<TARGET_FILE:COMPTON::compton> $<TARGET_FILE_DIR:Lib_compton> )
   endif()
 
   # -------------------------------------------------------------------------- #
   # Installation instructions
   # -------------------------------------------------------------------------- #
-
-  install( TARGETS Lib_compton EXPORT draco-targets DESTINATION
-    ${DBSCFGDIR}lib )
+  install( TARGETS Lib_compton Objlib_compton EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
   install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/compton )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_compton> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
-endif()
+  if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    install(FILES $<TARGET_PDB_FILE:Lib_compton> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
+  endif()
 
   # -------------------------------------------------------------------------- #
   # Unit tests
   # -------------------------------------------------------------------------- #
-
   if( BUILD_TESTING )
     add_subdirectory( test )
   endif()
@@ -70,7 +63,6 @@ endif()
   # -------------------------------------------------------------------------- #
   # Autodoc
   # -------------------------------------------------------------------------- #
-
   process_autodoc_pages()
 
 else()

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -37,7 +37,6 @@ if( HAVE_CUDA AND USE_CUDA )
     LIBRARY_TYPE STATIC
     SOURCES      "${sources}"
     HEADERS      "${headers}" )
-  install( TARGETS Lib_device Objlib_device EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 
 endif()
 

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -26,17 +26,18 @@ if( HAVE_CUDA AND USE_CUDA )
   list( APPEND headers
     GPU_Device.hh
     device_cuda.h )
+  set( include_dirs PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}> )
   add_component_library(
     TARGET       Lib_device
     TARGET_DEPS  Lib_dsxx
+    INCLUDE_DIRS "${include_dirs}"
     LIBRARY_NAME device
     LIBRARY_TYPE STATIC
     SOURCES      "${sources}"
     HEADERS      "${headers}" )
-  target_include_directories( Lib_device
-    PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}> )
-  install( TARGETS Lib_device EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+  install( TARGETS Lib_device Objlib_device EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 
 endif()
 
@@ -45,7 +46,6 @@ install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/device )
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
   add_subdirectory( test )
 endif()
@@ -53,7 +53,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 # Push some variables up one level

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -64,7 +64,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 set(deps Lib_c4)
 if(TARGET CALIPER::caliper)
   list(APPEND deps CALIPER::caliper)
@@ -73,13 +72,11 @@ endif()
 add_component_library(
   TARGET       Lib_diagnostics
   TARGET_DEPS  "${deps}"
+  INCLUDE_DIRS "PUBLIC;$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
   LIBRARY_NAME ${PROJECT_NAME}
   SOURCES      "${sources}"
   HEADERS      "${headers}"
-  PREFIX       Draco
-  )
-target_include_directories( Lib_diagnostics
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
+  PREFIX       Draco )
 
 add_component_executable(
   TARGET      Exe_draco_info
@@ -87,32 +84,26 @@ add_component_executable(
   EXE_NAME    draco_info
   SOURCES     ${PROJECT_SOURCE_DIR}/draco_info_main.cc
   HEADERS     ${PROJECT_SOURCE_DIR}/draco_info.hh
-  PREFIX       Draco
-  )
+  PREFIX       Draco )
 
 if( Qt5Core_DIR AND NOT "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le" )
   add_subdirectory( qt )
 endif()
 
-
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_diagnostics EXPORT draco-targets DESTINATION
+install( TARGETS Lib_diagnostics Objlib_diagnostics EXPORT draco-targets DESTINATION
   ${DBSCFGDIR}lib )
-install( TARGETS Exe_draco_info  EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}bin )
+install( TARGETS Exe_draco_info  EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 install( FILES ${headers}  DESTINATION ${DBSCFGDIR}include/diagnostics )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_diagnostics> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_diagnostics> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -120,7 +111,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -93,13 +93,8 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_diagnostics Objlib_diagnostics EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
 install( TARGETS Exe_draco_info  EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
 install( FILES ${headers}  DESTINATION ${DBSCFGDIR}include/diagnostics )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_diagnostics> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -119,28 +119,28 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
+set(include_dirs PUBLIC
+  $<BUILD_INTERFACE:${Draco_SOURCE_DIR}/src>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}> )
+if( WIN32 )
+  set(target_deps ${Lib_win_winsock})
+elseif( TARGET coverage_config )
+  set(target_deps coverage_config)
+endif()
 
 add_component_library(
    TARGET       Lib_dsxx
    LIBRARY_NAME ds++
    SOURCES      "${sources}"
-   HEADERS      "${dsxx_headers};${dsxx_terminal_headers}" )
-if( WIN32 )
-  target_link_libraries( Lib_dsxx PUBLIC ${Lib_win_winsock})
-else()
-  target_link_libraries( Lib_dsxx PUBLIC coverage_config )
-endif()
-target_include_directories( Lib_dsxx
-  PUBLIC
-    $<BUILD_INTERFACE:${Draco_SOURCE_DIR}/src>
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}> )
+   HEADERS      "${dsxx_headers};${dsxx_terminal_headers}"
+   INCLUDE_DIRS "${include_dirs}"
+   TARGET_DEPS  "${target_deps}")
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_dsxx EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_dsxx Objlib_dsxx EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( TARGETS coverage_config EXPORT draco-targets )
 install( FILES ${dsxx_headers} ${template_implementations} DESTINATION
   ${DBSCFGDIR}include/ds++ )
@@ -157,7 +157,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -168,7 +167,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 # ---------------------------------------------------------------------------- #

--- a/src/ds++/CMakeLists.txt
+++ b/src/ds++/CMakeLists.txt
@@ -140,7 +140,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_dsxx Objlib_dsxx EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( TARGETS coverage_config EXPORT draco-targets )
 install( FILES ${dsxx_headers} ${template_implementations} DESTINATION
   ${DBSCFGDIR}include/ds++ )
@@ -149,10 +148,6 @@ install( FILES
     ${PROJECT_SOURCE_DIR}/terminal/LICENSE
     ${PROJECT_SOURCE_DIR}/terminal/README.md
   DESTINATION ${DBSCFGDIR}include/terminal )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_dsxx> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/experimental/CMakeLists.txt
+++ b/src/experimental/CMakeLists.txt
@@ -15,17 +15,13 @@ project( experimental CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 set( experimental_headers ${PROJECT_SOURCE_DIR}/mdspan )
-file( GLOB supporting_headers_p0009_bits
-  ${PROJECT_SOURCE_DIR}/__p0009_bits/*.hpp)
+file( GLOB supporting_headers_p0009_bits ${PROJECT_SOURCE_DIR}/__p0009_bits/*.hpp)
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( FILES ${experimental_headers} DESTINATION
-  ${DBSCFGDIR}include/experimental )
+install( FILES ${experimental_headers} DESTINATION ${DBSCFGDIR}include/experimental )
 install( FILES ${supporting_headers_p0009_bits} DESTINATION
   ${DBSCFGDIR}include/experimental/__p0009_bits )
 

--- a/src/fit/CMakeLists.txt
+++ b/src/fit/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for fit.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,21 +12,17 @@ project( fit CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( FILES ${headers} ${template_implementations}
-  DESTINATION ${DBSCFGDIR}include/fit )
+install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/fit )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -34,7 +30,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/lapack_wrap/CMakeLists.txt
+++ b/src/lapack_wrap/CMakeLists.txt
@@ -14,7 +14,6 @@ project( lapack_wrap CXX )
 # 1. LAPACK isn't found.
 # 2. We are targeting an Xcode solution (necessary cmake logic is missing).
 #------------------------------------------------------------------------------#
-
 if( HAVE_Fortran )
 
 if( NOT TARGET lapack OR ${CMAKE_GENERATOR} MATCHES Xcode)

--- a/src/linear/CMakeLists.txt
+++ b/src/linear/CMakeLists.txt
@@ -12,7 +12,6 @@ project( linear CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
@@ -21,7 +20,6 @@ list( REMOVE_ITEM headers ${template_implementations} )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_linear
    TARGET_DEPS  Lib_dsxx
@@ -32,15 +30,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_linear EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
-install( FILES ${headers} ${template_implementations} DESTINATION
-  ${DBSCFGDIR}include/linear )
+install( TARGETS Lib_linear Objlib_linear EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/linear )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -48,7 +43,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 # ---------------------------------------------------------------------------- #

--- a/src/linear/CMakeLists.txt
+++ b/src/linear/CMakeLists.txt
@@ -30,7 +30,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_linear Objlib_linear EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/linear )
 
 # ---------------------------------------------------------------------------- #

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -30,7 +30,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_memory Objlib_memory EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/memory )
 
 # ---------------------------------------------------------------------------- #

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -12,7 +12,6 @@ project( memory CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
@@ -21,7 +20,6 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_memory
    TARGET_DEPS  Lib_dsxx
@@ -32,14 +30,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_memory EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_memory Objlib_memory EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/memory )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -47,7 +43,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Ryan Wollaeger <wollaeger@lanl.gov>
 # date   Thursday, Jun 07, 2018, 15:37 pm
 # brief  Generate build project files for mesh.
-# note   Copyright (C) 2018, Triad National Security, LLC.
+# note   Copyright (C) 2018-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,7 +12,6 @@ project( mesh CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
@@ -20,31 +19,25 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_mesh
    TARGET_DEPS  "Lib_RTT_Format_Reader;Lib_parser"
    LIBRARY_NAME ${PROJECT_NAME}
    SOURCES      "${sources}"
-   HEADERS      "${headers}"
-)
+   HEADERS      "${headers}")
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_mesh EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
+install( TARGETS Lib_mesh Objlib_mesh EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/mesh )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_mesh> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_mesh> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -52,7 +45,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 # ---------------------------------------------------------------------------- #

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -29,11 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_mesh Objlib_mesh EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/mesh )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_mesh> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/meshReaders/CMakeLists.txt
+++ b/src/meshReaders/CMakeLists.txt
@@ -12,7 +12,6 @@ project( meshReaders CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
@@ -20,7 +19,6 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_meshReaders
    TARGET_DEPS  Lib_mesh_element
@@ -31,20 +29,17 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_meshReaders
+install( TARGETS Lib_meshReaders Objlib_meshReaders
    EXPORT draco-targets
    DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/meshReaders )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_meshReaders> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_meshReaders> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -52,7 +47,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/meshReaders/CMakeLists.txt
+++ b/src/meshReaders/CMakeLists.txt
@@ -29,13 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_meshReaders Objlib_meshReaders
-   EXPORT draco-targets
-   DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/meshReaders )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_meshReaders> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/mesh_element/CMakeLists.txt
+++ b/src/mesh_element/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for mesh_element/test.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -29,12 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_mesh_element Objlib_mesh_element EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/mesh_element )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_mesh_element> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/mesh_element/CMakeLists.txt
+++ b/src/mesh_element/CMakeLists.txt
@@ -12,7 +12,6 @@ project( mesh_element CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
@@ -20,7 +19,6 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_mesh_element
    TARGET_DEPS  Lib_dsxx
@@ -31,19 +29,16 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_mesh_element EXPORT draco-targets DESTINATION
+install( TARGETS Lib_mesh_element Objlib_mesh_element EXPORT draco-targets DESTINATION
   ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/mesh_element )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_mesh_element> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_mesh_element> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -51,7 +46,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 # ---------------------------------------------------------------------------- #

--- a/src/min/CMakeLists.txt
+++ b/src/min/CMakeLists.txt
@@ -30,7 +30,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_min Objlib_min EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/min )
 
 # ---------------------------------------------------------------------------- #

--- a/src/min/CMakeLists.txt
+++ b/src/min/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for min.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,7 +12,6 @@ project( min CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
@@ -21,7 +20,6 @@ list( REMOVE_ITEM headers ${template_implementations} )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_min
    TARGET_DEPS  Lib_linear
@@ -32,15 +30,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_min EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
-install( FILES ${headers} ${template_implementations} DESTINATION
-  ${DBSCFGDIR}include/min )
+install( TARGETS Lib_min Objlib_min EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/min )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -48,7 +43,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/norms/CMakeLists.txt
+++ b/src/norms/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for norms.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,7 +12,6 @@ project( norms CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
@@ -20,7 +19,6 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_norms
    TARGET_DEPS  Lib_c4
@@ -31,14 +29,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_norms EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_norms Objlib_norms EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/norms )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -46,7 +42,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/norms/CMakeLists.txt
+++ b/src/norms/CMakeLists.txt
@@ -29,7 +29,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_norms Objlib_norms EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/norms )
 
 # ---------------------------------------------------------------------------- #

--- a/src/ode/CMakeLists.txt
+++ b/src/ode/CMakeLists.txt
@@ -12,7 +12,6 @@ project( ode CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
@@ -21,14 +20,11 @@ list( REMOVE_ITEM headers ${template_implementations} )
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( FILES ${headers} ${template_implementations} DESTINATION
-  ${DBSCFGDIR}include/ode )
+install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/ode )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -36,7 +32,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for parser.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,14 +12,12 @@ project( parser CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
 
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_parser
    TARGET_DEPS  "Lib_c4;Lib_units"
@@ -30,14 +28,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_parser EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_parser Objlib_parser EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/parser )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -45,7 +41,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -28,7 +28,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_parser Objlib_parser EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/parser )
 
 # ---------------------------------------------------------------------------- #

--- a/src/plot2D/CMakeLists.txt
+++ b/src/plot2D/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for plot2D.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -27,21 +27,21 @@ list( APPEND headers ${PROJECT_BINARY_DIR}/plot2D/config.h )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
+set(include_dirs PUBLIC
+  ${Grace_INCLUDE_DIR}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 add_component_library(
    TARGET       Lib_plot2D
    TARGET_DEPS  Lib_dsxx
+   INCLUDE_DIRS "${inlcude_dirs}"
    LIBRARY_NAME plot2D
    SOURCES      "${sources}"
    HEADERS      "${headers}" )
-target_include_directories( Lib_plot2D
-   PUBLIC
-     ${Grace_INCLUDE_DIR}
-     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_plot2D EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_plot2D Objlib_plot2D EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/plot2D )
 
 # ---------------------------------------------------------------------------- #

--- a/src/plot2D/CMakeLists.txt
+++ b/src/plot2D/CMakeLists.txt
@@ -42,7 +42,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_plot2D Objlib_plot2D EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/plot2D )
 
 # ---------------------------------------------------------------------------- #

--- a/src/plot2D/CMakeLists.txt
+++ b/src/plot2D/CMakeLists.txt
@@ -30,10 +30,11 @@ list( APPEND headers ${PROJECT_BINARY_DIR}/plot2D/config.h )
 set(include_dirs PUBLIC
   ${Grace_INCLUDE_DIR}
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> )
+
 add_component_library(
    TARGET       Lib_plot2D
    TARGET_DEPS  Lib_dsxx
-   INCLUDE_DIRS "${inlcude_dirs}"
+   INCLUDE_DIRS "${include_dirs}"
    LIBRARY_NAME plot2D
    SOURCES      "${sources}"
    HEADERS      "${headers}" )

--- a/src/quadrature/CMakeLists.txt
+++ b/src/quadrature/CMakeLists.txt
@@ -30,23 +30,22 @@ add_component_library(
    TARGET       Lib_quadrature
    TARGET_DEPS  "Lib_special_functions;Lib_parser;Lib_mesh_element"
    LIBRARY_NAME ${PROJECT_NAME} )
-target_sources( Lib_quadrature PRIVATE "${headers_public}" "${sources}" )
-set_target_properties(Lib_quadrature PROPERTIES
-  PUBLIC_HEADER "${headers_public}")
+foreach( LIB Lib_quadrature Objlib_quadrature )
+    target_sources( ${LIB} PRIVATE "${headers_public}" "${sources}" )
+    set_target_properties( ${LIB} PROPERTIES PUBLIC_HEADER "${headers_public}")
+endforeach()
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_quadrature EXPORT draco-targets
+install( TARGETS Lib_quadrature Objlib_quadrature EXPORT draco-targets
   LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
   ARCHIVE DESTINATION "${DBSCFGDIR}lib"
   RUNTIME DESTINATION "${DBSCFGDIR}bin"
   PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/quadrature" )
-install( FILES ${f90sources}
-  DESTINATION ${DBSCFGDIR}include/quadrature )
+install( FILES ${f90sources} DESTINATION ${DBSCFGDIR}include/quadrature )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_quadrature> DESTINATION ${DBSCFGDIR}bin
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_quadrature> DESTINATION ${DBSCFGDIR}bin OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/quadrature/CMakeLists.txt
+++ b/src/quadrature/CMakeLists.txt
@@ -29,24 +29,31 @@ endforeach()
 add_component_library(
    TARGET       Lib_quadrature
    TARGET_DEPS  "Lib_special_functions;Lib_parser;Lib_mesh_element"
-   LIBRARY_NAME ${PROJECT_NAME} )
-foreach( LIB Lib_quadrature Objlib_quadrature )
-    target_sources( ${LIB} PRIVATE "${headers_public}" "${sources}" )
-    set_target_properties( ${LIB} PROPERTIES PUBLIC_HEADER "${headers_public}")
-endforeach()
+   LIBRARY_NAME ${PROJECT_NAME} 
+   EXPORT_NAME  skip)
+target_sources( Lib_quadrature PRIVATE "${headers_public}" "${sources}" )
+set_target_properties( Lib_quadrature PROPERTIES PUBLIC_HEADER "${headers_public}")
+if(TARGET Objlib_quadrature)
+  target_sources( Objlib_quadrature PRIVATE "${headers_public}" "${sources}" )
+  set_target_properties( Objlib_quadrature PROPERTIES PUBLIC_HEADER "${headers_public}")
+endif()
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_quadrature Objlib_quadrature EXPORT draco-targets
+install( TARGETS Lib_quadrature EXPORT draco-targets
   LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
   ARCHIVE DESTINATION "${DBSCFGDIR}lib"
   RUNTIME DESTINATION "${DBSCFGDIR}bin"
   PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/quadrature" )
-install( FILES ${f90sources} DESTINATION ${DBSCFGDIR}include/quadrature )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_quadrature> DESTINATION ${DBSCFGDIR}bin OPTIONAL)
+if(TARGET Objlib_quadrature)
+  install( TARGETS Objlib_quadrature EXPORT draco-targets
+    LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
+    ARCHIVE DESTINATION "${DBSCFGDIR}lib"
+    RUNTIME DESTINATION "${DBSCFGDIR}bin"
+    PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/quadrature" )
 endif()
+install( FILES ${f90sources} DESTINATION ${DBSCFGDIR}include/quadrature )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.17.0)
 project( rng CXX )
 
 # Local variables -------------------------------------------------------------#
-string(CONCAT header_prefix_source 
+string(CONCAT header_prefix_source
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
   "$<INSTALL_INTERFACE:${DBSCFG_IMPORT_PREFIX}/rng>")
 string(CONCAT header_prefix_binary "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
@@ -43,33 +43,35 @@ if( HAVE_CUDA AND USE_CUDA )
 else()
   set(deps Lib_dsxx GSL::gsl )
 endif()
+
+# remove 'src/device' when 'device/CMakeFiles.txt' is updated?
+set( include_dirs PUBLIC
+  $<BUILD_INTERFACE:${draco_src_dir_BINARY_DIR}/device>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+  ${RANDOM123_INCLUDE_DIR} )
 add_component_library(
   TARGET       Lib_rng
   TARGET_DEPS  "${deps}"
+  INCLUDE_DIRS "${include_dirs}"
   LIBRARY_NAME ${PROJECT_NAME} )
 # Target sources should list headers as `PUBLIC` but this is broken as of
 # cmake-3.17.0 (might actually be a Visual Studio issue?). Because this is
 # broken we mark headers as `PRIVATE`.
-target_sources( Lib_rng PRIVATE "${headers_public}" PRIVATE "${sources}" )
-set_target_properties(Lib_rng PROPERTIES
-  PUBLIC_HEADER "${headers_public}")
-target_include_directories( Lib_rng PUBLIC
-  $<BUILD_INTERFACE:${draco_src_dir_BINARY_DIR}/device> # remove this when 'device/cmakefiles.txt' is updated?
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-  ${RANDOM123_INCLUDE_DIR} )
+foreach( LIB Lib_rng Objlib_rng )
+  target_sources( ${LIB} PRIVATE "${headers_public}" PRIVATE "${sources}" )
+  set_target_properties(${LIB} PROPERTIES PUBLIC_HEADER "${headers_public}")
+endforeach()
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_rng EXPORT draco-targets
+install( TARGETS Lib_rng Objlib_rng EXPORT draco-targets
   LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
   ARCHIVE DESTINATION "${DBSCFGDIR}lib"
   RUNTIME DESTINATION "${DBSCFGDIR}bin"
   PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/rng" )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_rng> DESTINATION ${DBSCFGDIR}bin
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_rng> DESTINATION ${DBSCFGDIR}bin OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -53,25 +53,32 @@ add_component_library(
   TARGET       Lib_rng
   TARGET_DEPS  "${deps}"
   INCLUDE_DIRS "${include_dirs}"
-  LIBRARY_NAME ${PROJECT_NAME} )
+  LIBRARY_NAME ${PROJECT_NAME} 
+  EXPORT_NAME  skip)
 # Target sources should list headers as `PUBLIC` but this is broken as of
 # cmake-3.17.0 (might actually be a Visual Studio issue?). Because this is
 # broken we mark headers as `PRIVATE`.
-foreach( LIB Lib_rng Objlib_rng )
-  target_sources( ${LIB} PRIVATE "${headers_public}" PRIVATE "${sources}" )
-  set_target_properties(${LIB} PROPERTIES PUBLIC_HEADER "${headers_public}")
-endforeach()
+target_sources(Lib_rng PRIVATE "${headers_public}" PRIVATE "${sources}" )
+set_target_properties(Lib_rng PROPERTIES PUBLIC_HEADER "${headers_public}")
+if(TARGET Objlib_rng)
+  target_sources(Objlib_rng PRIVATE "${headers_public}" PRIVATE "${sources}" )
+  set_target_properties($Objlib_rng PROPERTIES PUBLIC_HEADER "${headers_public}")
+endif()
 
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_rng Objlib_rng EXPORT draco-targets
+install( TARGETS Lib_rng EXPORT draco-targets
   LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
   ARCHIVE DESTINATION "${DBSCFGDIR}lib"
   RUNTIME DESTINATION "${DBSCFGDIR}bin"
   PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/rng" )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_rng> DESTINATION ${DBSCFGDIR}bin OPTIONAL)
+if(TARGET Objlib_rng)
+  install( TARGETS Objlib_rng EXPORT draco-targets
+    LIBRARY DESTINATION "${DBSCFGDIR_LIBRARY}"
+    ARCHIVE DESTINATION "${DBSCFGDIR}lib"
+    RUNTIME DESTINATION "${DBSCFGDIR}bin"
+    PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/rng" )
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -53,7 +53,7 @@ add_component_library(
   TARGET       Lib_rng
   TARGET_DEPS  "${deps}"
   INCLUDE_DIRS "${include_dirs}"
-  LIBRARY_NAME ${PROJECT_NAME} 
+  LIBRARY_NAME ${PROJECT_NAME}
   EXPORT_NAME  skip)
 # Target sources should list headers as `PUBLIC` but this is broken as of
 # cmake-3.17.0 (might actually be a Visual Studio issue?). Because this is
@@ -62,7 +62,7 @@ target_sources(Lib_rng PRIVATE "${headers_public}" PRIVATE "${sources}" )
 set_target_properties(Lib_rng PROPERTIES PUBLIC_HEADER "${headers_public}")
 if(TARGET Objlib_rng)
   target_sources(Objlib_rng PRIVATE "${headers_public}" PRIVATE "${sources}" )
-  set_target_properties($Objlib_rng PROPERTIES PUBLIC_HEADER "${headers_public}")
+  set_target_properties(Objlib_rng PROPERTIES PUBLIC_HEADER "${headers_public}")
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/roots/CMakeLists.txt
+++ b/src/roots/CMakeLists.txt
@@ -30,7 +30,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_roots Objlib_roots EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/roots )
 
 # ---------------------------------------------------------------------------- #

--- a/src/roots/CMakeLists.txt
+++ b/src/roots/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for roots.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,7 +12,6 @@ project( roots CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
@@ -21,7 +20,6 @@ list( REMOVE_ITEM headers ${template_implementations} )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_roots
    TARGET_DEPS  Lib_linear
@@ -32,15 +30,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_roots EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
-install( FILES ${headers} ${template_implementations} DESTINATION
-  ${DBSCFGDIR}include/roots )
+install( TARGETS Lib_roots Objlib_roots EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/roots )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -48,7 +43,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/special_functions/CMakeLists.txt
+++ b/src/special_functions/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for special_functions.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,7 +12,6 @@ project( special_functions CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
@@ -22,7 +21,6 @@ list( REMOVE_ITEM headers ${template_implementations} )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_special_functions
    TARGET_DEPS  "Lib_units;Lib_roots;GSL::gsl"
@@ -34,15 +32,14 @@ add_component_library(
 # Installation instructions
 # ---------------------------------------------------------------------------- #
 
-install( TARGETS Lib_special_functions EXPORT draco-targets DESTINATION
-  ${DBSCFGDIR}lib )
-install( FILES ${headers} ${template_implementations} DESTINATION
-  ${DBSCFGDIR}include/special_functions )
+install( TARGETS Lib_special_functions Objlib_special_functions EXPORT draco-targets
+  DESTINATION ${DBSCFGDIR}lib )
+install( FILES ${headers} ${template_implementations}
+  DESTINATION ${DBSCFGDIR}include/special_functions )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -50,7 +47,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/special_functions/CMakeLists.txt
+++ b/src/special_functions/CMakeLists.txt
@@ -31,9 +31,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_special_functions Objlib_special_functions EXPORT draco-targets
-  DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} ${template_implementations}
   DESTINATION ${DBSCFGDIR}include/special_functions )
 

--- a/src/units/CMakeLists.txt
+++ b/src/units/CMakeLists.txt
@@ -12,7 +12,6 @@ project( units CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB sources *.cc )
 file( GLOB explicit_instantiations *_pt.cc )
 file( GLOB headers *.hh )
@@ -20,7 +19,6 @@ file( GLOB headers *.hh )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_units
    TARGET_DEPS  Lib_dsxx
@@ -31,18 +29,15 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_units EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( TARGETS Lib_units Objlib_units EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/units )
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_units> DESTINATION ${DBSCFGDIR}lib
-    OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:Lib_units> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
 endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -50,7 +45,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#

--- a/src/units/CMakeLists.txt
+++ b/src/units/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for units.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -29,11 +29,7 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_units Objlib_units EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/units )
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  install(FILES $<TARGET_PDB_FILE:Lib_units> DESTINATION ${DBSCFGDIR}lib OPTIONAL)
-endif()
 
 # ---------------------------------------------------------------------------- #
 # Unit tests

--- a/src/viz/CMakeLists.txt
+++ b/src/viz/CMakeLists.txt
@@ -30,7 +30,6 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-install( TARGETS Lib_viz Objlib_viz EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
 install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/viz )
 
 # ---------------------------------------------------------------------------- #

--- a/src/viz/CMakeLists.txt
+++ b/src/viz/CMakeLists.txt
@@ -3,7 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for viz.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.9.0)
@@ -12,7 +12,6 @@ project( viz CXX )
 # ---------------------------------------------------------------------------- #
 # Source files
 # ---------------------------------------------------------------------------- #
-
 file( GLOB template_implementations *.t.hh *.i.hh )
 file( GLOB sources *.cc )
 file( GLOB headers *.hh )
@@ -21,7 +20,6 @@ list( REMOVE_ITEM headers ${template_implementations} )
 # ---------------------------------------------------------------------------- #
 # Build package library
 # ---------------------------------------------------------------------------- #
-
 add_component_library(
    TARGET       Lib_viz
    TARGET_DEPS  Lib_c4
@@ -32,15 +30,12 @@ add_component_library(
 # ---------------------------------------------------------------------------- #
 # Installation instructions
 # ---------------------------------------------------------------------------- #
-
-install( TARGETS Lib_viz EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
-install( FILES ${headers} ${template_implementations} DESTINATION
-  ${DBSCFGDIR}include/viz )
+install( TARGETS Lib_viz Objlib_viz EXPORT draco-targets DESTINATION ${DBSCFGDIR}lib )
+install( FILES ${headers} ${template_implementations} DESTINATION ${DBSCFGDIR}include/viz )
 
 # ---------------------------------------------------------------------------- #
 # Unit tests
 # ---------------------------------------------------------------------------- #
-
 if( BUILD_TESTING )
    add_subdirectory( test )
 endif()
@@ -48,7 +43,6 @@ endif()
 # ---------------------------------------------------------------------------- #
 # Autodoc
 # ---------------------------------------------------------------------------- #
-
 process_autodoc_pages()
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

+ This is based on Doug Jacobsen's work but incorporated into the the `add_component_library` macro.
+ With these changes, installing Draco will provide regular libraries per component as before, but it will now also provide a directory with all of the object files for each component.
+ The advantage of the object library approach is more aggressive link-time optimization.  On some platforms (e.g. KNL), this provides ~10% faster code.

### Purpose of Pull Request

* [Fixes Redmine Issue #?](https://rtt.lanl.gov/redmine/issues/?)

### Description of changes

* Update the `add_component_library` macro so that a regular library is created as before, but also generate an _object_ library and publish this information to `draco-config.cmake`. 
* Update `add_component_library`  to take a new argument `INCLUDE_DIRS` in the form normally used by cmake.  Values should use `PUBLIC/PRIVATE` keywords and can use generator-expressions.  This addition simplifies creation of the object libraries because both the regular library and the object library need to be give the same set of `target_include_directories`.
* Update individual `CMakeLists.txt` files as needed, including an additional instruction to install the new Object Library.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
* WIP:
  * [ ] This change may break client projects.  Testing of clients must be done before `WIP` is removed.
  * [ ] Something in this PR breaks MSVC calling gfortran via MSYS2.  Gotta find it and fix it.
