### PR TITLE
Fix warnings reported by gcc7 and xl16

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -41,6 +41,10 @@ if( NOT CXX_FLAGS_INITIALIZED )
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
     string( APPEND CMAKE_C_FLAGS " -Wnull-dereference" )
   endif()
+  if( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0 )
+    # Pragmas in rng and Random123 don't seem to disable this check.
+    string( APPEND CMAKE_C_FLAGS " -Wno-expansion-to-defined")
+  endif()
   string( CONCAT CMAKE_C_FLAGS_DEBUG "-g -fno-inline -fno-eliminate-unused-debug-types -O0"
     " -Wundef -Wunreachable-code -fsanitize=bounds-strict -fdiagnostics-color=auto -DDEBUG")
   # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,18 +16,6 @@ if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
   if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 )
     toggle_compiler_flag( TRUE "-Wconversion -Wdouble-promotion" "CXX" "DEBUG")
   endif()
-
-#  if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-# '-fsanitize=address' Not working just yet.  Issues...
-# 1. libasan.so.5: warning: the use of `tempnam' is dangerous, better use `mkstemp'
-# 2. ==134051==ASan runtime does not come first in initial library list; you should either link
-#    runtime to your application or manually preload it with LD_PRELOAD.
-# 3. many more run time issues, some may require suppression.
-#
-#    toggle_compiler_flag( TRUE
-#      "-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract" "CXX" "DEBUG")
-#  endif()
-
 elseif( CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" )
   string( REPLACE "/W2" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
   string( REPLACE "/W2" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )

--- a/src/ds++/terminal/terminal.h
+++ b/src/ds++/terminal/terminal.h
@@ -22,7 +22,7 @@
 #endif
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++98-compat"
 #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
@@ -770,7 +770,7 @@ public:
 #pragma diag_default unsigned_compare_with_negative
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic pop
 #endif
 

--- a/src/experimental/mdspan
+++ b/src/experimental/mdspan
@@ -49,7 +49,7 @@
 #pragma warning(disable : 4348)
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
@@ -83,7 +83,7 @@
 #pragma GCC diagnostic pop
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
 #endif

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -42,7 +42,7 @@
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wexpansion-to-defined"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
@@ -54,7 +54,7 @@
 #include "Random123/threefry.h"
 #include "uniform.hpp"
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
 #endif

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -47,11 +47,6 @@ set( random123_known_answer_tests
   ${PROJECT_SOURCE_DIR}/kat_c.cc
   ${PROJECT_SOURCE_DIR}/kat_cpp.cpp )
 
-# Ignore some warnings from Random123 tests that I can't suppress with a pragma.
-if( CMAKE_CXX_COMPILER_ID MATCHES GNU )
-  set_source_files_properties( kat_cpp.cpp PROPERTIES COMPILE_FLAGS "-Wno-expansion-to-defined")
-endif()
-
 #--------------------------------------------------------------------------------------------------#
 # Build Unit tests
 #--------------------------------------------------------------------------------------------------#

--- a/src/rng/test/kat_main.h
+++ b/src/rng/test/kat_main.h
@@ -73,7 +73,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wuseless-cast"
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-variable-declarations"
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
@@ -329,7 +329,7 @@ int main(int argc, char **argv) {
   }
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic pop
 #endif
 

--- a/src/rng/test/time_serial.cc
+++ b/src/rng/test/time_serial.cc
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -176,7 +176,7 @@ int main(int argc, char **argv) {
   return 0;
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic pop
 #endif
 

--- a/src/rng/test/ut_carray.cpp
+++ b/src/rng/test/ut_carray.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -355,7 +355,7 @@ int main(int, char **) {
   return 0;
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic pop
 #endif
 

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -77,7 +77,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wexpansion-to-defined"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
   return !!nfail;
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
 #endif

--- a/src/rng/test/util_cpu.h
+++ b/src/rng/test/util_cpu.h
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #pragma clang diagnostic ignored "-Wmissing-prototypes"
@@ -233,7 +233,7 @@ void cpu_done(CPUInfo *tp) {
   free(tp);
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
 #endif

--- a/src/rng/uniform.hpp
+++ b/src/rng/uniform.hpp
@@ -82,7 +82,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4127)
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
@@ -254,7 +254,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE Ftype u01fixedpt(Itype in) {
 #pragma warning(pop)
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
## Background

+ gcc-7 ignores pragmas that silence some for Random123 code.  Add special compiler flags for gcc7 to fix this issue.
+ New xlc++ defines `__clang__`, so replace `#ifdef __clang__` with `#if defined(__clang__) && !defined(__ibmxl__)`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
