### PR TITLE
Add support for cce/11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ query_have_sys_headers() # sets HAVE_UNISTD_H, etc.
 query_have_restrict_keyword()
 query_fma_on_hardware()
 
+# Find any globally required libraries
+include( FeatureSummary )
+include( vendor_libraries )
+setupVendorLibraries()
+
 # Set compiler options
 include( compilerEnv )
 dbsSetupCompilers()
@@ -85,11 +90,6 @@ dbsSetupFortran()
 dbsSetupCuda()
 dbsSetupProfilerTools()
 dbsSetupStaticAnalyzers()
-
-# Find any globally required libraries
-include( FeatureSummary )
-include( vendor_libraries )
-setupVendorLibraries()
 
 #
 # Build Draco components:

--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -42,9 +42,12 @@ if( NOT CXX_FLAGS_INITIALIZED )
     " -Wno-deprecated-declarations -Wno-missing-noreturn -Wno-unreachable-code"
     " -Wno-documentation-deprecated-sync -Wno-documentation -Wno-undefined-func-template"
     " -Wno-weak-template-vtables -Wno-comma")
-  if (NOT ${CMAKE_GENERATOR} MATCHES Xcode AND HAS_MARCH_NATIVE)
+
+  if( (NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv) AND
+      (NOT ${CMAKE_GENERATOR} MATCHES Xcode) AND HAS_MARCH_NATIVE)
     string( APPEND CMAKE_C_FLAGS " -march=native" )
   endif()
+
   set( CMAKE_C_FLAGS_DEBUG          "-g -fno-inline -O0 -DDEBUG")
   set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
@@ -54,6 +57,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # might not be called if the type can be deduced.
   string( APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS} -Wno-undefined-var-template"
     " -Wno-potentially-evaluated-expression" )
+
   if( DEFINED CMAKE_CXX_COMPILER_WRAPPER AND "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv" )
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libstdc++")
   else()

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -122,7 +122,11 @@ endfunction()
 macro( setupQt )
   message( STATUS "Looking for Qt SDK...." )
 
-  option (USE_QT "Build QT support for Draco" ON)
+  if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
+    option (USE_QT "Build QT support for Draco" OFF)
+  else()
+    option (USE_QT "Build QT support for Draco" OFF)
+  endif()
 
   if( USE_QT )
     # Find the QtWidgets library

--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -125,7 +125,7 @@ macro( setupQt )
   if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
     option (USE_QT "Build QT support for Draco" OFF)
   else()
-    option (USE_QT "Build QT support for Draco" OFF)
+    option (USE_QT "Build QT support for Draco" ON)
   endif()
 
   if( USE_QT )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,16 +152,13 @@ message("Library Type: ${DRACO_LIBRARY_TYPE}
 if( CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
   message("Cray system detected: CC -craype-verbose -V|--version:
 ")
-  if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel" OR
-      ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" )
-    set( ver_opt "--version")
-  else( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Cray" )
+  if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Cray" AND NOT DEFINED ENV{CRAY_PE_USE_CLANG} )
     set( ver_opt "-V")
+  else()
+    set( ver_opt "--version")
   endif()
-  execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} -craype-verbose ${ver_opt}
-    OUTPUT_VARIABLE tmp
-    )
+  execute_process( COMMAND ${CMAKE_CXX_COMPILER} -craype-verbose ${ver_opt}
+    OUTPUT_VARIABLE tmp )
   message("${tmp}")
 endif()
 

--- a/src/c4/fc4/Draco_MPI.F90
+++ b/src/c4/fc4/Draco_MPI.F90
@@ -4,8 +4,6 @@
 ! \date   Mon Jul 30 07:06:24 MDT 2012
 ! \brief  Helper functions to support scalar vs. distributed MPI tests.
 ! \note   Copyright (c) 2016-2020 Triad National Security, LLC., All rights reserved.
-!
-! This is a modified version of jayenne/src/api/ftest/API_MPI.F90
 !--------------------------------------------------------------------------------------------------!
 
 module draco_mpi


### PR DESCRIPTION
### Background

+ The Cray cce/11 compiler is based on LLVM for C/C++ and Cray `ftn` for Fortran. This set of compilers doesn't work with Draco unless these changes are made.
+ This is only a partial fix on the path to adding support for cce/11.  There is a link issue for `tstfc4_hw` that I am still working on.  This issue is a _canary in the coal mine_ for ensuring that multi-language linking with MPI compile-wrappers works. (It doesn't right now).

### Purpose of Pull Request

* [Related to Redmine Issue #1323](https://rtt.lanl.gov/redmine/issues/1323)

### Description of changes

+ We need cmake to discover MPI before appending options to the compiler flags.  This change is needed because `CMAKE_C_FLAGS="-Werror -Weverything"` will cause `find_package(MPI)` to fail every time.
+ The new Cray C/C++ compilers identify as LLVM and we use the options provided in `unix-clang.cmake`. The one exception is that we should not use `"-march=native"` because the Cray compile wrappers already do this for us.
+ When using the Cray Programming Environment, disable Qt by default. The installed Qt doesn't seem to work with the Cray compilers.
+ Fix the build report generated by cmake to correctly identify the Cray compiler wrapper

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
