### PR TITLE
Load modules in .bashrc_vm.

### DIFF
--- a/environment/bashrc/.bashrc_vm
+++ b/environment/bashrc/.bashrc_vm
@@ -13,9 +13,10 @@
 
 export dracomodules="git gcc cmake python openmpi intel-mkl trilinos superlu-dist metis numdiff numactl parmetis gsl random123 eospac csk ndi libquo"
 
+# shellcheck disable=SC2206
 mods=( ${dracomodules} )
-for m in ${mods[@]}; do
-    module load $m
+for m in "${mods[@]}"; do
+    module load "$m"
 done
 
 ##---------------------------------------------------------------------------##

--- a/environment/bashrc/.bashrc_vm
+++ b/environment/bashrc/.bashrc_vm
@@ -11,8 +11,12 @@
 ##  in the LAP virutal environment.
 ##---------------------------------------------------------------------------##
 
-export dracomodules="gcc cmake python openmpi intel-mkl trilinos superlu-dist metis numdiff numactl parmetis gsl random123 eospac csk ndi libquo"
+export dracomodules="git gcc cmake python openmpi intel-mkl trilinos superlu-dist metis numdiff numactl parmetis gsl random123 eospac csk ndi libquo"
 
+mods=( ${dracomodules} )
+for m in ${mods[@]}; do
+    module load $m
+done
 
 ##---------------------------------------------------------------------------##
 ## end of .bashrc_vm


### PR DESCRIPTION
### Background

* In preliminary building testing on a VM, it was noticed that sourcing the bashrc does not load modules.

### Purpose of Pull Request

* Load modules in .bashrc_vm

### Description of changes

* Load modules set in the `dracomodules` variable in .bashrc_vm
* Load git as well.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
