### PR TITLE
Convert typedef statements to using statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ set(ddesc "An object-oriented component library supporting radiation")
 string(APPEND ddesc " transport applications.")
 project( Draco DESCRIPTION ${ddesc} VERSION 7.8 LANGUAGES CXX C)
 
+# Export compile commands for compiler tools
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 # Do not look for Fortran/CUDA for
 # 1. XCode based Generators, or
 # 2. Visual Studio IDE or NMake Generators (MSYS or CYGWIN environments will look for Fortran).

--- a/src/RTT_Format_Reader/CellData.hh
+++ b/src/RTT_Format_Reader/CellData.hh
@@ -19,10 +19,10 @@ namespace rtt_RTT_Format_Reader {
  */
 class CellData {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<double> vector_dbl;
-  typedef std::vector<std::vector<double>> vector_vector_dbl;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_dbl = std::vector<double>;
+  using vector_vector_dbl = std::vector<std::vector<double>>;
 
   const Dims &dims;
   vector_vector_dbl data;

--- a/src/RTT_Format_Reader/CellDataIDs.hh
+++ b/src/RTT_Format_Reader/CellDataIDs.hh
@@ -28,9 +28,9 @@ namespace rtt_RTT_Format_Reader {
 //================================================================================================//
 class CellDataIDs {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<string> vector_str;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_str = std::vector<string>;
 
   const Dims &dims;
   vector_str names;

--- a/src/RTT_Format_Reader/CellDefs.hh
+++ b/src/RTT_Format_Reader/CellDefs.hh
@@ -27,14 +27,14 @@ class CellDefs;
 class CellDef {
   /* TYPEDEFS */
 
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::set<int> set_int;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<std::vector<int>> vector_vector_int;
-  typedef std::set<unsigned> set_uint;
-  typedef std::vector<unsigned> vector_uint;
-  typedef std::vector<std::vector<unsigned>> vector_vector_uint;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using set_int = std::set<int>;
+  using vector_int = std::vector<int>;
+  using vector_vector_int = std::vector<std::vector<int>>;
+  using set_uint = std::set<unsigned int>;
+  using vector_uint = std::vector<unsigned int>;
+  using vector_vector_uint = std::vector<std::vector<unsigned int>>;
 
   /* DATA */
 
@@ -124,15 +124,15 @@ public:
  */
 class CellDefs {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::set<int> set_int;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<std::vector<int>> vector_vector_int;
-  typedef std::vector<std::vector<std::vector<int>>> vector_vector_vector_int;
-  typedef std::set<unsigned> set_uint;
-  typedef std::vector<unsigned> vector_uint;
-  typedef std::vector<std::vector<unsigned>> vector_vector_uint;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using set_int = std::set<int>;
+  using vector_int = std::vector<int>;
+  using vector_vector_int = std::vector<std::vector<int>>;
+  using vector_vector_vector_int = std::vector<std::vector<std::vector<int>>>;
+  using set_uint = std::set<unsigned int>;
+  using vector_uint = std::vector<unsigned int>;
+  using vector_vector_uint = std::vector<std::vector<unsigned int>>;
 
   const Dims &dims;
   std::vector<std::shared_ptr<CellDef>> defs;

--- a/src/RTT_Format_Reader/CellFlags.hh
+++ b/src/RTT_Format_Reader/CellFlags.hh
@@ -25,8 +25,8 @@ namespace rtt_RTT_Format_Reader {
 //================================================================================================//
 class CellFlags {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
+  using ifstream = std::ifstream;
+  using string = std::string;
 
   const Dims &dims;
   std::vector<std::shared_ptr<Flags>> flagTypes;

--- a/src/RTT_Format_Reader/Cells.hh
+++ b/src/RTT_Format_Reader/Cells.hh
@@ -19,12 +19,12 @@ namespace rtt_RTT_Format_Reader {
 //! Controls parsing, storing, and accessing the data specific to the cells block of the mesh file.
 class Cells {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<std::vector<int>> vector_vector_int;
-  typedef std::vector<unsigned> vector_uint;
-  typedef std::vector<std::vector<unsigned>> vector_vector_uint;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_int = std::vector<int>;
+  using vector_vector_int = std::vector<std::vector<int>>;
+  using vector_uint = std::vector<unsigned int>;
+  using vector_vector_uint = std::vector<std::vector<unsigned int>>;
 
   const CellFlags &cellFlags;
   const Dims &dims;

--- a/src/RTT_Format_Reader/Dims.hh
+++ b/src/RTT_Format_Reader/Dims.hh
@@ -29,9 +29,9 @@ namespace rtt_RTT_Format_Reader {
 class Dims {
 
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<int> vector_int;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_int = std::vector<int>;
 
   string coor_units;
   string prob_time_units;

--- a/src/RTT_Format_Reader/Flags.hh
+++ b/src/RTT_Format_Reader/Flags.hh
@@ -28,10 +28,10 @@ namespace rtt_RTT_Format_Reader {
 class Flags {
 
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<string> vector_str;
-  typedef std::vector<int> vector_int;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_str = std::vector<string>;
+  using vector_int = std::vector<int>;
 
   size_t nflags;
   string name;

--- a/src/RTT_Format_Reader/Header.hh
+++ b/src/RTT_Format_Reader/Header.hh
@@ -22,9 +22,9 @@ namespace rtt_RTT_Format_Reader {
  */
 class Header {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<string> vector_str;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_str = std::vector<string>;
 
   string version;
   string title;

--- a/src/RTT_Format_Reader/NodeData.hh
+++ b/src/RTT_Format_Reader/NodeData.hh
@@ -19,10 +19,10 @@ namespace rtt_RTT_Format_Reader {
  */
 class NodeData {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<double> vector_dbl;
-  typedef std::vector<std::vector<double>> vector_vector_dbl;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_dbl = std::vector<double>;
+  using vector_vector_dbl = std::vector<std::vector<double>>;
 
   const Dims &dims;
   vector_vector_dbl data;

--- a/src/RTT_Format_Reader/NodeDataIDs.hh
+++ b/src/RTT_Format_Reader/NodeDataIDs.hh
@@ -19,9 +19,9 @@ namespace rtt_RTT_Format_Reader {
  */
 class NodeDataIDs {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<string> vector_str;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_str = std::vector<string>;
 
   const Dims &dims;
   vector_str names;

--- a/src/RTT_Format_Reader/NodeFlags.hh
+++ b/src/RTT_Format_Reader/NodeFlags.hh
@@ -25,8 +25,8 @@ namespace rtt_RTT_Format_Reader {
 //================================================================================================//
 class NodeFlags {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
+  using ifstream = std::ifstream;
+  using string = std::string;
 
   const Dims &dims;
   std::vector<std::shared_ptr<Flags>> flagTypes;

--- a/src/RTT_Format_Reader/Nodes.hh
+++ b/src/RTT_Format_Reader/Nodes.hh
@@ -19,12 +19,12 @@ namespace rtt_RTT_Format_Reader {
  */
 class Nodes {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<std::vector<int>> vector_vector_int;
-  typedef std::vector<double> vector_dbl;
-  typedef std::vector<std::vector<double>> vector_vector_dbl;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_int = std::vector<int>;
+  using vector_vector_int = std::vector<std::vector<int>>;
+  using vector_dbl = std::vector<double>;
+  using vector_vector_dbl = std::vector<std::vector<double>>;
 
   const NodeFlags &nodeFlags;
   const Dims &dims;

--- a/src/RTT_Format_Reader/RTT_Format_Reader.hh
+++ b/src/RTT_Format_Reader/RTT_Format_Reader.hh
@@ -33,15 +33,15 @@ namespace rtt_RTT_Format_Reader {
 
 class RTT_Format_Reader {
   // NESTED CLASSES AND TYPEDEFS
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<double> vector_dbl;
-  typedef std::vector<std::vector<double>> vector_vector_dbl;
-  typedef std::vector<string> vector_str;
-  typedef std::set<unsigned> set_uint;
-  typedef std::vector<unsigned> vector_uint;
-  typedef std::vector<std::vector<unsigned>> vector_vector_uint;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_int = std::vector<int>;
+  using vector_dbl = std::vector<double>;
+  using vector_vector_dbl = std::vector<std::vector<double>>;
+  using vector_str = std::vector<string>;
+  using set_uint = std::set<unsigned int>;
+  using vector_uint = std::vector<unsigned int>;
+  using vector_vector_uint = std::vector<std::vector<unsigned int>>;
 
   // DATA
 private:

--- a/src/RTT_Format_Reader/RTT_Mesh_Reader.hh
+++ b/src/RTT_Format_Reader/RTT_Mesh_Reader.hh
@@ -31,16 +31,16 @@ namespace rtt_RTT_Format_Reader {
 
 class RTT_Mesh_Reader : public rtt_meshReaders::Mesh_Reader {
   // NESTED CLASSES AND TYPEDEFS
-  typedef std::string string;
-  typedef std::set<int> set_int;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<std::vector<int>> vector_vector_int;
-  typedef std::vector<std::vector<std::vector<int>>> vector_vector_vector_int;
-  typedef std::vector<std::vector<double>> vector_vector_dbl;
-  typedef std::set<unsigned> set_uint;
-  typedef std::vector<unsigned> vector_uint;
-  typedef std::vector<std::vector<unsigned>> vector_vector_uint;
-  typedef std::vector<std::vector<std::vector<unsigned>>> vector_vector_vector_uint;
+  using string = std::string;
+  using set_int = std::set<int>;
+  using vector_int = std::vector<int>;
+  using vector_vector_int = std::vector<std::vector<int>>;
+  using vector_vector_vector_int = std::vector<std::vector<std::vector<int>>>;
+  using vector_vector_dbl = std::vector<std::vector<double>>;
+  using set_uint = std::set<unsigned int>;
+  using vector_uint = std::vector<unsigned int>;
+  using vector_vector_uint = std::vector<std::vector<unsigned int>>;
+  using vector_vector_vector_uint = std::vector<std::vector<std::vector<unsigned int>>>;
 
   // DATA
 

--- a/src/RTT_Format_Reader/SideData.hh
+++ b/src/RTT_Format_Reader/SideData.hh
@@ -20,10 +20,10 @@ namespace rtt_RTT_Format_Reader {
  */
 class SideData {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<double> vector_dbl;
-  typedef std::vector<std::vector<double>> vector_vector_dbl;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_dbl = std::vector<double>;
+  using vector_vector_dbl = std::vector<std::vector<double>>;
 
   const Dims &dims;
   vector_vector_dbl data;

--- a/src/RTT_Format_Reader/SideDataIDs.hh
+++ b/src/RTT_Format_Reader/SideDataIDs.hh
@@ -24,9 +24,9 @@ namespace rtt_RTT_Format_Reader {
  */
 class SideDataIDs {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<string> vector_str;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_str = std::vector<string>;
 
   const Dims &dims;
   vector_str names;

--- a/src/RTT_Format_Reader/SideFlags.hh
+++ b/src/RTT_Format_Reader/SideFlags.hh
@@ -21,8 +21,8 @@ namespace rtt_RTT_Format_Reader {
  */
 class SideFlags {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
+  using ifstream = std::ifstream;
+  using string = std::string;
 
   const Dims &dims;
   std::vector<std::shared_ptr<Flags>> flagTypes;

--- a/src/RTT_Format_Reader/Sides.hh
+++ b/src/RTT_Format_Reader/Sides.hh
@@ -25,12 +25,12 @@ namespace rtt_RTT_Format_Reader {
 //================================================================================================//
 class Sides {
   // typedefs
-  typedef std::ifstream ifstream;
-  typedef std::string string;
-  typedef std::vector<int> vector_int;
-  typedef std::vector<std::vector<int>> vector_vector_int;
-  typedef std::vector<unsigned> vector_uint;
-  typedef std::vector<std::vector<unsigned>> vector_vector_uint;
+  using ifstream = std::ifstream;
+  using string = std::string;
+  using vector_int = std::vector<int>;
+  using vector_vector_int = std::vector<std::vector<int>>;
+  using vector_uint = std::vector<unsigned int>;
+  using vector_vector_uint = std::vector<std::vector<unsigned int>>;
 
   const SideFlags &sideFlags;
   const Dims &dims;

--- a/src/RTT_Format_Reader/test/TestRTTFormatReader.hh
+++ b/src/RTT_Format_Reader/test/TestRTTFormatReader.hh
@@ -15,7 +15,7 @@
 #include <map>
 
 using rtt_dsxx::UnitTest;
-typedef rtt_RTT_Format_Reader::RTT_Format_Reader RTT_Format_Reader;
+using RTT_Format_Reader = rtt_RTT_Format_Reader::RTT_Format_Reader;
 
 enum Meshes { DEFINED, MESHES_LASTENTRY };
 

--- a/src/c4/xthi_cpuset.hh
+++ b/src/c4/xthi_cpuset.hh
@@ -73,9 +73,7 @@ namespace rtt_c4 {
 
 #define SYSCTL_CORE_COUNT "machdep.cpu.core_count"
 
-using cpu_set_t = struct cpu_set {
-  uint64_t count;
-};
+using cpu_set_t = struct cpu_set { uint64_t count; };
 
 static inline void CPU_ZERO(cpu_set_t *cs) { cs->count = 0; }
 
@@ -86,8 +84,7 @@ static inline bool CPU_ISSET(int num, cpu_set_t *cs) {
   return (cs->count & teh_bit) != 0;
 }
 
-inline int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/,
-                             cpu_set_t *cpu_set) {
+inline int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/, cpu_set_t *cpu_set) {
   int64_t core_count = 0;
   size_t len = sizeof(core_count);
   int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);
@@ -113,14 +110,11 @@ inline std::string cpuset_to_string(unsigned const num_cpu) {
   // return value;
   std::ostringstream cpuset;
   // The thread affinity bitmask functions used below are limited to 64.
-  Insist(
-      num_cpu <= 64,
-      "Might need to use alternate cpu-groups information with this fuction!");
+  Insist(num_cpu <= 64, "Might need to use alternate cpu-groups information with this fuction!");
 
   DWORD_PTR dwProcessAffinity;
   DWORD_PTR dwSystemAffinity;
-  bool ok = GetProcessAffinityMask(GetCurrentProcess(), &dwProcessAffinity,
-                                   &dwSystemAffinity);
+  bool ok = GetProcessAffinityMask(GetCurrentProcess(), &dwProcessAffinity, &dwSystemAffinity);
   Insist(ok, "GetProcessAffinityMask() failed!");
 
   // Convert the bitmask to an array of bools and then to a string to represent a CPU range

--- a/src/c4/xthi_cpuset.hh
+++ b/src/c4/xthi_cpuset.hh
@@ -73,9 +73,9 @@ namespace rtt_c4 {
 
 #define SYSCTL_CORE_COUNT "machdep.cpu.core_count"
 
-typedef struct cpu_set {
+using cpu_set_t = struct cpu_set {
   uint64_t count;
-} cpu_set_t;
+};
 
 static inline void CPU_ZERO(cpu_set_t *cs) { cs->count = 0; }
 

--- a/src/cdi_analytic/test/tstAnalytic_EICoupling.cc
+++ b/src/cdi_analytic/test/tstAnalytic_EICoupling.cc
@@ -28,7 +28,7 @@ using std::dynamic_pointer_cast;
 //------------------------------------------------------------------------------------------------//
 
 void analytic_ei_coupling_test(rtt_dsxx::UnitTest &ut) {
-  typedef Constant_Analytic_EICoupling_Model Constant_Model;
+  using Constant_Model = Constant_Analytic_EICoupling_Model;
 
   // make an analytic model (constant ei_coupling)
   shared_ptr<Constant_Model> model(new Constant_Model(1.1));

--- a/src/cdi_analytic/test/tstAnalytic_EoS.cc
+++ b/src/cdi_analytic/test/tstAnalytic_EoS.cc
@@ -28,7 +28,7 @@ using std::dynamic_pointer_cast;
 //------------------------------------------------------------------------------------------------//
 
 void analytic_eos_test(rtt_dsxx::UnitTest &ut) {
-  typedef Polynomial_Specific_Heat_Analytic_EoS_Model Polynomial_Model;
+  using Polynomial_Model = Polynomial_Specific_Heat_Analytic_EoS_Model;
 
   // make an analytic model (polynomial specific heats)
   // elec specific heat = a + bT^c

--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -48,10 +48,8 @@ namespace rtt_mesh {
 class Draco_Mesh {
 public:
   // >>> TYPEDEFS
-  typedef rtt_mesh_element::Geometry Geometry;
-  typedef std::map<unsigned,
-                   std::vector<std::pair<unsigned, std::vector<unsigned>>>>
-      Layout;
+  using Geometry = rtt_mesh_element::Geometry;
+  using Layout = std::map<unsigned int, std::vector<std::pair<unsigned int, std::vector<unsigned int>>>>;
 
 protected:
   // >>> DATA

--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -49,7 +49,8 @@ class Draco_Mesh {
 public:
   // >>> TYPEDEFS
   using Geometry = rtt_mesh_element::Geometry;
-  using Layout = std::map<unsigned int, std::vector<std::pair<unsigned int, std::vector<unsigned int>>>>;
+  using Layout =
+      std::map<unsigned int, std::vector<std::pair<unsigned int, std::vector<unsigned int>>>>;
 
 protected:
   // >>> DATA
@@ -123,25 +124,16 @@ public:
   std::vector<unsigned> get_side_set_flag() const { return side_set_flag; }
   std::vector<int> get_ghost_cell_numbers() const { return ghost_cell_number; }
   std::vector<int> get_ghost_cell_ranks() const { return ghost_cell_rank; }
-  std::vector<std::vector<double>> get_node_coord_vec() const {
-    return node_coord_vec;
-  }
-  std::vector<unsigned> get_num_faces_per_cell() const {
-    return m_num_faces_per_cell;
-  }
+  std::vector<std::vector<double>> get_node_coord_vec() const { return node_coord_vec; }
+  std::vector<unsigned> get_num_faces_per_cell() const { return m_num_faces_per_cell; }
   std::vector<unsigned> get_num_nodes_per_face_per_cell() const {
     return m_num_nodes_per_face_per_cell;
   }
-  std::vector<std::vector<std::vector<unsigned>>>
-  get_cell_to_node_linkage() const {
+  std::vector<std::vector<std::vector<unsigned>>> get_cell_to_node_linkage() const {
     return m_cell_to_node_linkage;
   }
-  std::vector<unsigned> get_side_node_count() const {
-    return m_side_node_count;
-  }
-  std::vector<unsigned> get_side_to_node_linkage() const {
-    return m_side_to_node_linkage;
-  }
+  std::vector<unsigned> get_side_node_count() const { return m_side_node_count; }
+  std::vector<unsigned> get_side_to_node_linkage() const { return m_side_to_node_linkage; }
   Layout get_cc_linkage() const { return cell_to_cell_linkage; }
   Layout get_cs_linkage() const { return cell_to_side_linkage; }
   Layout get_cg_linkage() const { return cell_to_ghost_cell_linkage; }
@@ -159,30 +151,29 @@ private:
   compute_node_coord_vec(const std::vector<double> &coordinates) const;
 
   //! Convert cell-node linkage into tensor for easier indexing by cell, face
-  std::vector<std::vector<std::vector<unsigned>>> compute_cell_to_node_tensor(
-      const std::vector<unsigned> &num_faces_per_cell,
-      const std::vector<unsigned> &num_nodes_per_face_per_cell,
-      const std::vector<unsigned> &cell_to_node_linkage) const;
+  std::vector<std::vector<std::vector<unsigned>>>
+  compute_cell_to_node_tensor(const std::vector<unsigned> &num_faces_per_cell,
+                              const std::vector<unsigned> &num_nodes_per_face_per_cell,
+                              const std::vector<unsigned> &cell_to_node_linkage) const;
 
   //! Calculate the cell-to-cell linkage with face type vector
-  void compute_cell_to_cell_linkage(
-      const std::vector<unsigned> &num_faces_per_cell,
-      const std::vector<unsigned> &cell_to_node_linkage,
-      const std::vector<unsigned> &num_nodes_per_face_per_cell,
-      const std::vector<unsigned> &side_node_count,
-      const std::vector<unsigned> &side_to_node_linkage,
-      const std::vector<unsigned> &ghost_cell_type,
-      const std::vector<unsigned> &ghost_cell_to_node_linkage);
+  void compute_cell_to_cell_linkage(const std::vector<unsigned> &num_faces_per_cell,
+                                    const std::vector<unsigned> &cell_to_node_linkage,
+                                    const std::vector<unsigned> &num_nodes_per_face_per_cell,
+                                    const std::vector<unsigned> &side_node_count,
+                                    const std::vector<unsigned> &side_to_node_linkage,
+                                    const std::vector<unsigned> &ghost_cell_type,
+                                    const std::vector<unsigned> &ghost_cell_to_node_linkage);
 
   //! Calculate a map of node to vectors of indices (cells, sides, ghost cells)
-  std::map<unsigned, std::vector<unsigned>> compute_node_indx_map(
-      const std::vector<unsigned> &indx_type,
-      const std::vector<unsigned> &indx_to_node_linkage) const;
+  std::map<unsigned, std::vector<unsigned>>
+  compute_node_indx_map(const std::vector<unsigned> &indx_type,
+                        const std::vector<unsigned> &indx_to_node_linkage) const;
 
   //! Calculate a map of node vectors to indices (sides, ghost cells)
-  std::map<std::set<unsigned>, unsigned> compute_node_vec_indx_map(
-      const std::vector<unsigned> &indx_type,
-      const std::vector<unsigned> &indx_to_node_linkage) const;
+  std::map<std::set<unsigned>, unsigned>
+  compute_node_vec_indx_map(const std::vector<unsigned> &indx_type,
+                            const std::vector<unsigned> &indx_to_node_linkage) const;
 };
 
 } // end namespace rtt_mesh

--- a/src/mesh/X3D_Draco_Mesh_Reader.hh
+++ b/src/mesh/X3D_Draco_Mesh_Reader.hh
@@ -45,8 +45,8 @@ namespace rtt_mesh {
 class X3D_Draco_Mesh_Reader : public Draco_Mesh_Reader {
 public:
   // >>> TYPEDEFS
-  typedef std::pair<std::string, std::vector<std::string>> Parsed_Element;
-  typedef std::vector<Parsed_Element> Parsed_Elements;
+  using Parsed_Element = std::pair<std::string, std::vector<std::string>>;
+  using Parsed_Elements = std::vector<Parsed_Element>;
 
 private:
   // >>> DATA

--- a/src/mesh/test/Test_Mesh_Interface.hh
+++ b/src/mesh/test/Test_Mesh_Interface.hh
@@ -30,7 +30,7 @@ namespace rtt_mesh_test {
 
 class Test_Mesh_Interface {
 public:
-  typedef rtt_mesh::Draco_Mesh::Layout Layout;
+  using Layout = rtt_mesh::Draco_Mesh::Layout;
 
   // >>> DATA
 

--- a/src/quadrature/Ordinate_Set_Mapper.cc
+++ b/src/quadrature/Ordinate_Set_Mapper.cc
@@ -45,7 +45,7 @@ bool check_2(Ordinate const &ordinate) {
 #endif
 
 //------------------------------------------------------------------------------------------------//
-typedef std::pair<double, size_t> dsp;
+using dsp = std::pair<double, size_t>;
 bool bigger_pair(const dsp &d1, const dsp &d2) { return (d1.first > d2.first); }
 
 } // end anonymous namespace

--- a/src/quadrature/Quadrature.cc
+++ b/src/quadrature/Quadrature.cc
@@ -15,7 +15,7 @@
 namespace rtt_quadrature {
 
 using std::make_shared;
-typedef Ordinate_Set::Ordering Ordering;
+using Ordering = Ordinate_Set::Ordering;
 using rtt_dsxx::soft_equiv;
 
 //------------------------------------------------------------------------------------------------//

--- a/src/quadrature/Quadrature__parser.hh
+++ b/src/quadrature/Quadrature__parser.hh
@@ -25,7 +25,7 @@ template <> class Class_Parse_Table<Quadrature> {
 public:
   // TYPEDEFS
 
-  typedef Quadrature Return_Class;
+  using Return_Class = Quadrature;
 
   // MANAGEMENT
 

--- a/src/quadrature/gauleg.hh
+++ b/src/quadrature/gauleg.hh
@@ -62,7 +62,7 @@ void gauleg(
   using std::cos;
   using std::numeric_limits;
 
-  typedef typename FieldVector::value_type Field;
+  using Field = typename FieldVector::value_type;
 
   Require(n > 0);
   Require(x2 > x1);

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -204,7 +204,7 @@ class Counter_RNG {
   friend class Rnd_Control;
 
 public:
-  typedef ctr_type::const_iterator const_iterator;
+  using const_iterator = ctr_type::const_iterator;
 
   /*! \brief Default constructor.
    *

--- a/src/rng/test/kat_cpp.cpp
+++ b/src/rng/test/kat_cpp.cpp
@@ -91,7 +91,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace std;
 
-typedef map<pair<method_e, unsigned>, void (*)(kat_instance *)> genmap_t;
+using genmap_t = map<pair<method_e, unsigned int>, void (*)(kat_instance *)>;
 genmap_t genmap;
 
 void dev_execute_tests(kat_instance *tests, unsigned ntests) {

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -161,7 +161,7 @@ template <typename T> R123_CONSTEXPR R123_STATIC_INLINE T maxTvalue() {
 //  If W<=M then the largest value returned is the largest Ftype less than 1.0.
 template <typename Ftype, typename Itype>
 R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01(Itype in) {
-  typedef typename make_unsigned<Itype>::type Utype;
+  using Utype = typename make_unsigned<Itype>::type;
   R123_CONSTEXPR Ftype factor =
       Ftype(1.) / (static_cast<Ftype>(maxTvalue<Utype>()) + Ftype(1.));
   R123_CONSTEXPR Ftype halffactor = Ftype(0.5) * factor;
@@ -189,7 +189,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01(Itype in) {
 //    and the smallest value returned is the smallest Ftype greater than -1.0.
 template <typename Ftype, typename Itype>
 R123_CUDA_DEVICE R123_STATIC_INLINE Ftype uneg11(Itype in) {
-  typedef typename make_signed<Itype>::type Stype;
+  using Stype = typename make_signed<Itype>::type;
   R123_CONSTEXPR Ftype factor =
       Ftype(1.) / (Ftype(maxTvalue<Stype>()) + Ftype(1.));
   R123_CONSTEXPR Ftype halffactor = Ftype(0.5) * factor;
@@ -216,7 +216,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype uneg11(Itype in) {
 //   - are balanced around 0.5
 template <typename Ftype, typename Itype>
 R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
-  typedef typename make_unsigned<Itype>::type Utype;
+  using Utype = typename make_unsigned<Itype>::type;
   R123_CONSTEXPR int excess =
       std::numeric_limits<Utype>::digits - std::numeric_limits<Ftype>::digits;
   if (excess >= 0) {

--- a/src/special_functions/gaulag.hh
+++ b/src/special_functions/gaulag.hh
@@ -36,7 +36,7 @@ template <class FieldVector>
 void gaulag(FieldVector &x, FieldVector &w, double const alf, unsigned const n) {
   using namespace std;
 
-  typedef typename FieldVector::value_type Field;
+  using Field = typename FieldVector::value_type;
 
   const unsigned MAXITS = 10;
 

--- a/src/viz/Ensight_Stream.hh
+++ b/src/viz/Ensight_Stream.hh
@@ -48,7 +48,7 @@ private:
   // TYPEDEFS
 
   // FP is a function pointer.  This is usd for stream manipulators, such as rtt_viz::endl.
-  typedef Ensight_Stream &(*FP)(Ensight_Stream &);
+  using FP = Ensight_Stream &(*)(Ensight_Stream &);
 
   // DATA
 

--- a/src/viz/Ensight_Translator.cc
+++ b/src/viz/Ensight_Translator.cc
@@ -266,7 +266,7 @@ void Ensight_Translator::initialize(const bool graphics_continue) {
   size_t nvdata = d_vdata_names.size();
   size_t ncdata = d_cdata_names.size();
 
-  typedef std::vector<sf_string::iterator> SFS_iter_vec;
+  using SFS_iter_vec = std::vector<sf_string::iterator>;
   // Create a name list for testing.
   sf_string name_tmp(nvdata + ncdata);
   for (size_t i = 0; i < nvdata; i++)


### PR DESCRIPTION
### Background

* Wish to convert typedef statements to using statements

### Purpose of Pull Request

* Convert typedef statements to using statements
* [Fixes Jayenne Redmine Issue #2204](https://rtt.lanl.gov/redmine/issues/2204)

### Description of changes

* Convert typedef statements to using statements via clang-tidy
* Adds `CMAKE_EXPORT_COMPILE_COMMANDS` to top-level `CMakeLists.txt` to assist clang-tidy

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
