### PR TITLE
Undo another overzealous linter fix that broke behavior.

### DIFF
--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -108,7 +108,7 @@ function npwd()
   # Indicator that there has been directory truncation:
   local trunc_symbol="..."
   # substitute ~ for $HOME to shorten the full path
-  newPWD="${PWD//${HOME}/~}"
+  newPWD=$(echo ${PWD} | sed -e "s%$HOME%~%")
   for dir in ${scratchdirs//:/ }; do
     newPWD="${newPWD//${dir}\/${USER}/#}"
   done

--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -108,7 +108,8 @@ function npwd()
   # Indicator that there has been directory truncation:
   local trunc_symbol="..."
   # substitute ~ for $HOME to shorten the full path
-  newPWD=$(echo ${PWD} | sed -e "s%$HOME%~%")
+  # shellcheck disable=SC2001
+  newPWD=$(echo "${PWD}" | sed -e "s%$HOME%~%")
   for dir in ${scratchdirs//:/ }; do
     newPWD="${newPWD//${dir}\/${USER}/#}"
   done


### PR DESCRIPTION
### Background

* Attempting to address the super-linter warnings for our bash sources resulted in a couple of broken features.  This PR undoes one of those fixed and restored the correct code behavior related to using `~ == $HOME` in the prompt.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
