### PR TITLE
Fix a build issue that prevents MPI from being found for LLVM Debug

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -609,6 +609,14 @@ Looking for Draco...\")
   # CMake macros that check the system for features like 'gethostname', etc.
   include( platform_checks )
 
+  # CMake macros to query the availability of TPLs.
+  # - Must do this before adding compiler flags. Otherwise find_package(MPI) will fail for LLVM
+  #   when using flags '-Werror -Weverything'.
+  include( vendor_libraries )
+
+  # Provide targets for MPI, Metis, etc.
+  setupVendorLibraries()
+
   # Set compiler options
   include( compilerEnv )
   dbsSetupCxx()
@@ -618,12 +626,6 @@ Looking for Draco...\")
 
   # CMake macros like 'add_component_library' and 'add_component_executable'
   include( component_macros )
-
-  # CMake macros to query the availability of TPLs.
-  include( vendor_libraries )
-
-  # Provide targets for MPI, Metis, etc.
-  setupVendorLibraries()
 
 endmacro()
 


### PR DESCRIPTION
### Background

* When LLVM is used as a compiler and compile options `-Werror -Weverything` are used (as is done in the CI), `find_package(MPI)` will fail because the underlying `try_compile` reports warnings that are promoted to errors.

### Description of changes

+ The fix is to run `setupVendorLibraries` (especially `setupMPI`) before appending extra compiler flags.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
