### PR TITLE
Fix the clang-tidy regression failure.

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -29,7 +29,6 @@ endif()
 #
 # Compiler Flags
 #
-
 if( NOT CXX_FLAGS_INITIALIZED )
   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
 
@@ -45,7 +44,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
 
   # Suppress warnings about typeid() called with function as an argument. In this case, the function
   # might not be called if the type can be deduced.
-  list( APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS} -Wno-undefined-var-template"
+  string( APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS} -Wno-undefined-var-template"
     " -Wno-potentially-evaluated-expression" )
   if( DEFINED CMAKE_CXX_COMPILER_WRAPPER AND "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv" )
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libstdc++")
@@ -61,31 +60,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
 
 endif()
 
-##---------------------------------------------------------------------------##
-# Ensure cache values always match current selection
-##---------------------------------------------------------------------------##
-set( CMAKE_C_FLAGS                "${CMAKE_C_FLAGS}"                CACHE STRING
-  "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG}"          CACHE STRING
-  "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}"        CACHE STRING
-  "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_MINSIZEREL}"     CACHE STRING
-  "compiler flags" FORCE )
-set( CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" CACHE STRING
-  "compiler flags" FORCE )
-
-set( CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS}"
-  CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG}"
-  CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE}"
-  CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL}"
-  CACHE STRING "compiler flags" FORCE )
-set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}"
-  CACHE STRING "compiler flags" FORCE )
-
+#--------------------------------------------------------------------------------------------------#
 # Toggle for OpenMP support
 if( OpenMP_C_FLAGS )
   toggle_compiler_flag( OPENMP_FOUND "${OpenMP_C_FLAGS}" "C" "" )
@@ -93,8 +68,13 @@ endif()
 if( OpenMP_CXX_FLAGS )
   toggle_compiler_flag( OPENMP_FOUND "${OpenMP_CXX_FLAGS}" "CXX" "" )
 endif()
-# adding openmp option to EXE_LINKER will break MPI detection for gfortran when running with
-# clang++/clang/gfortran.
+# Note: adding openmp option to EXE_LINKER will break MPI detection for gfortran when running with
+#       clang++/clang/gfortran.
+
+#--------------------------------------------------------------------------------------------------#
+# Ensure cache values always match current selection
+deduplicate_flags(CMAKE_CXX_FLAGS)
+force_compiler_flags_to_cache()
 
 #--------------------------------------------------------------------------------------------------#
 # End config/unix-clang.cmake

--- a/src/VendorChecks/test/tstMetis.cc
+++ b/src/VendorChecks/test/tstMetis.cc
@@ -3,18 +3,16 @@
  * \file   VendorChecks/test/tstMetis.cc
  * \date   Wednesday, May 11, 2016, 12:01 pm
  * \brief  Attempt to link to libmetis and run a simple problem.
- * \note   Copyright (C) 2016-2019, Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2020, Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
+#include "metis.h"
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include <array>
-#include <metis.h>
 #include <vector>
 
-// Original provided by Erik Zenker
-// https://gist.github.com/erikzenker/c4dc42c8d5a8c1cd3e5a
+// Original provided by Erik Zenker, https://gist.github.com/erikzenker/c4dc42c8d5a8c1cd3e5a
 
 void test_metis(rtt_dsxx::UnitTest &ut) {
   idx_t nVertices = 10;
@@ -24,8 +22,8 @@ void test_metis(rtt_dsxx::UnitTest &ut) {
   idx_t objval(0);
   std::vector<idx_t> part(nVertices, 0);
 
-  // here's the mesh, there is only one valid cut so the expected result (or a
-  // mirror of it) should alays be obtained
+  // here's the mesh, there is only one valid cut so the expected result (or a mirror of it) should
+  // alays be obtained
   //
   //  0 \       / 6
   //  1 \       / 7
@@ -38,18 +36,15 @@ void test_metis(rtt_dsxx::UnitTest &ut) {
   // Adjacent vertices in consecutive index order
   // conn. for:     0, 1, 2, 3, 4            , 5,            ,6, 7, 8, 9
   // index:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 14,15,16,17
-  std::array<idx_t, 18> adjncy = {4, 4, 4, 4, 0, 1, 2, 3, 5,
-                                  4, 6, 7, 8, 9, 5, 5, 5, 5};
+  std::array<idx_t, 18> adjncy = {4, 4, 4, 4, 0, 1, 2, 3, 5, 4, 6, 7, 8, 9, 5, 5, 5, 5};
 
-  // Weights of vertices
-  // if all weights are equal then can be set to NULL
+  // Weights of vertices: if all weights are equal then can be set to NULL
   std::vector<idx_t> vwgt(nVertices * nWeights, 0);
 
-  // Partition a graph into k parts using either multilevel recursive bisection
-  // or multilevel k-way partitioning.
-  int ret = METIS_PartGraphKway(
-      &nVertices, &nWeights, xadj.data(), adjncy.data(), nullptr, nullptr,
-      nullptr, &nParts, nullptr, nullptr, nullptr, &objval, &part[0]);
+  // Partition a graph into k parts using either multilevel recursive bisection or multilevel k-way
+  // partitioning.
+  int ret = METIS_PartGraphKway(&nVertices, &nWeights, xadj.data(), adjncy.data(), nullptr, nullptr,
+                                nullptr, &nParts, nullptr, nullptr, nullptr, &objval, &part[0]);
 
   std::cout << "partition: ";
   for (int32_t i = 0; i < nVertices; ++i) {
@@ -64,8 +59,7 @@ void test_metis(rtt_dsxx::UnitTest &ut) {
 
   std::array<int, 10> expectedResult = {1, 1, 1, 1, 1, 0, 0, 0, 0, 0};
   std::array<int, 10> mirrorExpectedResult = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
-  std::vector<idx_t> vExpectedResult(expectedResult.begin(),
-                                     expectedResult.end());
+  std::vector<idx_t> vExpectedResult(expectedResult.begin(), expectedResult.end());
   std::vector<idx_t> vMirrorExpectedResult(mirrorExpectedResult.begin(),
                                            mirrorExpectedResult.end());
   if (part == vExpectedResult || part == vMirrorExpectedResult)


### PR DESCRIPTION
### Background

+ There was a bug in how we set compiler flags for clang that was causing the clang-tidy regression to fail with the error `clang-9: error: no input files`.   This was caused by an unexpected semicolon in the list of compiler flags.
+ Error shown on cdash for `clang-9.0.0-clangtidy_Debug-develop`.

### Purpose of Pull Request

* [Fixes Redmine Issue #2165](https://rtt.lanl.gov/redmine/issues/2165)

### Description of changes

+ Cleaning up the logic used to set compiler flags fixes this issue.
  - Use `string` instead of `list` to append compiler flags.
  - Deduplicate the list of compiler flags.
  - Ensure that flags set in the environment or as cmake options are captured.
+ Provide two new cmake functions to reduce cmake code duplication.
+ Process `tstMetis.cc` for 100-column formatting.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
