### PR TITLE
Fix a couple of regression/CI issues.

### DIFF
--- a/src/c4/test/CMakeLists.txt
+++ b/src/c4/test/CMakeLists.txt
@@ -55,6 +55,9 @@ set( special_tests
 if( DEFINED ENV{TRAVIS} )
   # TRAVIS has severe limits on number of ranks/threads
   set( omp_test_pe_list "1" )
+elseif( CODE_COVERAGE )
+  # The 1 MPI rank version gets confused when running under code-coverage configurations.
+  set( omp_test_pe_list "2" )
 else()
   set( omp_test_pe_list "1;2" )
 endif()

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -8,7 +8,8 @@
 project( rng_test C CXX )
 
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0 )
-  toggle_compiler_flag( TRUE "-Wno-expansion-to-defined" "CXX" "DEBUG")
+  string(APPEND CMAKE_C_FLAGS " -Wno-expansion-to-defined")
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-expansion-to-defined")
 endif()
 
 #--------------------------------------------------------------------------------------------------#

--- a/src/rng/test/CMakeLists.txt
+++ b/src/rng/test/CMakeLists.txt
@@ -7,6 +7,10 @@
 #--------------------------------------------------------------------------------------------------#
 project( rng_test C CXX )
 
+if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0 )
+  toggle_compiler_flag( TRUE "-Wno-expansion-to-defined" "CXX" "DEBUG")
+endif()
+
 #--------------------------------------------------------------------------------------------------#
 # Source files
 #--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

* Regressions are reporting a couple of annoying errors and warnings.  These are false positives as far as our code is concerned.  

### Purpose of Pull Request

* fixes #1000 

### Description of changes

+ Don't run `tstOMP_1` under the coverage build. Collecting the coverage data slows the test down a bit and causes it to fail. This false positive is anoying and the coverage data is already collected for the `_2` case.
+ Use compiler flags to suppress a warning issued by gcc (`-Wexpansion-to-defined`) concerning Random123 code.  Pragmas don't seem to do the trick here.  Limit this flag to the `rng/test` subdirectory.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
