### PR TITLE
Use env/cmake variable MPIEXEC_PREFLAGS to add extra mpirun options.

### DIFF
--- a/tools/travis-run-tests.sh
+++ b/tools/travis-run-tests.sh
@@ -100,6 +100,9 @@ elif [[ "${COMPILER:=GCC}" == "GCC" ]]; then
   echo "FC     = ${FC}"
   echo "GCOV   = ${GCOV}"
 
+  # Extra options for mpirun
+  MPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe"
+
   export OMP_NUM_THREADS=2
   if [[ ${WERROR} ]]; then
     for i in C CXX Fortran; do

--- a/tools/travis-run-tests.sh
+++ b/tools/travis-run-tests.sh
@@ -100,8 +100,8 @@ elif [[ "${COMPILER:=GCC}" == "GCC" ]]; then
   echo "FC     = ${FC}"
   echo "GCOV   = ${GCOV}"
 
-  # Extra options for mpirun
-  MPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe"
+  # Extra options for mpirun. Travis requires these extra mpirun options
+  export MPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe"
 
   export OMP_NUM_THREADS=2
   if [[ ${WERROR} ]]; then

--- a/tools/travis-run-tests.sh
+++ b/tools/travis-run-tests.sh
@@ -176,6 +176,9 @@ elif [[ "${COMPILER}" == "LLVM" ]]; then
   echo "FC     = ${FC}"
   echo "GCOV   = ${GCOV}"
 
+  # Extra options for mpirun. Travis requires these extra mpirun options
+  export MPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe"
+
   export OMP_NUM_THREADS=2
   if [[ ${WERROR} ]]; then
     for i in C CXX Fortran; do


### PR DESCRIPTION
### Background

+ Teach the build system to look for and use mpirun command options found in the environment variable (or cmake variable) `MPIEXEC_PREFLAGS`.

### Description of changes

+ This allows the CI system to call cmake like this:
```
export MPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe" cmake $source/Draco
```
+ This mechanism can also be used to append other mpirun flags like `--mca btl ^openib` during test registration.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
