### PR TITLE
Add c4/global include so C4_MPI header can be used standalone

### DIFF
--- a/src/c4/C4_MPI.hh
+++ b/src/c4/C4_MPI.hh
@@ -11,6 +11,7 @@
 #define c4_C4_MPI_hh
 
 #include "c4/config.h"
+#include "c4/global.hh"
 #include <algorithm>
 
 #ifdef C4_MPI


### PR DESCRIPTION
### Background

* While trying to add a new file in a different project, I found that I couldn't include c4/C4_MPI.hh without including c4/global.hh as well. Code in C4_MPI needs access to definitions in C4_Functions, C4_Datatypes, and C4_Traits, all of which become available via the c4/global.hh include.

### Purpose of Pull Request

* Add global include to C4_MPI so it can be included elsewhere standalone

### Description of changes

* one-line change. Add include.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
