### PR TITLE
Bump Darwin environment to gcc9 (x64 nodes)

### DIFF
--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -26,9 +26,9 @@ if [[ -n "$MODULESHOME" ]]; then
     arm)     module load draco/arm-gcc930 ;;
     power9*) module load draco/power9-gcc730 ;;
     x86_64)
-      module load draco/x64-gcc730
+      module load draco/x64-gcc930
       if [[ "${SLURM_JOB_PARTITION}" =~ "volta" || "${SLURM_JOB_PARTITION}" =~ "gpu" ]]; then
-        module load cuda/10.2
+        module load cuda/11.2-beta
       fi
       ;;
   esac


### PR DESCRIPTION
### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
