### PR TITLE
Do not use dracoenv functions for ATS2.

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -51,35 +51,35 @@ else
 
 fi
 
-function dracoenv()
-{
-  module --force purge
-  module load StdEnv
-  module unload spectrum-mpi xl cuda
-  for m in $dracomodules; do
-    module load $m
-  done
-  unset MPI_ROOT
-  export CXX=`which g++`
-  export CC=`which gcc`
-  export FC=`which gfortran`
-  export MPIRUN="lrun"
-  export OMP_NUM_THREADS=10
-}
+# function dracoenv()
+# {
+#   module --force purge
+#   module load StdEnv
+#   module unload spectrum-mpi xl cuda
+#   for m in $dracomodules; do
+#     module load $m
+#   done
+#   unset MPI_ROOT
+#   export CXX=`which g++`
+#   export CC=`which gcc`
+#   export FC=`which gfortran`
+#   export MPIRUN="lrun"
+#   export OMP_NUM_THREADS=10
+# }
 
-function rmdracoenv()
-{
-  unset MPIRUN
-  unset FC
-  unset CC
-  unset CXX
+# function rmdracoenv()
+# {
+#   unset MPIRUN
+#   unset FC
+#   unset CC
+#   unset CXX
 
-  # unload in reverse order.
-  mods=( ${dracomodules} )
-  for ((i=${#mods[@]}-1; i>=0; i--)); do
-    module unload ${mods[$i]}
-  done
-}
+#   # unload in reverse order.
+#   mods=( ${dracomodules} )
+#   for ((i=${#mods[@]}-1; i>=0; i--)); do
+#     module unload ${mods[$i]}
+#   done
+# }
 
 # Do not escape $ for bash completion
 shopt -s direxpand


### PR DESCRIPTION
### Background

* These functions are no longer needed.  Use the _draco_ super-modules instead.

### Purpose of Pull Request

* Fixes a problem caused by setting `OMP_NUM_THREADS`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
