### PR TITLE
Default to power9-gcc930-smpi env and use --bind-to none

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -265,7 +265,7 @@ macro( setupOpenMPI )
   # https://www.ibm.com/support/knowledgecenter/SSZTET_EOS/eos/guide_101.pdf
   if( "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" )
     string(REPLACE "-bind-to none" "-bind-to core" MPIEXEC_PREFLAGS ${MPIEXEC_PREFLAGS})
-    string(REPLACE "-bind-to none" "-bind-to core" MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS})
+    # string(REPLACE "-bind-to none" "-bind-to core" MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS})
     set(smpi-sm-only "-intra sm -aff off --report-bindings")
     string(APPEND MPIEXEC_PREFLAGS     " ${smpi-sm-only}")
     string(APPEND MPIEXEC_OMP_PREFLAGS " ${smpi-sm-only}")

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -24,7 +24,7 @@ if [[ -n "$MODULESHOME" ]]; then
   module use --append /projects/draco/Modules
   case $DRACO_ARCH in
     arm)     module load draco/arm-gcc930 ;;
-    power9*) module load draco/power9-gcc730 ;;
+    power9*) module load draco/power9-gcc930-smpi ;;
     x86_64)
       module load draco/x64-gcc930
       if [[ "${SLURM_JOB_PARTITION}" =~ "volta" || "${SLURM_JOB_PARTITION}" =~ "gpu" ]]; then


### PR DESCRIPTION
### Background

* Set the default user environment to gcc930-smpi (to match CI and regression)
* Use `--bind-to none` for MPI+OpenMP tests to eliminate a run error about using too many threads.

### Purpose of Pull Request

* [Fixes Redmine Issue #2324](https://rtt.lanl.gov/redmine/issues/2324)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
