### PR TITLE
Disable tstQuoWrapper_4 unit test from running under valgrind.

### DIFF
--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -83,6 +83,10 @@ if( NOT ${DRACO_C4} STREQUAL "SCALAR" )
 endif()
 
 # Tests that expect exactly 4 PE (omit for DRACO_C4=SCALAR builds):
+# - There is a weird API conflict between libquo and openmpi@3.  The former uses hwloc@2 and the
+#   later uses hwloc@1.  Valgrind trips on this with an UMR that frequently leads to a code hang.
+#   The solution is to build openmpi~internal-hwloc or move openmpi@4 which uses hwloc@2.
+#   Ref: https://rtt.lanl.gov/redmine/issues/2163
 set( four_pe_tests ${PROJECT_SOURCE_DIR}/tstQuoWrapper.cc )
 list( REMOVE_ITEM test_sources ${four_pe_tests} )
 
@@ -90,7 +94,8 @@ if( NOT ${DRACO_C4} STREQUAL "SCALAR" )
   add_parallel_tests(
     SOURCES   "${four_pe_tests}"
     DEPS      Lib_c4
-    PE_LIST   "4" )
+    PE_LIST   "4"
+    LABEL     "nomemcheck" )
   if( NOT DEFINED MPI_MAX_NUMPROCS_PHYSICAL )
     message(FATAL_ERROR "need max procs in c4/tests/CMakeLists.txt")
   endif()


### PR DESCRIPTION
### Background

* This test fails to run under valgrind due to a hwloc API conflict between openmpi and libquo.  Disable for now.
* Might be fixed by moving to openmpi@4, but openmpi@4.0.3 has other issues that cause multiple regression failures.
* Might be fixed by using internal hwloc linkage in openmpi, but this build variant isn't available from [spack yet](https://github.com/spack/spack/pull/19109).

### Purpose of Pull Request

* [Fixes Redmine Issue #2163](https://rtt.lanl.gov/redmine/issues/2163)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
