### PR TITLE
Fix plot_ipcress_opacity.py to work with python@3.5+

### DIFF
--- a/src/cdi_ipcress/python/plot_ipcress_opacity.py
+++ b/src/cdi_ipcress/python/plot_ipcress_opacity.py
@@ -17,7 +17,7 @@ import matplotlib
 matplotlib.use('TkAgg')
 
 from numpy import arange, sin, pi, min, max
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 
 from matplotlib.figure import Figure
 
@@ -166,10 +166,10 @@ a.set_ylim([ 0.7*min_opacity, 1.3*max_opacity])
 a.legend(loc='best')
 
 canvas = FigureCanvasTkAgg(f, master=root)
-canvas.show()
+canvas.draw()
 canvas.get_tk_widget().pack(side=TOP, fill=BOTH, expand=1)
 
-toolbar = NavigationToolbar2TkAgg( canvas, root )
+toolbar = NavigationToolbar2Tk( canvas, root )
 toolbar.update()
 canvas._tkcanvas.pack(side=TOP, fill=BOTH, expand=1)
 
@@ -289,7 +289,7 @@ def plot_op():
   a.legend(loc='best')
   a.set_xlim([0.9*min(hnu_grid), 1.1*max(hnu_grid)])
   a.set_ylim([ 0.7*min_opacity, 1.3*max_opacity])
-  canvas.show()
+  canvas.draw()
   canvas.get_tk_widget().pack(side=TOP, fill=BOTH, expand=1)
 ###############################################################################
 


### PR DESCRIPTION
### Background

+ Starting with `python@3.5.0`, the python module `matplotlib.backends.backend_tkagg` has a slightly different API.

### Purpose of Pull Request

* [Fixes Redmine Issue #2231](https://rtt.lanl.gov/redmine/issues/2231)

### Description of changes

* As per discussion on stackoverflow, I am replacing `NavigationToolbar2TkAgg` with `NavigationToolbar2Tk`.
* I am also replacing the command `show` with `draw` as recommended [here](https://github.com/jarvisteach/appJar/issues/551).

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
