### PR TITLE
Clang tidy fixes and more.

### DIFF
--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -353,6 +353,7 @@ template <typename T> void global_max(T &x);
  * \brief Do an element-wise, global sum of an array.
  */
 template <typename T> void global_sum(T *x, int n);
+template <typename T> void global_sum(T *x, size_t n);
 
 //------------------------------------------------------------------------------------------------//
 /*!

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -318,7 +318,7 @@ template <typename T> void global_sum(T *x, int n) {
 }
 template <typename T> void global_sum(T *x, size_t n) {
   Require(n < INT32_MAX);
-  global_sum( x, static_cast<int>(n));
+  global_sum(x, static_cast<int>(n));
 }
 
 //------------------------------------------------------------------------------------------------//

--- a/src/c4/C4_MPI.t.hh
+++ b/src/c4/C4_MPI.t.hh
@@ -316,6 +316,10 @@ template <typename T> void global_sum(T *x, int n) {
   // do a element-wise global reduction (result is on all processors) into x
   MPI_Allreduce(MPI_IN_PLACE, x, n, MPI_Traits<T>::element_type(), MPI_SUM, communicator);
 }
+template <typename T> void global_sum(T *x, size_t n) {
+  Require(n < INT32_MAX);
+  global_sum( x, static_cast<int>(n));
+}
 
 //------------------------------------------------------------------------------------------------//
 

--- a/src/c4/C4_MPI_reductions_pt.cc
+++ b/src/c4/C4_MPI_reductions_pt.cc
@@ -92,6 +92,18 @@ template void global_sum<long double>(long double *, int);
 template void global_sum<long long>(long long *, int);
 template void global_sum<unsigned long long>(unsigned long long *, int);
 
+template void global_sum<short>(short *, size_t);
+template void global_sum<unsigned short>(unsigned short *, size_t);
+template void global_sum<int>(int *, size_t);
+template void global_sum<unsigned int>(unsigned int *, size_t);
+template void global_sum<long>(long *, size_t);
+template void global_sum<unsigned long>(unsigned long *, size_t);
+template void global_sum<float>(float *, size_t);
+template void global_sum<double>(double *, size_t);
+template void global_sum<long double>(long double *, size_t);
+template void global_sum<long long>(long long *, size_t);
+template void global_sum<unsigned long long>(unsigned long long *, size_t);
+
 template void global_prod<short>(short *, int);
 template void global_prod<unsigned short>(unsigned short *, int);
 template void global_prod<int>(int *, int);

--- a/src/c4/C4_Serial.t.hh
+++ b/src/c4/C4_Serial.t.hh
@@ -175,6 +175,8 @@ template <typename T> void global_max(T * /*x*/, int /*n*/) { /* empty */
 //------------------------------------------------------------------------------------------------//
 template <typename T> void global_sum(T * /*x*/, int /*n*/) { /* empty */
 }
+template <typename T> void global_sum(T * /*x*/, size_t /*n*/) { /* empty */
+}
 
 //------------------------------------------------------------------------------------------------//
 template <typename T> void global_prod(T & /*x*/) { /* empty */

--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -658,23 +658,23 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
     {
       c = x;
       global_sum(&c[0], 100);
-      if (!soft_equiv(c.begin(), c.end(), sum.begin(), sum.end()))
-        ITFAILS;
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
       global_prod(&c[0], 100);
-      if (!soft_equiv(c.begin(), c.end(), prod.begin(), prod.end()))
-        ITFAILS;
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), prod.begin(), prod.end()));
 
       c = x;
       global_min(&c[0], 100);
-      if (!soft_equiv(c.begin(), c.end(), lmin.begin(), lmin.end()))
-        ITFAILS;
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), lmin.begin(), lmin.end()));
 
       c = x;
       global_max(&c[0], 100);
-      if (!soft_equiv(c.begin(), c.end(), lmax.begin(), lmax.end()))
-        ITFAILS;
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), lmax.begin(), lmax.end()));
     }
   }
   { // T = float
@@ -703,6 +703,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
     {
       c = x;
       global_sum(&c[0], 100);
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), sum.begin(), sum.end(), eps));
+
+      c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
       FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), sum.begin(), sum.end(), eps));
 
       c = x;
@@ -747,6 +751,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), sum.begin(), sum.end(), eps));
 
       c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
+      FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), sum.begin(), sum.end(), eps));
+
+      c = x;
       global_prod(&c[0], 100);
       FAIL_IF_NOT(soft_equiv(c.begin(), c.end(), prod.begin(), prod.end(), eps));
 
@@ -784,6 +792,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
     {
       c = x;
       global_sum(&c[0], 100);
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
@@ -827,6 +839,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
       global_prod(&c[0], 100);
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), prod.begin(), prod.end()));
 
@@ -864,6 +880,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
     {
       c = x;
       global_sum(&c[0], 100);
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
@@ -912,6 +932,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
       global_prod(&c[0], 100);
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), prod.begin(), prod.end()));
 
@@ -956,6 +980,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
       global_prod(&c[0], 100);
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), prod.begin(), prod.end()));
 
@@ -996,6 +1024,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
       global_prod(&c[0], 100);
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), prod.begin(), prod.end()));
 
@@ -1033,6 +1065,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
     {
       c = x;
       global_sum(&c[0], 100);
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;
@@ -1078,6 +1114,10 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
     {
       c = x;
       global_sum(&c[0], 100);
+      FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
+
+      c = x;
+      global_sum(&c[0], static_cast<size_t>(100));
       FAIL_IF_NOT(std::equal(c.begin(), c.end(), sum.begin(), sum.end()));
 
       c = x;

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -104,8 +104,8 @@ NDI_Base::NDI_Base(const std::string &dataset_in, const std::string &library_in)
 //================================================================================================//
 
 //! Constructor for generic NDI reader- throws when NDI not available
-NDI_Base::NDI_Base(const std::string & /*gendir_in*/, const std::string & /*dataset_in*/,
-                   const std::string & /*library_in*/) {
+NDI_Base::NDI_Base(const std::string /*gendir_in*/, const std::string /*dataset_in*/,
+                   const std::string /*library_in*/) {
   Insist(0, "NDI default gendir path only available when NDI is found.");
 }
 

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -126,9 +126,9 @@ NDI_Base::NDI_Base(const std::string & /*gendir_in*/, const std::string & /*data
  * \param[in] dataset_in name of requested dataset (provided by inherited class)
  * \param[in] library_in name of requested NDI data library
  */
-NDI_Base::NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
-                   const std::string &library_in)
-    : gendir(gendir_in), dataset(dataset_in), library(library_in) {
+NDI_Base::NDI_Base(const std::string gendir_in, const std::string dataset_in,
+                   const std::string library_in)
+    : gendir(std::move(gendir_in)), dataset(std::move(dataset_in)), library(std::move(library_in)) {
 
   Require(rtt_dsxx::fileExists(gendir));
 

--- a/src/cdi_ndi/NDI_Base.hh
+++ b/src/cdi_ndi/NDI_Base.hh
@@ -53,11 +53,9 @@ protected:
   const std::string library;
 
 protected:
-  //! Constructor
+  //! Constructors
   NDI_Base(const std::string &dataset_in, const std::string &library_in);
-
-  NDI_Base(const std::string &gendir_in, const std::string &dataset_in,
-           const std::string &library_in);
+  NDI_Base(const std::string gendir_in, const std::string dataset_in, const std::string library_in);
 
 public:
   //! Default constructor

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -348,7 +348,7 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &
  * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
  */
 NDI_TNReaction::NDI_TNReaction(const std::string &library_in, const std::string & /*reaction_in*/,
-                               const std::vector<double> /*mg_e_bounds_in*/)
+                               const std::vector<double> & /*mg_e_bounds_in*/)
     : NDI_Base("tn", library_in) { /* ... */
 }
 

--- a/src/cdi_ndi/NDI_TNReaction.cc
+++ b/src/cdi_ndi/NDI_TNReaction.cc
@@ -8,8 +8,8 @@
 //------------------------------------------------------------------------------------------------//
 
 #include "NDI_TNReaction.hh"
-#include "ds++/dbc.hh"
 #include "ds++/Query_Env.hh"
+#include "ds++/dbc.hh"
 #include <array>
 #include <cmath>
 
@@ -39,7 +39,7 @@ NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &
   Require(reaction.length() > 0);
   Require(mg_e_bounds.size() > 0);
 
-  for ( double & eb : mg_e_bounds)
+  for (double &eb : mg_e_bounds)
     eb /= 1000.0; // keV -> MeV
 
   // Check that mg_e_bounds is monotonically decreasing (NDI requirement)
@@ -81,7 +81,7 @@ void NDI_TNReaction::load_ndi() {
   int dataset_handle = -1;
   int ndi_error = -9999;
   constexpr int c_str_len = 4096;
-  std::array<char,c_str_len> c_str_buf;
+  std::array<char, c_str_len> c_str_buf;
 
   // Open gendir file (index of a complete NDI dataset)
   ndi_error = NDI2_open_gendir(&gendir_handle, gendir.c_str());
@@ -333,7 +333,7 @@ std::vector<double> NDI_TNReaction::get_PDF(const int product_zaid,
  * \param[in] mg_e_bounds_in energy boundaries of multigroup bins (keV)
  */
 NDI_TNReaction::NDI_TNReaction(const std::string &gendir_in, const std::string &library_in,
-                               const std::string & /*reaction_in*/,
+                               const std::string /*reaction_in*/,
                                const std::vector<double> /*mg_e_bounds_in*/)
     : NDI_Base(gendir_in, "tn", library_in) { /* ... */
 }

--- a/src/cdi_ndi/NDI_TNReaction.hh
+++ b/src/cdi_ndi/NDI_TNReaction.hh
@@ -34,11 +34,11 @@ class NDI_TNReaction : public NDI_Base {
 public:
   //! Constructor (default gendir path)
   NDI_TNReaction(const std::string &library_in, const std::string &reaction_in,
-                 const std::vector<double> mg_e_bounds_in);
+                 const std::vector<double> &mg_e_bounds_in);
 
   //! Constructor (overridden gendir path)
   NDI_TNReaction(const std::string &gendir_in, const std::string &library_in,
-                 const std::string &reaction_in, const std::vector<double> mg_e_bounds_in);
+                 const std::string reaction_in, const std::vector<double> mg_e_bounds_in);
 
   //! Disable default constructor
   NDI_TNReaction() = delete;

--- a/src/compton_tools/Compton_Native.cc
+++ b/src/compton_tools/Compton_Native.cc
@@ -204,7 +204,7 @@ int Compton_Native::read_binary(const std::string &filename) {
   // (using vector of char to avoid using C-style strings)
   std::array<char, 6> expected = {' ', 'c', 's', 'k', ' ', '\0'};
   std::array<char, 6> actual;
-  for ( char & c : actual )
+  for (char &c : actual)
     fin.read(&c, sizeof(char));
   if (!std::equal(expected.begin(), expected.end(), actual.begin())) {
     std::cerr << "Expecting binary file " << filename << " to start with '";

--- a/src/compton_tools/Compton_Native.cc
+++ b/src/compton_tools/Compton_Native.cc
@@ -8,14 +8,10 @@
 //------------------------------------------------------------------------------------------------//
 
 #include "compton_tools/Compton_Native.hh"
-#include "c4/C4_Functions.hh"
 #include "c4/global.hh"
 #include "ds++/Assert.hh"
-#include <algorithm>
 #include <array>
-#include <cstring>
 #include <fstream>
-#include <iostream>
 
 using UINT64 = uint64_t;
 using FP = double;
@@ -208,8 +204,8 @@ int Compton_Native::read_binary(const std::string &filename) {
   // (using vector of char to avoid using C-style strings)
   std::array<char, 6> expected = {' ', 'c', 's', 'k', ' ', '\0'};
   std::array<char, 6> actual;
-  for (size_t i = 0; i < actual.size(); ++i)
-    fin.read(&actual[i], sizeof(actual[i]));
+  for ( char & c : actual )
+    fin.read(&c, sizeof(char));
   if (!std::equal(expected.begin(), expected.end(), actual.begin())) {
     std::cerr << "Expecting binary file " << filename << " to start with '";
     for (char c : expected)

--- a/src/ds++/DracoStrings.cc
+++ b/src/ds++/DracoStrings.cc
@@ -83,12 +83,13 @@ template <> auto parse_number_impl<double>(std::string const &str) -> double {
  * \return A new, probably shortened, string without unwanted leading/training characters.
  */
 std::string trim(std::string const &str, std::string const &whitespace) {
-  auto const strBegin = str.find_first_not_of(whitespace);
+  std::string retval(str.data()); // prune at first '\0' if str is a c-string.
+  auto const strBegin = retval.find_first_not_of(whitespace);
   if (strBegin == std::string::npos)
     return ""; // no content
-  auto const strEnd = str.find_last_not_of(whitespace);
+  auto const strEnd = retval.find_last_not_of(whitespace);
   auto const strRange = strEnd - strBegin + 1;
-  return str.substr(strBegin, strRange);
+  return retval.substr(strBegin, strRange);
 }
 
 //------------------------------------------------------------------------------------------------//

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -51,8 +51,7 @@ std::string string_toupper(std::string const &string_in);
  * \param[in] precision How many digits will be preserved? (default: 23)
  * \return A string representation of the numeric value
  *
- * \tparam T type of number that will be converted to a string. Typically a
- *           double or int.
+ * \tparam T type of number that will be converted to a string. Typically a double or int.
  *
  * \sa http://public.research.att.com/~bs/bs_faq2.html
  */
@@ -65,7 +64,7 @@ template <typename T> std::string to_string(T const num, unsigned int const prec
 
 //------------------------------------------------------------------------------------------------//
 //! trim whitespace (or other characters) from before and after main text.
-std::string trim(std::string const &str, std::string const &whitespace = " \t");
+std::string trim(std::string const &str, std::string const &whitespace = " \t\n");
 
 //------------------------------------------------------------------------------------------------//
 /*!
@@ -236,11 +235,10 @@ std::string remove_color(std::string const &colored_string);
  * \param[in] digits number of version digits to print. Default = 3.
  * \return The version as a substring.
  *
- * Ex: Given the string "/ccs/opt/vendors-ec/ndi/2.1.3/share/gendir.all", return
- * "2.1.3".
+ * Ex: Given the string "/ccs/opt/vendors-ec/ndi/2.1.3/share/gendir.all", return "2.1.3".
  *
- * A version includes any integers separated by a period.  A text postfix
- * 'alpha' or 'beta' is also supported for any portion of the version string.
+ * A version includes any integers separated by a period.  A text postfix 'alpha' or 'beta' is also
+ * supported for any portion of the version string.
  */
 std::string extract_version(std::string const &string_in, size_t digits = 3);
 

--- a/src/ds++/test/tstDracoStrings.cc
+++ b/src/ds++/test/tstDracoStrings.cc
@@ -12,6 +12,7 @@
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "ds++/Soft_Equivalence.hh"
+#include <array>
 
 using namespace std;
 using namespace rtt_dsxx;
@@ -32,6 +33,20 @@ void test_trim(UnitTest &ut) {
 
   string const case3("#  This is a string.  ");
   FAIL_IF_NOT(trim(case3, string("# ")) == string("This is a string."));
+
+  string const case4("This is a string.\0\0\0\0\1\0        ");
+  FAIL_IF_NOT(case4.length() == case2.length());
+  FAIL_IF_NOT(trim(case4) == string("This is a string."));
+
+  // tests that use std::array source data.
+  std::array<char, 20> case5arr = {'T', 'h', 'i', 's', ' ', 'i', 's', ' ',  'a',  ' ',
+                                   's', 't', 'r', 'i', 'n', 'g', '.', '\0', '\1', 'x'};
+  string const case5(case5arr.data()); // this ctor should prune '\0' and following chars.
+  FAIL_IF_NOT(case5.length() == case2.length());
+
+  string const case6(case5arr.data(), case5arr.size()); // keeps all 20 chars.
+  FAIL_IF_NOT(case6.length() == case5arr.size());
+  FAIL_IF_NOT(trim(case6) == string("This is a string."));
 
   if (ut.numFails == 0)
     PASSMSG("test_trim: All tests pass.");


### PR DESCRIPTION
### Background

+ This started out as a fix to some code flagged by clang-tidy.  I ended up changing additional code as a result.  All changes are minor and should not change behavior (minus a bug fix for `trim`).

### Description of changes

+ Add an overload of `global_sum` that takes a `size_t` as the array size.  This eliminates the need to downcast `size_type` to an `int`. Provide unit tests of this overload.
+ The `trim` function in `DracoStrings` had a minor deficiency that needed to be accounted for.  Previously, if the string passed to this function was a c-style string with null termination, the string was not trimmed correctly. Unit tests were added to check the new functionality.
+ `Compton_Native.cc` was updated to use a range-based for-loop.
+ `cdi_ndi` was updated with these fixes:
  - use `std::move` in constructors instead of `string const &`.
  - Use range-based for-loops when possible.
  - Use delegated constructor syntax to eliminate duplicate code.
  - Use `std::array` instead of c-style arrays.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
