### PR TITLE
CMAKE: add option to not use QT

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -318,22 +318,27 @@ endmacro()
 macro( setupQt )
   message( STATUS "Looking for Qt SDK...." )
 
-  # Find the QtWidgets library
-  find_package(Qt5 COMPONENTS Widgets QUIET)
+  option (USE_QT "Build QT support for Draco" ON)
 
-  if( Qt5Core_DIR )
-    mark_as_advanced( Qt5Core_DIR Qt5Gui_DIR Qt5Gui_EGL_LIBRARY
-      Qt5Widgets_DIR QTDIR)
-    message( STATUS "Looking for Qt SDK....found ${Qt5Core_DIR}" )
-  else()
-    message( STATUS "Looking for Qt SDK....not found." )
+  if( USE_QT )
+    # Find the QtWidgets library
+    find_package(Qt5 COMPONENTS Widgets QUIET)
+
+    if( Qt5Core_DIR )
+      mark_as_advanced( Qt5Core_DIR Qt5Gui_DIR Qt5Gui_EGL_LIBRARY
+        Qt5Widgets_DIR QTDIR)
+      message( STATUS "Looking for Qt SDK....found ${Qt5Core_DIR}" )
+    else()
+      message( STATUS "Looking for Qt SDK....not found." )
+    endif()
+
+    set_package_properties( Qt PROPERTIES
+      URL "http://qt.io"
+      DESCRIPTION "Qt is a comprehensive cross-platform C++ application framework."
+      TYPE OPTIONAL
+      PURPOSE "Only needed to demo qt version of draco_diagnostics." )
+
   endif()
-
-  set_package_properties( Qt PROPERTIES
-    URL "http://qt.io"
-    DESCRIPTION "Qt is a comprehensive cross-platform C++ application framework."
-    TYPE OPTIONAL
-    PURPOSE "Only needed to demo qt version of draco_diagnostics." )
 
 endmacro()
 


### PR DESCRIPTION
Signed-off-by: Howard Pritchard <hppritcha@gmail.com>

### Background

* The flag application's spack environment was not building with some combinations of compilers/cpu arch/qt installs owing to issues with QT's moc not working right.

### Purpose of Pull Request

* enable optional use of QT package - some compiler/QT install/archs don't work. 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation