### PR TITLE
Another fix for gfortran based MSVS-CAFS build.

### DIFF
--- a/config/CMakeAddFortranSubdirectory.cmake
+++ b/config/CMakeAddFortranSubdirectory.cmake
@@ -528,14 +528,14 @@ function( cafs_fix_mpi_library )
     # 2. Strip MPI deps from Lib_c4
     set_target_properties( Lib_c4 PROPERTIES INTERFACE_LINK_LIBRARIES "Lib_dsxx;MPI::MPI_cafs" )
 
-    # Force '-fno-range-check' gfortran compiler flag
+    # Remove '-fno-range-check' gfortran compiler flag (remove it from Debug flags)
     if( "${CMAKE_Fortran_FLAGS_DEBUG}" MATCHES "frange-check" )
       string(REPLACE "range-check" "no-range-check" CMAKE_Fortran_FLAGS_DEBUG
         ${CMAKE_Fortran_FLAGS_DEBUG} )
-    else()
-      string( APPEND CMAKE_Fortran_FLAGS_DEBUG " -fno-range-check")
+      set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}" PARENT_SCOPE )
     endif()
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}" PARENT_SCOPE )
+    string( APPEND CMAKE_Fortran_FLAGS " -fno-range-check")
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}" PARENT_SCOPE )
     if(verbose)
       message("CAFS: MPI_gfortran_LIBRARIES= ${MPI_gfortran_LIBRARIES}"
       "\n      CMAKE_Fortran_FLAGS_DEBUG = ${CMAKE_Fortran_FLAGS_DEBUG}")

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -457,6 +457,7 @@ endmacro()
 # Refs:
 # - https://blog.kitware.com/static-checks-with-cmake-cdash-iwyu-clang-tidy-lwyu-cpplint-and-cppcheck/
 # - https://github.com/KratosMultiphysics/Kratos/wiki/How-to-use-Clang-Tidy-to-automatically-correct-code
+# - https://www.kdab.com/clang-tidy-part-1-modernize-source-code-using-c11c14/
 #--------------------------------------------------------------------------------------------------#
 macro(dbsSetupStaticAnalyzers)
 


### PR DESCRIPTION
### Background

* #946 fixed the Debug build, but this issue also shows up in the Release build.

### Description of changes

* Use compile option `-fno-range-check` to suppress this warning/error.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
