### PR TITLE
Fix CI issues related to recent NDI stopping power PR

### DIFF
--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -147,6 +147,7 @@ void NDI_CP_Eloss::load_ndi() {
 
   //! Set projectile isotope
   ndi_error = NDI2_set_isotope(dataset_handle, std::to_string(projectile.get_zaid()).c_str());
+  Require(ndi_error == 0);
 
   int num_targets = 0;
   ndi_error = NDI2_get_int_val(dataset_handle, NDI_NUM_TARGET, &num_targets);

--- a/src/cdi_ndi/NDI_CP_Eloss.hh
+++ b/src/cdi_ndi/NDI_CP_Eloss.hh
@@ -52,28 +52,29 @@ public:
   // >>> ACCESSORS
 
   //! Get a stopping power.
-  double getEloss(const double temperature, const double density, const double partSpeed) const;
+  double getEloss(const double temperature, const double density,
+                  const double partSpeed) const override;
 
   //! Query to see if data is in tabular or functional form (true)
   static constexpr bool is_data_in_tabular_form() { return true; }
 
   //! Get the material temperature grid.
-  sf_double getTemperatureGrid() const { return temperatures; }
+  sf_double getTemperatureGrid() const override { return temperatures; }
 
   //! Get the material density grid.
-  sf_double getDensityGrid() const { return densities; }
+  sf_double getDensityGrid() const override { return densities; }
 
   //! Get the projectile energy grid.
-  sf_double getEnergyGrid() const { return energies; }
+  sf_double getEnergyGrid() const override { return energies; }
 
   //! Get the number of material temperature grid points.
-  size_t getNumTemperatures() const { return n_temperature; }
+  size_t getNumTemperatures() const override { return n_temperature; }
 
   //! Get the number of material density grid points.
-  size_t getNumDensities() const { return n_density; }
+  size_t getNumDensities() const override { return n_density; }
 
   //! Get the number of projectile energy grid points.
-  size_t getNumEnergies() const { return n_energy; }
+  size_t getNumEnergies() const override { return n_energy; }
 
   //! Get the general eloss model type
   rtt_cdi::CPModelType getModelType() const { return rtt_cdi::CPModelType::TABULAR_ETYPE; }


### PR DESCRIPTION
### Background

* #844 was merged in without waiting for the CI, and now there are some warnings-treated-as-errors in `develop`. This attempts to fix that

### Purpose of Pull Request

* Fix LLVM warnings

### Description of changes

* Decorate `NDI_CP_Eloss` member functions with `override` where appropriate.
* Add DBC for `ndi_error`from an NDI call.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
