### PR TITLE
change math.h to cmath import in KDE

### DIFF
--- a/src/kde/kde.cc
+++ b/src/kde/kde.cc
@@ -22,8 +22,8 @@
 //------------------------------------------------------------------------------------------------//
 
 #include "kde.hh"
+#include <cmath>
 #include <iostream>
-#include <math.h>
 #include <numeric>
 
 namespace rtt_kde {


### PR DESCRIPTION
### Background

* I minor oversight in the original KDE PR. In this PR we replace the math.h import with cmath.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
