### PR TITLE
Save ndi version to cdi_ndi/config.h

### DIFF
--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -62,8 +62,7 @@ include(FindPackageHandleStandardArgs)
 # at this location over system locations.
 if( EXISTS "$ENV{NDI_ROOT_DIR}" )
   file( TO_CMAKE_PATH "$ENV{NDI_ROOT_DIR}" NDI_ROOT_DIR )
-  set( NDI_ROOT_DIR "${NDI_ROOT_DIR}" CACHE PATH
-    "Prefix for NDI installation." )
+  set( NDI_ROOT_DIR "${NDI_ROOT_DIR}" CACHE PATH "Prefix for NDI installation." )
 endif()
 
 #=============================================================================
@@ -77,23 +76,33 @@ endif()
 find_path( NDI_INCLUDE_DIR
   NAMES ndi.h
   HINTS ${NDI_ROOT_DIR}/include/ndi ${NDI_ROOT_DIR}/include
-  PATH_SUFFIXES ndi
-  )
-
+  PATH_SUFFIXES ndi )
 set( NDI_LIBRARY_NAME ndipic ndi)
 
 find_library(NDI_LIBRARY
   NAMES ${NDI_LIBRARY_NAME}
-  PATHS ${NDI_ROOT_DIR}/lib
-  )
+  PATHS ${NDI_ROOT_DIR}/lib )
 # Do we also have debug versions?
 find_library( NDI_LIBRARY_DEBUG
   NAMES ${NDI_LIBRARY_NAME}
   HINTS ${NDI_ROOT_DIR}/lib
-  PATH_SUFFIXES Debug
-)
+  PATH_SUFFIXES Debug )
 set( NDI_INCLUDE_DIRS ${NDI_INCLUDE_DIR} )
 set( NDI_LIBRARIES ${NDI_LIBRARY} )
+
+# Try to find the version.
+if( NOT NDI_VERSION )
+  # We might also try scraping the directory name for a regex match "ndi-X.X.X"
+  if( NOT NDI_MAJOR )
+    string( REGEX REPLACE ".*ndi-([0-9]+).([0-9]+).([A-Za-z0-9]+).*" "\\1" NDI_MAJOR
+      ${NDI_INCLUDE_DIR} )
+    string( REGEX REPLACE ".*ndi-([0-9]+).([0-9]+).([A-Za-z0-9]+).*" "\\2" NDI_MINOR
+      ${NDI_INCLUDE_DIR} )
+    string( REGEX REPLACE ".*ndi-([0-9]+).([0-9]+).([A-Za-z0-9]+).*" "\\3" NDI_SUBMINOR
+      ${NDI_INCLUDE_DIR} )
+    set( NDI_VERSION "${NDI_MAJOR}.${NDI_MINOR}.${NDI_SUBMINOR}")
+  endif()
+endif()
 
 #=============================================================================
 # handle the QUIETLY and REQUIRED arguments and set NDI_FOUND to TRUE if
@@ -105,11 +114,10 @@ find_package_handle_standard_args( NDI
     NDI_INCLUDE_DIR
     NDI_LIBRARY
   VERSION_VAR
-    NDI_VERSION
-    )
+    NDI_VERSION )
 
-mark_as_advanced( NDI_ROOT_DIR NDI_VERSION NDI_LIBRARY
-  NDI_INCLUDE_DIR NDI_LIBRARY_DEBUG NDI_USE_PKGCONFIG NDI_CONFIG )
+mark_as_advanced( NDI_ROOT_DIR NDI_VERSION NDI_LIBRARY NDI_INCLUDE_DIR NDI_LIBRARY_DEBUG
+    NDI_USE_PKGCONFIG NDI_CONFIG )
 
 #=============================================================================
 # Register imported libraries:
@@ -120,10 +128,8 @@ mark_as_advanced( NDI_ROOT_DIR NDI_VERSION NDI_LIBRARY
 
 # Look for dlls, or Release and Debug libraries.
 if(WIN32)
-  string( REPLACE ".lib" ".dll" NDI_LIBRARY_DLL
-    "${NDI_LIBRARY}" )
-  string( REPLACE ".lib" ".dll" NDI_LIBRARY_DEBUG_DLL
-    "${NDI_LIBRARY_DEBUG}" )
+  string( REPLACE ".lib" ".dll" NDI_LIBRARY_DLL "${NDI_LIBRARY}" )
+  string( REPLACE ".lib" ".dll" NDI_LIBRARY_DEBUG_DLL "${NDI_LIBRARY_DEBUG}" )
 endif()
 
 if( NDI_FOUND AND NOT TARGET NDI::ndi )
@@ -143,8 +149,7 @@ if( NDI_FOUND AND NOT TARGET NDI::ndi )
 
       # If we have both Debug and Release libraries
       if( EXISTS "${NDI_LIBRARY_DEBUG_DLL}" )
-        set_property( TARGET NDI::ndi APPEND PROPERTY
-          IMPORTED_CONFIGURATIONS Debug )
+        set_property( TARGET NDI::ndi APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
         set_target_properties( NDI::ndi PROPERTIES
           IMPORTED_LOCATION_DEBUG           "${NDI_LIBRARY_DEBUG_DLL}"
           IMPORTED_IMPLIB_DEBUG             "${NDI_LIBRARY_DEBUG}" )
@@ -163,10 +168,8 @@ if( NDI_FOUND AND NOT TARGET NDI::ndi )
 
       # If we have both Debug and Release libraries
       if( EXISTS "${NDI_LIBRARY_DEBUG}" )
-        set_property( TARGET NDI::ndi APPEND PROPERTY
-          IMPORTED_CONFIGURATIONS Debug )
-        set_target_properties( NDI::ndi PROPERTIES
-          IMPORTED_LOCATION_DEBUG           "${NDI_LIBRARY_DEBUG}" )
+        set_property( TARGET NDI::ndi APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
+        set_target_properties( NDI::ndi PROPERTIES IMPORTED_LOCATION_DEBUG "${NDI_LIBRARY_DEBUG}" )
       endif()
 
     endif()

--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -92,14 +92,25 @@ set( NDI_LIBRARIES ${NDI_LIBRARY} )
 
 # Try to find the version.
 if( NOT NDI_VERSION )
-  # We might also try scraping the directory name for a regex match "ndi-X.X.X"
-  if( NOT NDI_MAJOR )
+  if( EXISTS "${NDI_INCLUDE_DIR}/ndi_version.h")
+    # pull data directly from the include file.
+    file( STRINGS "${NDI_INCLUDE_DIR}/ndi_version.h" include_version_h REGEX "NDI_VERSION_DATA" )
+    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([A-Za-z0-9]+).*" "\\1" NDI_MAJOR
+      ${include_version_h})
+    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([A-Za-z0-9]+).*" "\\2" NDI_MINOR
+      ${include_version_h})
+    string( REGEX REPLACE ".*([0-9]+)[.]([0-9]+)[.]([A-Za-z0-9]+).*" "\\3" NDI_SUBMINOR
+      ${include_version_h})
+  else()
+    # We might also try scraping the directory name for a regex match "ndi-X.X.X"
     string( REGEX REPLACE ".*ndi-([0-9]+).([0-9]+).([A-Za-z0-9]+).*" "\\1" NDI_MAJOR
       ${NDI_INCLUDE_DIR} )
     string( REGEX REPLACE ".*ndi-([0-9]+).([0-9]+).([A-Za-z0-9]+).*" "\\2" NDI_MINOR
       ${NDI_INCLUDE_DIR} )
     string( REGEX REPLACE ".*ndi-([0-9]+).([0-9]+).([A-Za-z0-9]+).*" "\\3" NDI_SUBMINOR
       ${NDI_INCLUDE_DIR} )
+  endif()
+  if( NDI_MAJOR )
     set( NDI_VERSION "${NDI_MAJOR}.${NDI_MINOR}.${NDI_SUBMINOR}")
   endif()
 endif()

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -22,7 +22,7 @@
 #endif
 
 /* NDI version (if found) */
-#cmakedefine NDI_VERSION "@NDI_VERSION@"
+#cmakedefine NDI_VERSION_STRING "@NDI_VERSION@"
 #cmakedefine NDI_MAJOR "@NDI_MAJOR@"
 #cmakedefine NDI_MINOR "@NDI_MINOR@"
 

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -21,6 +21,11 @@
  #include "ndi.h"
 #endif
 
+/* NDI version (if found) */
+#cmakedefine NDI_VERSION "@NDI_VERSION@"
+#cmakedefine NDI_MAJOR "@NDI_MAJOR@"
+#cmakedefine NDI_MINOR "@NDI_MINOR@"
+
 #endif // rtt_cdi_ndi_config_h
 
 /*------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
### Background

* Update build system to scrape NDI version and save it to `cdi_ndi/config.h`.
* Produces something like this:
```c++
#define NDI_VERSION_STRING "2.2.0alpha"
#define NDI_MAJOR "2"
#define NDI_MINOR "2"
```
* Note that NDI itself defines:
```
#define NDI_VERSION_DATA "2.2.0alpha"
...
# define NDI_VERSION 42
```
* We must be careful to avoid symbol collision.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
* WIP
  * [x] Fix warning ` warning #47: incompatible redefinition of macro "NDI_VERSION"`
