### PR TITLE
Make it easier to enable valgrind tests.

### DIFF
--- a/config/autodoc_macros.cmake
+++ b/config/autodoc_macros.cmake
@@ -125,15 +125,14 @@ function( set_doxygen_dot_num_threads )
   # hack in a couple of other settings based on the version of doxygen
   # discovered.
   if( ${DOXYGEN_VERSION} VERSION_GREATER 1.8.14 )
-    set( DOXYGEN_HTML_DYNAMIC_MENUS "HTML_DYNAMIC_MENUS = YES"
-      PARENT_SCOPE)
+    set( DOXYGEN_HTML_DYNAMIC_MENUS "HTML_DYNAMIC_MENUS = YES" PARENT_SCOPE)
   endif()
   if( ${DOXYGEN_VERSION} VERSION_LESS 1.8.17 )
     set( PERL_PATH "PERL_PATH = /usr/bin/perl" PARENT_SCOPE)
   endif()
 
   # Escalate doxygen warnings into errors for CI builds
-  if( DEFINED ENV{CI} AND DEFINED ENV{TRAVIS} )
+  if( DEFINED ENV{CI} )
     set( DOXYGEN_WARN_AS_ERROR "YES" PARENT_SCOPE )
   else()
     set( DOXYGEN_WARN_AS_ERROR "NO" PARENT_SCOPE )

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -429,13 +429,14 @@ macro( add_component_library )
 
 endmacro()
 
-# ------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------#
 # Register_scalar_test()
 #
 # 1. Special treatment for Roadrunner/ppe code (must ssh and then run)
 # 2. Register the test
 # 3. Register the pass/fail criteria.
-# ------------------------------------------------------------
+# 4. If valgrind is available and ENABLE_MEMORYCHECK=ON, also register a memcheck_<test> version.
+#--------------------------------------------------------------------------------------------------#
 macro( register_scalar_test targetname runcmd command cmd_args )
 
   separate_arguments( cmdargs UNIX_COMMAND ${cmd_args} )
@@ -446,53 +447,73 @@ macro( register_scalar_test targetname runcmd command cmd_args )
   endif()
   add_test( NAME ${targetname} COMMAND ${RUN_CMD} ${command} ${cmdargs} )
 
-  # Reserve enough threads for application unit tests. Normally we only need 1
-  # core for each scalar test.
+  # Reserve enough threads for application unit tests. Normally we only need 1 core for each scalar
+  # test.
   set( num_procs 1 )
 
   # For application unit tests, a parallel job is forked that needs more cores.
   if( addscalartest_APPLICATION_UNIT_TEST )
     if( "${cmd_args}" MATCHES "--np" AND NOT "${cmd_args}" MATCHES "scalar")
       string( REGEX REPLACE "--np ([0-9]+)" "\\1" num_procs "${cmd_args}" )
-      # the forked processes needs $num_proc threads.  add one for the master
-      # thread, the original scalar process.
+      # the forked processes needs $num_proc threads.  add one for the master thread, the original
+      # scalar process.
       math( EXPR num_procs  "${num_procs} + 1" )
     endif()
   endif()
 
   # set pass fail criteria, processors required, etc.
-  set_tests_properties( ${targetname}
-    PROPERTIES
+  set_tests_properties( ${targetname} PROPERTIES
     PASS_REGULAR_EXPRESSION "${addscalartest_PASS_REGEX}"
     FAIL_REGULAR_EXPRESSION "${addscalartest_FAIL_REGEX}"
     PROCESSORS              "${num_procs}"
-    WORKING_DIRECTORY       "${PROJECT_BINARY_DIR}"
-    )
+    WORKING_DIRECTORY       "${PROJECT_BINARY_DIR}"  )
   if( NOT "${addscalartest_RESOURCE_LOCK}none" STREQUAL "none" )
-    set_tests_properties( ${targetname}
-      PROPERTIES RESOURCE_LOCK "${addscalartest_RESOURCE_LOCK}" )
+    set_tests_properties( ${targetname} PROPERTIES RESOURCE_LOCK "${addscalartest_RESOURCE_LOCK}" )
   endif()
   if( NOT "${addscalartest_RUN_AFTER}none" STREQUAL "none" )
-    set_tests_properties( ${targetname}
-      PROPERTIES DEPENDS "${addscalartest_RUN_AFTER}" )
+    set_tests_properties( ${targetname} PROPERTIES DEPENDS "${addscalartest_RUN_AFTER}" )
   endif()
 
   # Labels
   # message("LABEL (ast) = ${addscalartest_LABEL}")
   if( NOT "${addscalartest_LABEL}x" STREQUAL "x" )
-    set_tests_properties( ${targetname}
-      PROPERTIES  LABELS "${addscalartest_LABEL}" )
+    set_tests_properties( ${targetname} PROPERTIES LABELS "${addscalartest_LABEL}" )
   endif()
+
+  # If ENABLE_MEMORYCHECK=ON, then also create a memcheck_<test> version
+  if( ENABLE_MEMORYCHECK AND (NOT "${addscalartest_LABEL}" MATCHES "nomemcheck") AND
+      EXISTS "${CMAKE_MEMORYCHECK_COMMAND}" )
+    separate_arguments(valgrindopts NATIVE_COMMAND ${CMAKE_MEMORYCHECK_COMMAND_OPTIONS})
+    add_test(
+      NAME    memcheck_${targetname}
+      COMMAND ${CMAKE_MEMORYCHECK_COMMAND} ${valgrindopts} ${RUN_CMD} ${command} ${cmdargs} )
+    set_tests_properties( memcheck_${targetname} PROPERTIES
+      PASS_REGULAR_EXPRESSION "${addscalartest_PASS_REGEX}"
+      FAIL_REGULAR_EXPRESSION "${addscalartest_FAIL_REGEX}"
+      PROCESSORS              "${num_procs}"
+      WORKING_DIRECTORY       "${PROJECT_BINARY_DIR}"
+      LABELS                  "memcheck;${addscalartest_LABEL}")
+    if( NOT "${addscalartest_RESOURCE_LOCK}none" STREQUAL "none" )
+      set_tests_properties( memcheck_${targetname} PROPERTIES RESOURCE_LOCK
+        "${addscalartest_RESOURCE_LOCK}" )
+    endif()
+    if( NOT "${addscalartest_RUN_AFTER}none" STREQUAL "none" )
+      set_tests_properties( memcheck_${targetname} PROPERTIES DEPENDS "${addscalartest_RUN_AFTER}" )
+    endif()
+    unset(valgrindopts)
+  endif()
+
   unset( num_procs )
   unset( lverbose )
 endmacro()
 
-# ------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------#
 # Register_parallel_test()
 #
 # 1. Register the test
 # 2. Register the pass/fail criteria.
-# ------------------------------------------------------------
+# 3. If valgrind is available and ENABLE_MEMORYCHECK=ON, also register a memcheck_<test> version.
+#--------------------------------------------------------------------------------------------------#
 macro( register_parallel_test targetname numPE command cmd_args )
   set( lverbose OFF )
   if( lverbose )
@@ -507,30 +528,26 @@ macro( register_parallel_test targetname numPE command cmd_args )
       COMMAND ${RUN_CMD} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${numPE}
               ${mpiexec_omp_preflags_list}
               ${command}
-              ${cmdarg}
-              )
+              ${cmdarg} )
   else()
     add_test(
       NAME    ${targetname}
       COMMAND ${RUN_CMD} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${numPE}
               ${MPIRUN_PREFLAGS}
               ${command}
-              ${cmdarg}
-              )
+              ${cmdarg} )
   endif()
   set_tests_properties( ${targetname}
     PROPERTIES
     PASS_REGULAR_EXPRESSION "${addparalleltest_PASS_REGEX}"
     FAIL_REGULAR_EXPRESSION "${addparalleltest_FAIL_REGEX}"
-    WORKING_DIRECTORY       "${PROJECT_BINARY_DIR}"
-    )
+    WORKING_DIRECTORY       "${PROJECT_BINARY_DIR}" )
   if( NOT "${addparalleltest_RESOURCE_LOCK}none" STREQUAL "none" )
     set_tests_properties( ${targetname}
       PROPERTIES RESOURCE_LOCK "${addparalleltest_RESOURCE_LOCK}" )
   endif()
   if( NOT "${addparalleltest_RUN_AFTER}none" STREQUAL "none" )
-    set_tests_properties( ${targetname}
-      PROPERTIES DEPENDS "${addparalleltest_RUN_AFTER}" )
+    set_tests_properties( ${targetname} PROPERTIES DEPENDS "${addparalleltest_RUN_AFTER}" )
   endif()
 
   if( addparalleltest_MPI_PLUS_OMP )
@@ -555,14 +572,42 @@ macro( register_parallel_test targetname numPE command cmd_args )
   else()
 
     if( DEFINED addparalleltest_LABEL )
-      set_tests_properties( ${targetname}
-          PROPERTIES LABELS "${addparalleltest_LABEL}" )
+      set_tests_properties( ${targetname} PROPERTIES LABELS "${addparalleltest_LABEL}" )
     endif()
     set_tests_properties( ${targetname} PROPERTIES PROCESSORS "${numPE}" )
 
   endif()
+
+  # ------------------------------------------------------------
+  # If ENABLE_MEMORYCHECK=ON, then also create a memcheck_<test> version
+  if( ENABLE_MEMORYCHECK AND (NOT "${addparalleltest_LABEL}" MATCHES "nomemcheck") AND
+      EXISTS "${CMAKE_MEMORYCHECK_COMMAND}" AND (NOT addparalleltest_MPI_PLUS_OMP ))
+    separate_arguments(valgrindopts NATIVE_COMMAND ${CMAKE_MEMORYCHECK_COMMAND_OPTIONS})
+    add_test(
+      NAME    memcheck_${targetname}
+      COMMAND ${CMAKE_MEMORYCHECK_COMMAND} ${valgrindopts}
+              ${RUN_CMD} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${numPE}
+              ${MPIRUN_PREFLAGS}
+              ${command}
+              ${cmdarg} )
+    set_tests_properties( memcheck_${targetname} PROPERTIES
+      PASS_REGULAR_EXPRESSION "${addparalleltest_PASS_REGEX}"
+      FAIL_REGULAR_EXPRESSION "${addparalleltest_FAIL_REGEX}"
+      WORKING_DIRECTORY       "${PROJECT_BINARY_DIR}"
+      LABELS                  "memcheck;${addparalleltest_LABEL}")
+    if( NOT "${addparalleltest_RESOURCE_LOCK}none" STREQUAL "none" )
+      set_tests_properties( memcheck_${targetname} PROPERTIES
+        RESOURCE_LOCK "${addparalleltest_RESOURCE_LOCK}" )
+    endif()
+    if( NOT "${addparalleltest_RUN_AFTER}none" STREQUAL "none" )
+      set_tests_properties( memcheck_${targetname} PROPERTIES
+        DEPENDS "${addparalleltest_RUN_AFTER}" )
+    endif()
+    set_tests_properties( ${targetname} PROPERTIES PROCESSORS "${numPE}" )
+    unset(valgrindopts)
+  endif()
   unset( lverbose )
-endmacro()
+endmacro(register_parallel_test)
 
 #--------------------------------------------------------------------------------------------------#
 # add_scalar_tests
@@ -617,14 +662,14 @@ macro( add_scalar_tests test_sources )
   if( NOT addscalartest_LINK_LANGUAGE )
     set( addscalartest_LINK_LANGUAGE CXX )
   endif()
- if( "${addscalartest_LINK_LANGUAGE}" STREQUAL "CUDA" )
-   set_source_files_properties( ${addscalartest_SOURCES} PROPERTIES LANGUAGE CUDA )
- endif()
+  if( "${addscalartest_LINK_LANGUAGE}" STREQUAL "CUDA" )
+    set_source_files_properties( ${addscalartest_SOURCES} PROPERTIES LANGUAGE CUDA )
+  endif()
 
   # Special Cases:
   # ------------------------------------------------------------
-  # On some platforms (Trinity, Sierra), even scalar tests must be run
-  # underneath MPIEXEC_EXECUTABLE (srun, jsrun, lrun):
+  # On some platforms (Trinity, Sierra), even scalar tests must be run underneath MPIEXEC_EXECUTABLE
+  # (srun, jsrun, lrun):
   separate_arguments(MPIEXEC_PREFLAGS)
   if( "${MPIEXEC_EXECUTABLE}" MATCHES "srun" OR
       "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
@@ -633,12 +678,12 @@ macro( add_scalar_tests test_sources )
     unset( RUN_CMD )
   endif()
 
-  # Special cases for tests that use the ApplicationUnitTest
-  # framework (see c4/ApplicationUnitTest.hh).
+  # Special cases for tests that use the ApplicationUnitTest framework (see
+  # c4/ApplicationUnitTest.hh).
   if( addscalartest_APPLICATION_UNIT_TEST )
-    # If this is an ApplicationUnitTest based test then the TEST_ARGS will look
-    # like "--np 1;--np 2;--np 4".  For the case where DRACO_C4 = SCALAR, we
-    # will automatically demote these arguments to "--np scalar."
+    # If this is an ApplicationUnitTest based test then the TEST_ARGS will look like "--np 1;--np
+    # 2;--np 4".  For the case where DRACO_C4 = SCALAR, we will automatically demote these arguments
+    # to "--np scalar."
     if( "${DRACO_C4}" MATCHES "SCALAR" )
       set( addscalartest_TEST_ARGS "--np scalar" )
     endif()
@@ -657,8 +702,7 @@ macro( add_scalar_tests test_sources )
 
   # Format resource lock command
   if( NOT "${addscalartest_RESOURCE_LOCK}none" STREQUAL "none" )
-    set( addscalartest_RESOURCE_LOCK
-      "RESOURCE_LOCK ${addscalartest_RESOURCE_LOCK}")
+    set( addscalartest_RESOURCE_LOCK "RESOURCE_LOCK ${addscalartest_RESOURCE_LOCK}")
   endif()
 
   # What is the component name (always use Lib_${compname} as a dependency).
@@ -677,24 +721,19 @@ macro( add_scalar_tests test_sources )
     get_filename_component( testname ${file} NAME_WE )
     add_executable( Ut_${compname}_${testname}_exe ${file} )
     dbs_std_tgt_props( Ut_${compname}_${testname}_exe )
-    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-      OUTPUT_NAME ${testname} )
-    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-      VS_KEYWORD  ${testname} )
-    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-      FOLDER      ${compname}_test )
-    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-      COMPILE_DEFINITIONS "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"" )
-    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-      COMPILE_DEFINITIONS "PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\"" )
-    if( DEFINED DRACO_LINK_OPTIONS AND
-        NOT "${DRACO_LINK_OPTIONS}x" STREQUAL "x")
-      set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY
-        LINK_OPTIONS ${DRACO_LINK_OPTIONS} )
+    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY OUTPUT_NAME ${testname} )
+    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY VS_KEYWORD  ${testname} )
+    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY FOLDER ${compname}_test )
+    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY COMPILE_DEFINITIONS
+      "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"" )
+    set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY COMPILE_DEFINITIONS
+      "PROJECT_BINARY_DIR=\"${PROJECT_BINARY_DIR}\"" )
+    if( DEFINED DRACO_LINK_OPTIONS AND NOT "${DRACO_LINK_OPTIONS}x" STREQUAL "x")
+      set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY LINK_OPTIONS
+        ${DRACO_LINK_OPTIONS} )
     endif()
     if( addscalartest_LINK_WITH_FORTRAN )
-      set_property( TARGET Ut_${compname}_${testname}_exe APPEND
-        PROPERTY LINKER_LANGUAGE Fortran )
+      set_property( TARGET Ut_${compname}_${testname}_exe APPEND PROPERTY LINKER_LANGUAGE Fortran )
     endif()
     target_link_libraries(
       Ut_${compname}_${testname}_exe
@@ -708,17 +747,19 @@ macro( add_scalar_tests test_sources )
     get_filename_component( testname ${file} NAME_WE )
 
     if( "${addscalartest_TEST_ARGS}none" STREQUAL "none" )
-      register_scalar_test( ${compname}_${testname}
-        "${RUN_CMD}" $<TARGET_FILE:Ut_${compname}_${testname}_exe> "" )
+      register_scalar_test( ${compname}_${testname} "${RUN_CMD}"
+        $<TARGET_FILE:Ut_${compname}_${testname}_exe> "" )
     else()
       set( iarg "0" )
       foreach( cmdarg ${addscalartest_TEST_ARGS} )
         math( EXPR iarg "${iarg} + 1" )
-        register_scalar_test( ${compname}_${testname}_arg${iarg}
-          "${RUN_CMD}" $<TARGET_FILE:Ut_${compname}_${testname}_exe> "${cmdarg}" )
+        register_scalar_test( ${compname}_${testname}_arg${iarg} "${RUN_CMD}"
+          $<TARGET_FILE:Ut_${compname}_${testname}_exe> "${cmdarg}" )
       endforeach()
     endif()
   endforeach()
+
+  unset(valgrindopts)
 
 endmacro(add_scalar_tests)
 
@@ -913,7 +954,7 @@ macro( add_parallel_tests )
           if( lverbose )
             message("   register_scalar_test( ${compname}_${testname}_arg${iarg}
             \"${RUN_CMD}\" ${testname} \"${cmdarg}\" ) ")
-            endif()
+          endif()
           register_scalar_test( ${compname}_${testname}_arg${iarg}
             "${RUN_CMD}" $<TARGET_FILE:Ut_${compname}_${testname}_exe> "${cmdarg}" )
         endforeach()
@@ -964,7 +1005,7 @@ macro( provide_aux_files )
     endif()
     set( outfile ${PROJECT_BINARY_DIR}/${srcfilenameonly} )
     if( "${file}x" STREQUAL "x" OR "${outfile}x" STREQUAL "x")
-    message( FATAL_ERROR " COMMAND ${CMAKE_COMMAND} -E copy_if_different ${file} ${outfile}")
+      message( FATAL_ERROR " COMMAND ${CMAKE_COMMAND} -E copy_if_different ${file} ${outfile}")
     endif()
     add_custom_command(
       OUTPUT  ${outfile}
@@ -1025,7 +1066,7 @@ macro( process_autodoc_pages )
     list( APPEND DOXYGEN_IMAGE_PATH "${PROJECT_SOURCE_DIR}/autodoc" )
   endif()
   set( DOXYGEN_IMAGE_PATH "${DOXYGEN_IMAGE_PATH}" CACHE PATH
-     "List of directories that contain images for doxygen pages." FORCE )
+    "List of directories that contain images for doxygen pages." FORCE )
   unset( images_in )
   unset( num_images )
 endmacro()

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -3,8 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2010 June 6
 # brief  Look for any libraries which are required at the top level.
-# note   Copyright (C) 2016-2020 Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 
 include_guard(GLOBAL)
@@ -17,6 +16,7 @@ include( setupMPI ) # defines the macros setupMPILibrariesUnix|Windows
 macro( setupPython )
 
   message( STATUS "Looking for Python...." )
+  # This module looks preferably for version 3 of Python. If not found, version 2 is searched.
   find_package(Python QUIET REQUIRED COMPONENTS Interpreter)
   #  Python_Interpreter_FOUND - Was the Python executable found
   #  Python_EXECUTABLE  - path to the Python interpreter
@@ -30,6 +30,12 @@ macro( setupPython )
     message( STATUS "Looking for Python....found ${Python_EXECUTABLE}" )
   else()
     message( STATUS "Looking for Python....not found" )
+  endif()
+  # As of 2020-11-10, we require 'python@3.6:' for correct dictionary sorting features.  We can
+  # build the code with 'python@2:' but some tests may fail.
+  if( Python_VERSION_MAJOR STREQUAL "3" AND Python_VERSION_MINOR VERSION_LESS "6")
+    message( FATAL_ERROR "When using python3, we require version 3.6+.  Python version "
+      "${Python_VERSION} was discovered, which doesn't satisfy the compatibility requirement.")
   endif()
 
 endmacro()

--- a/src/parser/test/CMakeLists.txt
+++ b/src/parser/test/CMakeLists.txt
@@ -3,8 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2012 Aug 1
 # brief  Generate build project files for parser/test.
-# note   Copyright (C) 2016-2019, Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 project( parser_test CXX )
 
@@ -43,9 +42,8 @@ add_scalar_tests(
 
 # Special case for driver4tstConsole_Token_Stream
 # 1. This test doesn't work under Xcode
-# 2. This test must have unique access to tstConsole_Token_Stream and we will
-#    use a RESOURCE_LOCK to prevent multiple simultaneous instances during
-#    parallel ctest.
+# 2. This test must have unique access to tstConsole_Token_Stream and we will use a RESOURCE_LOCK to
+#    prevent multiple simultaneous instances during parallel ctest.
 if( NOT ${CMAKE_GENERATOR} MATCHES "Xcode" )
   include( ApplicationUnitTest )
   add_app_unit_test(
@@ -70,13 +68,19 @@ add_parallel_tests(
    PE_LIST "1;2"
    DEPS    "Lib_parser;${MPI_CXX_LIBRARIES};${PAPI_LIBRARY}" )
 
-# To ensure that the file token stream tests of the #include capability know
-# where to look for the included file.
+# To ensure that the file token stream tests of the #include capability know where to look for the
+# included file.
  if( "${DRACO_C4}" STREQUAL "MPI" )
    set( tests_with_env_reqs
      parser_tstParallel_File_Token_Stream_1
      parser_tstParallel_File_Token_Stream_2
      parser_tstFile_Token_Stream_1 )
+   if( ENABLE_MEMORYCHECK )
+     set( tests_with_env_reqs
+       memcheck_parser_tstParallel_File_Token_Stream_1
+       memcheck_parser_tstParallel_File_Token_Stream_2
+       memcheck_parser_tstFile_Token_Stream_1 )
+   endif()
  else()
    set( tests_with_env_reqs
      parser_tstParallel_File_Token_Stream
@@ -84,7 +88,7 @@ add_parallel_tests(
  endif()
  set_tests_properties( ${tests_with_env_reqs} PROPERTIES
    ENVIRONMENT
-   DRACO_INCLUDE_PATH=${CMAKE_CURRENT_SOURCE_DIR})
+     DRACO_INCLUDE_PATH=${CMAKE_CURRENT_SOURCE_DIR})
 
 #--------------------------------------------------------------------------------------------------#
 # End parser/test/CMakeLists.txt


### PR DESCRIPTION
### Background

+ I am adopting a technique used in CSK.  If valgrind is available and `-DENABLE_MEMEORYCHECK=ON`, then register each unit test twice: (1) the regular `<test>` and (2) `memcheck_<test>`.  The latter test will run `<test>` under valgrind.  All `memcheck` tests will be have the test label `memcheck`.
+ Documented at https://rtt.lanl.gov/redmine/projects/draco/wiki/Common_Configure_Options.
+ This update was needed to allow Jayenne valgrind runs in gitlab setuid runners.
+ Preferred use is:
  ```
  cmake -DENABLE_MEMORYCHECK=ON
    -DCTEST_MEMORYCHECK_SUPPRESSIONS_FILE=/scratch/regress/ccsradregress/valgrind_suppress.txt
  ```
+ `CMAKE_MEMORYCHECK_COMMAND` and `CMAKE_MEMORYCHECK_COMMAND_OPTIONS` can also be set on the cmake line, but reasonable defaults will be used if omitted.
+ If enabled `ctest -N` will report double the normal number of tests.
+ Run only the memcheck tests with `ctest -L memcheck`.
+ Run all non-memcheck tests: `ctest -E memcheck`

### Description of changes

Also in this PR:

+ If `ENV{CI}` is defined, force doxygen to treat warnings as errors (for the gitlab setuid runner).
+ If python3 is found, require it to be version 3.6 or newer. This eliminates a dictionary ordering issue that exists in earlier versions.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
