### PR TITLE
Update gcc compile flags

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -37,11 +37,6 @@ include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 # arm --> -mcpu=thunderx2t99 ??? Darwin volta nodes?
 check_c_compiler_flag(   "-march=native" HAS_MARCH_NATIVE )
-if( DEFINED CMAKE_CXX_COMPILER_ID )
-  check_cxx_compiler_flag( "-Wnoexcept"    HAS_WNOEXCEPT )
-  check_cxx_compiler_flag( "-Wsuggest-attribute=const" HAS_WSUGGEST_ATTRIBUTE )
-  check_cxx_compiler_flag( "-Wunused-local-typedefs" HAS_WUNUSED_LOCAL_TYPEDEFS )
-endif()
 
 #
 # Compiler Flags
@@ -68,7 +63,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   string(APPEND CMAKE_C_FLAGS " -Wcast-align -Wpointer-arith -Wall -pedantic -Wfloat-equal"
     " -Wunused-macros -fsanitize=bounds-strict -Wshadow -Wformat=2")
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
-    string( APPEND CMAKE_C_FLAGS " -Wno-expansion-to-defined -Wnarrowing" )
+    string( APPEND CMAKE_C_FLAGS " -Wno-expansion-to-defined -Wnarrowing -Wnull-dereference" )
   endif()
   string( CONCAT CMAKE_C_FLAGS_DEBUG "-g -fno-inline -fno-eliminate-unused-debug-types -O0 -Wextra"
     " -Wundef -Wunreachable-code -DDEBUG")
@@ -109,12 +104,6 @@ if( NOT CXX_FLAGS_INITIALIZED )
     # string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=leak")
     # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
   endif()
-  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 )
-    # See https://gcc.gnu.org/gcc-6/changes.html
-    # -fsanitize=bounds-strict, which enables strict checking of array bounds. In particular, it
-    #            enables -fsanitize=bounds as well as instrumentation of flexible array member-like
-    #            arrays.
-  endif()
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
     # See https://gcc.gnu.org/gcc-7/changes.html
     # -fsanitize-address-use-after-scope: sanitation of variables whose address is taken and used
@@ -124,14 +113,6 @@ if( NOT CXX_FLAGS_INITIALIZED )
     if( NOT DEFINED ENV{TRAVIS} )
       string( APPEND CMAKE_C_FLAGS_DEBUG " -fsanitize=signed-integer-overflow")
     endif()
-  endif()
-  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0 )
-    # See https://gcc.gnu.org/gcc-8/changes.html
-    # -fsanitize=pointer-compare warn about subtraction (or comparison) of pointers that point to a
-    #                  different memory object.
-    # -fsanitize=pointer-subtract
-    string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wold-style-cast")
-    string( APPEND CMAKE_CXX_FLAGS_DEBUG " -fdiagnostics-show-template-tree")
   endif()
 
   # Systems running CrayPE use compile wrappers to specify this option.
@@ -151,14 +132,12 @@ if( NOT CXX_FLAGS_INITIALIZED )
   set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
 
-  # Extra Debug flags that only exist in newer gcc versions.
-  if( HAS_WNOEXCEPT )
-    string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wnoexcept" )
-  endif()
-  if( HAS_WSUGGEST_ATTRIBUTE )
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0 )
+    # See https://gcc.gnu.org/gcc-8/changes.html
+    string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wold-style-cast -Wnon-virtual-dtor -Wuseless-cast")
+    string( APPEND CMAKE_CXX_FLAGS_DEBUG " -fdiagnostics-show-template-tree")
+    string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wnoexcept")
     string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wsuggest-attribute=const" )
-  endif()
-  if( HAS_WUNUSED_LOCAL_TYPEDEFS )
     string( APPEND CMAKE_CXX_FLAGS_DEBUG " -Wunused-local-typedefs" )
   endif()
 

--- a/src/RTT_Format_Reader/CellDataIDs.cc
+++ b/src/RTT_Format_Reader/CellDataIDs.cc
@@ -39,7 +39,7 @@ void CellDataIDs::readData(ifstream &meshfile) {
   int dataIDNum;
   string dummyString;
 
-  for (size_t i = 0; i < static_cast<size_t>(dims.get_ncell_data()); ++i) {
+  for (size_t i = 0; i < dims.get_ncell_data(); ++i) {
     Check(i < names.size() && i < units.size());
     meshfile >> dataIDNum >> names[i] >> units[i];
     Insist(static_cast<size_t>(dataIDNum) == i + 1, "Invalid mesh file: cell data ID out of order");

--- a/src/RTT_Format_Reader/CellFlags.cc
+++ b/src/RTT_Format_Reader/CellFlags.cc
@@ -44,7 +44,7 @@ void CellFlags::readFlagTypes(ifstream &meshfile) {
   int flagTypeNum;
   string dummyString;
 
-  for (size_t i = 0; i < static_cast<size_t>(dims.get_ncell_flag_types()); ++i) {
+  for (size_t i = 0; i < dims.get_ncell_flag_types(); ++i) {
     meshfile >> flagTypeNum >> dummyString;
     Insist(static_cast<size_t>(flagTypeNum) == i + 1,
            "Invalid mesh file: cell flag type out of order");

--- a/src/RTT_Format_Reader/Cells.cc
+++ b/src/RTT_Format_Reader/Cells.cc
@@ -44,7 +44,7 @@ void Cells::readData(ifstream &meshfile) {
   string dummyString;
   int cellNum;
 
-  for (size_t i = 0; i < static_cast<size_t>(dims.get_ncells()); ++i) {
+  for (size_t i = 0; i < dims.get_ncells(); ++i) {
     cellNum = Nodes::readNextInt(meshfile);
     // meshfile >> cellNum;
     Insist(static_cast<size_t>(cellNum) == i + 1, "Invalid mesh file: cell index out of order");
@@ -60,7 +60,7 @@ void Cells::readData(ifstream &meshfile) {
       --nodes[i][j];
     }
 
-    for (size_t j = 0; j < static_cast<size_t>(dims.get_ncell_flag_types()); ++j) {
+    for (size_t j = 0; j < dims.get_ncell_flag_types(); ++j) {
       Check(j < flags[i].size());
       meshfile >> flags[i][j];
       Check(j < INT_MAX);

--- a/src/RTT_Format_Reader/NodeDataIDs.cc
+++ b/src/RTT_Format_Reader/NodeDataIDs.cc
@@ -39,7 +39,7 @@ void NodeDataIDs::readData(ifstream &meshfile) {
   int dataIDNum;
   string dummyString;
 
-  for (size_t i = 0; i < static_cast<size_t>(dims.get_nnode_data()); ++i) {
+  for (size_t i = 0; i < dims.get_nnode_data(); ++i) {
     Check(i < names.size() && i < units.size());
     meshfile >> dataIDNum >> names[i] >> units[i];
     Insist(static_cast<size_t>(dataIDNum) == i + 1, "Invalid mesh file: node data ID out of order");

--- a/src/RTT_Format_Reader/NodeFlags.cc
+++ b/src/RTT_Format_Reader/NodeFlags.cc
@@ -44,7 +44,7 @@ void NodeFlags::readFlagTypes(ifstream &meshfile) {
   int flagTypeNum;
   string dummyString;
 
-  for (size_t i = 0; i < static_cast<size_t>(dims.get_nnode_flag_types()); ++i) {
+  for (size_t i = 0; i < dims.get_nnode_flag_types(); ++i) {
     meshfile >> flagTypeNum >> dummyString;
     Insist(static_cast<size_t>(flagTypeNum) == i + 1,
            "Invalid mesh file: node flag type out of order");

--- a/src/RTT_Format_Reader/Nodes.cc
+++ b/src/RTT_Format_Reader/Nodes.cc
@@ -69,12 +69,12 @@ void Nodes::readData(ifstream &meshfile) {
   string dummyString;
   int nodeNum;
 
-  for (size_t i = 0; i < static_cast<size_t>(dims.get_nnodes()); ++i) {
+  for (size_t i = 0; i < dims.get_nnodes(); ++i) {
     nodeNum = readNextInt(meshfile);
     // meshfile >> nodeNum;
     Insist(static_cast<size_t>(nodeNum) == i + 1, "Invalid mesh file: node index out of order");
     Check(i < coords.size());
-    for (size_t j = 0; j < static_cast<size_t>(dims.get_ndim()); ++j) {
+    for (size_t j = 0; j < dims.get_ndim(); ++j) {
       Check(j < coords[i].size());
       meshfile >> coords[i][j];
     }
@@ -82,7 +82,7 @@ void Nodes::readData(ifstream &meshfile) {
     meshfile >> parents[i];
     --parents[i];
     Check(i < flags.size());
-    for (size_t j = 0; j < static_cast<size_t>(dims.get_nnode_flag_types()); ++j) {
+    for (size_t j = 0; j < dims.get_nnode_flag_types(); ++j) {
       Check(j < flags[i].size());
       meshfile >> flags[i][j];
       Check(j < INT_MAX);

--- a/src/RTT_Format_Reader/test/TestRTTFormatReader.cc
+++ b/src/RTT_Format_Reader/test/TestRTTFormatReader.cc
@@ -573,7 +573,7 @@ bool check_side_flags(RTT_Format_Reader const &mesh, Meshes const &meshtype, Uni
   // Check number of flags for each side flag type.
   bool got_side_flag_size = true;
   for (size_t i = 0; i < mesh.get_dims_nside_flag_types(); i++) {
-    if (flag_num_name[i].size() != static_cast<size_t>(mesh.get_side_flags_flag_size(i)))
+    if (flag_num_name[i].size() != mesh.get_side_flags_flag_size(i))
       got_side_flag_size = false;
   }
   if (!got_side_flag_size) {

--- a/src/RTT_Format_Reader/test/TestRTTPolyhedron.cc
+++ b/src/RTT_Format_Reader/test/TestRTTPolyhedron.cc
@@ -29,7 +29,7 @@ public:
    *         otherwise.
    */
   bool operator()(Element_Definition::Element_Type const type) {
-    return (static_cast<unsigned>(Element_Definition(type).get_dimension()) == dimensionality);
+    return (Element_Definition(type).get_dimension() == dimensionality);
   }
 
 private:

--- a/src/c4/scatterv.t.hh
+++ b/src/c4/scatterv.t.hh
@@ -79,7 +79,7 @@ void indeterminate_scatterv(vector<vector<T>> &outgoing_data, vector<T> &incomin
 //------------------------------------------------------------------------------------------------//
 template <typename T>
 void determinate_scatterv(vector<vector<T>> &outgoing_data, vector<T> &incoming_data) {
-  Require(outgoing_data.size() == rtt_c4::ranks());
+  Require(outgoing_data.size() == rtt_c4::nranks());
 
 #ifdef C4_MPI
   { // This block is a no-op for with-c4=scalar

--- a/src/c4/scatterv.t.hh
+++ b/src/c4/scatterv.t.hh
@@ -79,7 +79,7 @@ void indeterminate_scatterv(vector<vector<T>> &outgoing_data, vector<T> &incomin
 //------------------------------------------------------------------------------------------------//
 template <typename T>
 void determinate_scatterv(vector<vector<T>> &outgoing_data, vector<T> &incoming_data) {
-  Require(static_cast<int>(outgoing_data.size()) == rtt_c4::nodes());
+  Require(outgoing_data.size() == rtt_c4::ranks());
 
 #ifdef C4_MPI
   { // This block is a no-op for with-c4=scalar
@@ -96,7 +96,7 @@ void determinate_scatterv(vector<vector<T>> &outgoing_data, vector<T> &incoming_
         displs[p] = total_count;
         total_count += n;
       }
-      int count = counts[0];
+      int const count = counts.size() > 0 ? counts[0] : 0;
       Check(static_cast<int>(incoming_data.size()) == count);
 
       vector<T> sendbuf(total_count);
@@ -107,7 +107,7 @@ void determinate_scatterv(vector<vector<T>> &outgoing_data, vector<T> &incoming_
                        (incoming_data.size() > 0 ? &incoming_data[0] : nullptr), count);
     } else {
       Check(incoming_data.size() < INT_MAX);
-      auto count = static_cast<int>(incoming_data.size());
+      auto const count = static_cast<int>(incoming_data.size());
       rtt_c4::scatterv(static_cast<T *>(nullptr), static_cast<int *>(nullptr),
                        static_cast<int *>(nullptr), &incoming_data[0], count);
     }

--- a/src/c4/test/tstReduction.cc
+++ b/src/c4/test/tstReduction.cc
@@ -778,13 +778,13 @@ void array_reduction(rtt_dsxx::UnitTest &ut) {
 
     // fill it
     for (int i = 0; i < 100; i++) {
-      x[i] = static_cast<int>(rtt_c4::node()) + 1;
+      x[i] = rtt_c4::node() + 1;
       for (int j = 0; j < rtt_c4::nodes(); j++) {
-        sum[i] += (static_cast<int>(j) + 1);
-        prod[i] *= (static_cast<int>(j) + 1);
+        sum[i] += (j + 1);
+        prod[i] *= (j + 1);
       }
       lmin[i] = 1;
-      lmax[i] = static_cast<int>(rtt_c4::nodes());
+      lmax[i] = rtt_c4::nodes();
     }
 
     vector<int> c;

--- a/src/c4/test/tstsend_is.cc
+++ b/src/c4/test/tstsend_is.cc
@@ -4,8 +4,7 @@
  * \author Kelly Thompson
  * \date   Friday, Dec 07, 2012, 14:02 pm
  * \brief  Unit tests for rtt_c4::send_is()
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "c4/ParallelUnitTest.hh"
@@ -21,8 +20,7 @@ using rtt_dsxx::soft_equiv;
 // TESTS
 //------------------------------------------------------------------------------------------------//
 
-// This is a simple class that has a static MPI type and a method to commit that
-// type
+// This is a simple class that has a static MPI type and a method to commit that type
 class Custom {
 
 public:
@@ -74,8 +72,8 @@ public:
     // Commit the type to MPI so it recognizes it in communication calls
     MPI_Type_commit(&og_MPI_Custom);
 
-    // Duplicate the type so it's recognized when returned out of this context
-    // (I don't know why this is necessary)
+    // Duplicate the type so it's recognized when returned out of this context (I don't know why
+    // this is necessary)
     MPI_Type_dup(og_MPI_Custom, &MPI_Type);
   }
 #endif
@@ -116,8 +114,7 @@ void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
     rtt_c4::C4_Req *const comm(nullptr);
     const unsigned count(0);
 
-    // No actual messages to send -- verify that wait_all and
-    // wait_all_with_source correctly return.
+    // No actual messages to send -- verify that wait_all and wait_all_with_source correctly return.
     bool zerocount_failed = false;
 
     // result output from source version of wait_all:
@@ -151,9 +148,8 @@ void test_zerocount_and_inactive(rtt_dsxx::UnitTest &ut) {
     // Result from wait_all_with_source call
     std::vector<int> result;
 
-    // Test a null op -- I didn't actually send anything, so the MPI requests
-    // should be set to MPI_REQUEST_NULL and the wait_all should return
-    // immediately,
+    // Test a null op -- I didn't actually send anything, so the MPI requests should be set to
+    // MPI_REQUEST_NULL and the wait_all should return immediately,
     bool nullreq_failed = false;
     try {
       wait_all(static_cast<unsigned>(comm.size()), &comm[0]);
@@ -228,9 +224,8 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       FAIL_IF_NOT(sources.size() == 2);
       // First comm is receive from rank "left":
       FAIL_IF_NOT(sources[0] == left);
-      // NOTE: KPL: the value of MPI_SOURCE for a send
-      // operation does not appear to be set in all implementations, so we don't check
-      // the value for the send operation.
+      // NOTE: KPL: the value of MPI_SOURCE for a send operation does not appear to be set in all
+      // implementations, so we don't check the value for the send operation.
 
       // expected results
       vector<int> expected(bsize);
@@ -249,8 +244,8 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<int>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<int>() in a "
+              "C4_SCALAR build.");
 #else
       FAILMSG("Encountered a ds++ exception while testing send_is<int>().");
 #endif
@@ -270,7 +265,7 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
     vector<double> buffer2(bsize);
     vector<double> buffer1(bsize);
     for (unsigned i = 0; i < bsize; ++i) {
-      buffer1[i] = static_cast<double>(1000.0 * pid + i);
+      buffer1[i] = 1000.0 * pid + i;
     }
 
     // post asynchronous receives.
@@ -299,8 +294,8 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<double>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<double>() in a "
+              "C4_SCALAR build.");
 #else
       FAILMSG("Encountered a ds++ exception while testing send_is<double>().");
 #endif
@@ -350,8 +345,8 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<float>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<float>() in a "
+              "C4_SCALAR build.");
 #else
       FAILMSG("Encountered a ds++ exception while testing send_is<float>().");
 #endif
@@ -421,7 +416,7 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
     vector<unsigned int> buffer2(bsize);
     vector<unsigned int> buffer1(bsize);
     for (unsigned i = 0; i < bsize; ++i) {
-      buffer1[i] = static_cast<unsigned int>(1000 * pid + i);
+      buffer1[i] = 1000 * pid + i;
     }
 
     // post asynchronous receives.
@@ -445,18 +440,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected unsigned int data after send_is() on "
-               "node "
-            << pid << ".";
+        msg << "Did not find expected unsigned int data after send_is() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<unsigned int>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<unsigned int>() in "
+              "a C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "int>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned int>().");
 #endif
     }
   }
@@ -486,11 +478,18 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       // wait for all communication to finish
       rtt_c4::wait_all(static_cast<unsigned>(comm.size()), &comm[0]);
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
       // expected results
       vector<unsigned long> expected(bsize);
       for (size_t i = 0; i < bsize; ++i) {
         expected[i] = static_cast<unsigned long>(1000 * left + i);
       }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
       if (std::equal(expected.begin(), expected.end(), buffer2.begin(), buffer2.end())) {
         ostringstream msg;
@@ -498,9 +497,7 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected unsigned long data after send_is() on "
-               "node "
-            << pid << ".";
+        msg << "Did not find expected unsigned long data after send_is() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
@@ -508,8 +505,7 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       PASSMSG("Successfully caught a ds++ exception while trying to use "
               "send_is<unsigned long>() in a C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "long>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned long>().");
 #endif
     }
   }
@@ -551,18 +547,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected unsigned short data after send_is() on "
-               "node "
-            << pid << ".";
+        msg << "Did not find expected unsigned short data after send_is() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<unsigned short>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<unsigned short>() "
+              "in a C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "long>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned long>().");
 #endif
     }
   }
@@ -604,17 +597,16 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected unsigned long long data after send_is() "
-            << "on node " << pid << ".";
+        msg << "Did not find expected unsigned long long data after send_is() on node " << pid
+            << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<unsigned long long>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<unsigned long "
+              "long>() in a C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "long>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned long>().");
 #endif
     }
   }
@@ -655,17 +647,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected long data after send_is() "
-            << "on node " << pid << ".";
+        msg << "Did not find expected long data after send_is() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<long>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<long>() in a "
+              "C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "long>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned long>().");
 #endif
     }
   }
@@ -706,17 +696,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected short data after send_is() "
-            << "on node " << pid << ".";
+        msg << "Did not find expected short data after send_is() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<short>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<short>() in a "
+              "C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "short>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned short>().");
 #endif
     }
   }
@@ -758,17 +746,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected long long data after send_is() "
-            << "on node " << pid << ".";
+        msg << "Did not find expected long long data after send_is() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<long long>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<long long>() in a "
+              "C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "long long>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned long long>().");
 #endif
     }
   }
@@ -810,17 +796,15 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected bool data after send_is<bool>() "
-            << "on node " << pid << ".";
+        msg << "Did not find expected bool data after send_is<bool>() on node " << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<bool>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<bool>() in a "
+              "C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned "
-              "bool>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned bool>().");
 #endif
     }
   }
@@ -873,8 +857,7 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
       PASSMSG("Successfully caught a ds++ exception while trying to use "
               "send_is<char>() in a C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<"
-              "char>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<char>().");
 #endif
     }
   }
@@ -915,23 +898,21 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
 
       if (std::equal(expected.begin(), expected.end(), buffer2.begin(), buffer2.end())) {
         ostringstream msg;
-        msg << "Expected unsigned char data found after send_is<unsigned "
-            << "char>() on node " << pid << ".";
+        msg << "Expected unsigned char data found after send_is<unsigned char>() on node " << pid
+            << ".";
         PASSMSG(msg.str());
       } else {
         ostringstream msg;
-        msg << "Did not find expected unsigned char data after "
-               "send_is<unsigned char>() on node "
+        msg << "Did not find expected unsigned char data after send_is<unsigned char>() on node "
             << pid << ".";
         FAILMSG(msg.str());
       }
     } catch (rtt_dsxx::assertion const & /*error*/) {
 #ifdef C4_SCALAR
-      PASSMSG("Successfully caught a ds++ exception while trying to use "
-              "send_is<unsigned char>() in a C4_SCALAR build.");
+      PASSMSG("Successfully caught a ds++ exception while trying to use send_is<unsigned char>() "
+              "in a C4_SCALAR build.");
 #else
-      FAILMSG("Encountered a ds++ exception while testing send_is<"
-              "unsigned char>().");
+      FAILMSG("Encountered a ds++ exception while testing send_is<unsigned char>().");
 #endif
     }
   }
@@ -944,10 +925,9 @@ void test_simple(rtt_dsxx::UnitTest &ut) {
 void test_send_custom(rtt_dsxx::UnitTest &ut) {
   // borrowed from http://mpi.deino.net/mpi_functions/MPI_Issend.html.
 
-  // commit the MPI type for the Custom class. This must be done before
-  // send_is_custom is called. DMC checks will throw if the type has not been
-  // committed because size comparison will fail and MPI throws an error when an
-  // uncommitted type is used in a send/receive
+  // commit the MPI type for the Custom class. This must be done before send_is_custom is called.
+  // DMC checks will throw if the type has not been committed because size comparison will fail and
+  // MPI throws an error when an uncommitted type is used in a send/receive
   Custom::commit_mpi_type();
 
 #ifdef C4_SCALAR
@@ -971,8 +951,7 @@ void test_send_custom(rtt_dsxx::UnitTest &ut) {
 
 #ifndef __clang_analyzer__
 
-  // for point-to-point communication we need to know neighbor's identifiers:
-  // left, right.
+  // for point-to-point communication we need to know neighbor's identifiers: left, right.
   int right = (rtt_c4::node() + 1) % rtt_c4::nodes();
   int left = rtt_c4::node() - 1;
   if (left < 0)
@@ -987,8 +966,8 @@ void test_send_custom(rtt_dsxx::UnitTest &ut) {
 
   try {
 
-    // send data using non-blocking synchronous send. Custom sends check to make
-    // sure that the type, T is the same size as its MPI type
+    // send data using non-blocking synchronous send. Custom sends check to make sure that the type,
+    // T is the same size as its MPI type
     rtt_c4::send_is_custom(comm_int[1], &my_custom_object, 1, right, Custom::mpi_tag);
 
     // make status object to get the size of the received buffer
@@ -1034,8 +1013,7 @@ void test_send_custom(rtt_dsxx::UnitTest &ut) {
   }
 #endif
 
-  // do the send receive again with a blocking version of custom sends and
-  // receives
+  // do the send receive again with a blocking version of custom sends and receives
 
   // create some data to send/receive
 #ifndef __clang_analyzer__
@@ -1050,9 +1028,8 @@ void test_send_custom(rtt_dsxx::UnitTest &ut) {
 #endif
 
   if (rtt_c4::nodes() > 1) {
-    // send data using blocking synchronous send. Custom sends check to make
-    // sure that the type, T is the same size as its MPI type. Odd ranks send
-    // first
+    // send data using blocking synchronous send. Custom sends check to make sure that the type, T
+    // is the same size as its MPI type. Odd ranks send first
     int recv_size = -1;
     if (rtt_c4::node() % 2) {
       rtt_c4::send_custom(&my_custom_object_block, 1, right, Custom::mpi_tag);

--- a/src/cdi_ipcress/IpcressFile.cc
+++ b/src/cdi_ipcress/IpcressFile.cc
@@ -102,8 +102,7 @@ IpcressFile::IpcressFile(const std::string &ipcressDataFilename)
   //
   // read a list of materials from the file:
   // - dfo[0] contains the number of materials.
-  // - the memory block {dfo[1] ... dfo[0]+ds[0]} holds a list of material
-  //   numbers.
+  // - the memory block {dfo[1] ... dfo[0]+ds[0]} holds a list of material numbers.
   //
 
   byte_offset = ipcress_word_size * dfo[0];
@@ -111,9 +110,8 @@ IpcressFile::IpcressFile(const std::string &ipcressDataFilename)
   read_v(byte_offset, vdata);
   size_t nummat = vdata[0];
 
-  // Consistency check.  ds[0] is the total reserved space in the file for
-  // material IDs.
-  Check(nummat < static_cast<size_t>(ds[0]));
+  // Consistency check.  ds[0] is the total reserved space in the file for material IDs.
+  Check(nummat < ds[0]);
 
   // Resize the list of material IDs.
   this->matIDs.resize(nummat);

--- a/src/compton_tools/Compton_Native.cc
+++ b/src/compton_tools/Compton_Native.cc
@@ -234,13 +234,13 @@ int Compton_Native::read_binary(const std::string &filename) {
   for (size_t i = 0; i < n; ++i)
     fin.read(reinterpret_cast<char *>(&szs[i]), sizeof(szs[i]));
   size_t j = 0;
-  auto tsz = static_cast<size_t>(szs[j++]);
-  auto gsz = static_cast<size_t>(szs[j++]);
-  auto lsz = static_cast<size_t>(szs[j++]);
-  auto esz = static_cast<size_t>(szs[j++]);
-  auto fgsz = static_cast<size_t>(szs[j++]);
-  auto isz = static_cast<size_t>(szs[j++]);
-  auto dsz = static_cast<size_t>(szs[j++]);
+  size_t tsz = szs[j++];
+  size_t gsz = szs[j++];
+  size_t lsz = szs[j++];
+  size_t esz = szs[j++];
+  size_t fgsz = szs[j++];
+  size_t isz = szs[j++];
+  size_t dsz = szs[j++];
 
   num_temperatures_ = tsz;
   num_groups_ = gsz;
@@ -267,14 +267,14 @@ int Compton_Native::read_binary(const std::string &filename) {
     // Convert from FP (type in the binary file) to double
     FP tmp;
     fin.read(reinterpret_cast<char *>(&tmp), sizeof(FP));
-    Ts_[i] = static_cast<double>(tmp);
+    Ts_[i] = tmp;
   }
 
   Egs_.resize(egsz);
   for (size_t i = 0; i < egsz; ++i) {
     FP tmp;
     fin.read(reinterpret_cast<char *>(&tmp), sizeof(FP));
-    Egs_[i] = static_cast<double>(tmp);
+    Egs_[i] = tmp;
   }
 
   first_groups_.resize(fgsz);
@@ -282,28 +282,28 @@ int Compton_Native::read_binary(const std::string &filename) {
     // Convert from UINT (type in binary file) to size_t
     UINT64 tmp;
     fin.read(reinterpret_cast<char *>(&tmp), sizeof(UINT64));
-    first_groups_[i] = static_cast<size_t>(tmp);
+    first_groups_[i] = tmp;
   }
 
   indexes_.resize(isz);
   for (size_t i = 0; i < isz; ++i) {
     UINT64 tmp;
     fin.read(reinterpret_cast<char *>(&tmp), sizeof(UINT64));
-    indexes_[i] = static_cast<size_t>(tmp);
+    indexes_[i] = tmp;
   }
 
   data_.resize(dsz);
   for (size_t i = 0; i < dsz; ++i) {
     FP tmp;
     fin.read(reinterpret_cast<char *>(&tmp), sizeof(FP));
-    data_[i] = static_cast<double>(tmp);
+    data_[i] = tmp;
   }
 
   derivs_.resize(dsz);
   for (size_t i = 0; i < dsz; ++i) {
     FP tmp;
     fin.read(reinterpret_cast<char *>(&tmp), sizeof(FP));
-    derivs_[i] = static_cast<double>(tmp);
+    derivs_[i] = tmp;
   }
 
   fin.close();

--- a/src/compton_tools/Compton_Native.hh
+++ b/src/compton_tools/Compton_Native.hh
@@ -19,7 +19,7 @@ namespace rtt_compton_tools {
 
 enum class Eval : size_t { in_lin = 0, out_nonlin = 1, nl_diff = 2 };
 
-//------------------------------------------------------------------------------------------------//
+//================================================================================================//
 /*!
  * \class Compton_Native
  *
@@ -38,8 +38,7 @@ enum class Eval : size_t { in_lin = 0, out_nonlin = 1, nl_diff = 2 };
  * This unit test demonstrates the method for constructing a Compton object, and exercises all
  * routines for interpolation and data access.
 */
-
-//------------------------------------------------------------------------------------------------//
+//================================================================================================//
 class Compton_Native {
 
 public:
@@ -54,20 +53,19 @@ public:
   // TEMPERATURE INTERPOLATION FUNCTIONS
   //----------------------------------------------------------------------------------------------//
 
-  // Interpolate csk data in temperature for the linear inscattering and return a flattened dense
-  // matrix with ordering (slowest) [legendre moment, group to, group from] (fastest). Must specify
+  // Interpolate CSK data in temperature for the linear inscattering and return a flattened dense
+  // matrix with ordering (slowest) [Legendre moment, group to, group from] (fastest). Must specify
   // the largest desired Legendre moment.
   void interp_dense_inscat(std::vector<double> &inscat, double Te_keV,
                            size_t num_moments_truncate) const;
 
-  // Interpolate csk data in temperature for the linear outscattering
-  // and sum over outgoing group to return a vector with index [group from].
-  // outscat must be pre-sized to the number of groups.
+  // Interpolate CSK data in temperature for the linear outscattering and sum over outgoing group to
+  // return a vector with index [group from]. \c outscat must be pre-sized to the number of groups.
   void interp_linear_outscat(std::vector<double> &outscat, double Te_keV) const;
 
-  // Adds the nonlinear difference to the outscat vector phi is a group-sized vector for the scalar
-  // radiation intensity when the radiation is in equilibrium, sum_g phi_g = scale outscat must be
-  // pre-sized and pre-filled with the outscat data by calling interp_linear_outscat
+  // Adds the nonlinear difference to the \c outscat vector phi is a group-sized vector for the
+  // scalar radiation intensity when the radiation is in equilibrium, sum_g phi_g = scale \c outscat
+  // must be pre-sized and pre-filled with the \c outscat data by calling interp_linear_outscat
   void interp_nonlin_diff_and_add(std::vector<double> &outscat, double Te_keV,
                                   const std::vector<double> &phi, double scale) const;
 
@@ -163,19 +161,19 @@ private:
   // PRIVATE DATA
   //----------------------------------------------------------------------------------------------//
 
-  size_t num_temperatures_{0U}; //<! Number of temperature evaluations for csk data
-  size_t num_groups_{0U};       //<! Number of energy groups for csk data
-  size_t num_leg_moments_{0U};  //<! Number of Legendre moments for csk data
+  size_t num_temperatures_{0U}; //<! Number of temperature evaluations for CSK data
+  size_t num_groups_{0U};       //<! Number of energy groups for CSK data
+  size_t num_leg_moments_{0U};  //<! Number of Legendre moments for CSK data
   size_t num_evals_{0U};        //<! Number of "evaluations" (linear/nonlinear, in/out scattering)
 
-  // a point is a (Leg moment, eval) pair
-  // first eval has all Leg moments and all others have only the 0th moment
+  // a point is a (Legendre moment, evaluation) pair
+  // first evaluation has all Legendre moments and all others have only the 0th moment
   size_t num_points_{0U};
 
-  // Temperature grid for csk data (keV)
+  // Temperature grid for CSK data (keV)
   std::vector<double> Ts_{};
 
-  // Energy grid (MG energy boundaries) for csk data (keV)
+  // Energy grid (MG energy boundaries) for CSK data (keV)
   std::vector<double> Egs_{};
 
   // sparse data storage
@@ -188,11 +186,11 @@ private:
   // 1D array of [temperature, group-from]
   std::vector<size_t> indexes_{};
 
-  // csk data
+  // CSK data
   // 1D array of [eval, moment, temperature, group-from, group-to]
   std::vector<double> data_{};
 
-  // temperature derivatives of csk data
+  // temperature derivatives of CSK data
   // 1D array of [eval, moment, temperature, group-from, group-to]
   std::vector<double> derivs_{};
 

--- a/src/ds++/Endian.hh
+++ b/src/ds++/Endian.hh
@@ -92,9 +92,21 @@ inline void char_byte_swap(char *data, int n) {
  *
  * This function operates in place on its argument.
  */
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#if (DBS_GNUC_VERSION >= 70000)
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+#endif
+
 template <typename T> void byte_swap(T &value) {
   char_byte_swap((unsigned char *)(&value), sizeof(T));
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 //------------------------------------------------------------------------------------------------//
 /*!

--- a/src/ds++/Release.cc
+++ b/src/ds++/Release.cc
@@ -188,7 +188,7 @@ const std::string copyright() {
 //! This version can be called by Fortran and wraps the C++ version.
 extern "C" void ec_release(char *release_string, size_t maxlen) {
   std::string tmp_rel = rtt_dsxx::release();
-  if (tmp_rel.size() >= static_cast<size_t>(maxlen)) {
+  if (tmp_rel.size() >= maxlen) {
     tmp_rel = tmp_rel.substr(0, maxlen - 1);
   }
   std::memcpy(release_string, tmp_rel.c_str(), tmp_rel.size() + 1);

--- a/src/ds++/StackTrace.cc
+++ b/src/ds++/StackTrace.cc
@@ -83,14 +83,7 @@ std::string rtt_dsxx::print_stacktrace(std::string const &error_message) {
 
   // allocate string which will be filled with the demangled function name
   size_t funcnamesize = 256;
-  auto *funcname = (char *)malloc(funcnamesize);
-
-  // msg << "\nRAW format:" << std::endl;
-  // for( int i=0; i<stack_depth; ++i )
-  // {
-  //     msg << "  " << symbollist[i] << std::endl;
-  // }
-  // msg << "\nDemangled format:" << std::endl;
+  auto *funcname = static_cast<char *>(malloc(funcnamesize));
 
   // iterate over the returned symbol lines. skip first two, (addresses of this function and
   // handler)

--- a/src/ds++/SystemCall.cc
+++ b/src/ds++/SystemCall.cc
@@ -114,7 +114,7 @@ std::string draco_getcwd() {
   std::array<char, MAXPATHLEN> curr_path;
   curr_path.fill('z');
   Insist(getcwd(&curr_path[0], MAXPATHLEN) != nullptr,
-         std::string("getcwd failed: " + std::string(strerror(errno))));
+         "getcwd failed: " + std::string(strerror(errno)));
   std::string cwd(curr_path.data());
 #endif
 

--- a/src/ds++/path_getFilenameComponent.cc
+++ b/src/ds++/path_getFilenameComponent.cc
@@ -54,7 +54,7 @@ std::string getFilenameComponent(std::string const &fqName, FilenameComponent fc
     }
     // If we still cannot find a path separator, return "./"
     if (idx == string::npos)
-      retVal = string(string(".") + rtt_dsxx::dirSep);
+      retVal = string(".") + rtt_dsxx::dirSep;
     else
       retVal = fullName.substr(0, idx + 1);
     break;

--- a/src/ds++/terminal/terminal.h
+++ b/src/ds++/terminal/terminal.h
@@ -52,8 +52,8 @@
 #include <string>
 #include <vector>
 
-#define CTRL_KEY(k) (char)(((unsigned char)(k) & 0x1f))
-#define ALT_KEY(k) (char)(((unsigned char)(k) + 0x80))
+#define CTRL_KEY(k) static_cast<char>((static_cast<unsigned char>(k) & 0x1f))
+#define ALT_KEY(k) static_cast<char>((static_cast<unsigned char>(k) + 0x80))
 
 namespace Term {
 

--- a/src/experimental/mdspan
+++ b/src/experimental/mdspan
@@ -56,6 +56,11 @@
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "__p0009_bits/accessor_basic.hpp"
 #include "__p0009_bits/all_type.hpp"
 #include "__p0009_bits/array_workaround.hpp"
@@ -69,6 +74,10 @@
 #include "__p0009_bits/macros.hpp"
 #include "__p0009_bits/mixed_size_storage.hpp"
 #include "__p0009_bits/subspan.hpp"
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef __clang__
 // Restore clang diagnostics to previous state.

--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -161,7 +161,7 @@ public:
 private:
   // >>> SUPPORT FUNCTIONS
 
-  //! Calculate (merely de-serialize) the vector of node coordinates
+  //! Calculate (merely deserialize) the vector of node coordinates
   std::vector<std::vector<double>>
   compute_node_coord_vec(const std::vector<double> &coordinates) const;
 

--- a/src/mesh/RTT_Draco_Mesh_Reader.cc
+++ b/src/mesh/RTT_Draco_Mesh_Reader.cc
@@ -123,24 +123,25 @@ std::vector<unsigned> RTT_Draco_Mesh_Reader::get_cellnodes(size_t cell) const {
   return cellface_node;
 }
 
+//------------------------------------------------------------------------------------------------//
 std::vector<unsigned> RTT_Draco_Mesh_Reader::get_cellfacenodes(size_t cell, size_t face) const {
 
   // get the number of dimensions
-  unsigned num_dim = rtt_reader->get_dims_ndim();
+  unsigned const num_dim = rtt_reader->get_dims_ndim();
 
   // get the node list for this cell
   const std::vector<unsigned> &cell_node = rtt_reader->get_cells_nodes(cell);
 
   // get the number of nodes
-  size_t cell_type = cell_node.size();
+  size_t const cell_type = cell_node.size();
 
   // internal nodes are not supported in 1D
   Check(num_dim == 1 ? cell_type == 2 : cell_type > 2);
 
-  std::vector<unsigned> face_node(num_dim);
-  face_node[0] = cell_node[face];
+  std::vector<unsigned> face_node;
+  face_node.emplace_back(cell_node[face]);
   if (num_dim == 2)
-    face_node[1] = cell_node[(face + 1) % cell_type];
+    face_node.emplace_back(cell_node[(face + 1) % cell_type]);
 
   return face_node;
 }

--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -294,8 +294,6 @@ public:
   using Return_Class = Class;
   using Context_type = unsigned;
 
-  // MANAGEMENT
-
   // SERVICES
 
   bool allow_exit() const { return allow_an_exit; }
@@ -304,16 +302,7 @@ public:
 
   static Parse_Table &parse_table() { return parse_table_; }
 
-protected:
-  // DATA
-
-  // STATIC
-
 private:
-  // IMPLEMENTATION
-
-  // STATIC
-
   friend class Class_Parse_Table<Class>;
 
   void initialize(Keyword const *keywords, unsigned count) {
@@ -323,7 +312,7 @@ private:
       parse_table_.add(keywords, count);
       first_time = false;
     }
-    current_ = (Class_Parse_Table<Class> *)this;
+    current_ = static_cast<Class_Parse_Table<Class> *>(this);
   }
 
   static Class_Parse_Table<Class> *current_;

--- a/src/quadrature/Sn_Ordinate_Space.cc
+++ b/src/quadrature/Sn_Ordinate_Space.cc
@@ -78,7 +78,7 @@ vector<Moment> Sn_Ordinate_Space::compute_n2lk_3D_(Quadrature_Class, unsigned /*
 
   // Choose: l= 0, ..., L, k = -l, ..., l
   for (int ell = 0; ell <= static_cast<int>(L); ++ell)
-    for (int k(-static_cast<int>(ell)); k <= ell; ++k)
+    for (int k(-ell); k <= ell; ++k)
       result.emplace_back(Moment(ell, k));
 
   return result;

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -546,10 +546,9 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
                                        Ordinate_Set::LEVEL_ORDERED);
 
     if (ordinate_set->ordinates().size() >= 2) {
-      PASSMSG(string("Ordinate count is plausible. N = " +
-                     to_string(ordinate_set->ordinates().size())));
+      PASSMSG("Ordinate count is plausible. N = " + to_string(ordinate_set->ordinates().size()));
     } else {
-      FAILMSG(string("Ordinate count is NOT plausible. N = ") +
+      FAILMSG("Ordinate count is NOT plausible. N = " +
               to_string(ordinate_set->ordinates().size()));
     }
 

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -34,6 +34,7 @@
 #if (DBS_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"

--- a/src/rng/test/kat_cpp.cpp
+++ b/src/rng/test/kat_cpp.cpp
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
 #ifdef __clang__

--- a/src/rng/test/kat_main.h
+++ b/src/rng/test/kat_main.h
@@ -67,6 +67,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "kat.h"
 #include "util.h"
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
+
 #define LINESIZE 1024
 
 int have_aesni = 0;
@@ -316,6 +322,10 @@ int main(int argc, char **argv) {
     return 0;
   }
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 //------------------------------------------------------------------------------------------------//
 // end kat_cpp.cpp

--- a/src/rng/test/time_serial.cc
+++ b/src/rng/test/time_serial.cc
@@ -60,6 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
 #define TEST_TPL(NAME, N, W, R)                                                                    \

--- a/src/rng/test/ut_Engine.cpp
+++ b/src/rng/test/ut_Engine.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic push
 #endif
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 #endif
 

--- a/src/rng/test/ut_M128.cpp
+++ b/src/rng/test/ut_M128.cpp
@@ -49,6 +49,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include <Random123/features/compilerfeatures.h>
 #if !R123_USE_SSE
 #include <stdio.h>
@@ -182,6 +187,10 @@ int main(int, char **) {
   return 0;
 }
 
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
 #endif
 
 #ifdef __clang__

--- a/src/rng/test/ut_carray.cpp
+++ b/src/rng/test/ut_carray.cpp
@@ -45,6 +45,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4701 4521 4244 4127 4100)
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "ut_carray.hh"
 
 #include "util_demangle.hpp"
@@ -344,6 +349,10 @@ int main(int, char **) {
   cout << "ut_carray: all OK" << endl;
   return 0;
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _MSC_FULL_VER
 #pragma warning(pop)

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -66,15 +66,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Suppress GCC's "unused parameter" warning, about lhs and rhs in sse.h, and an
 // "unused local typedef" warning, from a pre-C++11 implementation of a static
 // assertion in compilerfeatures.h.
-#if (DBS_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
-#endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
 #ifdef __clang__
@@ -90,20 +90,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-
-#ifdef __clang__
-// Restore clang diagnostics to previous state.
-#pragma clang diagnostic pop
-#endif
-
-#if (DBS_GNUC_VERSION >= 40600)
-// Restore GCC diagnostics to previous state.
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_FULL_VER
-#pragma warning(pop)
-#endif
 
 using namespace r123;
 
@@ -211,6 +197,20 @@ int main(int argc, char **argv) {
 
   return !!nfail;
 }
+
+#ifdef __clang__
+// Restore clang diagnostics to previous state.
+#pragma clang diagnostic pop
+#endif
+
+#if (DBS_GNUC_VERSION >= 40600)
+// Restore GCC diagnostics to previous state.
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef _MSC_FULL_VER
+#pragma warning(pop)
+#endif
 
 #endif /* !defined(__clang_analyzer__) */
 

--- a/src/rng/test/util_cpu.h
+++ b/src/rng/test/util_cpu.h
@@ -34,12 +34,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef __GNUC__
 #if !defined(__ICC) && !defined(NVCC)
-// Suppress GCC's "unused variable" warning.
-#if (DBS_GNUC_VERSION >= 40600)
 #pragma GCC diagnostic push
-#endif
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 #endif
 
@@ -230,8 +228,7 @@ void cpu_done(CPUInfo *tp) {
 }
 
 #ifdef __GNUC__
-#if (DBS_GNUC_VERSION >= 40600)
-// Restore GCC diagnostics to previous state.
+#if !defined(__ICC) && !defined(NVCC)
 #pragma GCC diagnostic pop
 #endif
 #endif

--- a/src/rng/test/util_expandtpl.h
+++ b/src/rng/test/util_expandtpl.h
@@ -40,9 +40,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * and R being the number of rounds.
  */
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
 #if (DBS_GNUC_VERSION >= 70000)
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
 #endif
@@ -104,7 +105,7 @@ TEST_TPL(aesni, 4, 32, 10)
 #pragma clang diagnostic pop
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 // Restore GCC diagnostics to previous state.
 #pragma GCC diagnostic pop
 #endif

--- a/src/rng/test/util_print.h
+++ b/src/rng/test/util_print.h
@@ -34,6 +34,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 extern int verbose;
 
 #define TEST_TPL(NAME, N, W, R)                                                                    \
@@ -55,5 +60,9 @@ extern int verbose;
   }
 
 #include "util_expandtpl.h"
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* UTIL_PRINT_H */

--- a/src/special_functions/F_eta.cc
+++ b/src/special_functions/F_eta.cc
@@ -59,7 +59,7 @@ double F_eta(double const eta, double const gamma) {
         dep = dep * e + ep * dep;
         ep *= e;
         sign *= -1;
-        double srt = pow((double)j, i + 1.5);
+        double srt = pow(static_cast<double>(j), i + 1.5);
         double term = sign * ep / srt;
         if (fabs(term) < fabs(si) * std::numeric_limits<double>::epsilon())
           break;

--- a/src/viz/Ensight_Translator.i.hh
+++ b/src/viz/Ensight_Translator.i.hh
@@ -516,9 +516,8 @@ void Ensight_Translator::write_vrtx_data(const uint32_t part_num,
   size_t nvertices = vertices.size();
   size_t ndata = vrtx_data.ncols(0);
 
-  std::string err = "Vertex data files not open."
-                    "  Must call open() before write_part().";
-  Insist(d_vertex_out.size() == static_cast<size_t>(ndata), err.c_str());
+  std::string err = "Vertex data files not open. Must call open() before write_part().";
+  Insist(d_vertex_out.size() == ndata, err.c_str());
 
   // loop over all vertex data fields and write out data for each field
   for (size_t nvd = 0; nvd < ndata; nvd++) {


### PR DESCRIPTION
### Background

+ There was a bug in `config/unix-g++.cmake` that prevented some warning flags from being applied as intended.
+ I also added new GCC CXX flags `-Wuseless-cast`, `-Wnull-dereference`, and `-Wnon-virtual-dtor`

### Changes

+ The `-Wuseless-cast` and reactivation of `-Wold-style-cast` created build warnings that were fixed in this PR.  Most of the changes are represented by removing `static_cast<T>` code, although a few files required localized pragmas to disable the new warnings.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
* WIP - I expect these changes to generate a few warnings to be issued from non-GNU compilers.   