### PR TITLE
Apply clang-tidy transformations to 'viz'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
 #    runtime to your application or manually preload it with LD_PRELOAD.
 # 3. many more run time issues, some may require suppression.
 #
-#    toggle_compiler_flag( TRUE 
+#    toggle_compiler_flag( TRUE
 #      "-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract" "CXX" "DEBUG")
 #  endif()
 
@@ -78,11 +78,11 @@ add_dir_if_exists( norms )        # needs c4
 add_dir_if_exists( parser )       # needs units, c4, mesh_element
 add_dir_if_exists( roots )        # needs linear
 add_dir_if_exists( VendorChecks ) # needs c4
+add_dir_if_exists( viz )          # needs c4
 
 if( NOT CI_CLANG_TIDY )
 add_dir_if_exists( compton )      # needs c4, CSK
 add_dir_if_exists( rng )          # needs ds++, device
-add_dir_if_exists( viz )          # needs c4
 
 # Level 4
 message(" ")

--- a/src/viz/Ensight_Stream.cc
+++ b/src/viz/Ensight_Stream.cc
@@ -47,7 +47,7 @@ Ensight_Stream &endl(Ensight_Stream &s) {
  */
 Ensight_Stream::Ensight_Stream(const std::string &file_name, const bool binary,
                                const bool geom_file, const bool decomposed)
-    : d_decomposed_stream(), d_serial_stream(), d_stream(), d_binary(binary) {
+    : d_decomposed_stream(), d_serial_stream(), d_binary(binary) {
   if (!file_name.empty())
     open(file_name, d_binary, geom_file, decomposed);
 }
@@ -58,7 +58,7 @@ Ensight_Stream::Ensight_Stream(const std::string &file_name, const bool binary,
  *
  * Automatically closes stream, if open.
  */
-Ensight_Stream::~Ensight_Stream(void) { close(); }
+Ensight_Stream::~Ensight_Stream() { close(); }
 
 //------------------------------------------------------------------------------------------------//
 /*!
@@ -82,18 +82,18 @@ void Ensight_Stream::open(const std::string &file_name, const bool binary, const
   // Open the stream.
   if (decomposed) {
     if (binary)
-      d_decomposed_stream.reset(new rtt_c4::ofpstream(file_name, std::ios::binary));
+      d_decomposed_stream = std::make_unique<rtt_c4::ofpstream>(file_name, std::ios::binary);
     else
-      d_decomposed_stream.reset(new rtt_c4::ofpstream(file_name));
+      d_decomposed_stream = std::make_unique<rtt_c4::ofpstream>(file_name);
     // set to a generic ostream
     d_stream = &*d_decomposed_stream;
   } else {
     Insist(rtt_c4::node() == 0, "Ensight_Stream, called by nonzero rank without "
                                 "the domain decomposed flag");
     if (binary)
-      d_serial_stream.reset(new std::ofstream(file_name, std::ios::binary));
+      d_serial_stream = std::make_unique<std::ofstream>(file_name, std::ios::binary);
     else
-      d_serial_stream.reset(new std::ofstream(file_name));
+      d_serial_stream = std::make_unique<std::ofstream>(file_name);
     // set to a generic ostream
     d_stream = &*d_serial_stream;
   }
@@ -122,7 +122,7 @@ void Ensight_Stream::close() {
   if (d_serial_stream) {
     d_serial_stream->close();
   }
-  d_stream = NULL;
+  d_stream = nullptr;
 }
 
 //------------------------------------------------------------------------------------------------//

--- a/src/viz/Ensight_Stream.hh
+++ b/src/viz/Ensight_Stream.hh
@@ -105,7 +105,7 @@ public:
   Ensight_Stream &operator<<(const std::string &s);
   Ensight_Stream &operator<<(FP f);
 
-  friend DLL_PUBLIC_viz Ensight_Stream &endl(Ensight_Stream &s);
+  friend Ensight_Stream &endl(Ensight_Stream &s);
 
 private:
   // Does binary write of v.

--- a/src/viz/Ensight_Stream.hh
+++ b/src/viz/Ensight_Stream.hh
@@ -24,7 +24,7 @@ namespace rtt_viz {
 class Ensight_Stream;
 
 //! A specific "endl" manipulator for Ensight_Stream.
-DLL_PUBLIC_viz Ensight_Stream &endl(Ensight_Stream &s);
+Ensight_Stream &endl(Ensight_Stream &s);
 
 //================================================================================================//
 /*!
@@ -59,7 +59,7 @@ private:
   std::unique_ptr<std::ofstream> d_serial_stream;
 
   //! The standard stream for writing
-  std::ostream *d_stream;
+  std::ostream *d_stream{};
 
   //! If true, in binary mode.  Otherwise, ascii mode.
   bool d_binary;

--- a/src/viz/Ensight_Translator.hh
+++ b/src/viz/Ensight_Translator.hh
@@ -115,19 +115,17 @@ enum Ensight_Cell_Types {
 class Ensight_Translator {
 public:
   // Ensight_Translator typedefs.
-  typedef std::vector<int> sf_int;
-  typedef std::vector<double> sf_double;
-  typedef std::vector<std::string> sf_string;
-  typedef std::string std_string;
+  using sf_int = std::vector<int>;
+  using sf_double = std::vector<double>;
+  using sf_string = std::vector<std::string>;
+  using std_string = std::string;
+  using sf2_int = std::vector<sf_int>;
+  using sf3_int = std::vector<sf2_int>;
+  using set_int = std::set<int>;
+  using vec_set_int = std::vector<set_int>;
 
-  typedef std::vector<sf_int> sf2_int;
-  typedef std::vector<sf2_int> sf3_int;
-  typedef std::set<int> set_int;
-  typedef std::vector<set_int> vec_set_int;
-
-  typedef set_int::const_iterator set_const_iterator;
-
-  typedef std::vector<std::shared_ptr<Ensight_Stream>> vec_stream;
+  using set_const_iterator = set_int::const_iterator;
+  using vec_stream = std::vector<std::shared_ptr<Ensight_Stream>>;
 
 private:
   // >>> DATA
@@ -218,10 +216,10 @@ private:
 public:
   // Constructor.
   template <typename SSF>
-  Ensight_Translator(const std_string &prefix, const std_string &gd_wpath, const SSF &vdata_names,
-                     const SSF &cdata_names, const bool overwrite = false,
-                     const bool static_geom = false, const bool binary = false,
-                     const bool decomposed = false, const double reset_time = -1.0);
+  Ensight_Translator(const std_string &prefix, std_string gd_wpath, SSF vdata_names,
+                     SSF cdata_names, const bool overwrite = false, const bool static_geom = false,
+                     const bool binary = false, const bool decomposed = false,
+                     const double reset_time = -1.0);
 
   // Do an Ensight_Dump.
   template <typename ISF, typename IVF, typename SSF, typename FVF>

--- a/src/viz/Ensight_Translator.i.hh
+++ b/src/viz/Ensight_Translator.i.hh
@@ -42,16 +42,15 @@ namespace rtt_viz {
  * check and is left for a future exercise).
  */
 template <typename SSF>
-Ensight_Translator::Ensight_Translator(const std_string &prefix, const std_string &gd_wpath,
-                                       const SSF &vdata_names, const SSF &cdata_names,
-                                       const bool overwrite, const bool static_geom,
-                                       const bool binary, const bool decomposed,
-                                       const double reset_time)
-    : d_static_geom(static_geom), d_binary(binary), d_dump_dir(gd_wpath), d_num_cell_types(0),
-      d_cell_names(), d_vrtx_cnt(0), d_cell_type_index(), d_dump_times(), d_prefix(),
-      d_vdata_names(vdata_names), d_cdata_names(cdata_names), d_case_filename(), d_geo_dir(),
-      d_vdata_dirs(), d_cdata_dirs(), d_geom_out(), d_cell_out(), d_vertex_out(),
-      d_decomposed(decomposed) {
+Ensight_Translator::Ensight_Translator(const std_string &prefix, std_string gd_wpath,
+                                       SSF vdata_names, SSF cdata_names, const bool overwrite,
+                                       const bool static_geom, const bool binary,
+                                       const bool decomposed, const double reset_time)
+    : d_static_geom(static_geom), d_binary(binary), d_dump_dir(std::move(gd_wpath)),
+      d_num_cell_types(0), d_cell_names(), d_vrtx_cnt(0), d_cell_type_index(), d_dump_times(),
+      d_prefix(), d_vdata_names(std::move(vdata_names)), d_cdata_names(std::move(cdata_names)),
+      d_case_filename(), d_geo_dir(), d_vdata_dirs(), d_cdata_dirs(), d_geom_out(), d_cell_out(),
+      d_vertex_out(), d_decomposed(decomposed) {
   Require(d_dump_times.empty());
   create_filenames(prefix);
 
@@ -287,8 +286,8 @@ void Ensight_Translator::ensight_dump(int icycle, double time, double dt, const 
     set_int &v = vertices_of_part[ipart];
     sf_int vertices;
 
-    for (set_const_iterator iv = v.begin(); iv != v.end(); ++iv)
-      vertices.push_back(*iv);
+    for (auto &iv : v)
+      vertices.push_back(iv);
 
     // write the geometry data
     Check(ipart + 1 < INT_MAX);

--- a/src/viz/Viz_Traits.hh
+++ b/src/viz/Viz_Traits.hh
@@ -62,7 +62,7 @@ public:
 template <typename T> class Viz_Traits<std::vector<std::vector<T>>> {
 public:
   // Type traits
-  typedef T elementType;
+  using elementType = T;
 
 private:
   // Reference to vector<vector> field.

--- a/src/viz/test/tstEnsight_Stream.cc
+++ b/src/viz/test/tstEnsight_Stream.cc
@@ -12,6 +12,7 @@
 #include "ds++/Release.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include "viz/Ensight_Stream.hh"
+#include <array>
 
 using namespace std;
 using rtt_viz::Ensight_Stream;
@@ -93,31 +94,26 @@ void test_simple(rtt_dsxx::UnitTest &ut, bool const binary, bool const geom,
       cout << "Testing ascii mode." << endl;
 
     ifstream in(file.c_str(), mode);
-    //read out the "C Binary" data
-    // this doesn't work quite right can someone help with this?
+    // read out the "C Binary" data
     if (binary && geom) {
-      char buf[8];
-      in.read(buf, sizeof(char) * 8);
-      if (!strcmp(buf, "C Binary"))
-        ITFAILS;
+      std::array<char, 8> buf;
+      in.read(buf.data(), sizeof(char) * buf.size());
+      FAIL_IF_NOT(std::string("C Binary") == std::string(buf.begin(), buf.end()));
     }
 
     int i_in;
     readit(in, binary, i_in);
-    if (i != i_in)
-      ITFAILS;
+    FAIL_IF_NOT(i == i_in);
 
     double d_in;
     readit(in, binary, d_in);
     // floats are inaccurate
-    if (!rtt_dsxx::soft_equiv(d, d_in, 0.01))
-      ITFAILS;
+    FAIL_IF_NOT(rtt_dsxx::soft_equiv(d, d_in, 0.01));
 
     string s_in;
     readit(in, binary, s_in);
     for (size_t k = 0; k < s.size(); ++k)
-      if (s[k] != s_in[k])
-        ITFAILS;
+      FAIL_IF_NOT(s[k] == s_in[k]);
   }
 
   if (ut.numFails == 0)

--- a/src/viz/test/tstEnsight_Translator.cc
+++ b/src/viz/test/tstEnsight_Translator.cc
@@ -33,13 +33,13 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, string prefix, bool const binary,
   size_t nhexvert = 8;
   size_t nrgn = 2;
 
-  typedef vector<string> vec_s;
-  typedef vector<IT> vec_i;
-  typedef vector<vec_i> vec2_i;
-  typedef vector<vec2_i> vec3_i;
-  typedef vector<double> vec_d;
-  typedef vector<vec_d> vec2_d;
-  typedef vector<vec2_d> vec3_d;
+  using vec_s = vector<string>;
+  using vec_i = vector<IT>;
+  using vec2_i = vector<vec_i>;
+  using vec3_i = vector<vec2_i>;
+  using vec_d = vector<double>;
+  using vec2_d = vector<vec_d>;
+  using vec3_d = vector<vec2_d>;
 
   // do an Ensight Dump
   vec2_i ipar(ncells, vec_i(nhexvert));
@@ -98,9 +98,9 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, string prefix, bool const binary,
   if (!input)
     ITFAILS;
 
-  for (size_t i = 0; i < pt_coor.size(); i++)
-    for (size_t j = 0; j < pt_coor[i].size(); j++)
-      input >> pt_coor[i][j];
+  for (auto &vec1d : pt_coor)
+    for (auto &elem : vec1d)
+      input >> elem;
   for (size_t i = 0; i < ipar.size(); i++)
     for (size_t j = 0; j < ipar[i].size(); j++)
       input >> ipar[i][j];
@@ -117,11 +117,10 @@ void ensight_dump_test(rtt_dsxx::UnitTest &ut, string prefix, bool const binary,
       tmp_vrtx[ipart].insert(ipar[i][j] - 1);
   }
 
-  typedef set<int>::const_iterator set_iter;
   vec2_i g_vrtx_indices(nrgn);
   for (size_t i = 0; i < nrgn; i++) {
-    for (set_iter s = tmp_vrtx[i].begin(); s != tmp_vrtx[i].end(); ++s)
-      g_vrtx_indices[i].push_back(*s);
+    for (auto &s : tmp_vrtx[i])
+      g_vrtx_indices[i].push_back(s);
   }
 
   // Create the equivalent data arrays for the write_part() versions.

--- a/src/viz/test/tstEnsight_Translator_Unstructured.cc
+++ b/src/viz/test/tstEnsight_Translator_Unstructured.cc
@@ -20,11 +20,11 @@ void ensight_dump_test_unstr2d(rtt_dsxx::UnitTest &ut, std::string prefix, bool 
                                bool const geom, bool const decomposed) {
 
   // short-cuts
-  typedef std::vector<std::string> vec_s;
-  typedef std::vector<IT> vec_i;
-  typedef std::vector<vec_i> vec2_i;
-  typedef std::vector<double> vec_d;
-  typedef std::vector<vec_d> vec2_d;
+  using vec_s = std::vector<std::string>;
+  using vec_i = std::vector<IT>;
+  using vec2_i = std::vector<vec_i>;
+  using vec_d = std::vector<double>;
+  using vec2_d = std::vector<vec_d>;
 
   if (binary)
     std::cout << "\nGenerating binary files...\n" << std::endl;
@@ -92,10 +92,9 @@ void ensight_dump_test_unstr2d(rtt_dsxx::UnitTest &ut, std::string prefix, bool 
   if (!input)
     ITFAILS;
 
-  for (size_t i = 0; i < pt_coor.size(); i++) {
-    for (size_t j = 0; j < pt_coor[i].size(); j++)
-      input >> pt_coor[i][j];
-  }
+  for (auto &vec1d : pt_coor)
+    for (auto &elem : vec1d)
+      input >> elem;
   for (size_t i = 0; i < ipar.size(); i++) {
     for (size_t j = 0; j < ipar[i].size(); j++)
       input >> ipar[i][j];

--- a/src/viz/test/tstViz_Traits.cc
+++ b/src/viz/test/tstViz_Traits.cc
@@ -20,13 +20,13 @@ using rtt_viz::Viz_Traits;
 
 template <typename T> class Test_Field {
 public:
-  typedef T value_type;
+  using value_type = T;
 
 private:
   vector<vector<T>> data;
 
 public:
-  Test_Field(const vector<vector<T>> &data_in) : data(data_in) {}
+  Test_Field(vector<vector<T>> data_in) : data(std::move(data_in)) {}
 
   T operator()(size_t i, size_t j) const { return data[i][j]; }
   size_t nrows() const { return data.size(); }
@@ -44,7 +44,7 @@ bool compare_vdf_field(int const &v1, int const &v2) { return v1 == v2; }
 // test vector traits specialization
 
 template <typename VVF> void test_vector(rtt_dsxx::UnitTest &ut) {
-  typedef typename Viz_Traits<VVF>::elementType VVFet;
+  using VVFet = typename Viz_Traits<VVF>::elementType;
 
   VVF field(3);
 


### PR DESCRIPTION
### Background

+ Add the viz component to the list of packages checked nightly by clang-tidy.

### Description of changes

+ Initialize class data when declared when possible instead of using default initializer in the constructor.
+ Use `std::make_unique` instead of `reset` for shared_ptrs.
+ Use `nullptr` instead of `NULL`
+ Use range-based for-loops when possible.
+ Only use `std::endl` at the end of a composed iostream/string.
+ Make use of `using` instead of `typedef`.
+ Implement `std::move` in constructors in place of pass by reverence and then copy.
+ Replace c-style arrays with `std::array`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
