### PR TITLE
Provide an alternate implementation for global_sum

### DIFF
--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -351,9 +351,13 @@ template <typename T> void global_max(T &x);
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Do an element-wise, global sum of an array.
+ * 
+ * Only instantiate this function for types L that are integral. Details of this pattern are at
+ * https://en.cppreference.com/w/cpp/types/enable_if.
  */
-template <typename T, typename L>
-void global_sum(T *x, L n, typename std::enable_if<std::is_integral<L>::value, L>::type * = 0);
+template <typename T, typename L,
+          typename std::enable_if<std::is_integral<L>::value, bool>::type = true>
+void global_sum(T *x, L n);
 
 //------------------------------------------------------------------------------------------------//
 /*!

--- a/src/c4/C4_MPI.i.hh
+++ b/src/c4/C4_MPI.i.hh
@@ -17,9 +17,8 @@
 namespace rtt_c4 {
 
 //------------------------------------------------------------------------------------------------//
-
-template <typename T, typename L>
-void global_sum(T *x, L n, typename std::enable_if<std::is_integral<L>::value, L>::type *) {
+template <typename T, typename L, typename std::enable_if<std::is_integral<L>::value, bool>::type>
+void global_sum(T *x, L n) {
   Require(x != nullptr);
   Require(n > 0);
   Require(n < INT32_MAX);

--- a/src/c4/C4_Serial.hh
+++ b/src/c4/C4_Serial.hh
@@ -42,9 +42,8 @@ int create_vector_type(unsigned /*count*/, unsigned /*blocklength*/, unsigned /*
 // Global_<Op> functions
 //------------------------------------------------------------------------------------------------//
 
-template <typename T, typename L>
-void global_sum(T * /*x*/, L /*n*/,
-                typename std::enable_if<std::is_integral<L>::value, L>::type *) {
+template <typename T, typename L, typename std::enable_if<std::is_integral<L>::value, bool>::type>
+void global_sum(T * /*x*/, L /*n*/) {
   return;
 }
 


### PR DESCRIPTION
### Background

+ This approach is a little easier to parse the the previous solution merged in #979.
+ Also fixes 3 clang-tidy issues.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
