### PR TITLE
Test new CI system and associated docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@
 # File:   .travis.yml
 # Author: Kelly Thompson <kgt@lanl.gov>
 # Date:   Friday, Jul 13, 2018, 07:41 am
-# Purpose: Instructions for Travis continuous integration testing on GitHub.
-#         This script wil be run to test pull requests
-# Note:   Copyright (C) 2018-2020 Triad National Security, LLC.
-#         All rights reserved.
+# Purpose: Instructions for Travis continuous integration testing on GitHub.  This script wil be run
+#         to test pull requests
+# Note:   Copyright (C) 2018-2020 Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 
 language: cpp
@@ -17,28 +16,13 @@ services:
 # Notes: Build docker container before running this script:
 #
 # 1. cd to directory contataining Dockerfile.
-# 2. Build the docker container.  This can take an hour or more.  If you are
-#    starting from scratch, you will need to change the first line of the
-#    Dockerfile so that it starts from 'ubuntu' instead of 'draco-travis-ci'
+# 2. Build the docker container.  This can take an hour or more.  If you are starting from scratch,
+#    you will need to change the first line of the Dockerfile so that it starts from 'ubuntu'
+#    instead of 'draco-travis-ci'
 #
 #    docker build --rm --pull --tag draco-travis-ci:latest .
 #
-# 3. Commit and upload the updated container:
-#
-#    docker ps -a # find new container name
-#    docker commit -m "updated cmake version" -a <dockerhub moniker> \
-#           <container_name> kinetictheory/draco-travis-ci:latest
-#    docker login -u kinetictheory # must provide password to upload
-#    docker push
-#
-# 4. Optional: test the container with an interactive run (the -l is important!)
-#
-#    docker run -it kinetictheory/draco-travis-ci /bin/bash -l
-#
-#    or possibly
-#
-#    docker run -it -v /path/to/draco:/home/travis/draco -w /home/travis/draco kinetictheory/draco-travis-ci /bin/bash -l -c "./.travis-run-tests.sh"
-#
+# 3. Commit and upload the updated container. See more detailed notes in tools/Dockerfile.
 #--------------------------------------------------------------------------------------------------#
 
 #--------------------------------------------------------------------------------------------------#
@@ -50,11 +34,39 @@ services:
 #
 # Docker Environment:
 #
-# - The docker image mounts the PR sources (/home/travis/build/lanl/Draco) as
-#   /home/travis/Draco
+# - The docker image mounts the PR sources (/home/travis/build/lanl/Draco) as /home/travis/Draco
 # - The vendors are at /vendors/spack
 # - Spack is already in the environment
 #--------------------------------------------------------------------------------------------------#
+
+#branches:
+#  only:
+#  - master
+
+# stages:
+#   - name: style
+#     if: type = pull_request
+#   - name: test
+
+# jobs:
+#   fast_finish: true
+#   include::
+#     - stage: style
+#       env: STYLE=ON DOCKER_TAG=style-checks
+#       compiler: gcc
+#     - stage: test
+#       env: WERROR=ON COVERAGE=ON DRACO_C4=SCALAR DOCKER_TAG=spack-gcc
+#       compiler: gcc
+#     - stage: test
+#       env: WERROR=ON COVERAGE=ON DRACO_C4=MPI DOCKER_TAG=spack-gcc
+#       compiler: gcc
+#     - stage: test
+#       env: WERROR=ON DRACO_C4=MPI AUTODOC=ON DOCKER_TAG=autdoc
+#       compiler: gcc
+
+# compiler:
+#   - gcc
+#   - clang
 
 env:
   global:
@@ -62,15 +74,11 @@ env:
     - SOURCE_DIR=/home/travis/Draco
     - T_SOURCE_DIR=/home/travis/build/lanl/Draco
     - VENDOR_DIR=/vendors
-    - GCCVER=8
   matrix:
-  - STYLE=ON
-  - WERROR=ON COVERAGE=ON DRACO_C4=SCALAR
-  - WERROR=ON COVERAGE=ON DRACO_C4=MPI
-  - WERROR=ON DRACO_C4=MPI AUTODOC=ON
-
-jobs:
-  fast_finish: true
+  - STYLE=ON DOCKER_TAG=style-checks
+  - WERROR=ON COVERAGE=ON DRACO_C4=SCALAR DOCKER_TAG=spack-gcc
+  - WERROR=ON COVERAGE=ON DRACO_C4=MPI DOCKER_TAG=spack-gcc
+  - WERROR=ON DRACO_C4=MPI AUTODOC=ON DOCKER_TAG=autodoc
 
 # matrix:
 #   allow_failures:
@@ -85,12 +93,16 @@ jobs:
 #  - pip install --upgrade --user pip
 #  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
-install:
-  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2020may
+#install:
+#  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2020may:${DOCKER_TAG}
+
+jobs:
+  fast_finish: true
 
 script:
+  - travis_retry timeout 540 docker pull kinetictheory/draco-ci-2020nov:${DOCKER_TAG}
   - if [[ ${COVERAGE:-OFF} == "ON" ]]; then ci_env=`/bin/bash <(curl -s https://codecov.io/env)`; fi
-  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e GCCVER=${GCCVER} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2020may /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
+  - docker run ${ci_env} -v ${T_SOURCE_DIR}:${SOURCE_DIR} -e VENDOR_DIR=${VENDOR_DIR} -e BUILD_DIR=${BUILD_DIR} -e SOURCE_DIR=${SOURCE_DIR} -e STYLE=${STYLE} -e COVERAGE=${COVERAGE} -e WERROR=${WERROR} -e DRACO_C4=${DRACO_C4} -e AUTODOC=${AUTODOC} -e CI=${CI} -e TRAVIS=${TRAVIS} -e TRAVIS_BRANCH=${TRAVIS_BRANCH} -e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} kinetictheory/draco-ci-2020nov:${DOCKER_TAG} /bin/bash -l -c "${SOURCE_DIR}/tools/travis-run-tests.sh"
 
 #--------------------------------------------------------------------------------------------------#
 # See also:

--- a/tools/Dockerfile-autodoc.txt
+++ b/tools/Dockerfile-autodoc.txt
@@ -1,0 +1,55 @@
+# -*- Dockerfile -*-
+FROM kinetictheory/draco-ci-2020nov:spack-spack-gcc
+
+# Use ubuntu if building from scratch
+# FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-autodoc.txt --rm --pull --tag draco-ci-2020nov:autodoc .
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docerk ps -a ==> find NAME (eg. brave_shamir)
+# 7. docker commit -m "added doxygen and TPLs" brave_shamir kinetictheory/draco-ci-2020nov:autodoc # queues for upload
+# 8. docker push kinetictheory/draco-ci-2020nov:autodoc
+# 9. docker system prune -a (remove old dangling data)
+
+# See draco/.travis-run-tests.sh for some instructions.
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 eospac@6.4.0"
+ENV DRACO_DOC_TPL="mscgen doxygen"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper lcov"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## APT-GET ---------------------------------------------------------------------------
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ghostscript graphviz python3-sphinx python3-sphinx-rtd-theme texlive && \
+    apt-get autoremove && rm -rf /var/lib/apt/lists/*
+
+## SPACK -----------------------------------------------------------------------------
+
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && spack external find
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && \
+    if test $(spack find mscgen | grep -c mscgen) -lt 2 ; then \
+      for p in ${DRACO_DOC_TPL}; do \
+        spack install -n ${p} %gcc; \
+      done; \
+      spack clean -a; \
+    fi
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-basic.txt
+++ b/tools/Dockerfile-basic.txt
@@ -1,0 +1,45 @@
+# -*-Dockerfile-*-
+FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-basic.txt --rm --pull --tag draco-ci-2020nov:basic .
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "Ubuntu 20.04 + basic dev tools" kind_grothen kinetictheory/draco-ci-2020nov:basic # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:basic
+# 8. docker system prune -a (remove old dangling data)
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 mscgen lcov doxygen eospac@6.4.0"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## Update packages on the raw Ubuntu image -------------------------------------------
+
+# 1. Load the apt-get database and install apt-utils
+# 2. Install basic developer tools
+# 3. Remove cached files
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends apt-utils && \
+    apt-get install -y --no-install-recommends autoconf autotools-dev bison build-essential curl \
+        flex gcc gfortran git keychain libssl-dev libtool pkg-config python3 python3-pip \
+        software-properties-common ssh tar unzip wget automake && \
+    apt-get autoremove && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-codecov.txt
+++ b/tools/Dockerfile-codecov.txt
@@ -1,0 +1,36 @@
+# -*-Dockerfile-*-
+FROM kinetictheory/draco-ci-2020nov:basic
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-codecov.txt --rm --pull --tag draco-ci-2020nov:codecov .
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "Adding python codecov" loving_agnesi kinetictheory/draco-ci-2020nov:codecov # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:codecov
+# 8. docker system prune -a (remove old dangling data)
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 mscgen lcov doxygen eospac@6.4.0"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## Add codecov python capability -------------------------------------------
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install codecov
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-spack-common-tools.txt
+++ b/tools/Dockerfile-spack-common-tools.txt
@@ -1,0 +1,48 @@
+# -*- Dockerfile -*-
+FROM kinetictheory/draco-ci-2020nov:spack-setup
+
+# Use ubuntu if building from scratch
+# FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-spack-common-tools.txt --rm --pull --tag draco-ci-2020nov:spack-common-tools . gd
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "added shared TPLs%gcc" brave_lumiere kinetictheory/draco-ci-2020nov:spack-common-tools # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:spack-common-tools
+# 8. docker system prune -a (remove old dangling data)
+
+# See draco/.travis-run-tests.sh for some instructions.
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 eospac@6.4.0"
+ENV DRACO_DOC_TPL="mscgen doxygen"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper lcov"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## SPACK -----------------------------------------------------------------------------
+
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && \
+    if test $(spack find eospac | grep -c eospac) -lt 2 ; then \
+      for p in ${DRACO_TPL}; do \
+        spack install -n ${p} %gcc; \
+        spack load $p && spack external find --not-buildable $p; spack unload $p; \
+      done; \
+      spack clean -a; \
+    fi
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-spack-gcc.txt
+++ b/tools/Dockerfile-spack-gcc.txt
@@ -1,0 +1,47 @@
+# -*- Dockerfile -*-
+FROM kinetictheory/draco-ci-2020nov:spack-common-tools
+
+# Use ubuntu if building from scratch
+# FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-spack-gcc.txt --rm --pull --tag draco-ci-2020nov:spack-gcc .
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "added gcc TPLs" interesting_chaplygin kinetictheory/draco-ci-2020nov:spack-gcc # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:spack-gcc
+# 8. docker system prune -a (remove old dangling data)
+
+# See draco/.travis-run-tests.sh for some instructions.
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 eospac@6.4.0"
+ENV DRACO_DOC_TPL="mscgen doxygen"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper lcov"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## SPACK -----------------------------------------------------------------------------
+
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && \
+    if test $(spack find lcov | grep -c lcov) -lt 2 ; then \
+      for p in ${DRACO_GCC_TPL}; do \
+        spack install -n ${p} %gcc; \
+      done; \
+      spack clean -a; \
+    fi
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-spack-llvm.txt
+++ b/tools/Dockerfile-spack-llvm.txt
@@ -1,0 +1,74 @@
+# -*- Dockerfile -*-
+FROM kinetictheory/draco-ci-2020nov:spack-common-tools
+
+# Use ubuntu if building from scratch
+# FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-spack-llvm.txt --rm --pull --tag draco-ci-2020nov:spack-llvm .
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "added llvm TPLs" competent_curie kinetictheory/draco-ci-2020nov:spack-llvm # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:spack-llvm
+# 8. docker system prune -a (remove old dangling data)
+
+# See draco/.travis-run-tests.sh for some instructions.
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 eospac@6.4.0"
+ENV DRACO_DOC_TPL="mscgen doxygen"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper lcov"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## SPACK -----------------------------------------------------------------------------
+
+## Provide LLVM compiler and associated tools
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && \
+    spack compiler list && \
+    if test $(spack compiler list | grep -c clang) -lt 2 ; then \
+      spack install -j 4 llvm; \
+      spack clean -a; \
+      llvm_loc=$(spack location -i llvm); \
+      llvm_tag=$(spack find --no-groups llvm | sed -e 's/llvm/clang/');\
+      echo "- compiler:" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    spec: ${llvm_tag}" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    paths:" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      cc: ${llvm_loc}/bin/clang" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      cxx: ${llvm_loc}/bin/clang++" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      f77: /usr/bin/gfortran" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      fc: /usr/bin/gfortran" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    flags:" >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      cflags: -fPIC"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      cxxflags: -fPIC"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "      fflags: -fPIC"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    operating_system: ubuntu20.04"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    target: x86_64"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    modules: []"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    environment: {}"  >> $HOME/.spack/linux/compilers.yaml; \
+      echo "    extra_rpaths: []"  >> $HOME/.spack/linux/compilers.yaml; \
+      spack config get compilers; \
+    fi
+
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && \
+    if test $(spack find caliper | grep -c caliper) -lt 2 ; then \
+      for p in ${DRACO_LLVM_TPL}; do \
+        spack install -n ${p} %clang; \
+      done; \
+      spack clean -a; \
+    fi
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-spack-setup.txt
+++ b/tools/Dockerfile-spack-setup.txt
@@ -1,0 +1,67 @@
+# -*-Dockerfile-*-
+FROM kinetictheory/draco-ci-2020nov:codecov
+
+# Use ubuntu if building from scratch
+# FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-spack-setup.txt --rm --pull --tag draco-ci-2020nov:spack-setup .
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "added sphinx and mscgen"  nice_chatterjee kinetictheory/draco-ci-2020nov:spack-setup # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:spack-setup
+# 8. docker system prune -a (remove old dangling data)
+
+# See draco/.travis-run-tests.sh for some instructions.
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 mscgen lcov doxygen eospac@6.4.0"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10.0
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## SPACK -----------------------------------------------------------------------------
+
+# install/setup spack. Only download spack if it doesn't already exist.
+RUN mkdir -p $SPACK_ROOT/etc/spack/linux
+RUN if ! test -d $SPACK_ROOT/opt/spack ; then \
+      curl -s -L https://api.github.com/repos/spack/spack/tarball | tar xzC $SPACK_ROOT --strip 1; \
+    fi
+
+# metis/parmetis downloads are broken right now, use a mirror.
+#COPY mirrors.yaml $SPACK_ROOT/etc/spack
+COPY modules.yaml $SPACK_ROOT/etc/spack
+#RUN mkdir -p $SPACK_ROOT/spack.mirror/metis
+#RUN mkdir -p $SPACK_ROOT/spack.mirror/parmetis
+#COPY metis-5.1.0.tar.gz $SPACK_ROOT/spack.mirror/metis
+#COPY parmetis-4.0.3.tar.gz $SPACK_ROOT/spack.mirror/parmetis
+
+RUN if ! test -f /etc/profile.d/spack.sh; then \
+      echo "source $SPACK_ROOT/share/spack/setup-env.sh" > /etc/profile.d/spack.sh; \
+    fi
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && spack compiler add
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && spack external find
+
+RUN . "$SPACK_ROOT/share/spack/setup-env.sh" && \
+    if test $(spack find lmod | grep -c lmod) -lt 2 ; then \
+      spack install lmod; \
+      echo "source `spack location -i lmod`/lmod/lmod/init/bash" >> /etc/profile.d/spack.sh; \
+      core_loc=$(/usr/bin/ls -d $SPACK_ROOT/share/spack/lmod/*/Core); \
+      echo "module use ${core_loc}" >> /etc/profile.d/spack.sh; \
+      spack clean -a; \
+    fi
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/Dockerfile-style-checks.txt
+++ b/tools/Dockerfile-style-checks.txt
@@ -1,0 +1,59 @@
+# -*-Dockerfile-*-
+FROM kinetictheory/draco-ci-2020nov:spack-common-tools
+
+# Use ubuntu if building from scratch
+# FROM ubuntu:20.04
+
+# This image:
+# 1. cd /D c:\work\docker (copy Dockerfile and packages.yaml to this location).
+# 2. docker login -u kinetictheory (and password) # ref https://docs.docker.com/get-started/part2/
+# 3. docker build -f Dockerfile-style-checks.txt --rm --pull --tag draco-ci-2020nov:style-checks .
+#    OR: docker run -it -v /c/work:/work kinetictheory/draco-ci-2020nov /bin/bash -l
+#        apt-get install -y --no-install-recommends [ghostview]
+#        rm -rf /vendors/spack/var/spack/repos/builtin/cmake
+#        cp -r /work/kinetictheory/spack/var/spack/repos/builtin/cmake /vendors/spack/var/spack/repos/builtin/.
+#        spack install cmake@3.17.0
+#        exit
+#        docker ps -a
+#        docker commit -m "added cmake-3.17.0." kind_grothen kinetictheory/draco-ci-2020nov:style-checks
+#        docker push kinetictheory/draco-ci-2020nov:style-checks
+# 4. docker image ls -a ==> find container name (or docker ps)
+# 5. docker run -it -v /c/work:/work <image hash> /bin/bash -l
+# 6. docker commit -m "added clang-format-10 and emacs" blissful_lumiere kinetictheory/draco-ci-2020nov:style-checks # queues for upload
+# 7. docker push kinetictheory/draco-ci-2020nov:style-checks
+# 8. docker system prune -a (remove old dangling data)
+
+# See draco/.travis-run-tests.sh for some instructions.
+
+## Environment needed by 'docker build' ----------------------------------------
+
+## for apt to be noninteractive
+## https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
+## https://spack.readthedocs.io/en/latest/workflows.html?highlight=docker
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV SPACK_ROOT=/vendors/spack
+ENV DRACO_TPL="cmake numdiff random123 eospac@6.4.0"
+ENV DRACO_DOC_TPL="mscgen doxygen"
+ENV DRACO_GCC_TPL="gsl openmpi openblas metis parmetis libquo caliper lcov"
+ENV DRACO_LLVM_TPL="gsl openmpi openblas metis parmetis libquo caliper"
+ENV FORCE_UNSAFE_CONFIGURE=1
+ENV DISTRO=focal
+ENV CLANG_FORMAT_VER=10
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+## APT-GET -----------------------------------------------------------------------------
+
+# 1. Install gpg-agent
+# 2. LLVM tools like clang, clang-tidy, and clang-format, https://apt.llvm.org/
+# 3. Install emacs
+# 4. Autoremove apt-get cache
+RUN apt-get update && apt-get install -y --no-install-recommends gpg-agent; \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - ; \
+    apt-get install -y --no-install-recommends clang-format-${CLANG_FORMAT_VER}; \
+    ln -s /usr/bin/clang-format-${CLANG_FORMAT_VER} /usr/bin/clang-format; \
+    apt-get install -y --no-install-recommends emacs; \
+    apt-get autoremove && rm -rf /var/lib/apt/lists/*
+
+# image run hook: the -l will make sure /etc/profile.d/*.sh environments are loaded
+CMD /bin/bash -l

--- a/tools/README.docker
+++ b/tools/README.docker
@@ -1,0 +1,13 @@
+Docker images
+----------------------------------------
+
+The docker images kinetictheory/draco-ci-2020nov where created with the following patterns:
+
+basic              <-- Ubuntu:20.04
+codecov            <-- basic
+spack-setup        <-- codecov
+spack-common-tools <-- spack-setup
+spack-gcc          <-- spack-common-tools   # used for MPI, Scalar CI
+spack-llvm         <-- spack-common-tools
+autodoc            <-- spack-common-tools   # used for autodoc CI
+style-checks       <-- spack-common-tools   # used for style-checks CI

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -23,11 +23,6 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 rscriptdir="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-# load some common bash functions
-# rscriptdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" )
-# if ! [[ -d "${rscriptdir}" ]]; then
-#   rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# fi
 if [[ -f "${rscriptdir}/common.sh" ]]; then
   # shellcheck source=tools/common.sh
   source "${rscriptdir}/common.sh"

--- a/tools/mirrors.yaml
+++ b/tools/mirrors.yaml
@@ -1,0 +1,3 @@
+mirrors:
+  filesystem: file:///vendors/spack/spack.mirror
+#  lanl: https://pe-serve.lanl.gov

--- a/tools/modules.yaml
+++ b/tools/modules.yaml
@@ -1,0 +1,258 @@
+modules:
+  enable::
+    - lmod
+  lmod:
+    core_compilers: ['gcc@9.3.0']
+    hierarchy:
+      - mpi
+    hash_length: 0
+    blacklists_implicits: true
+    all:
+      # autoload: 'direct'
+      conflict:
+        - '{name}'
+      suffixes:
+        '^openblas': openblas
+        '^netlib-lapack': netlib
+        '^intel-mkl': mkl
+      filter:
+        environment_blacklist:
+          - "C_INCLUDE_PATH"
+          - "CPLUS_INCLUDE_PATH"
+          - "INCLUDE"
+          - "LIBRARY_PATH"
+          - "LD_LIBRARY_PATH"
+    eospac:
+      environment:
+        set:
+          SESPATHU: /ccs/codes/radtran/physical_data/eos
+          SESAMEPATH: /ccs/codes/radtran/physical_data/eos
+      filter:
+        environment_blacklist: ['PATH']
+    gcc:
+      environment:
+        set:
+          CC: gcc
+          CXX: g++
+          F90: gfortran
+          F95: gfortran
+          F77: gfortran
+          FC: gfortran
+          LCOMPILER: ${PACKAGE}
+          LCOMPILERVER: ${VERSION}
+    libquo:
+      environment:
+        set:
+          QUO_HOME: ${PREFIX}
+    llvm:
+      environment:
+        set:
+          CC: clang
+          CXX: clang++
+          F90: gfortran
+          F95: gfortran
+          F77: gfortran
+          FC: gfortran
+          LCOMPILER: ${PACKAGE}
+          LCOMPILERVER: ${VERSION}
+    whitelist:
+      - totalview
+    blacklist:
+      - adiak
+      - apr
+      - apr-util
+      - at-spi2-atk
+      - at-spi2-core
+      - atk
+      - autoconf
+      - autoconf-archive
+      - automake
+      - bdftopcf
+      - bdw-gc
+      - binutils
+      - bison
+      - bzip2
+      - cairo
+      - damageproto
+      - dbus
+      - diffutils
+      - docbook-xml
+      - docbook-xsl
+      - expat
+      - findutils
+      - fixesproto
+      - flex
+      - font
+      - font-util
+      - fontconfig
+      - fontsproto
+      - freetype
+      - gawk
+      - gdb
+      - gdbm
+      - gdk
+      - gdk-pixbuf
+      - gettext
+      - ghostscript
+      - ghostscript-fonts
+      - glib
+      - glm
+      - glproto
+      - gmake
+      - gmp
+      - gnutls
+      - gobject
+      - gobject-introspection
+      - gperf
+      - groff
+      - gtkplus
+      - guile
+      - harfbuzz
+      - help2man
+      - hwloc
+      - icu4c
+      - inputproto
+      - intltool
+      - isl
+      - kbproto
+      - lcms
+      - lebepoxy
+      - libassuan
+      - libatomic-ops
+      - libbsd
+      - libcerf
+      - libedit
+      - libffi
+      - libfontenc
+      - libgcrypt
+      - libgd
+      - libgpg
+      - libgpg-error
+      - libice
+      - libiconv
+      - libjpeg
+      - libjpeg-turbo
+      - libksba
+      - libmng
+      - libpciaccess
+      - libpfm4
+      - libpng
+      - libpthread
+      - libpthread-stubs
+      - libsfixes
+      - libsigsegv
+      - libsm
+      - libssh2
+      - libtiff
+      - libtool
+      - libunistring
+      - libunwind
+      - libuuid
+      - libx11
+      - libxau
+      - libxcb
+      - libxdmcp
+      - libxext
+      - libxfont
+      - libxft
+      - libxi
+      - libxinerama
+      - libxml2
+      - libxpm
+      - libxrender
+      - libxslt
+      - libxtst
+      - lmod
+      - lua
+      - lua-luafilesystem
+      - lua-luaposix
+      - m4
+      - mesa
+      - meson
+      - mkfontdir
+      - mkfontscale
+      - mpc
+      - mpfr
+      - nasm
+      - ncurses
+      - nettle
+      - npth
+      - numactl
+      - openssl
+      - pango
+      - papi
+      - patchelf
+      - pcre
+      - perl-data-dumper
+      - perl-encode-locale
+      - perl-extutils-config
+      - perl-extutils-helpers
+      - perl-extutils-installpaths
+      - perl-file-listing
+      - perl-html-parser
+      - perl-html-tagset
+      - perl-http-cookies
+      - perl-http-daemon
+      - perl-http-date
+      - perl-http-message
+      - perl-http-negotiate
+      - perl-io-html
+      - perl-libwww-perl
+      - perl-lwp-mediatypes
+      - perl-module-build
+      - perl-module-build-tiny
+      - perl-net-http
+      - perl-test-needs
+      - perl-try-tiny
+      - perl-uri
+      - perl-www-robotrules
+      - perl-xml-parser
+      - pixman
+      - pkg
+      - pkg-config
+      - pkgconf
+      - py-alabaster
+      - py-babel
+      - py-docutils
+      - py-imagesize
+      - py-jinja2
+      - py-lit
+      - py-mako
+      - py-markupsafe
+      - py-packaging
+      - py-pygments
+      - py-pyparsing
+      - py-pytz
+      - py-requests
+      - py-setuptools
+      - py-six
+      - py-snowballstemmer
+      - py-sphinx
+      - py-sphinx-rtd-theme
+      - py-sphinxcontrib-websupport
+      - py-typing
+      - readline
+      - recordproto
+      - renderproto
+      - sed
+      - serf
+      - shared
+      - shared-mime-info
+      - sqlite
+      - swig
+      - tar
+      - tcl
+      - texinfo
+      - unzip
+      - util
+      - util-macros
+      - xcb
+      - xcb-proto
+      - xextproto
+      - xineramaproto
+      - xproto
+      - xtrans
+      - xz
+      - z3
+      - zlib
+      - zstd

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1,0 +1,9 @@
+packages:
+  graphviz:
+    variants: [+graphviz+mscgen]
+  all:
+    compiler: [gcc, clang]
+    providers:
+      blas: [openblas]
+      lapack: [openblas]
+      mpi: [openmpi]

--- a/tools/travis-run-tests.sh
+++ b/tools/travis-run-tests.sh
@@ -1,20 +1,23 @@
 #!/bin/bash -l
-##---------------------------------------------------------------------------##
-## File  : ./travis-run-tests.sh
-## Date  : Tuesday, Jan 17, 2017, 15:55 pm
-## Author: Kelly Thompson
-## Note  : Copyright (C) 2017-2019, Triad National Security, LLC.
-##         All rights are reserved.
-##---------------------------------------------------------------------------##
-
+#--------------------------------------------------------------------------------------------------#
+# File  : ./travis-run-tests.sh
+# Date  : Tuesday, Jan 17, 2017, 15:55 pm
+# Author: Kelly Thompson
+# Note  : Copyright (C) 2017-2020, Triad National Security, LLC., All rights are reserved.
+#
 # .travis.yml calls this script to build draco and run the tests.
+#--------------------------------------------------------------------------------------------------#
+
 
 # preliminaries and environment
 set -e
 
-cd ${SOURCE_DIR:-/home/travis/Draco}
+cd "${SOURCE_DIR:-/home/travis/Draco}"
 source tools/common.sh
 
+#--------------------------------------------------------------------------------------------------#
+# Style Check
+#--------------------------------------------------------------------------------------------------#
 if [[ ${STYLE} ]]; then
   echo "checking style conformance..."
 
@@ -26,11 +29,11 @@ if [[ ${STYLE} ]]; then
     set +f
   }
 
-  # Ensure the 'develop' branch is available.  In some cases (merge a branch
-  # that lives at github.com/lanl), the develop branch is missing in the
-  # Travis checkout. Since we only test files that are modified when compared to
-  # the 'develop' branch, the develop branch must be available locally.
-  num_dev_branches_found=`find_dev_branch`
+  # Ensure the 'develop' branch is available.  In some cases (merge a branch that lives at
+  # github.com/lanl), the develop branch is missing in the Travis checkout. Since we only test files
+  # that are modified when compared to the 'develop' branch, the develop branch must be available
+  # locally.
+  num_dev_branches_found=$(find_dev_branch)
   if [[ $num_dev_branches_found == 0 ]]; then
     echo "no develop branches found."
     # Register the develop branch in draco/.git/config
@@ -44,37 +47,56 @@ if [[ ${STYLE} ]]; then
   # clang-format is installed at /usr/bin.
   export PATH=$PATH:/usr/bin
   # extract the TPL list from the Dockerfile
-  export CLANG_FORMAT_VER="`grep \"ENV CLANG_FORMAT_VER\" tools/Dockerfile | sed -e 's/.*=//' | sed -e 's/\"//g'`"
+  CLANG_FORMAT_VER="$(grep CLANG_FORMAT_VER tools/Dockerfile-style-checks.txt | head -n 1 | sed -e 's/.*=//')"
+  export CLANG_FORMAT_VER
   tools/check_style.sh -t
 
+#--------------------------------------------------------------------------------------------------#
+# 1. GCC based build and test, or
+# 2. Autodoc
+#--------------------------------------------------------------------------------------------------#
 else
-  echo "checking build and test..."
+  if [[ "${AUTODOC}" == "ON" ]]; then
+    echo "checking autodoc compliance..."
+  else
+    echo "checking build and test..."
+  fi
 
   # extract the TPL list from the Dockerfile
-  export DRACO_TPL="`grep \"ENV DRACO_TPL\" tools/Dockerfile | sed -e 's/.*=//' | sed -e 's/\"//g'`"
+  DRACO_TPL="$(grep DRACO_TPL tools/Dockerfile-spack-gcc.txt | sed -e 's/.*=//' | sed -e 's/\"//g')"
+  DRACO_GCC_TPL="$(grep DRACO_GCC_TPL tools/Dockerfile-spack-gcc.txt | head -n 1 | sed -e 's/.*=//' | sed -e 's/\"//g')"
+  DRACO_DOC_TPL="$(grep DRACO_DOC_TPL tools/Dockerfile-spack-gcc.txt | head -n 1 | sed -e 's/.*=//' | sed -e 's/\"//g')"
+  export DRACO_TPL DRACO_GCC_TPL DRACO_DOC_TPL
 
   # Environment setup for the build...
-  for item in ${DRACO_TPL}; do
-    run "spack load ${item}"
+  dmodules="${DRACO_TPL//@//} ${DRACO_GCC_TPL}"
+  if [[ "${AUTODOC}" == "ON" ]]; then
+    dmodules+=" ${DRACO_DOC_TPL}"
+  fi
+  for item in ${dmodules}; do
+    run "module load $item"
   done
+  run "module list"
+  run "module avail"
 
   # Provide a newer lcov that is compatible with gcc-8.
   #run "cp -r ${SOURCE_DIR}/tools/spack/lcov ${SPACK_ROOT}/var/spack/repos/builtin/packages/."
   #run "spack install lcov@1.14"
   #run "spack load lcov"
 
-  if [[ $GCCVER ]]; then
-    export CXX=`which g++-${GCCVER}`
-    export CC=`which gcc-${GCCVER}`
-    export FC=`which gfortran-${GCCVER}`
-    export GCOV=`which gcov-${GCCVER}`
-  else
-    export CXX=`which g++`
-    export CC=`which gcc`
-    export FC=`which gfortran`
-    export GCOV=`which gcov`
-  fi
   echo "GCCVER = ${GCCVER}"
+  if [[ "${GCCVER:=notset}" == "notset" ]]; then
+    CXX=$(which g++)
+    CC=$(which gcc)
+    FC=$(which gfortran)
+    GCOV=$(which gcov)
+  else
+    CXX=$(which "g++-${GCCVER}")
+    CC=$(which "gcc-${GCCVER}")
+    FC=$(which "gfortran-${GCCVER}")
+    GCOV=$(which "gcov-${GCCVER}")
+  fi
+  export CXX CC FC GCOV
   echo "CXX    = ${CXX}"
   echo "FC     = ${FC}"
   echo "GCOV   = ${GCOV}"
@@ -89,13 +111,12 @@ else
     CMAKE_OPTS="-DCODE_COVERAGE=ON"
   fi
 
-  #echo " "
-  #echo "========== printenv =========="
+  echo -e "\n========== printenv =========="
   #printenv
-  #printenv | grep _FLAGS
+  printenv | grep _FLAGS
   echo " "
 
-  if ! [[ $BUILD_DIR ]]; then die "BUILD_DIR not set by environment."; fi
+  if [[ ${BUILD_DIR:-notset} == "notset" ]]; then die "BUILD_DIR not set by environment."; fi
   run "mkdir -p ${BUILD_DIR}"
   run "cd ${BUILD_DIR}"
 
@@ -117,13 +138,18 @@ else
     run "ctest -j 2 -E \(c4_tstOMP_2\|c4_tstTermination_Detector_2\) --output-on-failure"
   fi
   if [[ ${COVERAGE} == "ON" ]]; then
-    echo "========"   
+    echo "========"
     run "make VERBOSE=1 covrep"
     # Uploading report to CodeCov
-    bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+    bash <(curl -s https://codecov.io/bash) -f coverage.info || \
+      echo "Codecov did not collect coverage reports"
   fi
   cd -
-  echo "======== end .travis-run-tests.sh =========="
 fi
 
 # Finish up and report
+echo "======== end .travis-run-tests.sh =========="
+
+#--------------------------------------------------------------------------------------------------#
+# End .travis-run-tests.sh
+#--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

* Testing new docker images that are used by the Travis-based CI system.  Use different images based on the requirements of each CI configuration (autodoc, style-check, gcc-mpi, gcc-scalar).
  * Update to Ubuntu 20.04
  * Update to gcc-9.3.0 and openmpi-3.1.6
  * Add caliper

### Purpose of Pull Request

* The main issue with the older test setup was that clang-format was too old.  Moving from version 6 to 10.
* The old system also lacked caliper.
* Paves the way for adding LLVM-based CI testing.

### Description of changes

* Provide a new set of docker files and README that details how the images are created.
* Tweaks to the `travis.yml` file and the main `travis-run-tests.sh` script.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
* WIP
  * [x] Demo style-check mode
  * [x] Demo autodoc mode
  * [x] Demo gcc-mpi and gcc-scalar mode