### PR TITLE
Explore the impact of using scoped enum for mesh_element Geometry.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -1,7 +1,7 @@
 #--------------------------------------------*-cmake-*---------------------------------------------#
 # file   config/compilerEnv.cmake
 # brief  Default CMake build parameters
-# note   Copyright (C) 2019-2021 Triad National Security, LLC., All rights reserved.
+# note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 
 include_guard(GLOBAL)
@@ -518,7 +518,7 @@ macro(dbsSetupStaticAnalyzers)
         if(NOT CLANG_TIDY_CHECKS)
           # * -checks=mpi-*,bugprone-*,performance-*,modernize-*
           # * See full list: `clang-tidy -check=* -list-checks'
-          # * Default: all modernize checks; except use-triling-return-type.
+          # * Default: all modernize checks; except use-trailing-return-type.
           set(CLANG_TIDY_CHECKS "-checks=modernize-*,-modernize-use-trailing-return-type")
           if(DEFINED ENV{CI})
             string(REPLACE "-checks=" "--warnings-as-errors=" tmp ${CLANG_TIDY_CHECKS})

--- a/src/RTT_Format_Reader/CellData.cc
+++ b/src/RTT_Format_Reader/CellData.cc
@@ -4,7 +4,7 @@
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Implementation file for RTT_Format_Reader/CellData class.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "CellData.hh"
@@ -57,7 +57,7 @@ void CellData::readData(ifstream &meshfile) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Reads and validate the end_celldat block keyworde.
+ * \brief Reads and validate the end_celldat block keyword.
  * \param meshfile Mesh file name.
  */
 void CellData::readEndKeyword(ifstream &meshfile) {

--- a/src/mesh/Draco_Mesh.cc
+++ b/src/mesh/Draco_Mesh.cc
@@ -4,7 +4,7 @@
  * \author Ryan Wollaeger <wollaeger@lanl.gov>
  * \date   Thursday, Jun 07, 2018, 15:38 pm
  * \brief  Draco_Mesh class implementation file.
- * \note   Copyright (C) 2018-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2018-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Draco_Mesh.hh"
@@ -171,7 +171,7 @@ Draco_Mesh::compute_node_coord_vec(const std::vector<double> &coordinates) const
   // resize this class's coordinate data member
   std::vector<std::vector<double>> ret_node_coord_vec(num_nodes, std::vector<double>(dimension));
 
-  // de-serialize the vector of node coordinates
+  // deserialize the vector of node coordinates
   auto ncv_first = coordinates.begin();
   for (unsigned node = 0; node < num_nodes; ++node) {
 
@@ -207,7 +207,7 @@ Draco_Mesh::compute_cell_to_node_tensor(const std::vector<unsigned> &num_faces_p
 
   std::vector<std::vector<std::vector<unsigned>>> ret_cn_tensor(num_cells);
 
-  // de-serialize the cell-node linkage vector
+  // deserialize the cell-node linkage vector
   auto cfn_first = cell_to_node_linkage.begin();
   unsigned cf_indx = 0;
   for (unsigned cell = 0; cell < num_cells; ++cell) {
@@ -399,7 +399,7 @@ void Draco_Mesh::compute_cell_to_cell_linkage(
 /*!
  * \brief Build a map of node vectors to indices map for boundary layouts.
  *
- * Note: the ordering of the nodes in the mesh ctor must match the node ordering of the
+ * Note: the ordering of the nodes in the mesh constructor must match the node ordering of the
  * corresponding (local) cell face.
  *
  * \param[in] indx_type vector of number of nodes, subscripted by index.
@@ -677,7 +677,7 @@ void Draco_Mesh::compute_node_to_cell_linkage(
     auto last_v2 = std::unique(v2.begin(), v2.end());
     v2.erase(last_v2, v2.end());
 
-    // perform set intsection of my rank global nodes with this rank's global nodes
+    // perform set intersection of my rank global nodes with this rank's global nodes
     std::vector<unsigned> rank_my_rank_node_intersect;
     std::set_intersection(v1.begin(), v1.end(), v2.begin(), v2.end(),
                           std::back_inserter(rank_my_rank_node_intersect));

--- a/src/mesh/Draco_Mesh.hh
+++ b/src/mesh/Draco_Mesh.hh
@@ -4,7 +4,7 @@
  * \author Ryan Wollaeger <wollaeger@lanl.gov>
  * \date   Thursday, Jun 07, 2018, 15:38 pm
  * \brief  Draco_Mesh class header file.
- * \note   Copyright (C) 2018-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2018-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_mesh_Draco_Mesh_hh
@@ -191,11 +191,6 @@ private:
                                     const std::vector<unsigned> &side_to_node_linkage,
                                     const std::vector<unsigned> &ghost_cell_type,
                                     const std::vector<unsigned> &ghost_cell_to_node_linkage);
-
-  //! Calculate a map of node to vectors of indices (cells, sides, ghost cells)
-  std::map<unsigned, std::vector<unsigned>>
-  compute_node_indx_map(const std::vector<unsigned> &indx_type,
-                        const std::vector<unsigned> &indx_to_node_linkage) const;
 
   //! Calculate a map of node vectors to indices (sides, ghost cells)
   std::map<std::set<unsigned>, unsigned>

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -4,7 +4,7 @@
  * \author Ryan Wollaeger <wollaeger@lanl.gov>
  * \date   Tuesday, Jul 03, 2018, 11:26 am
  * \brief  Draco_Mesh_Builder class header file.
- * \note   Copyright (C) 2018-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2018-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Draco_Mesh.hh"
@@ -49,7 +49,7 @@ template <typename FRT>
 std::shared_ptr<Draco_Mesh>
 Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
 
-  Require(geometry != rtt_mesh_element::END_GEOMETRY);
+  Require(geometry != rtt_mesh_element::Geometry::END_GEOMETRY);
 
   // >>> GENERATE MESH CONSTRUCTOR ARGUMENTS
 

--- a/src/mesh/test/tstDraco_Mesh_Builder.cc
+++ b/src/mesh/test/tstDraco_Mesh_Builder.cc
@@ -4,8 +4,7 @@
  * \author Ryan Wollaeger <wollaeger@lanl.gov>
  * \date   Sunday, Jul 01, 2018, 18:21 pm
  * \brief  Draco_Mesh_Builder class unit test.
- * \note   Copyright (C) 2018-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2018-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Test_Mesh_Interface.hh"
@@ -134,11 +133,9 @@ void build_cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
     std::vector<unsigned>::const_iterator sn_first = sn_linkage.begin();
     for (unsigned side = 0; side < mesh_iface.num_sides; ++side) {
 
-      // check that sn_linkage is a permutation of the original side-node
-      // linkage
-      if (!std::is_permutation(sn_first, sn_first + side_node_count[side], ref_sn_first,
-                               ref_sn_first + side_node_count[side]))
-        ITFAILS;
+      // check that sn_linkage is a permutation of the original side-node linkage
+      FAIL_IF_NOT(std::is_permutation(sn_first, sn_first + side_node_count[side], ref_sn_first,
+                                      ref_sn_first + side_node_count[side]));
 
       // update the iterators
       ref_sn_first += side_node_count[side];
@@ -148,7 +145,7 @@ void build_cartesian_mesh_2d(rtt_c4::ParallelUnitTest &ut) {
 
   // successful test output
   if (ut.numFails == 0)
-    PASSMSG("2D Cartesian Draco_Mesh_Builder tests ok.");
+    PASSMSG("2D Cartesian Draco_Mesh_Builder tests okay.");
   return;
 }
 

--- a/src/mesh_element/Geometry.hh
+++ b/src/mesh_element/Geometry.hh
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Tue Dec 21 14:28:56 2004
  * \brief  Define an enumeration to specify supported geometric types.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef mesh_element_Geometry_hh
@@ -14,7 +14,7 @@ namespace rtt_mesh_element {
 
 /*! Enumerates supported geometries.
  *
- * The order of enumerated values is not arbiterary. The corresponding integral value is the number
+ * The order of enumerated values is not arbitrary. The corresponding integral value is the number
  * of suppressed dimensions in the geometry, e.g., axisymmetric geometry looks 2-D but is actually
  * 3-D (one suppressed dimension) while spherical geometry looks 1-D but is actually 3-D (two
  * suppressed dimensions.) The number of suppressed dimensions is used in some formulas in a number
@@ -22,7 +22,7 @@ namespace rtt_mesh_element {
  *
  * We specify the base as int to guarantee better interoperability with FORTRAN codes.
  */
-enum Geometry : int {
+enum class Geometry : int {
   CARTESIAN,    //!< 1D (slab) or 2D (XY) Cartesian geometry
   AXISYMMETRIC, //!< 2D (cylindrical) R-Z
   SPHERICAL,    //!< 1D SPHERICAL

--- a/src/parser/test/tstutilities.cc
+++ b/src/parser/test/tstutilities.cc
@@ -3,8 +3,7 @@
  * \file   parser/test/tstutilities.cc
  * \author Kent G. Budge
  * \date   Feb 18 2003
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -353,23 +352,23 @@ void tstutilities(UnitTest &ut) {
   }
 
   // Try reading a geometry.
-  rtt_mesh_element::Geometry geometry = rtt_mesh_element::END_GEOMETRY;
+  rtt_mesh_element::Geometry geometry = rtt_mesh_element::Geometry::END_GEOMETRY;
   parse_geometry(tokens, geometry);
-  if (geometry != rtt_mesh_element::AXISYMMETRIC)
+  if (geometry != rtt_mesh_element::Geometry::AXISYMMETRIC)
     FAILMSG("axisymmetric geometry NOT successfully parsed");
   else
     PASSMSG("geometry successfully parsed");
 
-  geometry = rtt_mesh_element::END_GEOMETRY;
+  geometry = rtt_mesh_element::Geometry::END_GEOMETRY;
   parse_geometry(tokens, geometry);
-  if (geometry != rtt_mesh_element::CARTESIAN)
+  if (geometry != rtt_mesh_element::Geometry::CARTESIAN)
     FAILMSG("cartesian geometry NOT successfully parsed");
   else
     PASSMSG("geometry successfully parsed");
 
-  geometry = rtt_mesh_element::END_GEOMETRY;
+  geometry = rtt_mesh_element::Geometry::END_GEOMETRY;
   parse_geometry(tokens, geometry);
-  if (geometry != rtt_mesh_element::SPHERICAL)
+  if (geometry != rtt_mesh_element::Geometry::SPHERICAL)
     FAILMSG("spherical geometry NOT successfully parsed");
   else
     PASSMSG("geometry successfully parsed");
@@ -384,20 +383,20 @@ void tstutilities(UnitTest &ut) {
 
   {
     String_Token_Stream ltokens("cylindrical, cartesian, xy, bad");
-    rtt_mesh_element::Geometry parsed_geometry = rtt_mesh_element::AXISYMMETRIC;
+    rtt_mesh_element::Geometry parsed_geometry = rtt_mesh_element::Geometry::AXISYMMETRIC;
     parse_geometry(ltokens, parsed_geometry);
     if (ltokens.error_count() == 0) {
       FAILMSG("did NOT detect duplicate geometry definition");
     }
-    if (parsed_geometry != rtt_mesh_element::AXISYMMETRIC) {
+    if (parsed_geometry != rtt_mesh_element::Geometry::AXISYMMETRIC) {
       FAILMSG("did NOT parse cylindrical geometry correctly");
     }
     parse_geometry(ltokens, parsed_geometry);
-    if (parsed_geometry != rtt_mesh_element::CARTESIAN) {
+    if (parsed_geometry != rtt_mesh_element::Geometry::CARTESIAN) {
       FAILMSG("did NOT parse cartesian geometry correctly");
     }
     parse_geometry(ltokens, parsed_geometry);
-    if (parsed_geometry != rtt_mesh_element::CARTESIAN) {
+    if (parsed_geometry != rtt_mesh_element::Geometry::CARTESIAN) {
       FAILMSG("did NOT parse xy geometry correctly");
     }
     try {

--- a/src/parser/utilities.cc
+++ b/src/parser/utilities.cc
@@ -1,11 +1,10 @@
-//---------------------------------*-C++-*-----------------------------------//
+//--------------------------------------------*-C++-*---------------------------------------------//
 /*!
  * \file   parser/utilities.cc
  * \author Kent G. Budge
  * \date   18 Feb 2003
  * \brief  Definitions of parsing utility functions.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "utilities.hh"
@@ -32,31 +31,28 @@ using namespace std;
 //------------------------------------------------------------------------------------------------//
 /*! Set the unit system to which all parser code converts unit expressions.
  *
- * By default, all unit expressions are converted to SI values by the parser
- * utility routines. For example, if the double parse_quantity function is given
- * the text "2.7 cm", it will return a value of 0.027. The function
- * set_common_unit_system can be used to change the internal unit system, for
- * example, to CGS, so that if the double parse_quantity function is given the
- * text "2.7 cm", it will return a value of 2.7.
+ * By default, all unit expressions are converted to SI values by the parser utility routines. For
+ * example, if the double parse_quantity function is given the text "2.7 cm", it will return a value
+ * of 0.027. The function set_common_unit_system can be used to change the internal unit system, for
+ * example, to CGS, so that if the double parse_quantity function is given the text "2.7 cm", it
+ * will return a value of 2.7.
  *
- * Similarly, by default,the Expression parse_quantity function assumes that all
- * input quantities to the Expression it constructs will be in SI units, but
- * this will be overridden if set_common_unit_system is used to change the
- * internal unit system. Thus, if Expression parse_quantity is given the text
- * "0.5*(t+2*x*s/cm)*erg" then by default it will construct an Expression that
- * computes 0.5e-7*(t+200*x). However, if set_internal_unit_system had
- * previously been called to set the internal unit system to CGS, the Expression
- * constructed would compute 0.5*(t+2*x).
+ * Similarly, by default,the Expression parse_quantity function assumes that all input quantities to
+ * the Expression it constructs will be in SI units, but this will be overridden if
+ * set_common_unit_system is used to change the internal unit system. Thus, if Expression
+ * parse_quantity is given the text "0.5*(t+2*x*s/cm)*erg" then by default it will construct an
+ * Expression that computes 0.5e-7*(t+200*x). However, if set_internal_unit_system had previously
+ * been called to set the internal unit system to CGS, the Expression constructed would compute
+ * 0.5*(t+2*x).
  *
- * This function will normally be called once at the beginning of a parse, since
- * if the internal unit system changes halfway through a parse, there is rarely
- * any easy way to go back and convert quantities parsed earlier to the new
- * internal unit system. For example, if an input file is allowed to specify the
- * internal unit system, this specification should normally be required to be
+ * This function will normally be called once at the beginning of a parse, since if the internal
+ * unit system changes halfway through a parse, there is rarely any easy way to go back and convert
+ * quantities parsed earlier to the new internal unit system. For example, if an input file is
+ * allowed to specify the internal unit system, this specification should normally be required to be
  * the first line in the input file.
  *
- * There is no delete associated with the new global static value. It remains in
- * scope until the program terminates.
+ * There is no delete associated with the new global static value. It remains in scope until the
+ * program terminates.
  */
 void set_internal_unit_system(rtt_units::UnitSystem const &units) {
   if (internal_unit_system != nullptr)
@@ -76,34 +72,29 @@ void free_internal_unit_system() {
 //------------------------------------------------------------------------------------------------//
 /*! Set whether unit expressions are mandatory.
  *
- * By default,the parse_quantity routines expect the texts they parse to be of
- * the form "2.99792e10 cm/s", that is, a real number followed by a unit
- * expression. However, set_are_unit_expressions_required can be used to either
- * turn on or turn off the mandatory unit expression. Quantities can always have
- * a unit expression, and the quantity will then be converted to the internal
- * unit system, but if the mandatory unit expression flag is turned off,
- * quantities may optionally omit the unit expression and will be assumed to be
- * expressed in the internal unit system.
+ * By default,the parse_quantity routines expect the texts they parse to be of the form "2.99792e10
+ * cm/s", that is, a real number followed by a unit expression. However,
+ * set_are_unit_expressions_required can be used to either turn on or turn off the mandatory unit
+ * expression. Quantities can always have a unit expression, and the quantity will then be converted
+ * to the internal unit system, but if the mandatory unit expression flag is turned off, quantities
+ * may optionally omit the unit expression and will be assumed to be expressed in the internal unit
+ * system.
  *
- * Thus, if unit expressions are mandatory and the internal unit system has been
- * set to CGS, then "2.7 m" will be read by double parse_quantity as 270 while
- * "2.7" will be an error. If unit expressions are not mandatory and the
- * internal unit system has been set to CGS, then "2.7 m" will still be read by
- * double parse_quantity as 270, but "2.7" will be read as 2.7.
+ * Thus, if unit expressions are mandatory and the internal unit system has been set to CGS, then
+ * "2.7 m" will be read by double parse_quantity as 270 while "2.7" will be an error. If unit
+ * expressions are not mandatory and the internal unit system has been set to CGS, then "2.7 m" will
+ * still be read by double parse_quantity as 270, but "2.7" will be read as 2.7.
  *
- * It should be clear that mandatory unit expressions are preferable when humans
- * are writing the input files being parsed, since input files that consistently
- * use unit expressions will be less ambiguous, better documented, and more
- * likely to be free from error. The ability to turn off mandatory unit
- * expressions is targeted primarily at situations where it is programs that are
- * communicating with each other through text files rather than humans
- * communicating to a program.
+ * It should be clear that mandatory unit expressions are preferable when humans are writing the
+ * input files being parsed, since input files that consistently use unit expressions will be less
+ * ambiguous, better documented, and more likely to be free from error. The ability to turn off
+ * mandatory unit expressions is targeted primarily at situations where it is programs that are
+ * communicating with each other through text files rather than humans communicating to a program.
  *
- * It is particularly not recommended that unit expressions be made optional
- * where humans will be composing Expressions, since the effect of turning off
- * mandatory unit expressions is to turn off checking of internal dimensional
- * consistency of Expressions. This is a powerful error checking capability that
- * should not be discarded lightly.
+ * It is particularly not recommended that unit expressions be made optional where humans will be
+ * composing Expressions, since the effect of turning off mandatory unit expressions is to turn off
+ * checking of internal dimensional consistency of Expressions. This is a powerful error checking
+ * capability that should not be discarded lightly.
  */
 void set_unit_expressions_are_required(bool const b) { require_unit_expressions = b; }
 
@@ -124,8 +115,7 @@ bool unit_expressions_are_required() { return require_unit_expressions; }
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \param tokens
- * Token stream from which to parse the quantity.
+ * \param[in,out] tokens Token stream from which to parse the quantity.
  *
  * \return The parsed quantity.
  */
@@ -146,7 +136,7 @@ unsigned parse_unsigned_integer(Token_Stream &tokens) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \param tokens Token stream from which to parse the quantity.
+ * \param[in,out] tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 unsigned parse_positive_integer(Token_Stream &tokens) {
@@ -162,7 +152,7 @@ unsigned parse_positive_integer(Token_Stream &tokens) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \param tokens Token stream from which to parse the quantity.
+ * \param[in,out] tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 int parse_integer(Token_Stream &tokens) {
@@ -210,11 +200,11 @@ bool at_real(Token_Stream &tokens) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * We permit an integer token to appear where a real is expected, consistent
- * with the integers being a subset of reals, and with about five decades of
- * common practice in the computer language community.
+ * We permit an integer token to appear where a real is expected, consistent with the integers being
+ * a subset of reals, and with about five decades of common practice in the computer language
+ * community.
  *
- * \param tokens Token stream from which to parse the quantity.
+ * \param[in,out] tokens Token stream from which to parse the quantity.
  * \return The parsed quantity.
  */
 double parse_real(Token_Stream &tokens) {
@@ -331,13 +321,11 @@ void parse_unsigned_vector(Token_Stream &tokens, unsigned *x, unsigned size) {
 /*!
  * \brief Are we at a unit term?
  *
- * We are at a unit term if the next token on the Token_Stream is a valid unit
- * name.
+ * We are at a unit term if the next token on the Token_Stream is a valid unit name.
  *
  * \param tokens Token_Stream from which to parse.
- * \param position Position in Token_Stream at which to parse.  This lookahead
- * capability is needed by parse_unit to see if a hyphen '-' is part of a unit
- * expression.
+ * \param position Position in Token_Stream at which to parse.  This lookahead capability is needed
+ *        by parse_unit to see if a hyphen '-' is part of a unit expression.
  *
  * \return \c true if we are at the start of a unit term; \c false otherwise
  */
@@ -442,8 +430,7 @@ Unit parse_unit(Token_Stream &tokens);
 /*!
  * \brief Parse a unit name.
  *
- * A unit name can either be a literal unit name, like "kg", or a parenthesized
- * unit expression.
+ * A unit name can either be a literal unit name, like "kg", or a parenthesized unit expression.
  *
  * \param tokens Token_Stream from which to parse.
  * \return The unit.
@@ -694,12 +681,11 @@ static Unit parse_unit_term(Token_Stream &tokens) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * A unit expression is a sequence of tokens with a form such as "kg-m/sec" or
- * "erg/cm^2/sec/Hz" that gives the dimensions of a physical quantity.  This
- * function parses such an expression from its Token_Stream, returning the
- * result as a Unit whose conversion factor is relative to SI.  An empty unit
- * expression is permitted and returns rtt_parser::dimensionless, the
- * identity Unit representing the pure number 1.
+ * A unit expression is a sequence of tokens with a form such as "kg-m/sec" or "erg/cm^2/sec/Hz"
+ * that gives the dimensions of a physical quantity.  This function parses such an expression from
+ * its Token_Stream, returning the result as a Unit whose conversion factor is relative to SI.  An
+ * empty unit expression is permitted and returns rtt_parser::dimensionless, the identity Unit
+ * representing the pure number 1.
  *
  * \param tokens Token_Stream from which to parse.
  * \return The unit expression.
@@ -730,17 +716,15 @@ Unit parse_unit(Token_Stream &tokens) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function parses a quantity having dimensions. It is assumed that the
- * client expects certain dimensions for the quantity, and an exception is
- * thrown if the dimensions are not what the client expected. The quantity
- * will be converted to the desired unit system, as indicated by the \c .conv
+ * This function parses a quantity having dimensions. It is assumed that the client expects certain
+ * dimensions for the quantity, and an exception is thrown if the dimensions are not what the client
+ * expected. The quantity will be converted to the desired unit system, as indicated by the \c .conv
  * member of the \c target_unit argument.
  *
  * \param tokens Token stream from which to parse the quantity.
- * \param target_unit Expected units for the quantity parsed, including
- * conversion factor.
- * \param name Name of the units expected for the quantity parsed, such as
- * "length" or "ergs/cm/sec/Hz". Used to generate diagnostic messages.
+ * \param target_unit Expected units for the quantity parsed, including* conversion factor.
+ * \param name Name of the units expected for the quantity parsed, such as "length" or
+ *        "ergs/cm/sec/Hz". Used to generate diagnostic messages.
  *
  * \return The parsed value, converted to the desired unit system.
  */
@@ -763,9 +747,9 @@ double parse_quantity(Token_Stream &tokens, Unit const &target_unit, char const 
 /*!
  * \brief Parse a temperature specification
  *
- * It is very common for transport researchers to specify a temperature in units
- * of energy, using Boltzmann's constant as the conversion factor.  This
- * function is useful for parsers that accommodate this convention.
+ * It is very common for transport researchers to specify a temperature in units of energy, using
+ * Boltzmann's constant as the conversion factor.  This function is useful for parsers that
+ * accommodate this convention.
  *
  * \param tokens Token stream from which to parse the specification.
  * \return The parsed temperature.
@@ -803,20 +787,16 @@ double parse_temperature(Token_Stream &tokens) {
 /*!
  * \brief Parse a temperature specification
  *
- * It is very common for transport researchers to specify a temperature in units
- * of energy, using Boltzmann's constant as the conversion factor.  This
- * function is useful for parsers that accommodate this convention.
+ * It is very common for transport researchers to specify a temperature in units of energy, using
+ * Boltzmann's constant as the conversion factor.  This function is useful for parsers that
+ * accommodate this convention.
  *
- * This version of the function parses a temperature expression containing
- * user-defined variables.
+ * This version of the function parses a temperature expression containing user-defined variables.
  *
  * \param tokens Token stream from which to parse the specification.
- *
- * \param number_of_variables Number of user-defined variables potentially
- * present in the parsed expression.
- *
+ * \param number_of_variables Number of user-defined variables potentially present in the parsed
+ *        expression.
  * \param variable_map Map of variable names to variables indices.
- *
  * \return The parsed temperature.
  *
  * \post \c Result>=0.0
@@ -871,31 +851,29 @@ std::string parse_manifest_string(Token_Stream &tokens) {
  * \brief Parse a geometry specification.
  *
  * \param tokens Token stream from which to parse the geometry.
- * \param parsed_geometry On entry, if the value is not \c END_GEOMETRY, a
- *           diagnostic is generated to the token stream. On return, contains
- *           the geometry that was parsed.
+ * \param parsed_geometry On entry, if the value is not \c END_GEOMETRY, a diagnostic is generated
+ *           to the token stream. On return, contains the geometry that was parsed.
  *
- * \post <code> parsed_geometry == rtt_mesh_element::AXISYMMETRIC ||
- *         parsed_geometry == rtt_mesh_element::CARTESIAN    ||
- *         parsed_geometry == rtt_mesh_element::SPHERICAL </code>
+ * \post <code> parsed_geometry == rtt_mesh_element::AXISYMMETRIC || parsed_geometry ==
+ *         rtt_mesh_element::CARTESIAN || parsed_geometry == rtt_mesh_element::SPHERICAL </code>
  */
 void parse_geometry(Token_Stream &tokens, rtt_mesh_element::Geometry &parsed_geometry) {
-  tokens.check_semantics(parsed_geometry == rtt_mesh_element::END_GEOMETRY,
+  tokens.check_semantics(parsed_geometry == rtt_mesh_element::Geometry::END_GEOMETRY,
                          "geometry specified twice");
 
   Token const token = tokens.shift();
   if (token.text() == "axisymmetric" || token.text() == "cylindrical") {
-    parsed_geometry = rtt_mesh_element::AXISYMMETRIC;
+    parsed_geometry = rtt_mesh_element::Geometry::AXISYMMETRIC;
   } else if (token.text() == "cartesian" || token.text() == "xy" || token.text() == "slab") {
-    parsed_geometry = rtt_mesh_element::CARTESIAN;
+    parsed_geometry = rtt_mesh_element::Geometry::CARTESIAN;
   } else if (token.text() == "spherical") {
-    parsed_geometry = rtt_mesh_element::SPHERICAL;
+    parsed_geometry = rtt_mesh_element::Geometry::SPHERICAL;
   } else {
     tokens.report_syntax_error(token, "expected a geometry option, but saw " + token.text());
   }
-  Ensure(parsed_geometry == rtt_mesh_element::AXISYMMETRIC ||
-         parsed_geometry == rtt_mesh_element::CARTESIAN ||
-         parsed_geometry == rtt_mesh_element::SPHERICAL);
+  Ensure(parsed_geometry == rtt_mesh_element::Geometry::AXISYMMETRIC ||
+         parsed_geometry == rtt_mesh_element::Geometry::CARTESIAN ||
+         parsed_geometry == rtt_mesh_element::Geometry::SPHERICAL);
   return;
 }
 
@@ -916,19 +894,17 @@ bool parse_bool(Token_Stream &tokens) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function parses an expression having dimensions. It is assumed that the
- * client expects certain dimensions for the quantity, and an exception is
- * thrown if the dimensions are not what the client expected. The quantity
- * will be converted to the desired unit system, as indicated by the \c .conv
- * member of the \c target_unit argument.
+ * This function parses an expression having dimensions. It is assumed that the client expects
+ * certain dimensions for the quantity, and an exception is thrown if the dimensions are not what
+ * the client expected. The quantity will be converted to the desired unit system, as indicated by
+ * the \c .conv member of the \c target_unit argument.
  *
  * \param tokens Token stream from which to parse the quantity.
- * \param target_unit Expected units for the quantity parsed, including
- * conversion factor.
- * \param name Name of the units expected for the quantity parsed, such as
- * "length" or "ergs/cm/sec/Hz". Used to generate diagnostic messages.
- * \param number_of_variables Number of user-defined variables potentially
- * present in the parsed expression.
+ * \param target_unit Expected units for the quantity parsed, including conversion factor.
+ * \param name Name of the units expected for the quantity parsed, such as "length" or
+ *        "ergs/cm/sec/Hz". Used to generate diagnostic messages.
+ * \param number_of_variables Number of user-defined variables potentially present in the parsed
+ &        expression.
  * \param variable_map Map of variable names to variables indices.
  * \return The parsed value, converted to the desired unit system.
  */

--- a/src/quadrature/Galerkin_Ordinate_Space.cc
+++ b/src/quadrature/Galerkin_Ordinate_Space.cc
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Define methods of class Galerkin_Ordinate_Space
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2012-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Galerkin_Ordinate_Space.hh"
@@ -150,7 +150,7 @@ Galerkin_Ordinate_Space::Galerkin_Ordinate_Space(
                      ordering),
       method_(method), D_(), M_() {
   Require(dimension > 0 && dimension < 4);
-  Require(geometry != rtt_mesh_element::END_GEOMETRY);
+  Require(geometry != rtt_mesh_element::Geometry::END_GEOMETRY);
   Require(sn_order > 0 && sn_order % 2 == 0);
   Require(method_ == GQ1 || method_ == GQ2 || method_ == GQF);
 
@@ -284,7 +284,7 @@ void Galerkin_Ordinate_Space::compute_operators() {
 
   // store the final form of the operators in M_ and D_
 
-  if (geometry == rtt_mesh_element::CARTESIAN) {
+  if (geometry == rtt_mesh_element::Geometry::CARTESIAN) {
     M_ = cartesian_M;
     D_ = cartesian_D;
   } else // augment the Cartesian operators for the zero-weight starting directions then store
@@ -386,7 +386,8 @@ vector<double> Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ord
     int const k(n2lk[n].M());
 
     for (unsigned m = 0; m < numOrdinates; ++m) {
-      if (dim == 1 && geometry != rtt_mesh_element::AXISYMMETRIC) // 1D mesh, 1D quadrature
+      if (dim == 1 &&
+          geometry != rtt_mesh_element::Geometry::AXISYMMETRIC) // 1D mesh, 1D quadrature
       {
         double mu(ordinates[m].mu());
         M[n + m * numMoments] = Ylm(ell, k, mu, 0.0, sumwt);
@@ -395,7 +396,7 @@ vector<double> Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ord
         double eta(ordinates[m].eta());
         double xi(ordinates[m].xi());
 
-        if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+        if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
           // R-Z coordinate system
           //
           // It is important to remember here that the positive mu axis points to the left and the
@@ -408,7 +409,7 @@ vector<double> Galerkin_Ordinate_Space::compute_M_SN(vector<Ordinate> const &ord
 
           double phi(compute_azimuthalAngle(mu, xi));
           M[n + m * numMoments] = Ylm(ell, k, eta, phi, sumwt);
-        } else if (geometry == rtt_mesh_element::CARTESIAN) {
+        } else if (geometry == rtt_mesh_element::Geometry::CARTESIAN) {
           // X-Y coordinate system
           //
           // In order to make the harmonic trial space is correctly oriented with respect to the

--- a/src/quadrature/Octant_Quadrature.cc
+++ b/src/quadrature/Octant_Quadrature.cc
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Friday, Nov 30, 2012, 08:27 am
  * \brief  Implementation for Octant_Quadrature
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2012-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Octant_Quadrature.hh"
@@ -106,7 +106,7 @@ std::vector<Ordinate> Octant_Quadrature::create_ordinates_(
     for (size_t i = 0; i < numOrdinates; ++i) {
       Result[i] = Ordinate(mu[i], eta[i], xi[i], wt[i]);
     }
-  } else if (dimension == 2 || geometry == rtt_mesh_element::AXISYMMETRIC) {
+  } else if (dimension == 2 || geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
     map_axes_(mu_axis, eta_axis, mu, eta, xi);
 
     // Copy the half-sphere
@@ -124,7 +124,7 @@ std::vector<Ordinate> Octant_Quadrature::create_ordinates_(
     add_2D_starting_directions_(geometry, include_starting_directions, include_extra_directions,
                                 Result);
   } else {
-    Check(dimension == 1 && geometry != rtt_mesh_element::AXISYMMETRIC);
+    Check(dimension == 1 && geometry != rtt_mesh_element::Geometry::AXISYMMETRIC);
     Check(mu_axis == 2);
 
     map_axes_(0, 2, mu, eta, xi);
@@ -177,7 +177,7 @@ std::vector<Ordinate> Octant_Quadrature::create_ordinates_(
   for (size_t n = 0; n <= numOrdinates - 1; ++n)
     wsum = wsum + Result[n].wt();
 
-  if (dimension == 1 && geometry != rtt_mesh_element::AXISYMMETRIC) {
+  if (dimension == 1 && geometry != rtt_mesh_element::Geometry::AXISYMMETRIC) {
     for (size_t n = 0; n <= numOrdinates - 1; ++n)
       Result[n] = Ordinate(Result[n].mu(), Result[n].wt() * (norm / wsum));
   } else {
@@ -201,7 +201,7 @@ std::vector<Ordinate> Octant_Quadrature::create_ordinates_(unsigned dimension, G
     switch (dimension) {
     case 1:
       switch (geometry) {
-      case rtt_mesh_element::AXISYMMETRIC:
+      case rtt_mesh_element::Geometry::AXISYMMETRIC:
         mu_axis = 0;
         eta_axis = 2;
         break;
@@ -215,7 +215,7 @@ std::vector<Ordinate> Octant_Quadrature::create_ordinates_(unsigned dimension, G
 
     case 2:
       switch (geometry) {
-      case rtt_mesh_element::AXISYMMETRIC:
+      case rtt_mesh_element::Geometry::AXISYMMETRIC:
         mu_axis = 0;
         eta_axis = 2;
         break;

--- a/src/quadrature/Ordinate_Set.cc
+++ b/src/quadrature/Ordinate_Set.cc
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Tue Dec 21 14:20:03 2004
  * \brief  Declaration file for the class rtt_quadrature::Ordinate.
- * \note   Copyright (C)  2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2012-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Ordinate_Set.hh"
@@ -120,10 +120,10 @@ Ordinate_Set::Ordinate_Set(unsigned const dimension, rtt_mesh_element::Geometry 
       has_extra_starting_directions_(has_extra_starting_directions), ordering_(ordering),
       norm_(0.0), ordinates_(ordinates) {
   Require(dimension >= 1 && dimension <= 3);
-  Require(geometry != rtt_mesh_element::AXISYMMETRIC || dimension < 3);
-  Require(geometry != rtt_mesh_element::SPHERICAL || dimension < 2);
+  Require(geometry != rtt_mesh_element::Geometry::AXISYMMETRIC || dimension < 3);
+  Require(geometry != rtt_mesh_element::Geometry::SPHERICAL || dimension < 2);
   Require(has_starting_directions || !has_extra_starting_directions);
-  Require(dimension > 1 || geometry == rtt_mesh_element::SPHERICAL || check_4(ordinates));
+  Require(dimension > 1 || geometry == rtt_mesh_element::Geometry::SPHERICAL || check_4(ordinates));
   Require(dimension != 2 || check_2(ordinates));
 
   norm_ = 0.0;
@@ -158,10 +158,11 @@ Ordinate_Set::Ordinate_Set(Ordinate_Set const &other)
 //------------------------------------------------------------------------------------------------//
 bool Ordinate_Set::check_class_invariants() const {
   return (dimension_ >= 1 && dimension_ <= 3) &&
-         (geometry_ != rtt_mesh_element::AXISYMMETRIC || dimension_ < 3) &&
-         (geometry_ != rtt_mesh_element::SPHERICAL || dimension_ < 2) &&
+         (geometry_ != rtt_mesh_element::Geometry::AXISYMMETRIC || dimension_ < 3) &&
+         (geometry_ != rtt_mesh_element::Geometry::SPHERICAL || dimension_ < 2) &&
          (has_starting_directions_ || !has_extra_starting_directions_) &&
-         (dimension_ > 1 || geometry_ == rtt_mesh_element::SPHERICAL || check_4(ordinates_)) &&
+         (dimension_ > 1 || geometry_ == rtt_mesh_element::Geometry::SPHERICAL ||
+          check_4(ordinates_)) &&
          (dimension_ != 2 || check_2(ordinates_));
 }
 
@@ -171,7 +172,7 @@ void Ordinate_Set::display() const {
   using std::endl;
   using std::setprecision;
 
-  if (dimension() == 1 && geometry() != rtt_mesh_element::AXISYMMETRIC) {
+  if (dimension() == 1 && geometry() != rtt_mesh_element::Geometry::AXISYMMETRIC) {
     cout << endl << "The Quadrature directions and weights are:" << endl << endl;
     cout << "   m  \t    mu        \t     wt      " << endl;
     cout << "  --- \t------------- \t-------------" << endl;

--- a/src/quadrature/Ordinate_Set_Factory.cc
+++ b/src/quadrature/Ordinate_Set_Factory.cc
@@ -3,10 +3,8 @@
  * \file   quadrature/Ordinate_Set_Factory.cc
  * \author Allan Wollaber
  * \date   Mon Mar  7 10:42:56 EST 2016
- * \brief  Implementation file for the class
- *         rtt_quadrature::Ordinate_Set_Factory.
- * \note   Copyright (C)  2016-2020 Triad National Security, LLC.
- *         All rights reserved.  */
+ * \brief  Implementation file for the class rtt_quadrature::Ordinate_Set_Factory.
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Ordinate_Set_Factory.hh"
@@ -31,18 +29,16 @@ namespace rtt_quadrature {
  *
  * \return A smart pointer to the correctly instantiated Ordinate_Set
  *
- *  All of the "magic numbers" in the quadrature_data struct get interpreted
- *  here to build the Ordinate_Set object.
+ *  All of the "magic numbers" in the quadrature_data struct get interpreted here to build the
+ *  Ordinate_Set object.
  *
- *  This class/method combination would be better suited as a factory method
- *  (and not a factory class) within Ordinate_Set, but this would introduce a
- *  cyclic dependency between Quadrature and Ordinate_Set. Alternatively, it
- *  could be a factory method in Quadrature, but we'd then need an additional
- *  factory method to create the Quadrature object itself. As seen below,
- *  the derived Quadrature object need only exist temporarily
- *  in order to call "create_ordinate_set".  This solution avoids both of those
- *  pitfalls, but it is not ideal and could be refactored into one or the other
- *  classes if their design ever changes.
+ *  This class/method combination would be better suited as a factory method (and not a factory
+ *  class) within Ordinate_Set, but this would introduce a cyclic dependency between Quadrature and
+ *  Ordinate_Set. Alternatively, it could be a factory method in Quadrature, but we'd then need an
+ *  additional factory method to create the Quadrature object itself. As seen below, the derived
+ *  Quadrature object need only exist temporarily in order to call "create_ordinate_set".  This
+ *  solution avoids both of those pitfalls, but it is not ideal and could be refactored into one or
+ *  the other classes if their design ever changes.
  */
 std::shared_ptr<Ordinate_Set> Ordinate_Set_Factory::get_Ordinate_Set() const {
 
@@ -56,22 +52,22 @@ std::shared_ptr<Ordinate_Set> Ordinate_Set_Factory::get_Ordinate_Set() const {
   // Find the geometry
   switch (quad_.geometry) {
   case 0:
-    geometry = rtt_mesh_element::CARTESIAN;
+    geometry = rtt_mesh_element::Geometry::CARTESIAN;
     break;
 
   case 1:
-    geometry = rtt_mesh_element::AXISYMMETRIC;
+    geometry = rtt_mesh_element::Geometry::AXISYMMETRIC;
     add_starting_directions = true;
     break;
 
   case 2:
-    geometry = rtt_mesh_element::SPHERICAL;
+    geometry = rtt_mesh_element::Geometry::SPHERICAL;
     add_starting_directions = true;
     break;
 
   default:
     Insist(false, "Unrecognized Geometry");
-    geometry = rtt_mesh_element::CARTESIAN;
+    geometry = rtt_mesh_element::Geometry::CARTESIAN;
   }
 
   std::shared_ptr<Ordinate_Set> ordinate_set;

--- a/src/quadrature/Ordinate_Space.cc
+++ b/src/quadrature/Ordinate_Space.cc
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Define methods of class Ordinate_Space
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2012-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Ordinate_Space.hh"
@@ -45,7 +45,7 @@ double Ordinate_Space::compute_azimuthalAngle(double const mu, double const eta)
   // making the computation of the azimuthal angle here consistent with the discretization by using
   // the eta and mu ordinates to define phi.
 
-  if (this->geometry() == rtt_mesh_element::AXISYMMETRIC && azimuthalAngle < 0.0)
+  if (this->geometry() == rtt_mesh_element::Geometry::AXISYMMETRIC && azimuthalAngle < 0.0)
     azimuthalAngle += 2 * PI;
 
   return azimuthalAngle;
@@ -75,7 +75,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
   // weight.
 
   levels_.resize(number_of_ordinates);
-  if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+  if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
     vector<double> C;
 
     double Csum = 0;
@@ -174,7 +174,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
         Check(tau_[a] >= 0.0 && tau_[a] < 1.0);
       }
     }
-  } else if (geometry == rtt_mesh_element::SPHERICAL) {
+  } else if (geometry == rtt_mesh_element::Geometry::SPHERICAL) {
     number_of_levels_ = 1;
     double norm(0);
     for (unsigned a = 0; a < number_of_ordinates; ++a) {
@@ -222,7 +222,7 @@ void Ordinate_Space::compute_angle_operator_coefficients_() {
         Check(tau_[a] > 0.0 && tau_[a] <= 1.0);
       }
     }
-  } else if (geometry == rtt_mesh_element::CARTESIAN) {
+  } else if (geometry == rtt_mesh_element::Geometry::CARTESIAN) {
     if (this->dimension() == 2 && this->ordering() == LEVEL_ORDERED) {
       // NEW: organize quadratures for 2D into levels, even for Cartesian coordinates, but do not
       // compute angular derivative approximation coefficients For our purposes here, the use of the
@@ -274,13 +274,13 @@ vector<Moment> Ordinate_Space::compute_n2lk_(Quadrature_Class const quadrature_c
   if (dim == 3) {
     return compute_n2lk_3D_(quadrature_class, sn_order);
   } else if (dim == 2) {
-    if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+    if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
       return compute_n2lk_2Da_(quadrature_class, sn_order);
     } else
       return compute_n2lk_2D_(quadrature_class, sn_order);
   } else {
     Check(dim == 1);
-    if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+    if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
       return compute_n2lk_1Da_(quadrature_class, sn_order);
     } else
       return compute_n2lk_1D_(quadrature_class, sn_order);
@@ -344,7 +344,8 @@ void Ordinate_Space::compute_moments_(Quadrature_Class const quadrature_class, i
 Ordinate_Space::Ordinate_Space(unsigned const dimension, rtt_mesh_element::Geometry const geometry,
                                vector<Ordinate> const &ordinates, int const expansion_order,
                                bool const extra_starting_directions, Ordering const ordering)
-    : Ordinate_Set(dimension, geometry, ordinates, geometry != rtt_mesh_element::CARTESIAN,
+    : Ordinate_Set(dimension, geometry, ordinates,
+                   geometry != rtt_mesh_element::Geometry::CARTESIAN,
                    // include starting directions if curvilinear
                    extra_starting_directions, ordering),
       expansion_order_(expansion_order), has_extra_starting_directions_(extra_starting_directions),
@@ -352,7 +353,7 @@ Ordinate_Space::Ordinate_Space(unsigned const dimension, rtt_mesh_element::Geome
       reflect_eta_(), reflect_xi_(), alpha_(), tau_(), number_of_moments_(0), moments_(),
       moments_per_order_() {
   Require(dimension > 0 && dimension < 4);
-  Require(geometry != rtt_mesh_element::END_GEOMETRY);
+  Require(geometry != rtt_mesh_element::Geometry::END_GEOMETRY);
 
   compute_angle_operator_coefficients_();
 
@@ -408,7 +409,7 @@ double Ordinate_Space::bookkeeping_coefficient(unsigned const a) const {
 
 //------------------------------------------------------------------------------------------------//
 bool Ordinate_Space::check_class_invariants() const {
-  if (geometry() == rtt_mesh_element::CARTESIAN) {
+  if (geometry() == rtt_mesh_element::Geometry::CARTESIAN) {
     return ((this->dimension() != 2 || this->ordering() != LEVEL_ORDERED) ||
             (first_angles_.size() == number_of_levels_));
   } else {
@@ -492,7 +493,7 @@ void Ordinate_Space::moment_to_flux(std::array<unsigned, 3> &flux_map,
 
   if (dimension() == 1) {
     flux_map[0] = 0;
-    if (geometry() != rtt_mesh_element::AXISYMMETRIC)
+    if (geometry() != rtt_mesh_element::Geometry::AXISYMMETRIC)
       flux_fact[0] = RROOT3;
     else
       flux_fact[0] = -RROOT3;
@@ -544,7 +545,7 @@ void Ordinate_Space::flux_to_moment(std::array<unsigned, 3> &flux_map,
     // harmonics is aligned along the coordinate axis for consistency with 2-D axisymmetric, and so
     // the flux is the -Y(1,1) harmonic (times the normalization).
     flux_map[0] = 0;
-    if (geometry() != rtt_mesh_element::AXISYMMETRIC)
+    if (geometry() != rtt_mesh_element::Geometry::AXISYMMETRIC)
       flux_fact[0] = ROOT3;
     else
       flux_fact[0] = -ROOT3;

--- a/src/quadrature/Quadrature.cc
+++ b/src/quadrature/Quadrature.cc
@@ -3,7 +3,7 @@
  * \file   quadrature/Quadrature.cc
  * \author Kelly Thompson
  * \date   Tue Feb 22 15:38:56 2000
- * \brief  Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \brief  Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Quadrature.hh"
@@ -117,7 +117,7 @@ void Quadrature::add_1D_starting_directions_(Geometry const geometry,
   // Add starting directions if necessary
 
   if (add_starting_directions) {
-    if (geometry == rtt_mesh_element::SPHERICAL) {
+    if (geometry == rtt_mesh_element::Geometry::SPHERICAL) {
       // insert mu=-1 starting direction
       auto a = ordinates.begin();
       a = ordinates.insert(a, Ordinate(-1.0, 0.0, 0.0, 0.0));
@@ -125,7 +125,7 @@ void Quadrature::add_1D_starting_directions_(Geometry const geometry,
       // insert mu=1 starting direction
       if (add_extra_starting_directions)
         ordinates.emplace_back(Ordinate(1.0, 0.0, 0.0, 0.0));
-    } else if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+    } else if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
       Insist(false, "should not be reached");
     }
   }
@@ -140,7 +140,7 @@ void Quadrature::add_2D_starting_directions_(Geometry const geometry,
   // Add starting directions if necessary
 
   if (add_starting_directions) {
-    if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+    if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
       std::sort(ordinates.begin(), ordinates.end(), Ordinate_Set::level_compare);
 
       // Define an impossible value for a direction cosine.  We use this to simplify the logic of
@@ -282,11 +282,12 @@ std::shared_ptr<Ordinate_Space> Quadrature::create_ordinate_space(
   Require(qim == SN || qim == GQ1 || qim == GQ2 || qim == GQF);
   Require(qim == SN || moment_expansion_order >= 0);
 
-  std::vector<Ordinate> ordinates = create_ordinates(dimension, geometry,
-                                                     1.0, // hardwired norm
-                                                     geometry != rtt_mesh_element::CARTESIAN,
-                                                     // include starting directions if curvilinear
-                                                     include_extra_directions);
+  std::vector<Ordinate> ordinates =
+      create_ordinates(dimension, geometry,
+                       1.0, // hardwired norm
+                       geometry != rtt_mesh_element::Geometry::CARTESIAN,
+                       // include starting directions if curvilinear
+                       include_extra_directions);
 
   std::shared_ptr<Ordinate_Space> Result;
   if (qim == SN)

--- a/src/quadrature/Sn_Ordinate_Space.cc
+++ b/src/quadrature/Sn_Ordinate_Space.cc
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Mon Mar 26 16:11:19 2007
  * \brief  Define methods of class Sn_Ordinate_Space
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2012-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Sn_Ordinate_Space.hh"
@@ -106,7 +106,8 @@ void Sn_Ordinate_Space::compute_M() {
       unsigned const ell(n2lk[n].L());
       int const k(n2lk[n].M());
 
-      if (dim == 1 && geometry != rtt_mesh_element::AXISYMMETRIC) // 1D mesh, 1D quadrature
+      if (dim == 1 &&
+          geometry != rtt_mesh_element::Geometry::AXISYMMETRIC) // 1D mesh, 1D quadrature
       {
         double mu(ordinates[m].mu());
         M_[n + m * numMoments] = Ylm(ell, k, mu, 0.0, sumwt);
@@ -117,33 +118,29 @@ void Sn_Ordinate_Space::compute_M() {
 
         // R-Z coordinate system
         //
-        // It is important to remember here that the positive mu axis points to
-        // the left and the positive eta axis points up, when the unit sphere is
-        // projected on the plane of the mu- and eta-axis in R-Z. In this case,
-        // phi is measured from the mu-axis counterclockwise.
+        // It is important to remember here that the positive mu axis points to the left and the
+        // positive eta axis points up, when the unit sphere is projected on the plane of the mu-
+        // and eta-axis in R-Z. In this case, phi is measured from the mu-axis counterclockwise.
         //
-        // This accounts for the fact that the azimuthal angle is discretized on
-        // levels of the xi-axis, making the computation of the azimuthal angle
-        // here consistent with the discretization by using the eta and mu
-        // ordinates to define phi.
+        // This accounts for the fact that the azimuthal angle is discretized on levels of the
+        // xi-axis, making the computation of the azimuthal angle here consistent with the
+        // discretization by using the eta and mu ordinates to define phi.
 
         // X-Y coordinate system
         //
-        // Note that we choose the same moments and spherical harmonics as for
-        // R-Z in this case, unlike the Galerkin method.
+        // Note that we choose the same moments and spherical harmonics as for R-Z in this case,
+        // unlike the Galerkin method.
         //
-        // This is because we choose the "front" of the hemisphere, here, so
-        // that the spherical harmonics chosen are even in the azimuthal angle
-        // (symmetry from front to back) and not even in the polar angle. Thus,
-        // in this case, the polar angle is measured from the eta-axis [0, Pi],
-        // and the azimuthal angle is measured from the mu-axis [0,Pi].
+        // This is because we choose the "front" of the hemisphere, here, so that the spherical
+        // harmonics chosen are even in the azimuthal angle (symmetry from front to back) and not
+        // even in the polar angle. Thus, in this case, the polar angle is measured from the
+        // eta-axis [0, Pi], and the azimuthal angle is measured from the mu-axis [0,Pi].
         //
-        // In contrast, the Galerkin methods chooses the "top" hemisphere, and
-        // projects down onto the x-y plane. Hence the polar angle in that case
-        // is xi and extends from [0,Pi/2] while the azimuthal angle is on [0, 2
-        // Pi]. Therefore, in that case, the spherical harmonics must be those
-        // that are even in the polar angle. That may be determined by
-        // considering the even-ness of the associated Legendre polynomials.
+        // In contrast, the Galerkin methods chooses the "top" hemisphere, and projects down onto
+        // the x-y plane. Hence the polar angle in that case is xi and extends from [0,Pi/2] while
+        // the azimuthal angle is on [0, 2 Pi]. Therefore, in that case, the spherical harmonics
+        // must be those that are even in the polar angle. That may be determined by considering the
+        // even-ness of the associated Legendre polynomials.
 
         double phi(compute_azimuthalAngle(mu, xi));
         M_[n + m * numMoments] = Ylm(ell, k, eta, phi, sumwt);
@@ -153,9 +150,7 @@ void Sn_Ordinate_Space::compute_M() {
 }
 
 //------------------------------------------------------------------------------------------------//
-/*! This computation requires that the moment-to-discrete matrix M is already
- *  created.
- */
+//! This computation requires that the moment-to-discrete matrix M is already created.
 void Sn_Ordinate_Space::compute_D() {
 
   Insist(!M_.empty(), "The SN ordinate space computation for D requires that M be available.");
@@ -197,32 +192,21 @@ void Sn_Ordinate_Space::compute_D() {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- *
- * The computation of the tau and alpha coefficients is described by Morel in
- * various technical notes on the treatment of the angle derivatives in the
- * streaming operator.
+ * The computation of the tau and alpha coefficients is described by Morel in various technical
+ * notes on the treatment of the angle derivatives in the streaming operator.
  *
  * \param dimension Dimension of the physical problem space (1, 2, or 3)
- *
- * \param geometry Geometry of the physical problem space (spherical,
- * axisymmetric, Cartesian)
- *
+ * \param geometry Geometry of the physical problem space (spherical, axisymmetric, Cartesian)
  * \param ordinates Set of ordinate directions
- *
- * \param expansion_order Expansion order of the desired scattering moment
- * space. If negative, the moment space is not needed.
- *
- * \param extra_starting_directions Add extra directions to each level set. In
- * most geometries, an additional ordinate is added that is opposite in
- * direction to the starting direction. This is used to implement reflection
- * exactly in curvilinear coordinates. In 1D spherical, that means an
- * additional angle is added at mu=1. In axisymmetric, that means additional
- * angles are added that are oriented opposite to the incoming starting
- * direction on each level.
- *
+ * \param expansion_order Expansion order of the desired scattering moment space. If negative, the
+ *        moment space is not needed.
+ * \param extra_starting_directions Add extra directions to each level set. In most geometries, an
+ *        additional ordinate is added that is opposite in direction to the starting direction. This
+ *        is used to implement reflection exactly in curvilinear coordinates. In 1D spherical, that
+ *        means an additional angle is added at mu=1. In axisymmetric, that means additional angles
+ *        are added that are oriented opposite to the incoming starting direction on each level.
  * \param ordering Ordering into which to sort the ordinates.
  */
-
 Sn_Ordinate_Space::Sn_Ordinate_Space(unsigned const dimension,
                                      rtt_mesh_element::Geometry const geometry,
                                      vector<Ordinate> const &ordinates, int const expansion_order,
@@ -231,7 +215,7 @@ Sn_Ordinate_Space::Sn_Ordinate_Space(unsigned const dimension,
                      ordering),
       D_(), M_() {
   Require(dimension > 0 && dimension < 4);
-  Require(geometry != rtt_mesh_element::END_GEOMETRY);
+  Require(geometry != rtt_mesh_element::Geometry::END_GEOMETRY);
 
   compute_moments_(END_QUADRATURE,   // not used by Sn
                    expansion_order); // also not actually used

--- a/src/quadrature/test/quadrature_test.cc
+++ b/src/quadrature/test/quadrature_test.cc
@@ -3,7 +3,7 @@
  * \file   quadrature/test/quadrature_test.cc
  * \author Kent G. Budge
  * \brief  Define class quadrature_test
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC. All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "quadrature_test.hh"
@@ -55,7 +55,7 @@ void test_either(UnitTest &ut, std::shared_ptr<Ordinate_Space> const &ordinate_s
   vector<unsigned> const &first_angles = ordinate_space->first_angles();
   unsigned const number_of_levels = quadrature.number_of_levels();
 
-  if (geometry == rtt_mesh_element::SPHERICAL) {
+  if (geometry == rtt_mesh_element::Geometry::SPHERICAL) {
     if (first_angles.size() == 1) {
       PASSMSG("first angles is correct");
     } else {
@@ -71,7 +71,7 @@ void test_either(UnitTest &ut, std::shared_ptr<Ordinate_Space> const &ordinate_s
     ordinate_space->psi_coefficient(static_cast<unsigned>(number_of_ordinates - 1));
     ordinate_space->source_coefficient(static_cast<unsigned>(number_of_ordinates - 1));
     // check that throws no exception
-  } else if (geometry == rtt_mesh_element::AXISYMMETRIC) {
+  } else if (geometry == rtt_mesh_element::Geometry::AXISYMMETRIC) {
     if ((dimension > 1 && first_angles.size() == number_of_levels) ||
         (dimension == 1 && 2 * first_angles.size() == number_of_levels)) {
       PASSMSG("first angles is correct");
@@ -192,7 +192,7 @@ void test_either(UnitTest &ut, std::shared_ptr<Ordinate_Space> const &ordinate_s
   switch (quadrature.quadrature_class()) {
   case TRIANGLE_QUADRATURE:
     if (dimension == 1) {
-      if (geometry == rtt_mesh_element::CARTESIAN && L != Num)
+      if (geometry == rtt_mesh_element::Geometry::CARTESIAN && L != Num)
         FAILMSG("ordinate count is wrong for triangular quadrature");
     } else if (dimension == 3) {
       if (L * (L + 2) != Num)
@@ -389,7 +389,7 @@ void quadrature_integration_test(UnitTest & /*ut*/, Quadrature &quadrature) {
     // Build an ordinate set
     std::shared_ptr<Ordinate_Set> ordinate_set =
         quadrature.create_ordinate_set(3U, // dimension
-                                       rtt_mesh_element::CARTESIAN,
+                                       rtt_mesh_element::Geometry::CARTESIAN,
                                        1.0,   // norm,
                                        false, // add_starting_directions
                                        false, // add_extra_directions,
@@ -539,7 +539,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     std::shared_ptr<Ordinate_Set> ordinate_set =
         quadrature.create_ordinate_set(1U, // dimension
-                                       rtt_mesh_element::CARTESIAN,
+                                       rtt_mesh_element::Geometry::CARTESIAN,
                                        1.0,   // norm,
                                        false, // add_starting_directions
                                        false, // add_extra_directions,
@@ -563,7 +563,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     test_no_axis(ut, quadrature,
                  1U, // dimension,
-                 rtt_mesh_element::CARTESIAN,
+                 rtt_mesh_element::Geometry::CARTESIAN,
                  1U, // expansion_order,
                  "SN",
                  false, // add_extra_directions,
@@ -571,7 +571,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     test_no_axis(ut, quadrature,
                  1U, // dimension,
-                 rtt_mesh_element::CARTESIAN,
+                 rtt_mesh_element::Geometry::CARTESIAN,
                  1U, // expansion_order,
                  "GQ1",
                  false, // add_extra_directions,
@@ -579,7 +579,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     test_no_axis(ut, quadrature,
                  1U, // dimension,
-                 rtt_mesh_element::CARTESIAN,
+                 rtt_mesh_element::Geometry::CARTESIAN,
                  1U, // expansion_order,
                  "GQF",
                  false, // add_extra_directions,
@@ -592,7 +592,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
         test_no_axis(ut, quadrature,
                      1U, // dimension,
-                     rtt_mesh_element::SPHERICAL,
+                     rtt_mesh_element::Geometry::SPHERICAL,
                      1U, // expansion_order,
                      "SN",
                      false, // add_extra_directions,
@@ -600,7 +600,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
         test_no_axis(ut, quadrature,
                      1U, // dimension,
-                     rtt_mesh_element::SPHERICAL,
+                     rtt_mesh_element::Geometry::SPHERICAL,
                      1U, // expansion_order,
                      "GQ1",
                      false, // add_extra_directions,
@@ -616,7 +616,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     std::shared_ptr<Ordinate_Set> ordinate_set =
         quadrature.create_ordinate_set(3U, // dimension
-                                       rtt_mesh_element::CARTESIAN,
+                                       rtt_mesh_element::Geometry::CARTESIAN,
                                        1.0,   // norm,
                                        false, // add_starting_directions
                                        false, // add_extra_directions,
@@ -638,7 +638,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     test_no_axis(ut, quadrature,
                  2U, // dimension,
-                 rtt_mesh_element::CARTESIAN,
+                 rtt_mesh_element::Geometry::CARTESIAN,
                  8U, // expansion_order,
                  "SN",
                  false, // add_extra_directions,
@@ -646,7 +646,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     test_no_axis(ut, quadrature,
                  3U, // dimension,
-                 rtt_mesh_element::CARTESIAN,
+                 rtt_mesh_element::Geometry::CARTESIAN,
                  8U, // expansion_order,
                  "SN",
                  false, // add_extra_directions,
@@ -655,7 +655,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
     if (quadrature.quadrature_class() == TRIANGLE_QUADRATURE) {
       test_no_axis(ut, quadrature,
                    2U, // dimension,
-                   rtt_mesh_element::CARTESIAN,
+                   rtt_mesh_element::Geometry::CARTESIAN,
                    // expansion_order
                    min(8U, quadrature.number_of_levels()), "GQ1",
                    false, // add_extra_directions,
@@ -663,7 +663,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
       test_no_axis(ut, quadrature,
                    3U, // dimension,
-                   rtt_mesh_element::CARTESIAN,
+                   rtt_mesh_element::Geometry::CARTESIAN,
                    // expansion_order
                    quadrature.number_of_levels() - 1, "GQ1",
                    false, // add_extra_directions,
@@ -673,7 +673,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
     if (!cartesian_tests_only) {
       test_no_axis(ut, quadrature,
                    1U, // dimension,
-                   rtt_mesh_element::AXISYMMETRIC,
+                   rtt_mesh_element::Geometry::AXISYMMETRIC,
                    8U, // expansion_order,
                    "SN",
                    false, // add_extra_directions,
@@ -681,7 +681,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
       test_no_axis(ut, quadrature,
                    2U, // dimension,
-                   rtt_mesh_element::AXISYMMETRIC,
+                   rtt_mesh_element::Geometry::AXISYMMETRIC,
                    8U, // expansion_order,
                    "SN",
                    false, // add_extra_directions,
@@ -692,7 +692,7 @@ void quadrature_test(UnitTest &ut, Quadrature &quadrature, bool const cartesian_
 
     test_axis(ut, quadrature,
               3U, // dimension,
-              rtt_mesh_element::CARTESIAN,
+              rtt_mesh_element::Geometry::CARTESIAN,
               8U, // expansion_order,
               "SN",
               false, // add_extra_directions,

--- a/src/quadrature/test/tstOrdinate_Set_Mapper.cc
+++ b/src/quadrature/test/tstOrdinate_Set_Mapper.cc
@@ -4,8 +4,7 @@
  * \author Allan Wollaber
  * \date   Mon Mar  7 16:21:45 EST 2016
  * \brief  Ordinate Set Mapper tests
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -191,7 +190,7 @@ void nearest_three_test(rtt_dsxx::UnitTest &ut, const Ordinate &ord, const Ordin
 // -----------------------------------------------------------------------------
 void ordinate_set_2D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(2); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::CARTESIAN);
   Level_Symmetric quadrature(N);
 
   std::shared_ptr<Ordinate_Set> os_LS2 =
@@ -288,7 +287,7 @@ void ordinate_set_2D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
 //------------------------------------------------------------------------------------------------//
 void ordinate_set_1D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(4); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::CARTESIAN);
   Gauss_Legendre quadrature(N);
 
   std::shared_ptr<Ordinate_Set> os_LS4 =
@@ -382,7 +381,7 @@ void ordinate_set_1D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
 //------------------------------------------------------------------------------------------------//
 void ordinate_set_3D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(4); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::CARTESIAN);
   Product_Chebyshev_Legendre quadrature(N, N);
 
   std::shared_ptr<Ordinate_Set> os_LS2 =
@@ -484,7 +483,7 @@ void ordinate_set_3D_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
 //------------------------------------------------------------------------------------------------//
 void ordinate_set_1D_sph_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(2); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::SPHERICAL);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::SPHERICAL);
   Gauss_Legendre quadrature(N);
 
   // Note that this test uses "starting directions" in the Ordinate_Set These
@@ -540,7 +539,7 @@ void ordinate_set_1D_sph_nn_mapper_test(rtt_dsxx::UnitTest &ut) {
 //------------------------------------------------------------------------------------------------//
 void ordinate_set_1D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(8); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::CARTESIAN);
   Gauss_Legendre quadrature(N);
 
   std::shared_ptr<Ordinate_Set> os_LS4 =
@@ -664,7 +663,7 @@ void ordinate_set_1D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
 // -----------------------------------------------------------------------------
 void ordinate_set_2D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(6); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::CARTESIAN);
   Level_Symmetric quadrature(N);
 
   std::shared_ptr<Ordinate_Set> os_LS2 =
@@ -761,7 +760,7 @@ void ordinate_set_2D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
 //------------------------------------------------------------------------------------------------//
 void ordinate_set_3D_nt_mapper_test(rtt_dsxx::UnitTest &ut) {
   int N(4); // quadrature order
-  rtt_mesh_element::Geometry geometry(rtt_mesh_element::CARTESIAN);
+  rtt_mesh_element::Geometry geometry(rtt_mesh_element::Geometry::CARTESIAN);
   Product_Chebyshev_Legendre quadrature(N, N);
 
   std::shared_ptr<Ordinate_Set> os_LS2 =


### PR DESCRIPTION
### Background

+ Convert `mesh_element`'s `Geometry` into a scoped enum and examine the fallout.
+ Scoped enum help to eliminate variable shadowing (two enums with the same name in the same scope). Most lint programs flag our 'traditional' use of `Enum` as bug-prone.

### Description of changes

+ For Draco, the impact is minimal.  Other codes that include Draco headers will need to be evaluated against this PR before merging.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
