### PR TITLE
Bug fix: CMAKE_CONFIGURATION_TYPES should not be set for Makefiles

### DIFF
--- a/config/draco-config-install.cmake.in
+++ b/config/draco-config-install.cmake.in
@@ -16,16 +16,15 @@ include( "${_SELF_DIR}/draco-targets.cmake" )
 set( DRACO_CONFIG_DIR "${_SELF_DIR}" )
 
 # Inspect properties of Lib_dsxx to find a list of configurations
-if( TARGET Lib_dsxx )
-  get_target_property( DRACO_CONFIGURATION_TYPES Lib_dsxx IMPORTED_CONFIGURATIONS)
+if( CMAKE_CONFIGURATION_TYPES ) # multi-config project files (not Makefiles)
+  if( TARGET Lib_dsxx )
+    get_target_property( DRACO_CONFIGURATION_TYPES Lib_dsxx IMPORTED_CONFIGURATIONS)
+  endif()
+  if( DRACO_CONFIGURATION_TYPES )
+    set( CMAKE_CONFIGURATION_TYPES "${DRACO_CONFIGURATION_TYPES}" CACHE STRING
+      "Available build configurations" FORCE )
+  endif()
 endif()
-if( DRACO_CONFIGURATION_TYPES )
-  set( CMAKE_CONFIGURATION_TYPES "${DRACO_CONFIGURATION_TYPES}")
-else()
-  set( CMAKE_CONFIGURATION_TYPES "@CMAKE_CONFIGURATION_TYPES@")
-endif()
-set( CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
-  "Available build configurations" FORCE )
 
 # Provide some pretty print information during configure
 include( FeatureSummary )


### PR DESCRIPTION
### Background

* Pull request #990 introduced a bug that broke Makefile-based projects.  

### Description of changes

* `CMAKE_CONFIGURATION_TYPES` must only be set for CMake projects that support multi-config builds (not Makefiles).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
