### PR TITLE
Fix device insist issues

### DIFF
--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -177,7 +177,6 @@ void show_cookies(std::string const &cond, std::string const &file, int const li
                              int const line);
 
 #if defined __CUDA_ARCH__ && defined USE_CUDA
-
 /*! \brief A special version of insist that does not throw.  Useful for GPU code. \sa
  *         device/config.h.in */
 __host__ __device__ inline void no_exception_insist(char const *const cond, char const *const msg,
@@ -186,7 +185,6 @@ __host__ __device__ inline void no_exception_insist(char const *const cond, char
   printf("The following message was provided: \"%s\"", msg);
   return;
 }
-
 #endif
 
 #if DBC & 16

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -381,6 +381,7 @@ std::string verbose_error(std::string const &message);
 //------------------------------------------------------------------------------------------------//
 // Always on
 //------------------------------------------------------------------------------------------------//
+#define Insist_device(c, m) rtt_dsxx::check_insist(!!(c), #c, m, __FILE__, __LINE__)
 #define Insist(c, m) rtt_dsxx::check_insist(!!(c), #c, m, __FILE__, __LINE__)
 #define Insist_ptr(c,m) rtt_dsxx::check_insist_ptr( !!(c), #c, m, __FILE__, __LINE__ )
 
@@ -417,6 +418,7 @@ std::string verbose_error(std::string const &message);
 //------------------------------------------------------------------------------------------------//
 // Always on
 //------------------------------------------------------------------------------------------------//
+#define Insist_device(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
 #define Insist(c,m) if (!(c)) rtt_dsxx::insist( #c, m, __FILE__, __LINE__ )
 #define Insist_ptr(c,m) if (!(c)) rtt_dsxx::insist_ptr( #c, m, __FILE__, __LINE__ )
 
@@ -493,7 +495,7 @@ std::string verbose_error(std::string const &message);
 #ifndef Insist
 #define Insist(c,m)
 #endif
-#ifndef Insist
+#ifndef Insist_device
 #define Insist_device(c,m)
 #endif
 #ifndef Insist_ptr

--- a/src/ds++/test/tstAssert.cc
+++ b/src/ds++/test/tstAssert.cc
@@ -410,6 +410,50 @@ void tinsist(rtt_dsxx::UnitTest &ut) {
       ITFAILS;
     }
   }
+
+  // you should always get the throwing version of Insist_device when building ds++ library tests
+  {
+    std::cout << "Insist device test (should map to Insist in CPU builds: ";
+    char const *const insist_message("You must be kidding!");
+    try {
+      Insist_device(0, insist_message);
+      throw "Bogus!";
+    } catch (rtt_dsxx::assertion const &a) {
+      PASSMSG("tinsist_device: caught rtt_dsxx::assertion");
+      std::cout << "t-Insist device message value test: ";
+      {
+        bool passed(true);
+        std::string msg(a.what());
+        std::string expected_value("You must be kidding!");
+        string::size_type idx(msg.find(expected_value));
+        if (idx == string::npos)
+          passed = false;
+        idx = msg.find(insist_message);
+        if (idx == string::npos)
+          passed = false;
+        if (!passed)
+          ITFAILS;
+      }
+    } catch (...) {
+      ITFAILS;
+    }
+  }
+
+  // make sure no_exception_insist doesn't throw
+  /*
+  {
+    std::cout << "Insist no exception test"
+    char const *const insist_message("You must be kidding!");
+    try {
+      rtt_dsxx::no_exception_insist(0, insist_message);
+      throw "Bogus!";
+    } catch (rtt_dsxx::assertion const &a) {
+      ITFAILS;
+    } catch (...) {
+      PASSMSG("no_exception_insist did not throw");
+    }
+  }
+  */
   return;
 }
 


### PR DESCRIPTION


### Background

* Introducing a new insist specifically for device code helped the NVCC kokkos wrapper compile draco. This PR just cleans up a few issues with the `Insist_device` function--it's added to the other DBC modes (hard to see in Draco's `Assert.hh` since preprocessor logic is not indented).

### Purpose of Pull Request

* Improve on device insist macros
* Make a clearer distinction between non-throwing insists

### Description of changes

* Define Insist_device in other DBC modes to be standard insist
* Fix the last fall through check in `Assert.hh` that checked if `Insist` was defined instead of `Insist_device`

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
