### PR TITLE
Process ndi_cdi with clang-format at 100 columns

### DIFF
--- a/src/cdi_ndi/CMakeLists.txt
+++ b/src/cdi_ndi/CMakeLists.txt
@@ -1,8 +1,7 @@
 #--------------------------------------------*-cmake-*---------------------------------------------#
 # file   cdi_ndi/CMakeLists.txt
 # brief  Instructions for building cdi_ndi Makefiles.
-# note   Copyright (C) 2020 Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.17.0)
 project( cdi_ndi CXX )
@@ -15,8 +14,8 @@ file( GLOB headers *.hh )
 list( APPEND headers ${PROJECT_BINARY_DIR}/cdi_ndi/config.h )
 set(deps Lib_cdi Lib_rng Lib_units)
 
-# If NDI is found, set the associated variables. Otherwise, the cdi_ndi lib will
-# be built with stubbed-out routines.
+# If NDI is found, set the associated variables. Otherwise, the cdi_ndi lib will be built with
+# stubbed-out routines.
 if(TARGET NDI::ndi)
   list(APPEND deps NDI::ndi)
 
@@ -25,8 +24,7 @@ if(TARGET NDI::ndi)
   endif()
 
   if( NOT DEFINED NDI_ROOT_DIR )
-    # if not set in the environment (by modulefile?), set NDI_ROOT_DIR to the
-    # prefix_path for NDI
+    # if not set in the environment (by modulefile?), set NDI_ROOT_DIR to the prefix_path for NDI
     get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY)
     get_filename_component(NDI_ROOT_DIR "${NDI_LIBRARY}" DIRECTORY CACHE)
   endif()

--- a/src/cdi_ndi/NDI_AtomicMass.cc
+++ b/src/cdi_ndi/NDI_AtomicMass.cc
@@ -28,8 +28,7 @@ namespace rtt_cdi_ndi {
 NDI_AtomicMass::NDI_AtomicMass(std::string gendir_path_in)
     : gendir_path(std::move(gendir_path_in)), pc() {
   Insist(rtt_dsxx::fileExists(gendir_path),
-         "Specified NDI library is not available. gendir_path = " +
-             gendir_path);
+         "Specified NDI library is not available. gendir_path = " + gendir_path);
   NDI_Base::warn_ndi_version_mismatch(gendir_path);
 }
 
@@ -58,24 +57,21 @@ double NDI_AtomicMass::get_amw(const int zaid) const {
   Require(ndi_error == 0);
   Insist(gendir_handle != -1, "gendir_handle still has default value!");
 
-  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIB_TYPE_DEFAULT,
-                                     "multigroup_neutron");
+  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIB_TYPE_DEFAULT, "multigroup_neutron");
   Require(ndi_error == 0);
 
-  ndi_error =
-      NDI2_set_option_gendir(gendir_handle, NDI_LIBRARY_DEFAULT, "mendf71x");
+  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIBRARY_DEFAULT, "mendf71x");
   Require(ndi_error == 0);
 
   std::string zaid_formatted = std::to_string(zaid) + ".";
 
-  int size = NDI2_get_size_x(gendir_handle, NDI_AT_WGT, zaid_formatted.c_str(),
-                             &ndi_error);
+  int size = NDI2_get_size_x(gendir_handle, NDI_AT_WGT, zaid_formatted.c_str(), &ndi_error);
   Require(ndi_error == 0);
   Insist(size == 1, "NDI returned more or fewer than one atomic weight?");
 
   std::array<double, 1> arr;
-  ndi_error = NDI2_get_float64_vec_x(gendir_handle, NDI_AT_WGT,
-                                     zaid_formatted.c_str(), arr.data(), size);
+  ndi_error =
+      NDI2_get_float64_vec_x(gendir_handle, NDI_AT_WGT, zaid_formatted.c_str(), arr.data(), size);
   Require(ndi_error == 0);
 
   ndi_error = NDI2_close_gendir(gendir_handle);
@@ -85,8 +81,7 @@ double NDI_AtomicMass::get_amw(const int zaid) const {
 #else
   // NDI gendir not available.
   Insist(rtt_dsxx::fileExists(gendir_path),
-         "Specified NDI library is not available. gendir_path = " +
-             gendir_path);
+         "Specified NDI library is not available. gendir_path = " + gendir_path);
   return 0.0;
 #endif
 }

--- a/src/cdi_ndi/NDI_AtomicMass.cc
+++ b/src/cdi_ndi/NDI_AtomicMass.cc
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2020 Mar 6
  * \brief  NDI_AtomicMass class declaration.
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "NDI_AtomicMass.hh"
@@ -18,12 +17,10 @@ namespace rtt_cdi_ndi {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructor for NDI atomic mass weight reader, using custom path to
- *        NDI gendir file.
+ * \brief Constructor for NDI atomic mass weight reader, using custom path to NDI gendir file.
  * \param[in] gendir_path_in path to gendir file
  *
- * Print a warning if the gendir version and the ndi library version are not
- * compatible.
+ * Print a warning if the gendir version and the ndi library version are not compatible.
  */
 NDI_AtomicMass::NDI_AtomicMass(std::string gendir_path_in)
     : gendir_path(std::move(gendir_path_in)), pc() {
@@ -34,12 +31,11 @@ NDI_AtomicMass::NDI_AtomicMass(std::string gendir_path_in)
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Get atomic mass weight of an isotope with given ZAID. Use method due
- *        to T. Saller that invokes multigroup_neutron dataset which includes
- *        atomic weights.
+ * \brief Get atomic mass weight of an isotope with given ZAID. Use method due to T. Saller that
+ *        invokes multigroup_neutron dataset which includes atomic weights.
  *
- * \pre This function requires gendir_path to be valid.  If it isn't valid this
- *      NDI_atomicMass object will fail to contruct at run time.
+ * \pre This function requires gendir_path to be valid.  If it isn't valid this NDI_atomicMass
+ *      object will fail to contruct at run time.
  *
  * \param[in] zaid ZAID of isotope for which to return the atomic mass.
  * \return mass of isotope in grams

--- a/src/cdi_ndi/NDI_AtomicMass.hh
+++ b/src/cdi_ndi/NDI_AtomicMass.hh
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2020 Mar 6
  * \brief  NDI_AtomicMass class definition.
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef cdi_ndi_NDI_AtomicMass_hh
@@ -24,16 +23,14 @@ namespace rtt_cdi_ndi {
 /*!
  * \class NDI_AtomicMass
  *
- * \brief Class for getting atomic mass weights by ZAID from NDI data using a
- *        method due to T. Saller. For more details on NDI, see
- *        https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
- *        Currently only multigroup data is supported, continuous energy data
- *        is probably best added through a refactor.
+ * \brief Class for getting atomic mass weights by ZAID from NDI data using a method due to
+ *        T. Saller. For more details on NDI, see
+ *        https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html Currently only multigroup data is
+ *        supported, continuous energy data is probably best added through a refactor.
  * \example cdi_ndi/test/tstNDI_AtomicMass.cc
  *
- * Upon contruction, warn if the NDI library version is different that the NDI
- * gendir version.  Assume versions are compatible for differences in the patch
- * version.
+ * Upon contruction, warn if the NDI library version is different that the NDI gendir version.
+ * Assume versions are compatible for differences in the patch version.
  */
 //================================================================================================//
 class NDI_AtomicMass {

--- a/src/cdi_ndi/NDI_AtomicMass.hh
+++ b/src/cdi_ndi/NDI_AtomicMass.hh
@@ -40,8 +40,7 @@ class NDI_AtomicMass {
 public:
   //! Default constructor
   explicit NDI_AtomicMass(
-      std::string gendir_path_in =
-          rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH").second);
+      std::string gendir_path_in = rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH").second);
 
   //! Retrieve atomic mass weight for isotope with given ZAID
   double get_amw(const int zaid) const;

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -41,8 +41,7 @@ void NDI_Base::warn_ndi_version_mismatch(std::string const &gendir) {
     std::cout << "\n"
               << Term::ccolor(DT::error) << "WARNING: In the cdi_ndi/NDI_Base "
               << "constructor, the NDI library version (" << ndi_ver << ") is "
-              << "different than the NDI GENDIR version (" << gendir_ver
-              << "). \n"
+              << "different than the NDI GENDIR version (" << gendir_ver << "). \n"
               << Term::ccolor(DT::reset) << std::endl;
   }
 }
@@ -72,11 +71,10 @@ void NDI_Base::warn_ndi_version_mismatch(std::string const & /*gendir*/) {}
  * \param[in] mg_e_bounds_in multigroup energy bin boundaries (keV)
  */
 NDI_Base::NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
-                   const std::string &library_in,
-                   const std::string &reaction_in,
+                   const std::string &library_in, const std::string &reaction_in,
                    const std::vector<double> mg_e_bounds_in)
-    : gendir(gendir_in), dataset(dataset_in), library(library_in),
-      reaction(reaction_in), mg_e_bounds(mg_e_bounds_in) {
+    : gendir(gendir_in), dataset(dataset_in), library(library_in), reaction(reaction_in),
+      mg_e_bounds(mg_e_bounds_in) {
 
   Require(rtt_dsxx::fileExists(gendir));
 
@@ -105,8 +103,7 @@ NDI_Base::NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
 #ifndef NDI_FOUND
 
 //! Constructor for generic NDI reader- throws when NDI not available
-NDI_Base::NDI_Base(const std::string & /*dataset_in*/,
-                   const std::string & /*library_in*/,
+NDI_Base::NDI_Base(const std::string & /*dataset_in*/, const std::string & /*library_in*/,
                    const std::string & /*reaction_in*/,
                    const std::vector<double> /*mg_e_bounds_in*/) {
   Insist(0, "NDI default gendir path only available when NDI is found.");
@@ -132,11 +129,9 @@ NDI_Base::NDI_Base(const std::string & /*dataset_in*/,
  * \param[in] mg_e_bounds_in multigroup energy bin boundaries (keV)
  */
 NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
-                   const std::string &reaction_in,
-                   const std::vector<double> mg_e_bounds_in)
-    : gendir(rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH").second),
-      dataset(dataset_in), library(library_in), reaction(reaction_in),
-      mg_e_bounds(mg_e_bounds_in) {
+                   const std::string &reaction_in, const std::vector<double> mg_e_bounds_in)
+    : gendir(rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH").second), dataset(dataset_in),
+      library(library_in), reaction(reaction_in), mg_e_bounds(mg_e_bounds_in) {
 
   Require(rtt_dsxx::fileExists(gendir));
 
@@ -152,8 +147,7 @@ NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in,
   }
 
   // Check that mg_e_bounds is monotonically decreasing (NDI requirement)
-  Require(rtt_dsxx::is_strict_monotonic_decreasing(mg_e_bounds.begin(),
-                                                   mg_e_bounds.end()));
+  Require(rtt_dsxx::is_strict_monotonic_decreasing(mg_e_bounds.begin(), mg_e_bounds.end()));
   Require(mg_e_bounds.back() > 0);
 }
 

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2020 Feb 4
  * \brief  NDI_Base member definitions.
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "NDI_Base.hh"
@@ -47,8 +46,8 @@ void NDI_Base::warn_ndi_version_mismatch(std::string const &gendir) {
 }
 #else
 /*!
- * \brief Warn if NDI library version doesn't match GENDIR version to 2 digits.
- *        No-op when NDI_FOUND is false. */
+ * \brief Warn if NDI library version doesn't match GENDIR version to 2 digits.  No-op when
+ *        NDI_FOUND is false. */
 void NDI_Base::warn_ndi_version_mismatch(std::string const & /*gendir*/) {}
 #endif
 
@@ -57,12 +56,11 @@ void NDI_Base::warn_ndi_version_mismatch(std::string const & /*gendir*/) {}
 //------------------------------------------------------------------------------------------------//
 
 /*!
- * \brief Constructor for generic NDI reader, to be inherited by readers for
- *        specific gendir file path and dataset.
+ * \brief Constructor for generic NDI reader, to be inherited by readers for specific gendir file
+ *        path and dataset.
  *
- * This base constructor only sets some data members based on constructor input.
- * For more details on NDI, see
- * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
+ * This base constructor only sets some data members based on constructor input.  For more details
+ * on NDI, see https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
  *
  * \param[in] gendir_in path to non-standard NDI gendir file
  * \param[in] dataset_in name of requested dataset (provided by inherited class)
@@ -116,12 +114,10 @@ NDI_Base::NDI_Base(const std::string & /*dataset_in*/, const std::string & /*lib
 //================================================================================================//
 
 /*!
- * \brief Constructor for generic NDI reader, to be inherited by readers for
- *        specific dataset.
+ * \brief Constructor for generic NDI reader, to be inherited by readers for specific dataset.
  *
- * This base constructor only sets some data members based on constructor input.
- * For more details on NDI, see
- * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
+ * This base constructor only sets some data members based on constructor input.  For more details
+ * on NDI, see https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
  *
  * \param[in] dataset_in name of requested dataset (provided by inherited class)
  * \param[in] library_in name of requested NDI data library

--- a/src/cdi_ndi/NDI_Base.hh
+++ b/src/cdi_ndi/NDI_Base.hh
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2019 Nov 4
  * \brief  NDI_Base class definition.
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef cdi_ndi_NDI_Base_hh
@@ -30,15 +29,13 @@ namespace rtt_cdi_ndi {
  *
  * \brief Base class for wrapping NDI calls to NDI data.
  *
- * Reads data, constructs internal storage amenable to radiation calculations,
- * and provides accessors. Instantiated only through a data type-specific
- * derived class. Energies and temperatures are in units of keV. Velocity-
- * averaged cross sections are in units of cm^3 sh^-1. Probability density
- * functions sum to unity. Unit conversions from NDI data are done when data is
- * initially read in. For more details on NDI, see
- * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html Currently only
- * multigroup data is supported, continuous energy data is probably best added
- * through a refactor.
+ * Reads data, constructs internal storage amenable to radiation calculations, and provides
+ * accessors. Instantiated only through a data type-specific derived class. Energies and
+ * temperatures are in units of keV. Velocity- averaged cross sections are in units of cm^3
+ * sh^-1. Probability density functions sum to unity. Unit conversions from NDI data are done when
+ * data is initially read in. For more details on NDI, see
+ * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html Currently only multigroup data is
+ * supported, continuous energy data is probably best added through a refactor.
  */
 //================================================================================================//
 
@@ -48,8 +45,8 @@ protected:
   //! Path to gendir file, which indexes an NDI dataset
   std::string gendir;
 
-  //! Type of data to read (NDI supports multigroup_neutron, multigroup_photon,
-  //! multigroup_multi, tn, tnreactions, and dosimetry_neutrons)
+  //! Type of data to read (NDI supports multigroup_neutron, multigroup_photon, multigroup_multi,
+  //! tn, tnreactions, and dosimetry_neutrons)
   const std::string dataset;
 
   //! Name of library in which to find reaction

--- a/src/cdi_ndi/NDI_Base.hh
+++ b/src/cdi_ndi/NDI_Base.hh
@@ -103,8 +103,7 @@ protected:
 protected:
   //! Constructor
   NDI_Base(const std::string &dataset_in, const std::string &library_in,
-           const std::string &reaction_in,
-           const std::vector<double> mg_e_bounds_in);
+           const std::string &reaction_in, const std::vector<double> mg_e_bounds_in);
 
   NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
            const std::string &library_in, const std::string &reaction_in,
@@ -133,22 +132,16 @@ public:
   inline std::string get_reaction_name() const & { return reaction_name; }
 
   //! Get number of reaction products
-  inline uint32_t get_num_products() const {
-    return static_cast<uint32_t>(products.size());
-  }
+  inline uint32_t get_num_products() const { return static_cast<uint32_t>(products.size()); }
 
   //! Get vector of reaction products
   inline std::vector<int> get_products() const & { return products; }
 
   //! Get vector of reaction product multiplicities
-  inline std::vector<int> get_product_multiplicities() const & {
-    return product_multiplicities;
-  }
+  inline std::vector<int> get_product_multiplicities() const & { return product_multiplicities; }
 
   //! Get vector of reaction temperature grid support points
-  inline std::vector<double> get_reaction_temperature() const & {
-    return reaction_temperature;
-  }
+  inline std::vector<double> get_reaction_temperature() const & { return reaction_temperature; }
 
   //! Get vector of incident energy support points
   inline std::vector<double> get_einbar() const & { return einbar; }
@@ -166,9 +159,7 @@ public:
   inline std::vector<double> get_group_bounds() const & { return group_bounds; }
 
   //! Get group energies
-  inline std::vector<double> get_group_energies() const & {
-    return group_energies;
-  }
+  inline std::vector<double> get_group_energies() const & { return group_energies; }
 
   // >> Non-interacting helper functions.
 

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2020 Feb 4
  * \brief  NDI_TNReaction member definitions.
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 #include "NDI_TNReaction.hh"
 #include <cmath>
@@ -18,8 +17,7 @@ namespace rtt_cdi_ndi {
 // CONSTRUCTORS
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructor for NDI reader specific to TN reaction data with provided
- *        path to gendir file.
+ * \brief Constructor for NDI reader specific to TN reaction data with provided path to gendir file.
  *
  * \param[in] gendir_in path to gendir file
  * \param[in] library_in name of requested NDI data library
@@ -35,8 +33,7 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &
 }
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructor for NDI reader specific to TN reaction data using default
- *        gendir file.
+ * \brief Constructor for NDI reader specific to TN reaction data using default gendir file.
  *
  * \param[in] library_in name of requested NDI data library
  * \param[in] reaction_in name of requested reaction
@@ -50,12 +47,12 @@ NDI_TNReaction::NDI_TNReaction(const std::string &library_in, const std::string 
 }
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Load NDI dataset. Split off from constructor to allow for both
- *        default and overridden gendir paths.
+ * \brief Load NDI dataset. Split off from constructor to allow for both default and overridden
+ *        gendir paths.
  *
- * This function opens an NDI file, navigates to the appropriate data, reads
- * the data into internal buffers, and closes the file. For more details on NDI,
- * see https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
+ * This function opens an NDI file, navigates to the appropriate data, reads the data into internal
+ * buffers, and closes the file. For more details on NDI, see
+ * https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
  */
 void NDI_TNReaction::load_ndi() {
   int gendir_handle = -1;
@@ -121,8 +118,7 @@ void NDI_TNReaction::load_ndi() {
     energy *= 1000.;
   }
 
-  //! Get the number of interp regions... for now just throw an exception if
-  //! this is not equal to 1
+  //! Get the number of interp regions... for now just throw an exception if this is not equal to 1
   int num_einbar_interp_regions = NDI2_get_size(dataset_handle, NDI_EINBAR_INTERP_REG, &ndi_error);
   Require(ndi_error == 0);
   Insist(num_einbar_interp_regions == 1, "Only 1 einbar interp region supported!");
@@ -141,8 +137,7 @@ void NDI_TNReaction::load_ndi() {
     sigma *= 1.e-8;
   }
 
-  //! Get the number of interp regions... for now just throw an exception if
-  //! this is not equal to 1
+  //! Get the number of interp regions... for now just throw an exception if this is not equal to 1
   int num_sigvbar_interp_regions =
       NDI2_get_size(dataset_handle, NDI_SIGVBAR_INTERP_REG, &ndi_error);
   Require(ndi_error == 0);
@@ -218,8 +213,7 @@ void NDI_TNReaction::load_ndi() {
     ndi_error = NDI2_set_option(dataset_handle, NDI_CURR_PART, product_zaid.c_str());
     Require(ndi_error == 0);
 
-    //! Get number of temperature support points (this can depend on reaction
-    //! product)
+    //! Get number of temperature support points (this can depend on reaction product)
     const int num_product_temps = NDI2_get_size(dataset_handle, NDI_EDIST_TEMPS, &ndi_error);
     Require(ndi_error == 0);
     Require(num_product_temps > 1);
@@ -235,8 +229,8 @@ void NDI_TNReaction::load_ndi() {
       temperature *= 1000.;
     }
 
-    //! Get the number of interp regions... for now just throw an exception if
-    //! this is not equal to 1
+    //! Get the number of interp regions... for now just throw an exception if this is not equal to
+    //! 1
     int num_edist_interp_regions = NDI2_get_size(dataset_handle, NDI_EDIST_INTERP_REG, &ndi_error);
     Require(ndi_error == 0);
     Insist(num_edist_interp_regions == 1, "Only 1 edist interp region supported!");
@@ -263,8 +257,8 @@ void NDI_TNReaction::load_ndi() {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Return normalized probability distribution function for energy of a
- *        reaction product at a given temperature.
+ * \brief Return normalized probability distribution function for energy of a reaction product at a
+ *        given temperature.
  * \param[in] product_zaid ZAID of reaction product to sample
  * \param[in] temperature of plasma (keV)
  * \return Normalized PDF of reaction product energy
@@ -302,12 +296,13 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
   return pdf;
 }
 #else
+
 //------------------------------------------------------------------------------------------------//
 // CONSTRUCTORS
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructor for NDI reader -- base class constructor will throw
- *        because NDI is not available.
+ * \brief Constructor for NDI reader -- base class constructor will throw because NDI is not
+ *        available.
  *
  * \param[in] gendir_in path to gendir file
  * \param[in] library_in name of requested NDI data library
@@ -320,9 +315,10 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &
     : NDI_Base(gendir_in, "tn", library_in, reaction_in, mg_e_bounds_in) { /* ... */
 }
 
+//------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructor for NDI reader -- base class constructor will throw
- *        because NDI is not available.
+ * \brief Constructor for NDI reader -- base class constructor will throw because NDI is not
+ *        available.
  *
  * \param[in] library_in name of requested NDI data library
  * \param[in] reaction_in name of requested reaction
@@ -337,7 +333,9 @@ std::vector<double> NDI_TNReaction::get_PDF(const int /*product_zaid*/,
                                             const double /*temperature*/) const {
   Insist(0, "get_PDF() only available when NDI library is found");
 }
+
 #endif // NDI_FOUND
+
 } // namespace rtt_cdi_ndi
 
 //------------------------------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -26,8 +26,7 @@ namespace rtt_cdi_ndi {
  * \param[in] reaction_in name of requested reaction
  * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
  */
-NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in,
-                               const std::string &library_in,
+NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &library_in,
                                const std::string &reaction_in,
                                const std::vector<double> mg_e_bounds_in)
     : NDI_Base(gendir_in, "tn", library_in, reaction_in, mg_e_bounds_in) {
@@ -43,8 +42,7 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in,
  * \param[in] reaction_in name of requested reaction
  * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
  */
-NDI_TNReaction::NDI_TNReaction(const std::string &library_in,
-                               const std::string &reaction_in,
+NDI_TNReaction::NDI_TNReaction(const std::string &library_in, const std::string &reaction_in,
                                const std::vector<double> mg_e_bounds_in)
     : NDI_Base("tn", library_in, reaction_in, mg_e_bounds_in) {
 
@@ -72,13 +70,11 @@ void NDI_TNReaction::load_ndi() {
   Insist(gendir_handle != -1, "gendir_handle still has default value!");
 
   // Set dataset option by changing default value for this handle
-  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIB_TYPE_DEFAULT,
-                                     dataset.c_str());
+  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIB_TYPE_DEFAULT, dataset.c_str());
   Require(ndi_error == 0);
 
   //! Set library option by changing default value for this handle
-  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIBRARY_DEFAULT,
-                                     library.c_str());
+  ndi_error = NDI2_set_option_gendir(gendir_handle, NDI_LIBRARY_DEFAULT, library.c_str());
   Require(ndi_error == 0);
 
   //! Get dataset handle
@@ -91,8 +87,7 @@ void NDI_TNReaction::load_ndi() {
   Require(ndi_error == 0);
 
   //! Store reaction name from NDI file
-  ndi_error =
-      NDI2_get_string_val(dataset_handle, NDI_ZAID, c_str_buf, c_str_len);
+  ndi_error = NDI2_get_string_val(dataset_handle, NDI_ZAID, c_str_buf, c_str_len);
   Require(ndi_error == 0);
   reaction_name = c_str_buf;
 
@@ -104,9 +99,8 @@ void NDI_TNReaction::load_ndi() {
   reaction_temperature.resize(num_temps);
 
   //! Get temperature support points for reaction
-  ndi_error = NDI2_get_float64_vec(
-      dataset_handle, NDI_TEMPS, reaction_temperature.data(),
-      static_cast<int>(reaction_temperature.size()));
+  ndi_error = NDI2_get_float64_vec(dataset_handle, NDI_TEMPS, reaction_temperature.data(),
+                                   static_cast<int>(reaction_temperature.size()));
   Require(ndi_error == 0);
   // MeV -> keV
   for (auto &temperature : reaction_temperature) {
@@ -129,11 +123,9 @@ void NDI_TNReaction::load_ndi() {
 
   //! Get the number of interp regions... for now just throw an exception if
   //! this is not equal to 1
-  int num_einbar_interp_regions =
-      NDI2_get_size(dataset_handle, NDI_EINBAR_INTERP_REG, &ndi_error);
+  int num_einbar_interp_regions = NDI2_get_size(dataset_handle, NDI_EINBAR_INTERP_REG, &ndi_error);
   Require(ndi_error == 0);
-  Insist(num_einbar_interp_regions == 1,
-         "Only 1 einbar interp region supported!");
+  Insist(num_einbar_interp_regions == 1, "Only 1 einbar interp region supported!");
 
   //! Get number of cross section support points for reaction
   int num_sigvbar = NDI2_get_size(dataset_handle, NDI_SIGVBARS, &ndi_error);
@@ -154,13 +146,11 @@ void NDI_TNReaction::load_ndi() {
   int num_sigvbar_interp_regions =
       NDI2_get_size(dataset_handle, NDI_SIGVBAR_INTERP_REG, &ndi_error);
   Require(ndi_error == 0);
-  Insist(num_sigvbar_interp_regions == 1,
-         "Only 1 sigvbar interp region supported!");
+  Insist(num_sigvbar_interp_regions == 1, "Only 1 sigvbar interp region supported!");
 
   //! Get number of reaction products
   int num_products;
-  ndi_error =
-      NDI2_get_int_val(dataset_handle, NDI_NUM_SEC_PARTS, &num_products);
+  ndi_error = NDI2_get_int_val(dataset_handle, NDI_NUM_SEC_PARTS, &num_products);
   Require(ndi_error == 0);
   Require(num_products > 0);
   products.resize(num_products);
@@ -170,8 +160,7 @@ void NDI_TNReaction::load_ndi() {
   Require(num_products > 0);
 
   //! Get reaction product multiplicity
-  ndi_error = NDI2_get_int_vec(dataset_handle, NDI_RPRODS_MLT,
-                               product_multiplicities.data(),
+  ndi_error = NDI2_get_int_vec(dataset_handle, NDI_RPRODS_MLT, product_multiplicities.data(),
                                static_cast<int>(product_multiplicities.size()));
   Require(ndi_error == 0);
 
@@ -181,8 +170,7 @@ void NDI_TNReaction::load_ndi() {
   q_reaction *= 1000.; // MeV -> keV
 
   //! Specify multigroup option
-  ndi_error = NDI2_set_float64_vec_option(dataset_handle, NDI_COLLAPSE,
-                                          mg_e_bounds.data(),
+  ndi_error = NDI2_set_float64_vec_option(dataset_handle, NDI_COLLAPSE, mg_e_bounds.data(),
                                           static_cast<int>(mg_e_bounds.size()));
   Require(ndi_error == 0);
 
@@ -196,9 +184,8 @@ void NDI_TNReaction::load_ndi() {
   group_energies.resize(num_groups);
 
   //! Get boundaries of energy groups
-  ndi_error =
-      NDI2_get_float64_vec(dataset_handle, NDI_E_BOUNDS, group_bounds.data(),
-                           static_cast<int>(group_bounds.size()));
+  ndi_error = NDI2_get_float64_vec(dataset_handle, NDI_E_BOUNDS, group_bounds.data(),
+                                   static_cast<int>(group_bounds.size()));
   Require(ndi_error == 0);
   // MeV -> keV
   for (auto &bound : group_bounds) {
@@ -206,9 +193,8 @@ void NDI_TNReaction::load_ndi() {
   }
 
   //! Get average energies of energy groups
-  ndi_error =
-      NDI2_get_float64_vec(dataset_handle, NDI_E_AVG, group_energies.data(),
-                           static_cast<int>(group_energies.size()));
+  ndi_error = NDI2_get_float64_vec(dataset_handle, NDI_E_AVG, group_energies.data(),
+                                   static_cast<int>(group_energies.size()));
   Require(ndi_error == 0);
   // MeV -> keV
   for (auto &energy : group_energies) {
@@ -218,36 +204,31 @@ void NDI_TNReaction::load_ndi() {
   //! Loop over reaction products
   for (int n = 0; n < num_products; n++) {
     //! Get ZAID of reaction product
-    ndi_error = NDI2_get_string_val_n(dataset_handle, NDI_SEC_PART_TYPES, n,
-                                      c_str_buf, c_str_len);
+    ndi_error = NDI2_get_string_val_n(dataset_handle, NDI_SEC_PART_TYPES, n, c_str_buf, c_str_len);
     Require(ndi_error == 0);
     const std::string product_zaid = c_str_buf;
 
     // Ensure no duplicate products
-    Require(std::count(products.begin(), products.end(),
-                       std::stoi(product_zaid)) == 0);
+    Require(std::count(products.begin(), products.end(), std::stoi(product_zaid)) == 0);
 
     products[n] = std::stoi(product_zaid);
     product_zaid_to_index.insert(std::pair<int, int>(products[n], n));
 
     //! Set NDI to reaction product
-    ndi_error =
-        NDI2_set_option(dataset_handle, NDI_CURR_PART, product_zaid.c_str());
+    ndi_error = NDI2_set_option(dataset_handle, NDI_CURR_PART, product_zaid.c_str());
     Require(ndi_error == 0);
 
     //! Get number of temperature support points (this can depend on reaction
     //! product)
-    const int num_product_temps =
-        NDI2_get_size(dataset_handle, NDI_EDIST_TEMPS, &ndi_error);
+    const int num_product_temps = NDI2_get_size(dataset_handle, NDI_EDIST_TEMPS, &ndi_error);
     Require(ndi_error == 0);
     Require(num_product_temps > 1);
     product_temperatures[n].resize(num_product_temps);
     product_distributions[n].resize(num_product_temps);
 
     //! Get temperature support points
-    ndi_error = NDI2_get_float64_vec(
-        dataset_handle, NDI_TEMPS, product_temperatures[n].data(),
-        static_cast<int>(product_temperatures[n].size()));
+    ndi_error = NDI2_get_float64_vec(dataset_handle, NDI_TEMPS, product_temperatures[n].data(),
+                                     static_cast<int>(product_temperatures[n].size()));
     Require(ndi_error == 0);
     // MeV -> keV
     for (auto &temperature : product_temperatures[n]) {
@@ -256,24 +237,21 @@ void NDI_TNReaction::load_ndi() {
 
     //! Get the number of interp regions... for now just throw an exception if
     //! this is not equal to 1
-    int num_edist_interp_regions =
-        NDI2_get_size(dataset_handle, NDI_EDIST_INTERP_REG, &ndi_error);
+    int num_edist_interp_regions = NDI2_get_size(dataset_handle, NDI_EDIST_INTERP_REG, &ndi_error);
     Require(ndi_error == 0);
-    Insist(num_edist_interp_regions == 1,
-           "Only 1 edist interp region supported!");
+    Insist(num_edist_interp_regions == 1, "Only 1 edist interp region supported!");
 
     // Loop over temperatures
     for (size_t m = 0; m < product_temperatures[n].size(); m++) {
       std::ostringstream temp_stream;
       temp_stream << product_temperatures[n][m] / 1000; // keV -> MeV
-      ndi_error =
-          NDI2_set_option(dataset_handle, NDI_TEMP, temp_stream.str().c_str());
+      ndi_error = NDI2_set_option(dataset_handle, NDI_TEMP, temp_stream.str().c_str());
       Require(ndi_error == 0);
 
       product_distributions[n][m].resize(num_groups);
-      ndi_error = NDI2_get_float64_vec(
-          dataset_handle, NDI_EDIST, product_distributions[n][m].data(),
-          static_cast<int>(product_distributions[n][m].size()));
+      ndi_error =
+          NDI2_get_float64_vec(dataset_handle, NDI_EDIST, product_distributions[n][m].data(),
+                               static_cast<int>(product_distributions[n][m].size()));
       Require(ndi_error == 0);
     }
   }
@@ -297,17 +275,14 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
 
   Require(std::count(products.begin(), products.end(), product_zaid) == 1);
 
-  const int product_index =
-      (*(product_zaid_to_index.find(product_zaid))).second;
+  const int product_index = (*(product_zaid_to_index.find(product_zaid))).second;
 
   Require(temperature > product_temperatures[product_index].front());
   Require(temperature < product_temperatures[product_index].back());
 
-  auto temp_1 =
-      std::upper_bound(product_temperatures[product_index].begin(),
-                       product_temperatures[product_index].end(), temperature);
-  uint32_t index_1 = static_cast<uint32_t>(
-      temp_1 - product_temperatures[product_index].begin());
+  auto temp_1 = std::upper_bound(product_temperatures[product_index].begin(),
+                                 product_temperatures[product_index].end(), temperature);
+  uint32_t index_1 = static_cast<uint32_t>(temp_1 - product_temperatures[product_index].begin());
   uint32_t index_0 = index_1 - 1;
   double temp_0 = product_temperatures[product_index][index_0];
   Check(*temp_1 - temp_0 > std::numeric_limits<double>::min());
@@ -339,12 +314,10 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
  * \param[in] reaction_in name of requested reaction
  * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
  */
-NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in,
-                               const std::string &library_in,
+NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &library_in,
                                const std::string &reaction_in,
                                const std::vector<double> mg_e_bounds_in)
-    : NDI_Base(gendir_in, "tn", library_in, reaction_in,
-               mg_e_bounds_in) { /* ... */
+    : NDI_Base(gendir_in, "tn", library_in, reaction_in, mg_e_bounds_in) { /* ... */
 }
 
 /*!
@@ -355,15 +328,13 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in,
  * \param[in] reaction_in name of requested reaction
  * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
  */
-NDI_TNReaction::NDI_TNReaction(const std::string &library_in,
-                               const std::string &reaction_in,
+NDI_TNReaction::NDI_TNReaction(const std::string &library_in, const std::string &reaction_in,
                                const std::vector<double> mg_e_bounds_in)
     : NDI_Base("tn", library_in, reaction_in, mg_e_bounds_in) { /* ... */
 }
 
-std::vector<double>
-NDI_TNReaction::get_PDF(const int /*product_zaid*/,
-                        const double /*temperature*/) const {
+std::vector<double> NDI_TNReaction::get_PDF(const int /*product_zaid*/,
+                                            const double /*temperature*/) const {
   Insist(0, "get_PDF() only available when NDI library is found");
 }
 #endif // NDI_FOUND

--- a/src/cdi_ndi/NDI_TNReaction.hh
+++ b/src/cdi_ndi/NDI_TNReaction.hh
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2019 Nov 4
  * \brief  NDI_TNReaction class definition.
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef cdi_ndi_NDI_TNReaction_hh
@@ -24,9 +23,8 @@ namespace rtt_cdi_ndi {
 /*!
  * \class NDI_TNReaction
  *
- * \brief Class for wrapping NDI calls to NDI tn data. Reads data, constructs
- *        internal storage amenable to radiation calculations, and provides
- *        accessors.
+ * \brief Class for wrapping NDI calls to NDI tn data. Reads data, constructs internal storage
+ *        amenable to radiation calculations, and provides accessors.
  * \example cdi_ndi/test/tstNDI_TNReaction.cc
  */
 //================================================================================================//
@@ -45,8 +43,7 @@ public:
   //! Disable default constructor
   NDI_TNReaction() = delete;
 
-  //! Disable copy constructor (meaning no implicit move assignment operator
-  //! or move constructor)
+  //! Disable copy constructor (meaning no implicit move assignment operator or move constructor)
   NDI_TNReaction(const NDI_TNReaction &) = delete;
 
   //! Return spectrum PDF at a given temperature

--- a/src/cdi_ndi/NDI_TNReaction.hh
+++ b/src/cdi_ndi/NDI_TNReaction.hh
@@ -40,8 +40,7 @@ public:
 
   //! Constructor (overridden gendir path)
   NDI_TNReaction(const std::string &gendir_in, const std::string &library_in,
-                 const std::string &reaction_in,
-                 const std::vector<double> mg_e_bounds_in);
+                 const std::string &reaction_in, const std::vector<double> mg_e_bounds_in);
 
   //! Disable default constructor
   NDI_TNReaction() = delete;
@@ -51,8 +50,7 @@ public:
   NDI_TNReaction(const NDI_TNReaction &) = delete;
 
   //! Return spectrum PDF at a given temperature
-  std::vector<double> get_PDF(const int product_zaid,
-                              const double temperature) const;
+  std::vector<double> get_PDF(const int product_zaid, const double temperature) const;
 
 private:
 // Only implemented if NDI is found

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -2,8 +2,7 @@
 /*!
  * \file   cdi_ndi/config.h
  * \brief  CPP defines necessary for the cdi_ndi package.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
 /*------------------------------------------------------------------------------------------------*/
 
 #ifndef rtt_cdi_ndi_config_h

--- a/src/cdi_ndi/test/CMakeLists.txt
+++ b/src/cdi_ndi/test/CMakeLists.txt
@@ -3,8 +3,7 @@
 # author Ben. R. Ryan <brryan@lanl.gov>
 # date   2020 Feb 4
 # brief  Generate build project files for cdi_ndi/test.
-# note   Copyright (C) 2020, Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2020, Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 project( cdi_ndi_test CXX )
 
@@ -20,9 +19,8 @@ set( test_sources
 # Build Unit tests
 #--------------------------------------------------------------------------------------------------#
 
-# Both tests read a local test data file, 'ndi_data'. To avoid resource issues,
-# tell ctest to avoid running these two test at the same time with the keyword
-# RESOURCE_LOCK.
+# Both tests read a local test data file, 'ndi_data'. To avoid resource issues, tell ctest to avoid
+# running these two test at the same time with the keyword RESOURCE_LOCK.
 if(TARGET NDI::ndi)
 
 add_scalar_tests(

--- a/src/cdi_ndi/test/tstNDI_AtomicMass.cc
+++ b/src/cdi_ndi/test/tstNDI_AtomicMass.cc
@@ -41,8 +41,7 @@ void amw_test(rtt_dsxx::UnitTest &ut) {
   gendir_tmp_file << "    f=fake/data/path\n";
   gendir_tmp_file << "    ft=asc  ln=2  o=28\n";
   gendir_tmp_file << "    ng=618  t=2.5300642359999999e-08  s0=10000000000\n";
-  gendir_tmp_file
-      << "    aw=1.0078249887344399  awr=0.99916729999999998  end\n";
+  gendir_tmp_file << "    aw=1.0078249887344399  awr=0.99916729999999998  end\n";
   gendir_tmp_file.close();
 
   NDI_AtomicMass ndi_amw(gendir_tmp_path);
@@ -94,8 +93,7 @@ int main(int argc, char *argv[]) {
     amw_test(ut);
     std::string gendir_default;
     bool def_gendir{false};
-    std::tie(def_gendir, gendir_default) =
-        rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH");
+    std::tie(def_gendir, gendir_default) = rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH");
 
     if (def_gendir && rtt_dsxx::fileExists(gendir_default)) {
       amw_default_test(ut);

--- a/src/cdi_ndi/test/tstNDI_AtomicMass.cc
+++ b/src/cdi_ndi/test/tstNDI_AtomicMass.cc
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2020 Mar 6
  * \brief  NDI_AtomicMass test
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "cdi/CDI.hh"

--- a/src/cdi_ndi/test/tstNDI_TNReaction.cc
+++ b/src/cdi_ndi/test/tstNDI_TNReaction.cc
@@ -4,8 +4,7 @@
  * \author Ben R. Ryan
  * \date   2019 Nov 18
  * \brief  NDI_TNReaction test
- * \note   Copyright (C) 2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "cdi/CDI.hh"

--- a/src/cdi_ndi/test/tstNDI_TNReaction.cc
+++ b/src/cdi_ndi/test/tstNDI_TNReaction.cc
@@ -56,39 +56,31 @@ void gendir_test(rtt_dsxx::UnitTest &ut) {
   FAIL_IF_NOT(tn.get_reaction_name() == "n+be7->p+li7.040ztn");
   FAIL_IF_NOT(tn.get_num_products() == 2);
   auto products = tn.get_products();
-  FAIL_IF_NOT(products.size() == 2 && products[0] == 1001 &&
-              products[1] == 3007);
+  FAIL_IF_NOT(products.size() == 2 && products[0] == 1001 && products[1] == 3007);
   auto multiplicities = tn.get_product_multiplicities();
-  FAIL_IF_NOT(multiplicities.size() == 2 && multiplicities[0] == 1 &&
-              multiplicities[1] == 1);
+  FAIL_IF_NOT(multiplicities.size() == 2 && multiplicities[0] == 1 && multiplicities[1] == 1);
   auto reaction_temperature = tn.get_reaction_temperature();
   FAIL_IF_NOT(reaction_temperature.size() == 3);
-  FAIL_IF_NOT(soft_equiv(reaction_temperature.front(), 1.000000000000000056e-01,
-                         1.e-8));
-  FAIL_IF_NOT(
-      soft_equiv(reaction_temperature.back(), 1.165914400000000045e-01, 1.e-8));
+  FAIL_IF_NOT(soft_equiv(reaction_temperature.front(), 1.000000000000000056e-01, 1.e-8));
+  FAIL_IF_NOT(soft_equiv(reaction_temperature.back(), 1.165914400000000045e-01, 1.e-8));
   auto einbar = tn.get_einbar();
   FAIL_IF_NOT(einbar.size() == 3);
   FAIL_IF_NOT(soft_equiv(einbar.front(), 2.968071330000000008e-01, 1.e-8));
   FAIL_IF_NOT(soft_equiv(einbar.back(), 3.458878690000000145e-01, 1.e-8));
   auto sigvbar = tn.get_sigvbar();
   FAIL_IF_NOT(sigvbar.size() == 3);
-  FAIL_IF_NOT(
-      soft_equiv(sigvbar.front() / 1.e-23, 7.504850620000000827, 1.e-8));
+  FAIL_IF_NOT(soft_equiv(sigvbar.front() / 1.e-23, 7.504850620000000827, 1.e-8));
   FAIL_IF_NOT(soft_equiv(sigvbar.back() / 1.e-23, 7.467488500000000044, 1.e-8));
   FAIL_IF_NOT(soft_equiv(tn.get_reaction_q(), 1.644289999999999964e+03, 1.e-8));
   FAIL_IF_NOT(tn.get_num_groups() == 4);
   auto group_bounds = tn.get_group_bounds();
   FAIL_IF_NOT(group_bounds.size() == 5);
-  FAIL_IF_NOT(
-      soft_equiv(group_bounds.front(), 1.700000000000000000e+04, 1.e-8));
+  FAIL_IF_NOT(soft_equiv(group_bounds.front(), 1.700000000000000000e+04, 1.e-8));
   FAIL_IF_NOT(soft_equiv(group_bounds.back(), 1.669999999999999818e-01, 1.e-8));
   auto group_energies = tn.get_group_energies();
   FAIL_IF_NOT(group_energies.size() == 4);
-  FAIL_IF_NOT(
-      soft_equiv(group_energies.front(), 1.239500000000000000e+04, 1.e-8));
-  FAIL_IF_NOT(
-      soft_equiv(group_energies.back(), 9.208350000000000080e+01, 1.e-8));
+  FAIL_IF_NOT(soft_equiv(group_energies.front(), 1.239500000000000000e+04, 1.e-8));
+  FAIL_IF_NOT(soft_equiv(group_energies.back(), 9.208350000000000080e+01, 1.e-8));
 
   int product_zaid_1 = 1001;            // proton
   int product_zaid_2 = 3007;            // Lithium-7
@@ -115,8 +107,7 @@ void gendir_test(rtt_dsxx::UnitTest &ut) {
   // Check that non-monotonically-decreasing multigroup bounds fail
   try {
     std::vector<double> increasing_mg_e_bounds = {1.e0, 1.e1, 1.e2};
-    NDI_TNReaction bad_tn(gendir_path, library_in, reaction_in,
-                          increasing_mg_e_bounds);
+    NDI_TNReaction bad_tn(gendir_path, library_in, reaction_in, increasing_mg_e_bounds);
     FAILMSG("Did not catch expected assertion for non-monotonically-decreasing "
             "multigroup bounds");
   } catch (...) {
@@ -153,8 +144,7 @@ int main(int argc, char *argv[]) {
     gendir_test(ut);
     std::string gendir_default;
     bool def_gendir{false};
-    std::tie(def_gendir, gendir_default) =
-        rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH");
+    std::tie(def_gendir, gendir_default) = rtt_dsxx::get_env_val<std::string>("NDI_GENDIR_PATH");
 
     if (def_gendir && rtt_dsxx::fileExists(gendir_default)) {
       gendir_default_test(ut);


### PR DESCRIPTION
### Background

* Cleaning up the code base for the 100 column format.
* No code changes.

### Description of changes

* Processed files with clang-format wrapping at 100 cols.
* Manually processed files to rewrap comment blocks at 100 cols.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
