### PR TITLE
Remove openmpi debug-daemons option.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,32 @@
+# -*- conf -*-
+# flake8 settings for Spack core files.
+#
+# These exceptions are for Spack core files. We're slightly more lenient
+# with packages.  See .flake8_packages for that.
+#
+# E1: Indentation
+# - E129: visually indented line with same indent as next logical line
+#
+# E2: Whitespace
+# - E221: multiple spaces before operator
+# - E241: multiple spaces after ','
+# - E272: multiple spaces before keyword
+#
+# E7: Statement
+# - E731: do not assign a lambda expression, use a def
+#
+# W5: Line break warning
+# - W503: line break before binary operator
+# - W504: line break after binary operator
+#
+# These are required to get the package.py files to test clean:
+# - F999: syntax error in doctest
+#
+# N8: PEP8-naming
+# - N801: class names should use CapWords convention
+# - N813: camelcase imported as lowercase
+# - N814: camelcase imported as constant
+#
+[flake8]
+ignore = E129,E221,E241,E272,E731,W503,W504,F999,N801,N813,N814
+max-line-length = 79

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -52,19 +52,26 @@ jobs:
         uses: github/super-linter@v3
         env:
           DEFAULT_BRANCH: develop
-          FILTER_REGEX_EXCLUDE: .*.cc
+          ERROR_ON_MISSING_EXEC_BIT: true
+          FILTER_REGEX_EXCLUDE: .*/.*.cc
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON_FLAKE8_CONFIG_FILE: .flake8
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
           VALIDATE_DOCKERFILE: true
           VALIDATE_ENV: true
           VALIDATE_HTML: true
           VALIDATE_JSON: true
           VALIDATE_LATEX: true
           VALIDATE_LUA: true
+          VALIDATE_MARKDOWN: true
           VALIDATE_PERL: true
           VALIDATE_PYTHON: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_POWERSHELL: true
           VALIDATE_RUBY: true
+          VALIDATE_SHELL_SHFMT: true
           VALIDATE_XML: true
           VALIDATE_YAML: true
 ...

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -31,24 +31,20 @@ include( FeatureSummary )
 ##---------------------------------------------------------------------------##
 function( setMPIflavorVer )
 
-  # First attempt to determine MPI flavor -- scape flavor from full path
-  # (this ususally works for HPC or systems with modules)
+  # First attempt to determine MPI flavor -- scape flavor from full path (this ususally works for
+  # HPC or systems with modules)
   if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
     set( MPI_FLAVOR "cray" )
-  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "openmpi" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" )
+  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "openmpi" OR "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" )
     set( MPI_FLAVOR "openmpi" )
-  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mpich" OR
-      "${MPI_C_HEADER_DIR}" MATCHES "mpich")
+  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mpich" OR "${MPI_C_HEADER_DIR}" MATCHES "mpich")
     set( MPI_FLAVOR "mpich" )
-  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "impi" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "clusterstudio" )
+  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "impi" OR "${MPIEXEC_EXECUTABLE}" MATCHES "clusterstudio")
     set( MPI_FLAVOR "intel" )
   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mvapich2")
     set( MPI_FLAVOR "mvapich2" )
-  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "spectrum-mpi" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "lrun" OR
-      "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
+  elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "spectrum-mpi" OR "${MPIEXEC_EXECUTABLE}" MATCHES "lrun"
+      OR "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
     set( MPI_FLAVOR "spectrum")
   endif()
 
@@ -160,33 +156,28 @@ macro( setupDracoMPIVars )
 
 endmacro()
 
-##---------------------------------------------------------------------------##
-## Query CPU topology
-##
-## Returns:
-##   MPI_CORES_PER_CPU
-##   MPI_CPUS_PER_NODE
-##   MPI_PHYSICAL_CORES
-##   MPI_MAX_NUMPROCS_PHYSICAL
-##   MPI_HYPERTHREADING
-##
-## See also:
-##   - Try running 'lstopo' for a graphical view of the local topology or
-##     'lscpu' for a text version.
-##   - EAP's flags can be found in Test.rh/General/run_job.pl (look for
-##     $other_args).  In particular, it may be useful to examine EAP's options
-##     for srun or aprun.
-##---------------------------------------------------------------------------##
+#--------------------------------------------------------------------------------------------------#
+# Query CPU topology
+#
+# Returns:
+#   MPI_CORES_PER_CPU
+#   MPI_CPUS_PER_NODE
+#   MPI_PHYSICAL_CORES
+#   MPI_MAX_NUMPROCS_PHYSICAL
+#   MPI_HYPERTHREADING
+#
+# See also:
+#   - Try running 'lstopo' for a graphical view of the local topology or 'lscpu' for a text version.
+#   - EAP's flags can be found in Test.rh/General/run_job.pl (look for $other_args).  In
+#     particular, it may be useful to examine EAP's options for srun or aprun.
+#--------------------------------------------------------------------------------------------------#
 macro( query_topology )
 
-  # These cmake commands, while useful, don't provide the topology detail that
-  # we are interested in (i.e. number of sockets per node). We could use the
-  # results of these queries to know if hyper-threading is enabled (if logical
-  # != physical cores)
-  # - cmake_host_system_information(RESULT MPI_PHYSICAL_CORES
-  #   QUERY NUMBER_OF_PHYSICAL_CORES)
-  # - cmake_host_system_information(RESULT MPI_LOGICAL_CORES
-  #   QUERY NUMBER_OF_LOGICAL_CORES)
+  # These cmake commands, while useful, don't provide the topology detail that we are interested in
+  # (i.e. number of sockets per node). We could use the results of these queries to know if
+  # hyper-threading is enabled (if logical != physical cores)
+  # - cmake_host_system_information(RESULT MPI_PHYSICAL_CORES QUERY NUMBER_OF_PHYSICAL_CORES)
+  # - cmake_host_system_information(RESULT MPI_LOGICAL_CORES  QUERY NUMBER_OF_LOGICAL_CORES)
 
   # start with default values
   set( MPI_CORES_PER_CPU 4 )
@@ -231,8 +222,7 @@ macro( query_topology )
     "Number of cores per cpu" FORCE )
 
   #
-  # Check for hyper-threading - This is important for reserving threads for
-  # OpenMP tests...
+  # Check for hyper-threading - This is important for reserving threads for OpenMP tests...
   #
   math( EXPR MPI_MAX_NUMPROCS_PHYSICAL
     "${MPI_PHYSICAL_CORES} * ${MPI_CORES_PER_CPU}" )
@@ -245,9 +235,9 @@ macro( query_topology )
   endif()
 endmacro()
 
-##---------------------------------------------------------------------------##
-## Setup OpenMPI
-##---------------------------------------------------------------------------##
+#--------------------------------------------------------------------------------------------------#
+# Setup OpenMPI
+#--------------------------------------------------------------------------------------------------#
 macro( setupOpenMPI )
 
   # sanity check, these OpenMPI flags (below) require version >= 1.8
@@ -258,15 +248,17 @@ macro( setupOpenMPI )
   # Find cores/cpu, cpu/node, hyper-threading
   query_topology()
 
-  # For PERFBENCH that use Quo, we need '--map-by socket:SPAN' instead of
-  # '-bind-to none'.  The 'bind-to none' is required to pack a node.
-  set( MPIEXEC_PREFLAGS "-bind-to none --debug-daemons")
-  set( MPIEXEC_PREFLAGS_PERFBENCH "--map-by socket:SPAN --debug-daemons")
+  # Notes:
+  # - For PERFBENCH that use Quo, we need '--map-by socket:SPAN' instead of '-bind-to none'.  The
+  #   'bind-to none' is required to pack a node.
+  # - Adding '--debug-daemons' is often requested by the OpenMPI dev team in conjunction with
+  #   'export OMPI_MCA_btl_base_verbose=100' to obtain debug traces from openmpi.
+  set( MPIEXEC_PREFLAGS "-bind-to none")
+  set( MPIEXEC_PREFLAGS_PERFBENCH "--map-by socket:SPAN")
   # Setup for OMP plus MPI
   if( NOT APPLE )
     # -bind-to fails on OSX, See #691
-    set( MPIEXEC_OMP_PREFLAGS
-      "--map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings" )
+    set( MPIEXEC_OMP_PREFLAGS "--map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings" )
   endif()
 
   # Special settings for CI
@@ -334,24 +326,20 @@ macro( setupCrayMPI )
   # salloc/sbatch options:
   # --------------------
   # -N        limit job to a single node.
-  # --gres=craynetwork:0 This option allows more than one srun to be running at
-  #           the same time on the Cray. There are 4 gres “tokens” available. If
-  #           unspecified, each srun invocation will consume all of
-  #           them. Setting the value to 0 means consume none and allow the user
-  #           to run as many concurrent jobs as there are cores available on the
-  #           node. This should only be specified on the salloc/sbatch command.
-  #           Gabe doesn't recommend this option for regression testing.
+  # --gres=craynetwork:0 This option allows more than one srun to be running at the same time on the
+  #           Cray. There are 4 gres “tokens” available. If unspecified, each srun invocation will
+  #           consume all of them. Setting the value to 0 means consume none and allow the user to
+  #           run as many concurrent jobs as there are cores available on the node. This should only
+  #           be specified on the salloc/sbatch command.  Gabe doesn't recommend this option for
+  #           regression testing.
   # --vm-overcommit=disable|enable Do not allow overcommit of heap resources.
   # -p knl    Limit allocation to KNL nodes.
   # srun options:
   # --------------------
-  # --cpu_bind=verbose,cores
-  #           bind MPI ranks to cores
-  #           print a summary of binding when run
-  # --exclusive This option will keep concurrent jobs from running on the same
-  #           cores. If you want to background tasks to have them run
-  #           simultaneously, this option is required to be set or they will
-  #           stomp on the same cores.
+  # --cpu_bind=verbose,cores Bind MPI ranks to cores and print a summary of binding when run
+  # --exclusive This option will keep concurrent jobs from running on the same cores. If you want to
+  #           background tasks to have them run simultaneously, this option is required to be set or
+  #           they will stomp on the same cores.
 
   set(preflags " ") # -N 1 --cpu_bind=verbose,cores
   string(APPEND preflags " --gres=craynetwork:0") # --exclusive
@@ -454,8 +442,8 @@ macro( setupMPILibrariesUnix )
         "Program to execute MPI parallel programs." )
     endif()
 
-    # If this is a Cray system and the Cray MPI compile wrappers are used, then
-    # do some special setup:
+    # If this is a Cray system and the Cray MPI compile wrappers are used, then do some special
+    # setup:
 
     if(  CMAKE_CXX_COMPILER_WRAPPER MATCHES CrayPrgEnv )
       if( NOT EXISTS ${MPIEXEC_EXECUTABLE} )
@@ -479,8 +467,8 @@ macro( setupMPILibrariesUnix )
     # Call the standard CMake FindMPI macro.
     find_package( MPI QUIET )
 
-    # Try to discover the MPI flavor and the vendor version. Returns
-    # MPI_VERSION, MPI_FLAVOR as cache variables
+    # Try to discover the MPI flavor and the vendor version. Returns MPI_VERSION, MPI_FLAVOR as
+    # cache variables
     setMPIflavorVer()
 
     # Set additional flags, environments that are MPI vendor specific.
@@ -502,8 +490,8 @@ The Draco build system doesn't know how to configure the build for
   CMAKE_CXX_COMPILER_WRAPPER = ${CMAKE_CXX_COMPILER_WRAPPER}")
     endif()
 
-    # Mark some of the variables created by the above logic as 'advanced' so
-    # that they do not show up in the 'simple' ccmake view.
+    # Mark some of the variables created by the above logic as 'advanced' so that they do not show
+    # up in the 'simple' ccmake view.
     mark_as_advanced( MPI_EXTRA_LIBRARY MPI_LIBRARY )
 
     message(STATUS "Looking for MPI.......found ${MPIEXEC_EXECUTABLE}")
@@ -546,8 +534,7 @@ macro( setupMPILibrariesWindows )
     find_package( MPI QUIET )
 
     if( EXISTS "$ENV{MSMPI_INC}" )
-      # if msmpi is installed via vcpkg, then use the vcpkg include path
-      # instead of the system one.
+      # if msmpi is installed via vcpkg, then use the vcpkg include path instead of the system one.
       file(TO_CMAKE_PATH $ENV{MSMPI_INC} MSMPI_INC)
       unset(tmp)
       foreach( ipath ${MPI_C_INCLUDE_DIRS} )
@@ -573,10 +560,9 @@ macro( setupMPILibrariesWindows )
         MPI_C_VERSION_MAJOR = ${MPI_C_VERSION_MAJOR}")
     endif()
 
-    # If this macro is called from a MinGW builds system (for a CAFS
-    # subdirectory) and is trying to discover MS-MPI, the above check will fail
-    # (when CMake > 3.12). However, MS-MPI is known to be good when linking with
-    # Visual Studio so override the 'failed' report.
+    # If this macro is called from a MinGW builds system (for a CAFS subdirectory) and is trying to
+    # discover MS-MPI, the above check will fail (when CMake > 3.12). However, MS-MPI is known to be
+    # good when linking with Visual Studio so override the 'failed' report.
     if( "${MPI_C_LIBRARIES}" MATCHES "msmpi" AND
         "${CMAKE_GENERATOR}" STREQUAL "MinGW Makefiles")
       if( EXISTS "${MPI_C_LIBRARIES}" AND EXISTS "${MPI_C_INCLUDE_DIRS}" )
@@ -591,8 +577,8 @@ macro( setupMPILibrariesWindows )
         MPI_Fortran_FOUND = ${MPI_Fortran_FOUND}")
     endif()
 
-    # For MS-MPI, mpifptr.h is architecture dependent. Figure out what arch this
-    # is and save this path to MPI_Fortran_INCLUDE_PATH
+    # For MS-MPI, mpifptr.h is architecture dependent. Figure out what arch this is and save this
+    # path to MPI_Fortran_INCLUDE_PATH
     list( GET MPI_C_LIBRARIES 0 first_c_mpi_library )
     if( first_c_mpi_library AND NOT MPI_Fortran_INCLUDE_PATH )
       get_filename_component( MPI_Fortran_INCLUDE_PATH
@@ -676,8 +662,7 @@ macro( setupMPILibrariesWindows )
       set( MPIEXEC_MAX_NUMPROCS ${MPIEXEC_MAX_NUMPROCS} CACHE STRING
         "Total number of available MPI ranks" FORCE )
 
-      # Check for hyper-threading - This is important for reserving threads for
-      # OpenMP tests...
+      # Check for hyper-threading - This is important for reserving threads for OpenMP tests...
 
       math( EXPR MPI_MAX_NUMPROCS_PHYSICAL
         "${MPI_CPUS_PER_NODE} * ${MPI_CORES_PER_CPU}" )
@@ -726,14 +711,13 @@ macro( setupMPILibrariesWindows )
 
   endif()
 
-  # Don't link to the C++ MS-MPI library when compiling with MinGW gfortran.
-  # Instead, link to libmsmpi.a that was created via gendef.exe and dlltool.exe
-  # from msmpi.dll.  Ref: http://www.geuz.org/pipermail/getdp/2012/001520.html,
-  # or
+  # Don't link to the C++ MS-MPI library when compiling with MinGW gfortran.  Instead, link to
+  # libmsmpi.a that was created via gendef.exe and dlltool.exe from msmpi.dll.  Ref:
+  # http://www.geuz.org/pipermail/getdp/2012/001520.html, or
   # https://github.com/KineticTheory/Linux-HPC-Env/wiki/Setup-Win32-development-environment
 
-  # Preparing Microsoft's MPI to work with x86_64-w64-mingw32-gfortran by
-  # creating libmsmpi.a. (Last tested: 2017-08-31)
+  # Preparing Microsoft's MPI to work with x86_64-w64-mingw32-gfortran by creating libmsmpi.a. (Last
+  # tested: 2017-08-31)
   #
   # 1.) You need MinGW/MSYS. Please make sure that the Devel tools are
   #     installed.
@@ -755,12 +739,11 @@ macro( setupMPILibrariesWindows )
       ")
     endif()
 
-    # only do this if we are in a CMakeAddFortranSubdirectory directive when
-    # the main Generator is Visual Studio and the Fortran subdirectory uses
-    # gfortran with Makefiles.
+    # only do this if we are in a CMakeAddFortranSubdirectory directive when the main Generator is
+    # Visual Studio and the Fortran subdirectory uses gfortran with Makefiles.
 
-    # MS-MPI has an architecture specific include directory that FindMPI.cmake
-    # doesn't seem to pickup correctly.  Add it here.
+    # MS-MPI has an architecture specific include directory that FindMPI.cmake doesn't seem to
+    # pickup correctly.  Add it here.
     get_target_property(mpilibdir MPI::MPI_Fortran INTERFACE_LINK_LIBRARIES)
     get_target_property(mpiincdir MPI::MPI_Fortran
       INTERFACE_INCLUDE_DIRECTORIES)
@@ -775,8 +758,8 @@ macro( setupMPILibrariesWindows )
       endif()
     endforeach()
 
-    # Reset the include directories for MPI::MPI_Fortran to pull in the extra
-    # $arch locations (if any)
+    # Reset the include directories for MPI::MPI_Fortran to pull in the extra $arch locations (if
+    # any)
 
     list(REMOVE_DUPLICATES mpiincdir)
     set_target_properties(MPI::MPI_Fortran
@@ -810,6 +793,6 @@ macro(setupMPILibraries)
   endif()
 endmacro()
 
-#----------------------------------------------------------------------#
-# End setupMPI.cmake
-#----------------------------------------------------------------------#
+#--------------------------------------------------------------------------------------------------#
+# End of setupMPI.cmake
+#--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

* We are trying to debug openmpi run failures on ccs-net.  Howard asked that I add `--debug-daemons` to our run line.  Unfortunately, this generates a lot of output and seems to destabilize some of our regressions, so I'm reverting this change.
+ We are also in the process of using more static analysis (lint) tools.

### Description of changes

+ Remove the `--debug-daemons` command line parameter for OpenMPI's `mpiexec` command.  This seems to be causing some issues for regressions even though Howard Pritchard wants to see the debug output from OpenMPI when our tests fail.
+ Adopt Spack's `.flake8` formatting rules for python style checks.
+ Update the superlinter configuration file to use `.flake8`. Also make another stab at setting `FILTER_REGEX_EXCLUDE` for `.cc` files.  I'm having trouble getting this right.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
