### PR TITLE
Fix Fortran Flags used by MSVC+CAFS build.

### DIFF
--- a/config/unix-gfortran.cmake
+++ b/config/unix-gfortran.cmake
@@ -8,17 +8,6 @@
 
 include_guard(GLOBAL)
 
-if( NOT Fortran_FLAGS_INITIALIZED )
-  # gfortran < 4.7 won't compile Jayenne
-  set( CMAKE_Fortran_COMPILER_VERSION ${CMAKE_Fortran_COMPILER_VERSION} CACHE STRING
-  "Fortran compiler version string" FORCE )
-  if( "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "4.7" )
-    message( FATAL_ERROR "*** Compiler incompatibility: gfortran < 4.7 will not compile this "
-      "code. You are trying to use gfortran ${CMAKE_Fortran_COMPILER_VERSION}." )
-  endif()
-  mark_as_advanced( CMAKE_Fortran_COMPILER_VERSION )
-endif()
-
 #
 # Compiler Flags
 #

--- a/src/c4/fc4/CMakeLists.txt
+++ b/src/c4/fc4/CMakeLists.txt
@@ -67,7 +67,7 @@ install( TARGETS Lib_c4_fc4 EXPORT draco-targets
   PUBLIC_HEADER DESTINATION "${DBSCFGDIR}include/fc4" )
 install( DIRECTORY ${fc4_BINARY_DIR}
   DESTINATION "${DBSCFGDIR}include"
-  FILES_MATCHING PATTERN "*.mod" 
+  FILES_MATCHING PATTERN "*.mod"
   PATTERN CMakeFiles EXCLUDE)
 
 #--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

+ After #939 modified how compiler flags are set, the CAFS specific compiler flag manipulation no longer worked as originally designed.

### Purpose of Pull Request

* Fixes #945

### Description of changes

+ Tweak how Fortran_FLAGS are modified for CAFS-gfortran builds under MSVC so that `-fno-range-check` is correctly specified.
+ Remove check for too old a version of gfortran.
+ Apply 100 column formatting update for these cmake files.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
