### PR TITLE
Update release scripts for +gpu builds.

### DIFF
--- a/tools/ats2-env.sh
+++ b/tools/ats2-env.sh
@@ -75,7 +75,6 @@ case $ddir in
       CXX=$(which g++)
       CC=$(which gcc)
       FC=$(which gfortran)
-      unset MPI_ROOT
       export CXX CC FC
     }
     function xl20200819env()
@@ -90,7 +89,6 @@ case $ddir in
       run "module load draco/xl2020.08.19-cuda-11.0.2"
       run "module list"
       export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
-      unset MPI_ROOT
     }
     ;;
 

--- a/tools/ats2-release.sh
+++ b/tools/ats2-release.sh
@@ -9,7 +9,7 @@ export logfile="${source_prefix:-unknoan}/logs/release-$buildflavor-$rttversion\
 # shellcheck disable=SC2154
 cmd="bsub ${job_launch_options} -nnodes 1 -W 8:00 \
 -J rel_${package:0:3}-${buildflavor: -12}-$rttversion -o $logfile -e $logfile"
-echo "$cmd $draco_script_dir/release.msub"
+echo "$cmd ${draco_script_dir:-unknown}/release.msub"
 jobid=$(${cmd} "$draco_script_dir/release.msub")
 echo "jobid = $jobid"
 sleep 2m

--- a/tools/ats2-release.sh
+++ b/tools/ats2-release.sh
@@ -5,7 +5,7 @@ echo -e "\nConfigure, build, and test $package for $buildflavor-$rttversion."
 echo
 export steps="config build test"
 export logfile="$source_prefix/logs/release-$buildflavor-$rttversion-cbt${jobnameext}.log"
-cmd="bsub $job_launch_options -nnodes 1 -W 4:00 \
+cmd="bsub $job_launch_options -nnodes 1 -W 8:00 \
 -J rel_${package:0:3}-${buildflavor: -12}-$rttversion -o $logfile -e $logfile"
 echo "$cmd $draco_script_dir/release.msub"
 jobid=`$cmd $draco_script_dir/release.msub`

--- a/tools/ats2-release.sh
+++ b/tools/ats2-release.sh
@@ -1,21 +1,23 @@
 #!/bin/bash -l
 
 # export dry_run=1
-echo -e "\nConfigure, build, and test $package for $buildflavor-$rttversion."
-echo
+echo -ne "\nConfigure, build, and test ${package:-unknown} for "
+echo -ne "${buildflavor:-unknown}-${rttversion:-unknown}.\n"
 export steps="config build test"
-export logfile="$source_prefix/logs/release-$buildflavor-$rttversion-cbt${jobnameext}.log"
-cmd="bsub $job_launch_options -nnodes 1 -W 8:00 \
+export logfile="${source_prefix:-unknoan}/logs/release-$buildflavor-$rttversion\
+-cbt${jobnameext:-unknown}.log"
+# shellcheck disable=SC2154
+cmd="bsub ${job_launch_options} -nnodes 1 -W 8:00 \
 -J rel_${package:0:3}-${buildflavor: -12}-$rttversion -o $logfile -e $logfile"
 echo "$cmd $draco_script_dir/release.msub"
-jobid=`$cmd $draco_script_dir/release.msub`
+jobid=$(${cmd} "$draco_script_dir/release.msub")
 echo "jobid = $jobid"
 sleep 2m
 # trim extra whitespace from number
-jobid=`echo ${jobid//[^0-9]/}`
+jobid="${jobid//[^0-9]/}"
 export jobids="$jobid $jobids"
 echo "jobids = $jobids"
 
-##---------------------------------------------------------------------------##
-## End
-##---------------------------------------------------------------------------##
+# ------------------------------------------------------------------------------------------------ #
+# End ats2-release.sh
+# ------------------------------------------------------------------------------------------------ #

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -85,9 +85,11 @@ function machineName
       rzmanta*) sysName=rzmanta ;;
       sierra*) sysName=sierra ;;
     esac
+  else
+    sysName=$(uname -n | sed -e 's/[.].*//')
   fi
   if [[ "$sysName" == "unknown" ]]; then
-    echo "Unable to determine machine name, please edit scripts/common.sh."
+    echo "Unable to determine machine name, please edit tools/common.sh."
     return 1
   fi
   echo $sysName
@@ -111,6 +113,9 @@ function osName
     elif [[ -d /usr/gapps/jayenne ]]; then
       osName=$(uname -p)
     fi
+  fi
+  if [[ ${osName} == "unknown" ]]; then
+    osName=$(uname -p)
   fi
   if [[ "$osName" == "unknown" ]]; then
     echo "Unable to determine system OS, please edit scripts/common.sh."
@@ -268,6 +273,11 @@ function flavor
       # CCS-NET machines or generic Linux?
       if [[ $MPI_NAME ]]; then
         mpiflavor="$MPI_NAME-$MPI_VERSION"
+      elif [[ $LMOD_MPI_NAME ]]; then
+        mpiflavor="$LMOD_MPI_NAME"
+        if [[ $LMOD_MPI_VERSION ]]; then
+          mpiflavor+="-${LMOD_MPI_VERSION//-*/}"
+        fi
       else
         mpiflavor="unknown"
       fi

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -92,7 +92,7 @@ function machineName
     echo "Unable to determine machine name, please edit tools/common.sh."
     return 1
   fi
-  echo $sysName
+  echo "$sysName"
 }
 
 # Logic taken from /usr/projects/hpcsoft/templates/header

--- a/tools/release.msub
+++ b/tools/release.msub
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# For config and build steps, this file is run as a bash script on the
-# front-end.  For the test step, this file is submitted to the batch system.
-# This file is designed to be called from scripts/release_cray.sh.
+# For config and build steps, this file is run as a bash script on the front-end.  For the test
+# step, this file is submitted to the batch system.  This file is designed to be called from
+# scripts/release_cray.sh.
 
-##---------------------------------------------------------------------------##
-## Generic setup
-##---------------------------------------------------------------------------##
+# ------------------------------------------------------------------------------------------------ #
+# Generic setup
+# ------------------------------------------------------------------------------------------------ #
 
 # shellcheck source=tools/common.sh
-source "$draco_script_dir/common.sh"
-export buildflavor=$(flavor)
-export build_pe=$(npes_build)
+source "${draco_script_dir:-unknown}/common.sh"
+buildflavor=$(flavor)
+build_pe=$(npes_build)
 test_pe=$(npes_test)
 
 # For Darwin and ATS-2, if the cuda module is loaded, then limit testing parallelism to avoid
@@ -19,16 +19,19 @@ test_pe=$(npes_test)
 if [[ $(echo "${_LMFILES_}" | grep -c /cuda/) -gt 0 ]]; then
   test_pe=12
 fi
-export test_pe
 
-##---------------------------------------------------------------------------##
-## Print a summary of this build
-##---------------------------------------------------------------------------##
+export test_pe
+export buildflavor
+export build_pe
+
+# ------------------------------------------------------------------------------------------------ #
+# Print a summary of this build
+# ------------------------------------------------------------------------------------------------ #
 
 verbose=1
 if test $verbose == 1; then
-  echo
-  echo "Starting release build for ${package:-unknown} - ${rttversion:-unknown} - ${buildflavor} - $TARGET:"
+  echo -ne "\nStarting release build for ${package:-unknown} - ${rttversion:-unknown} "
+  echo "- ${buildflavor} - ${TARGET:-unknown}:"
   echo "================================================================================"
   echo "install_prefix = ${install_prefix:-unknown}/$rttversion"
   echo "build_prefix   = ${build_prefix:-unknown}/$rttversion"
@@ -38,8 +41,7 @@ if test $verbose == 1; then
   echo "steps        = ${steps:-unknown}"
   # shellcheck disable=SC2154
   echo "queue        = ${access_queue}"
-  echo "cmake opts   = $CONFIG_EXTRA"
-  echo
+  echo -e "cmake opts   = $CONFIG_EXTRA\n"
 fi
 
 # dry_run=1
@@ -47,6 +49,6 @@ install_versions
 
 echo -e "\nAll done with $0\n"
 
-##---------------------------------------------------------------------------##
-## End
-##---------------------------------------------------------------------------##
+# ------------------------------------------------------------------------------------------------ #
+# End
+# ------------------------------------------------------------------------------------------------ #

--- a/tools/release.msub
+++ b/tools/release.msub
@@ -8,14 +8,15 @@
 ## Generic setup
 ##---------------------------------------------------------------------------##
 
-source $draco_script_dir/common.sh
-export buildflavor=`flavor`
-export build_pe=`npes_build`
-test_pe=`npes_test`
+# shellcheck source=tools/common.sh
+source "$draco_script_dir/common.sh"
+export buildflavor=$(flavor)
+export build_pe=$(npes_build)
+test_pe=$(npes_test)
 
 # For Darwin and ATS-2, if the cuda module is loaded, then limit testing parallelism to avoid
 # crashing the GPU.
-if [[ $(echo $_LMFILES_ | grep -c /cuda/) -gt 0 ]]; then
+if [[ $(echo "${_LMFILES_}" | grep -c /cuda/) -gt 0 ]]; then
   test_pe=12
 fi
 export test_pe
@@ -27,15 +28,16 @@ export test_pe
 verbose=1
 if test $verbose == 1; then
   echo
-  echo "Starting release build for $package - $rttversion - $buildflavor - $TARGET:"
+  echo "Starting release build for ${package:-unknown} - ${rttversion:-unknown} - ${buildflavor} - $TARGET:"
   echo "================================================================================"
-  echo "install_prefix = $install_prefix/$rttversion"
-  echo "build_prefix   = $build_prefix/$rttversion"
+  echo "install_prefix = ${install_prefix:-unknown}/$rttversion"
+  echo "build_prefix   = ${build_prefix:-unknown}/$rttversion"
   echo
   echo "make command = make -j $build_pe -l $build_pe"
   echo "test command = ctest -j $test_pe"
-  echo "steps        = ${steps}"
-  echo "queue        = $access_queue"
+  echo "steps        = ${steps:-unknown}"
+  # shellcheck disable=SC2154
+  echo "queue        = ${access_queue}"
   echo "cmake opts   = $CONFIG_EXTRA"
   echo
 fi

--- a/tools/release.msub
+++ b/tools/release.msub
@@ -11,11 +11,14 @@
 source $draco_script_dir/common.sh
 export buildflavor=`flavor`
 export build_pe=`npes_build`
-export test_pe=`npes_test`
-case `uname -n` in
-rzansel* | sierra* )  export test_pe=80 ;;
-esac
+test_pe=`npes_test`
 
+# For Darwin and ATS-2, if the cuda module is loaded, then limit testing parallelism to avoid
+# crashing the GPU.
+if [[ $(echo $_LMFILES_ | grep -c /cuda/) -gt 0 ]]; then
+  test_pe=12
+fi
+export test_pe
 
 ##---------------------------------------------------------------------------##
 ## Print a summary of this build


### PR DESCRIPTION
### Background

* These changes should have been made during the draco-7_9_1 release cycle but were accidentally omitted form the tag.

### Description of changes

+ Some systems needed extra settings for successful installation of Draco.
+ Request longer allocation times for gpu enabled testing.
+ Use less parallelism when running tests that need access to a GPU.
+ Leave MPI_ROOT set as this is needed by SMPI+LSF environments.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
