### PR TITLE
Ensure installed python programs have the exec bit set.

### DIFF
--- a/src/cdi_ipcress/CMakeLists.txt
+++ b/src/cdi_ipcress/CMakeLists.txt
@@ -47,7 +47,11 @@ add_component_executable(
 
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/cdi_ipcress )
 install( TARGETS Exe_Ipcress_Interpreter EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
-install( FILES python/ipcress_reader.py python/plot_ipcress_opacity.py DESTINATION ${DBSCFGDIR}bin )
+install(
+  PROGRAMS
+    python/ipcress_reader.py
+    python/plot_ipcress_opacity.py
+  DESTINATION ${DBSCFGDIR}bin )
 
 #--------------------------------------------------------------------------------------------------#
 # Unit tests

--- a/src/compton_tools/CMakeLists.txt
+++ b/src/compton_tools/CMakeLists.txt
@@ -11,15 +11,8 @@ project( compton_tools CXX )
 #--------------------------------------------------------------------------------------------------#
 # Source files
 #--------------------------------------------------------------------------------------------------#
-set( sources
-    #${PROJECT_SOURCE_DIR}/Sparse_Compton_Matrix.cc
-    ${PROJECT_SOURCE_DIR}/Compton_Native.cc
-)
-
-set( headers
-    #${PROJECT_SOURCE_DIR}/Sparse_Compton_Matrix.hh
-  ${PROJECT_SOURCE_DIR}/Compton_Native.hh
-)
+set( sources ${PROJECT_SOURCE_DIR}/Compton_Native.cc )
+set( headers ${PROJECT_SOURCE_DIR}/Compton_Native.hh )
 
 #--------------------------------------------------------------------------------------------------#
 # Build package library
@@ -40,10 +33,10 @@ add_component_executable(
 #--------------------------------------------------------------------------------------------------#
 # Installation instructions
 #--------------------------------------------------------------------------------------------------#
-set( CMAKE_INSTALL_DO_STRIP NO ) # ??
+set( CMAKE_INSTALL_DO_STRIP NO )
 install( FILES ${headers} DESTINATION ${DBSCFGDIR}include/compton_tools )
 install( TARGETS Exe_CSKrw EXPORT draco-targets DESTINATION ${DBSCFGDIR}bin )
-install( FILES
+install( PROGRAMS
     python/common_compton.py
     python/csk_reader.py
     python/merge_csk.py


### PR DESCRIPTION
### Background

+ Use CMake's `install( PROGRAMS ...)` command instead of `install( FILES ...)` to ensure that the group and world execute bits are set for installed python scripts.

### Purpose of Pull Request

* [Fixes Redmine Issue #2176](https://rtt.lanl.gov/redmine/issues/2176)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
