### PR TITLE
Fix bug in DRACO_SHARED_LIBS CPP macro saved to config.h

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -145,13 +145,12 @@ macro(dbsSetupCompilers)
       # This CPP symbol is used by config.h to signal if we are need to add declspec(dllimport) or
       # declspec(dllexport) for MSVC.
       set( DRACO_SHARED_LIBS 1 )
-      mark_as_advanced(DRACO_SHARED_LIBS)
     else()
       message( FATAL_ERROR "DRACO_LIBRARY_TYPE must be set to either STATIC or SHARED.")
     endif()
-    set( DRACO_SHARED_LIBS "${DRACO_SHARED_LIBS}" CACHE BOOL
-      "This CPP symbol is used by config.h to signal if we are need to add declspec(dllimport) or"
-      " declspec(dllexport) for MSVC." )
+    set( DRACO_SHARED_LIBS "${DRACO_SHARED_LIBS}" CACHE STRING
+      "Do we activate declspec(dllimport) or declspec(dllexport) for MSVC." FORCE )
+    mark_as_advanced(DRACO_SHARED_LIBS)
 
     #----------------------------------------------------------------------------------------------#
     # Setup common options for targets


### PR DESCRIPTION
### Background

* While debugging a different issue, I realized that the value of `DRACO_SHARED_LIBS` that was saved to `ds++/config.h` was corrupt.  I tracked the issue to storing a cmake string into a bool variable.  It is possible that this issue only appeared after we adopted cmake-3.18+, but I didn't try to track it down since the old behavior was wrong.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
