### PR TITLE
Patch up module environments on ATS-2 (and elisp)

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -33,7 +33,8 @@ fi
 modcmd=`declare -f module`
 # If not found, look for it in /usr/share/Modules (ML)
 if [[ ! ${modcmd} ]]; then
-  source /usr/share/lmod/lmod/init/bash || die "ERROR: The module command was not found. No modules will be loaded."
+  source /usr/share/lmod/lmod/init/bash || die \
+    "ERROR: The module command was not found. No modules will be loaded."
 fi
 modcmd=`declare -f module`
 
@@ -41,45 +42,11 @@ modcmd=`declare -f module`
 if [[ ! ${modcmd} ]]; then
   echo "ERROR: The module command was not found. No modules will be loaded."
 else
-
-  module use /usr/gapps/user_contrib/spack.20200402/share/spack/lmod/linux-rhel7-ppc64le/Core
   module use --append /usr/gapps/jayenne/Modules
-
   module unuse /usr/share/lmod/lmod/modulefiles/Core
   module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
   module load draco/xl2020.08.19-cuda-11.0.2
-
 fi
-
-# function dracoenv()
-# {
-#   module --force purge
-#   module load StdEnv
-#   module unload spectrum-mpi xl cuda
-#   for m in $dracomodules; do
-#     module load $m
-#   done
-#   unset MPI_ROOT
-#   export CXX=`which g++`
-#   export CC=`which gcc`
-#   export FC=`which gfortran`
-#   export MPIRUN="lrun"
-#   export OMP_NUM_THREADS=10
-# }
-
-# function rmdracoenv()
-# {
-#   unset MPIRUN
-#   unset FC
-#   unset CC
-#   unset CXX
-
-#   # unload in reverse order.
-#   mods=( ${dracomodules} )
-#   for ((i=${#mods[@]}-1; i>=0; i--)); do
-#     module unload ${mods[$i]}
-#   done
-# }
 
 # Do not escape $ for bash completion
 shopt -s direxpand

--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -76,8 +76,10 @@ and add turn-on-auto-fill to the yaml-mode-hook."
       (turn-on-draco-mode)
       (turn-off-auto-fill)
       (set-fill-column draco-code-comment-width)
-      (require 'fill-column-indicator)
-      (fci-mode))
+      (if (> emacs-major-version 24)
+          (require 'fill-column-indicator)
+        (fci-mode)
+        ))
     (add-hook 'yaml-mode-hook 'draco-yaml-mode-hook)))
 
 ;; ========================================
@@ -126,8 +128,9 @@ auto-mode-alist."
 	(turn-on-draco-mode)
         (set-fill-column draco-code-comment-width)
 	(turn-on-auto-fill)
-        (require 'fill-column-indicator)
-        (fci-mode))
+        (if (> emacs-major-version 24)
+            (require 'fill-column-indicator)
+        (fci-mode)))
       (add-hook 'python-mode-hook 'draco-python-mode-hook)))
 
 ;; ========================================
@@ -155,8 +158,9 @@ auto-mode-alist."
       (turn-on-draco-mode)
       (turn-on-auto-fill)
       (set-fill-column draco-code-comment-width)
-      (require 'fill-column-indicator)
-      (fci-mode))
+      (if (> emacs-major-version 24)
+          (require 'fill-column-indicator)
+        (fci-mode)))
     (add-hook 'cmake-mode-hook 'draco-cmake-mode-hook)))
 
 ;; ========================================
@@ -462,20 +466,14 @@ auto-mode-alist."
       (setq f90-font-lock-keywords f90-font-lock-keywords-3)
       (setq f90-beginning-ampersand nil)
       (setq f90-associate-indent 0)
-      (require 'fill-column-indicator)
-      (fci-mode))
+        (if (> emacs-major-version 24)
+            (require 'fill-column-indicator)
+          (fci-mode)))
      ;; let .F denone Fortran and not freeze files
     (defvar crypt-freeze-vs-fortran nil)
     (add-hook 'f90-mode-hook 'draco-f90-mode-hook)
     (add-hook 'f90-mode-hook 'turn-on-draco-mode)
     (add-hook 'f90-mode-hook 'turn-on-auto-fill)
-    ; should add this sometime
-    ; (add-hook 'font-lock-mode-hook
-    ;          '(lambda ()
-    ;             (if (major-mode 'f90-mode)
-    ;                 (draco-f90-font-lock)))) ; create this function
-                                        ; based on draco-font-lock but
-                                        ; for f90
     ))
 
 ;; ========================================
@@ -709,7 +707,7 @@ auto-mode-alist and set up some customizations for DRACO."
     (defun draco-dired-mode-hook ()
       "Hooks added to dired-mode"
       (local-set-key [(f5)] 'dired-redisplay-subdir)
-      (setq dired-listing-switches "-alh")
+      (setq dired-listing-switches "-alh"))
     (add-hook 'dired-setup-keys-hook 'draco-dired-mode-hook)
     (add-hook 'dired-mode-hook 'turn-on-draco-mode)))
 
@@ -726,7 +724,7 @@ auto-mode-alist and set up some customizations for DRACO."
     (add-hook 'perl-mode-hook 'turn-on-font-lock)
     (defun draco-perl-mode-hook ()
       "Hooks added to perl-mode"
-      (local-set-key [(f5)] 'dired-redisplay-subdir)
+      (local-set-key [(f5)] 'dired-redisplay-subdir))
     (setq auto-mode-alist
           (append
            '(("\\.perl$" . perl-mode)
@@ -734,7 +732,6 @@ auto-mode-alist and set up some customizations for DRACO."
     (add-hook 'perl-mode-hook 'turn-on-draco-mode)
     )
   )
-
 
 ;; ========================================
 ;; ECB & CEDET

--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -77,9 +77,9 @@ and add turn-on-auto-fill to the yaml-mode-hook."
       (turn-off-auto-fill)
       (set-fill-column draco-code-comment-width)
       (if (> emacs-major-version 24)
-          (require 'fill-column-indicator)
-        (fci-mode)
-        ))
+          (progn
+            (require 'fill-column-indicator)
+            (fci-mode))))
     (add-hook 'yaml-mode-hook 'draco-yaml-mode-hook)))
 
 ;; ========================================
@@ -129,8 +129,9 @@ auto-mode-alist."
         (set-fill-column draco-code-comment-width)
 	(turn-on-auto-fill)
         (if (> emacs-major-version 24)
-            (require 'fill-column-indicator)
-        (fci-mode)))
+            (progn
+              (require 'fill-column-indicator)
+              (fci-mode))))
       (add-hook 'python-mode-hook 'draco-python-mode-hook)))
 
 ;; ========================================
@@ -159,8 +160,9 @@ auto-mode-alist."
       (turn-on-auto-fill)
       (set-fill-column draco-code-comment-width)
       (if (> emacs-major-version 24)
-          (require 'fill-column-indicator)
-        (fci-mode)))
+          (progn
+            (require 'fill-column-indicator)
+            (fci-mode))))
     (add-hook 'cmake-mode-hook 'draco-cmake-mode-hook)))
 
 ;; ========================================
@@ -351,8 +353,9 @@ parameters on creation of buffers managed by cc-mode.el for Nix's personal codin
 	(draco-mode-update-menu (draco-menu-insert-comments-cc))
 	(turn-on-font-lock)
         (if (> emacs-major-version 24)
-            (require 'fill-column-indicator)
-          (fci-mode))
+            (progn
+              (require 'fill-column-indicator)
+              (fci-mode)))
 	(turn-on-auto-fill))
       ;; register the draco-c-mode-hook
       (add-hook 'c-mode-common-hook 'draco-c-mode-hook)
@@ -467,8 +470,9 @@ auto-mode-alist."
       (setq f90-beginning-ampersand nil)
       (setq f90-associate-indent 0)
         (if (> emacs-major-version 24)
-            (require 'fill-column-indicator)
-          (fci-mode)))
+            (progn
+              (require 'fill-column-indicator)
+              (fci-mode))))
      ;; let .F denone Fortran and not freeze files
     (defvar crypt-freeze-vs-fortran nil)
     (add-hook 'f90-mode-hook 'draco-f90-mode-hook)
@@ -580,8 +584,9 @@ customizations for DRACO."
       (local-set-key [(control c)(control c)] 'comment-region)
       (set-fill-column draco-code-comment-width)
       (if (> emacs-major-version 24)
-          (require 'fill-column-indicator)
-        (fci-mode t))
+          (progn
+            (require 'fill-column-indicator)
+            (fci-mode t)))
       )
     (add-hook 'emacs-lisp-mode-hook 'turn-on-draco-mode)
     (add-hook 'emacs-lisp-mode-hook 'draco-elisp-mode-hook)
@@ -598,8 +603,10 @@ customizations for DRACO."
   (progn
     (autoload 'shell-mode "shell-mode" "Interactive Shell Mode" t)
     (set-fill-column draco-code-comment-width)
-    (require 'fill-column-indicator)
-    (fci-mode)
+    (if (> emacs-major-version 24)
+        (progn
+          (require 'fill-column-indicator)
+          (fci-mode)))
     (add-hook 'shell-mode-hook 'turn-on-draco-mode)
     (add-hook 'shell-mode-hook 'ansi-color-for-comint-mode-on)
     (add-to-list 'comint-output-filter-functions 'ansi-color-process-output)

--- a/environment/elisp/draco-setup.el
+++ b/environment/elisp/draco-setup.el
@@ -374,7 +374,6 @@ compilation-mode?"
 (if draco-want-cc-mode         (draco-setup-cc-mode))
 (if draco-want-change-log-mode (draco-setup-change-log-mode))
 (if draco-want-compilation-mode (draco-setup-compilation-mode))
-(if draco-want-cvs-mode        (draco-setup-cvs-mode))
 (if draco-want-dired-mode      (draco-setup-dired-mode))
 (if draco-want-perl-mode       (draco-setup-perl-mode))
 ;(if draco-want-doxymacs-mode   (draco-setup-doxymacs-mode))


### PR DESCRIPTION
### Background

* No longer add `/usr/gapps/user_contrib/spack.20200402/share/spack/lmod/linux-rhel7-ppc64le/Core` automatically. Let the draco module do this.
* Hide `fci-mode` behind an emacs version check and fix a couple of elisp paren issues.

### Purpose of Pull Request

* [Fixes Redmine Issue #2322](https://rtt.lanl.gov/redmine/issues/2322)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
