### PR TITLE
Provide a build error if C4_MPI.hh is included directly.

### DIFF
--- a/config/doxygen_config.in
+++ b/config/doxygen_config.in
@@ -2095,7 +2095,10 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = "Remember(c)=c"
+# https://www.doxygen.nl/manual/preprocessing.html
+
+PREDEFINED             = "Remember(c)=c" \
+                         "C4_MPI=1"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/c4/C4_MPI.hh
+++ b/src/c4/C4_MPI.hh
@@ -13,11 +13,13 @@
 #include "c4/config.h"
 #include <algorithm>
 
+#if !defined(rtt_c4_global_hh) && !defined(rtt_c4_C4_Functions_hh)
+#error "Include c4/C4_Functions.hh instead of this c4/C4_MPI.hh"
+#endif
+
 #ifdef C4_MPI
 
 #include "MPI_Traits.hh"
-#include "c4_mpi.h"
-#include "ds++/Assert.hh"
 
 //------------------------------------------------------------------------------------------------//
 // Prototypes

--- a/src/c4/C4_Req.hh
+++ b/src/c4/C4_Req.hh
@@ -14,11 +14,6 @@
 #include "C4_Status.hh"
 #include "C4_Traits.hh"
 #include "c4/config.h"
-#include "ds++/Assert.hh"
-
-#ifdef C4_MPI
-#include "c4_mpi.h"
-#endif
 
 namespace rtt_c4 {
 //================================================================================================//

--- a/src/c4/C4_Serial.hh
+++ b/src/c4/C4_Serial.hh
@@ -1,4 +1,4 @@
-//-----------------------------------*-C++-*----------------------------------//
+//--------------------------------------------*-C++-*---------------------------------------------//
 /*!
  * \file   c4/C4_Serial.hh
  * \author Thomas M. Evans
@@ -13,6 +13,10 @@
 #include "c4/config.h"
 #include "ds++/Assert.hh"
 #include <algorithm>
+
+#if !defined(rtt_c4_global_hh) && !defined(rtt_c4_C4_Functions_hh)
+#error "Include c4/C4_Functions.hh instead of this c4/C4_Serial.hh"
+#endif
 
 #ifdef C4_SCALAR
 

--- a/src/cdi_CPEloss/Analytic_CP_Eloss.cc
+++ b/src/cdi_CPEloss/Analytic_CP_Eloss.cc
@@ -4,8 +4,7 @@
  * \author Kendra P. Long
  * \date   Fri Aug  2 14:28:08 2019
  * \brief  Analytic_CP_Eloss member definitions.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Analytic_CP_Eloss.hh"
@@ -19,19 +18,16 @@ namespace rtt_cdi_cpeloss {
 /*!
  * \brief Constructor for an analytic gray eloss model.
  *
- * This constructor builds an eloss model defined by the
- * rtt_cdi_analytic::Analytic_Eloss_Model derived class argument.
+ * This constructor builds an eloss model defined by the rtt_cdi_analytic::Analytic_Eloss_Model
+ * derived class argument.
  *
- * The reaction type for this instance of the class is determined by the
- * rtt_cdi::Reaction argument.
+ * The reaction type for this instance of the class is determined by the rtt_cdi::Reaction argument.
  *
- * \param[in] model_in shared_ptr to a derived
- *                 rtt_cdi_analytic::Analytic_Eloss_Model object
+ * \param[in] model_in shared_ptr to a derived rtt_cdi_analytic::Analytic_Eloss_Model object
  * \param[in] target_in int32_t target particle
  * \param[in] projectile_in int32_t particle being transported
- * \param[in] model_angle_cutoff_in rtt_cdi::CPModelAngleCutoff the angle
- *                 separating the stopping power approximation from analog
- *                 scattering
+ * \param[in] model_angle_cutoff_in rtt_cdi::CPModelAngleCutoff the angle separating the stopping
+ *                 power approximation from analog scattering
  */
 Analytic_CP_Eloss::Analytic_CP_Eloss(SP_Analytic_Model model_in,
                                      rtt_cdi::CParticle target_in, // NOLINT
@@ -39,7 +35,7 @@ Analytic_CP_Eloss::Analytic_CP_Eloss(SP_Analytic_Model model_in,
                                      rtt_cdi::CPModelAngleCutoff model_angle_cutoff_in)
     : rtt_cdi::CPEloss(target_in, projectile_in, rtt_cdi::CPModelType::ANALYTIC_ETYPE,
                        model_angle_cutoff_in),
-      analytic_model(model_in) {
+      analytic_model(std::move(model_in)) {
   Ensure(analytic_model);
 }
 
@@ -47,18 +43,15 @@ Analytic_CP_Eloss::Analytic_CP_Eloss(SP_Analytic_Model model_in,
 // ELOSS INTERFACE FUNCTIONS
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Return a scalar eloss given a scalar temperature, density, and
- *        particle speed.
+ * \brief Return a scalar eloss given a scalar temperature, density, and particle speed.
  *
- * Given a scalar temperature/density/speed, return an eloss for the reaction
- * type specified by the constructor.  The analytic eloss model is
- * specified in the constructor (Analytic_CP_Eloss()).
+ * Given a scalar temperature/density/speed, return an eloss for the reaction type specified by the
+ * constructor.  The analytic eloss model is specified in the constructor (Analytic_CP_Eloss()).
  *
- * \param temperature material temperature in keV
- * \param density material density in g/cm^3
- * \param v0 incident particle speed in cm/shk
+ * \param[in] temperature material temperature in keV
+ * \param[in] density material density in g/cm^3
+ * \param[in] v0 incident particle speed in cm/shk
  * \return eloss (time coefficient) in shk^-1
- *
  */
 double Analytic_CP_Eloss::getEloss(double temperature, double density, double v0) const {
   Require(temperature >= 0.0);


### PR DESCRIPTION
### Background

+ C4 is designed so that `c4/global.hh` or `c4/C4_Functions.hh` should be called instead of `c4/C4_MPI.hh` or `c4/C4_Serial.hh`.  Update the headers to enforce this inclusion model.

### Description of changes

+ Remove some redundant include directives from c4.
+ Force the CPP macro `C4_MPI=1` for doxygen builds.  This provides the correct file-to-file hyperlinks.
+ Fix a clang-tidy warning issued from `Analytic_CP_Eloss.cc` and rewrap the comment blocks to 100 columns.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
