### PR TITLE
Fix broken logic that sets CMAKE_CONFIGURATION_TYPES.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -3,8 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2010 Nov 2
 # brief  Install the config directory in the target directory
-# note   Copyright (C) 2016-2020, Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.17.0)
 project( config )
@@ -27,36 +26,17 @@ set( CMake_AFSD CMakeAddFortranSubdirectory/config_cafs_proj.cmake.in  )
 #--------------------------------------------------------------------------------------------------#
 
 string( TOUPPER "${CMAKE_BUILD_TYPE}" upper_build_type )
-set( Draco_CXX_COMPILER_FLAGS
-   "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${upper_build_type}}" )
-set( Draco_C_COMPILER_FLAGS
-   "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${upper_build_type}}" )
+set( Draco_CXX_COMPILER_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${upper_build_type}}" )
+set( Draco_C_COMPILER_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${upper_build_type}}" )
 set( Draco_Fortran_COMPILER_FLAGS
-   "${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${upper_build_type}}" )
+    "${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${upper_build_type}}" )
 
-# Publish the active build_types (A subset of CMAKE_CONFIGURATION_TYPES)
-if( CMAKE_CONFIGURATION_TYPES )
-   unset( DRACO_CONFIGURATION_TYPES CACHE)
-   foreach( cfg ${CMAKE_CONFIGURATION_TYPES} )
-      if( EXISTS ${Draco_BINARY_DIR}/${cfg} )
-         if( "${DRACO_CONFIGURATION_TYPES}x" STREQUAL "x" )
-            set( DRACO_CONFIGURATION_TYPES "${cfg}" )
-         else()
-            list( APPEND DRACO_CONFIGURATION_TYPES ${cfg} )
-         endif()
-      endif()
-   endforeach()
-   set( DRACO_CONFIGURATION_TYPES "${DRACO_CONFIGURATION_TYPES}"
-      CACHE STRING "Available multiconfig builds." )
-endif()
-
-# What MPI import targets should be found by clients (captured in
-# draco-config.cmake).
+# What MPI import targets should be found by clients (captured in draco-config.cmake).
 if ( "${DRACO_C4}" STREQUAL "MPI" )
   # c4 requires MPI::MPI_CXX if DRACO_C4==MPI.
   set( Draco_MPI_LANG_LIST "CXX" )
-  # If Draco found other MPI imported targets, then ensure they are defined for
-  # client software packages (e.g.: MPI::MPI_Fortran)
+  # If Draco found other MPI imported targets, then ensure they are defined for client software
+  # packages (e.g.: MPI::MPI_Fortran)
   foreach( lang C Fortran )
     if( TARGET MPI::MPI_${lang} )
       list( APPEND Draco_MPI_LANG_LIST ${lang} )

--- a/config/draco-config-install.cmake.in
+++ b/config/draco-config-install.cmake.in
@@ -14,7 +14,17 @@ include( "${_SELF_DIR}/draco-targets.cmake" )
 
 # Also set the draco install dir
 set( DRACO_CONFIG_DIR "${_SELF_DIR}" )
-set( DRACO_CONFIGURATION_TYPES "@DRACO_CONFIGURATION_TYPES@" CACHE STRING
+
+# Inspect properties of Lib_dsxx to find a list of configurations
+if( TARGET Lib_dsxx )
+  get_target_property( DRACO_CONFIGURATION_TYPES Lib_dsxx IMPORTED_CONFIGURATIONS)
+endif()
+if( DRACO_CONFIGURATION_TYPES )
+  set( CMAKE_CONFIGURATION_TYPES "${DRACO_CONFIGURATION_TYPES}")
+else()
+  set( CMAKE_CONFIGURATION_TYPES "@CMAKE_CONFIGURATION_TYPES@")
+endif()
+set( CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
   "Available build configurations" FORCE )
 
 # Provide some pretty print information during configure
@@ -24,8 +34,8 @@ set_package_properties( draco PROPERTIES
    DESCRIPTION "Draco is a comprehensive, radiation transport framework that provides key, reusable
  components for serial and parallel computational physics codes."
    TYPE REQUIRED
-   PURPOSE "Provides underlying capabilities required by Capsaicin and Jayenne (smart pointers,
- data access, random number generators, etc.)" )
+   PURPOSE "Provides underlying capabilities required by TRT codes (smart pointers, data access,
+ random number generators, etc.)" )
 
 #--------------------------------------------------------------------------------------------------#
 # Basic build information


### PR DESCRIPTION
### Background

+ Previous logic was broken but harmless. Newer versions of cmake are now issuing warnings about this broken logic.  Previously, a list of build types was saved to the list `CMAKE_CONFIGURATION_TYPES`, but this list cannot be known at configure time and construction  must be delayed until `find_package(draco)` is called.
+ This change only affects multi-config build tools like Visual Studio.

### Purpose of Pull Request

* [Related to Redmine Issue #2096](https://rtt.lanl.gov/redmine/issues/2096)

### Description of changes

+ Also fix some 100 column wrap formatting.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
