### PR TITLE
Fix a build warning issued by gcc on ARM and Power9.

### DIFF
--- a/src/compton_tools/cskrw.cc
+++ b/src/compton_tools/cskrw.cc
@@ -215,10 +215,9 @@ void Dense_Compton_Data::read_from_file(UINT64 eval, std::string filename, bool 
       f.get(c);
       Check(c == '\n');
 
-      // Look-ahead to next line to see if a blank line,
-      // signalling end of temperature data
+      // Look-ahead to next line to see if a blank line, signalling end of temperature data
       f.get(c);
-      if (c == '\n' || c == EOF) {
+      if (c == '\n') { // [kt] || c == EOF) { // EOF is not a char. This is alwasy false.
         finished = true;
       } else {
         f.putback(c);


### PR DESCRIPTION
### Background

* Fix compile warning issued by gcc on Power9 and ARM architectures.

### Description of changes

```
/projects/gitlab-runner/jayenne/jayenne/builds/users/kellyt/Hu51Ct7C/2/jayenne/jayenne/draco/src/compton_tools/\
cskrw.cc: In member function 'void Dense_Compton_Data::read_from_file(UINT64, std::string, bool)': 
/projects/gitlab-runner/jayenne/jayenne/builds/users/kellyt/Hu51Ct7C/2/jayenne/jayenne/draco/src/compton_tools\
/cskrw.cc:221:26: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  221 |       if (c == '\n' || c == EOF) {
      |                          ^
```

* Remove 2nd part of the conditional since it is always `False`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
