### PR TITLE
Disable NDI stopping powers if NDI version < 2.2.x

### DIFF
--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -124,13 +124,12 @@ find_package_handle_standard_args( NDI
   REQUIRED_VARS
     NDI_INCLUDE_DIR
     NDI_LIBRARY
+    NDI_VERSION
   VERSION_VAR
     NDI_VERSION )
 
 mark_as_advanced( NDI_ROOT_DIR NDI_VERSION NDI_LIBRARY NDI_INCLUDE_DIR NDI_LIBRARY_DEBUG
     NDI_USE_PKGCONFIG NDI_CONFIG )
-
-message(FATAL_ERROR, ${NDI_VERSION})
 
 #=============================================================================
 # Register imported libraries:

--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -112,6 +112,7 @@ if( NOT NDI_VERSION )
   endif()
   if( NDI_MAJOR )
     set( NDI_VERSION "${NDI_MAJOR}.${NDI_MINOR}.${NDI_SUBMINOR}")
+    set( NDI_MAJOR_INTEGER ${NDI_MAJOR} )
   endif()
 endif()
 

--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -112,6 +112,7 @@ if( NOT NDI_VERSION )
   endif()
   if( NDI_MAJOR )
     set( NDI_VERSION "${NDI_MAJOR}.${NDI_MINOR}.${NDI_SUBMINOR}")
+    set( NDI_VERSION_STRING "${NDI_VERSION}" )
   endif()
 endif()
 

--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -112,7 +112,6 @@ if( NOT NDI_VERSION )
   endif()
   if( NDI_MAJOR )
     set( NDI_VERSION "${NDI_MAJOR}.${NDI_MINOR}.${NDI_SUBMINOR}")
-    set( NDI_MAJOR_INTEGER ${NDI_MAJOR} )
   endif()
 endif()
 

--- a/config/FindNDI.cmake
+++ b/config/FindNDI.cmake
@@ -111,6 +111,8 @@ find_package_handle_standard_args( NDI
 mark_as_advanced( NDI_ROOT_DIR NDI_VERSION NDI_LIBRARY
   NDI_INCLUDE_DIR NDI_LIBRARY_DEBUG NDI_USE_PKGCONFIG NDI_CONFIG )
 
+message(FATAL_ERROR, ${NDI_VERSION})
+
 #=============================================================================
 # Register imported libraries:
 # 1. If we can find a Windows .dll file (or if we can find both Debug and

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -32,7 +32,6 @@ void NDI_Base::warn_ndi_version_mismatch(std::string const &gendir) {
 
   std::string gendir_ver = rtt_dsxx::extract_version(gendir, 2);
   std::string ndi_ver = rtt_dsxx::extract_version(NDI_ROOT_DIR, 2);
-  printf("gendir_ver: %s ndi_ver: %s\n", gendir_ver.c_str(), ndi_ver.c_str());
   if (gendir_ver.size() == 0)
     gendir_ver = "version unknown";
   if (ndi_ver.size() == 0)

--- a/src/cdi_ndi/NDI_Base.cc
+++ b/src/cdi_ndi/NDI_Base.cc
@@ -32,6 +32,7 @@ void NDI_Base::warn_ndi_version_mismatch(std::string const &gendir) {
 
   std::string gendir_ver = rtt_dsxx::extract_version(gendir, 2);
   std::string ndi_ver = rtt_dsxx::extract_version(NDI_ROOT_DIR, 2);
+  printf("gendir_ver: %s ndi_ver: %s\n", gendir_ver.c_str(), ndi_ver.c_str());
   if (gendir_ver.size() == 0)
     gendir_ver = "version unknown";
   if (ndi_ver.size() == 0)

--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -237,7 +237,8 @@ void NDI_CP_Eloss::load_ndi() {
     temperature = exp(temperature);
   }
 #else
-  Insist(0, "NDI version " + std::to_string(NDI_MAJOR) + "." + std::to_string(NDI_MINOR) + " does not support stopping powers!");
+  Insist(0, "NDI version " + std::to_string(NDI_MAJOR) + "." + std::to_string(NDI_MINOR) +
+                " does not support stopping powers!");
 #endif // NDI_DEDX_SUPPORT
 }
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -238,7 +238,7 @@ void NDI_CP_Eloss::load_ndi() {
   }
 #else
   Insist(0, "NDI version " + std::to_string(NDI_MAJOR) + "." + std::to_string(NDI_MINOR) +
-                " does not support stopping powers!");
+                ".x does not support stopping powers!");
 #endif // NDI_DEDX_SUPPORT
 }
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -237,7 +237,8 @@ void NDI_CP_Eloss::load_ndi() {
     temperature = exp(temperature);
   }
 #else
-  Insist(0, NDI_VERSION_STRING + " does not support stopping powers!");
+  Insist(0,
+         "NDI version " + std::string(NDI_VERSION_STRING) + " does not support stopping powers!");
 #endif // NDI_DEDX_SUPPORT
 }
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -124,6 +124,7 @@ NDI_CP_Eloss::NDI_CP_Eloss(const std::string &library_in, rtt_cdi::CParticle tar
  * see https://xweb.lanl.gov/projects/data/nuclear/ndi/ndi.html
  */
 void NDI_CP_Eloss::load_ndi() {
+#if NDI_DEDX_SUPPORT
   int gendir_handle = -1;
   int dataset_handle = -1;
   int ndi_error = -9999;
@@ -235,6 +236,9 @@ void NDI_CP_Eloss::load_ndi() {
   for (auto &temperature : temperatures) {
     temperature = exp(temperature);
   }
+#else
+  Insist(0, "NDI version " + std::to_string(NDI_MAJOR) + "." + std::to_string(NDI_MINOR) + " does not support stopping powers!");
+#endif // NDI_DEDX_SUPPORT
 }
 //----------------------------------------------------------------------------//
 /*!

--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -237,8 +237,7 @@ void NDI_CP_Eloss::load_ndi() {
     temperature = exp(temperature);
   }
 #else
-  Insist(0, "NDI version " + std::to_string(NDI_MAJOR) + "." + std::to_string(NDI_MINOR) +
-                ".x does not support stopping powers!");
+  Insist(0, NDI_VERSION_STRING + " does not support stopping powers!");
 #endif // NDI_DEDX_SUPPORT
 }
 //----------------------------------------------------------------------------//

--- a/src/cdi_ndi/NDI_CP_Eloss.hh
+++ b/src/cdi_ndi/NDI_CP_Eloss.hh
@@ -11,6 +11,8 @@
 #ifndef cdi_ndi_NDI_CP_Eloss_hh
 #define cdi_ndi_NDI_CP_Eloss_hh
 
+#define NDI_DEDX_SUPPORT (NDI_MAJOR > 2 || (NDI_MAJOR == 2 && NDI_MINOR >= 2))
+
 #include "NDI_Base.hh"
 #include "cdi/CPCommon.hh"
 #include "cdi/CPEloss.hh"

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -22,7 +22,7 @@
 #endif
 
 /* NDI version (if found) */
-#cmakedefine NDI_VERSION_STRING "@NDI_VERSION@"
+#cmakedefine NDI_VERSION_STRING "@NDI_VERSION_STRING@"
 #cmakedefine NDI_MAJOR @NDI_MAJOR@
 #cmakedefine NDI_MINOR @NDI_MINOR@
 

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -22,9 +22,8 @@
 #endif
 
 /* NDI version (if found) */
-#cmakedefine NDI_VERSION_STRING "@NDI_VERSION@"
-#cmakedefine NDI_MAJOR "@NDI_MAJOR@"
-#cmakedefine NDI_MINOR "@NDI_MINOR@"
+#cmakedefine NDI_MAJOR @NDI_MAJOR@
+#cmakedefine NDI_MINOR @NDI_MINOR@
 
 #endif // rtt_cdi_ndi_config_h
 

--- a/src/cdi_ndi/config.h.in
+++ b/src/cdi_ndi/config.h.in
@@ -22,6 +22,7 @@
 #endif
 
 /* NDI version (if found) */
+#cmakedefine NDI_VERSION_STRING "@NDI_VERSION@"
 #cmakedefine NDI_MAJOR @NDI_MAJOR@
 #cmakedefine NDI_MINOR @NDI_MINOR@
 


### PR DESCRIPTION
### Background

* NDI added stopping power support with 2.2.0alpha, which we want to use if possible.

### Purpose of Pull Request

* Hide macros added with NDI 2.2.0alpha behind preprocessor logic
* [Fixes Redmine Issue #2285](https://rtt.lanl.gov/redmine/issues/2285)

### Description of changes

* Changed `NDI_MAJOR` and `NDI_MINOR` in `config.h` to integers from strings to facilitate comparisons.
* `load_ndi()` fails if `NDI_MAJOR`, `NDI_MINOR` indicate insufficient support.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
