### PR TITLE
Nvcc wrapper support

### DIFF
--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -333,11 +333,10 @@ std::string verbose_error(std::string const &message);
 // Always on
 //------------------------------------------------------------------------------------------------//
 #if ( defined __CUDA_ARCH__  && defined USE_CUDA )
-#define Insist(c, m) if(!(c)) rtt_dsxx::no_exception_insist( #c, m, __FILE__, __LINE__)
-#else
+#define Insist_device(c, m) if(!(c)) rtt_dsxx::no_exception_insist( #c, m, __FILE__, __LINE__)
+#endif
 #define Insist(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
 #define Insist_ptr(c,m) if (!(c)) rtt_dsxx::insist_ptr( #c, m, __FILE__, __LINE__ )
-#endif
 
 #elif DBC & 16
 
@@ -490,6 +489,9 @@ std::string verbose_error(std::string const &message);
 #endif
 #ifndef Insist
 #define Insist(c,m)
+#endif
+#ifndef Insist
+#define Insist_device(c,m)
 #endif
 #ifndef Insist_ptr
 #define Insist_ptr(c,m)

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -176,7 +176,7 @@ void show_cookies(std::string const &cond, std::string const &file, int const li
 [[noreturn]] void insist_ptr(char const *const cond, char const *const msg, char const *const file,
                              int const line);
 
-#if defined __NVCC__ && defined USE_CUDA
+#if defined __CUDA_ARCH__ && defined USE_CUDA
 
 /*! \brief A special version of insist that does not throw.  Useful for GPU code. \sa
  *         device/config.h.in */
@@ -254,7 +254,7 @@ std::string verbose_error(std::string const &message);
  *
  * Special code for CUDA.
  *
- * If __NVCC__ (processing with nvcc) and USE_CUDA=ON, then alter the behavior of the DbC macros
+ * If __CUDA_ARCH__ (processing with nvcc) and USE_CUDA=ON, then alter the behavior of the DbC macros
  * because cuda code cannot throw.
  */
 /*!
@@ -304,16 +304,16 @@ std::string verbose_error(std::string const &message);
  * Eventually, we want the DBC to work in GPU/Cuda code, but for now just disable DBC.
  */
 //------------------------------------------------------------------------------------------------//
-#if ( DBC & 8 ) || ( defined __NVCC__ && defined USE_CUDA )
+#if ( DBC & 8 ) || ( defined __CUDA_ARCH__ && defined USE_CUDA )
 
-#if ( DBC & 1 ) && !( defined __NVCC__ && defined USE_CUDA )
+#if ( DBC & 1 ) && !( defined __CUDA_ARCH__ && defined USE_CUDA )
 #define REQUIRE_ON
 #define Require(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
 #else
 #define Require(c)
 #endif
 
-#if ( DBC & 2 ) && !( defined __NVCC__ && defined USE_CUDA )
+#if ( DBC & 2 ) && !( defined __CUDA_ARCH__ && defined USE_CUDA )
 #define CHECK_ON
 #define Check(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
 #define Assert(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
@@ -322,7 +322,7 @@ std::string verbose_error(std::string const &message);
 #define Assert(c)
 #endif
 
-#if ( DBC & 4 ) && !( defined __NVCC__ && defined USE_CUDA )
+#if ( DBC & 4 ) && !( defined __CUDA_ARCH__ && defined USE_CUDA )
 #define ENSURE_ON
 #define Ensure(c) if (!(c)) rtt_dsxx::show_cookies( #c, __FILE__, __LINE__ )
 #else
@@ -332,7 +332,7 @@ std::string verbose_error(std::string const &message);
 //------------------------------------------------------------------------------------------------//
 // Always on
 //------------------------------------------------------------------------------------------------//
-#if ( defined __NVCC__  && defined USE_CUDA )
+#if ( defined __CUDA_ARCH__  && defined USE_CUDA )
 #define Insist(c, m) if(!(c)) rtt_dsxx::no_exception_insist( #c, m, __FILE__, __LINE__)
 #else
 #define Insist(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
@@ -423,7 +423,7 @@ std::string verbose_error(std::string const &message);
 //------------------------------------------------------------------------------------------------//
 // If any of DBC is on, then make the remember macro active and the NOEXCEPT inactive.
 //------------------------------------------------------------------------------------------------//
-#if DBC && !( defined USE_CUDA && defined __NVCC__ )
+#if DBC && !( defined USE_CUDA && defined __CUDA_ARCH__ )
 #define REMEMBER_ON
 #define Remember(c) c
 #define NOEXCEPT

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -334,7 +334,10 @@ std::string verbose_error(std::string const &message);
 //------------------------------------------------------------------------------------------------//
 #if ( defined __CUDA_ARCH__  && defined USE_CUDA )
 #define Insist_device(c, m) if(!(c)) rtt_dsxx::no_exception_insist( #c, m, __FILE__, __LINE__)
+#else
+#define Insist_device(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
 #endif
+
 #define Insist(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
 #define Insist_ptr(c,m) if (!(c)) rtt_dsxx::insist_ptr( #c, m, __FILE__, __LINE__ )
 


### PR DESCRIPTION
### Background

* nvcc_wrapper preprocesses everything with nvcc. As such, any cpu code that includes the previous version of Assert.hh and uses Insist was getting the version intended for device code. This causes API breaks when compiling with the wrapper were strings are generally passed to this function in most cpu code.

### Purpose of Pull Request

* Add another macro that is explicitly for use in device code until kokkos developers fix the wrapper.

### Description of changes

* One will find general replacement of __NVCC__ with __CUDA_ARCH__ which was thought to correct the issue before we fully understood what the root cause was. However this change remained as it is more general.
* Added the Insist_device macro which is an alias to no_exception_insist and is only for use in device code.

### Status
This was tested by hand when in a build context and we also tested a deployment in client code.

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
