### PR TITLE
Make the explicit Counter_RNG constructor available on the GPU

### DIFF
--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -218,6 +218,7 @@ public:
   }
 
   //! Construct a Counter_RNG using a seed and stream number.
+  GPU_HOST_DEVICE
   Counter_RNG(const uint32_t seed, const uint64_t streamnum) { initialize(seed, streamnum); }
 
   //! Create a new Counter_RNG from data.


### PR DESCRIPTION
### Background

* In a future PR for Jayenne I've started sourcing particles on the GPU and need to make RNG objects. Previously I only called RNG functions to generate doubles. This PR just adds the decorator for GPUs to the RNG constructor.

### Purpose of Pull Request

* Allow particles to be constructed on the GPU

### Description of changes

* Add GPU decorator to the Counter_RNG constructor

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
