### PR TITLE
Use the Insist_device function in device test code

### DIFF
--- a/src/device/test/Dual_Call.cu
+++ b/src/device/test/Dual_Call.cu
@@ -32,6 +32,8 @@ __host__ __device__ unsigned long long sub_conserve_calc_num_src_particles(
 
   ntot = 0;
 
+  Insist_device(part_per_e > 0, "Use the Insist_device function");
+
   // sweep through cells and calculate number of particles per cell
   for (size_t cell = cell_start; cell < cell_end; cell++) {
     // if the cell has any energy try to put some particles in it

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -182,7 +182,7 @@ void show_cookies(std::string const &cond, std::string const &file, int const li
 __host__ __device__ inline void no_exception_insist(char const *const cond, char const *const msg,
                                                     char const *const file, int const line) {
   printf("Insist: %s, failed in %s, line %d.\n", cond, file, line);
-  printf("The following message was provided: \"%s\"", msg);
+  printf("The following message was provided: \"%s\"\n", msg);
   return;
 }
 #endif


### PR DESCRIPTION
### Background

* This should be the last PR for the `Insist_device` change. This adds an `Insist_device` call to a test in `src/device/test` and adds a newline to the end of the printf in `no_exception_insist`.

### Purpose of Pull Request

* Clean up the `Insist_device` function

### Description of changes

* Add an Insist_device call to Dual_Call.cu
* Add a newline character to the end of the printf in no_exception_insist

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
