### PR TITLE
Remove trailing period in config file

### DIFF
--- a/config/apple-clang.cmake
+++ b/config/apple-clang.cmake
@@ -30,7 +30,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
    set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
    set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
 
-endif().
+endif()
 
 #--------------------------------------------------------------------------------------------------#
 # Ensure cache values always match current selection


### PR DESCRIPTION
### Background

* `apple-clang` config file has stray period that causes configuration to end in error.

### Purpose of Pull Request

* Restore apple / Clang cmake configuration!

### Description of changes

* Remove period (.) 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
