### PR TITLE
WIP: Address warnings reported by the appveyour CI.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
   PATH: c:\projects\win32-vs16-tools\bin;$(PATH);c:\msys64\mingw64\bin
   VCPKGDIR: C:\Tools\vcpkg
   GENERATOR: "Visual Studio 16 2019"
-  CMAKE_OPTIONS: "-DCMAKE_TOOLCHAIN_FILE=%VENDOR_DIR%\\vs2019-toolchain.cmake"
+  CMAKE_OPTIONS: "-Wno-dev -DCMAKE_TOOLCHAIN_FILE=%VENDOR_DIR%\\vs2019-toolchain.cmake"
   CMAKE_CXX_FLAGS: "/WX"
   CMAKE_C_FLAGS: "/WX"
   #-DCMAKE_VERBOSE_MAKEFILE=ON"


### PR DESCRIPTION
### Background

* Appveyor is reporting some warnings that we aren't interested in tracking.  Try to silence these warnings.
* I tried a lot of different things to eliminate the gfortran BOZ warning but was unsuccessful. Leaving that alone for now.  There is an MS-MPI ticket that tracks the issue.  With any luck the next version will fix the problem

### Purpose of Pull Request

* [Fixes Redmine Issue #2331](https://rtt.lanl.gov/redmine/issues/2331)

### Description of changes

+ Add CMake options `-Wno-dev` to silence warning about `find_package(LAPACK)` calling `find_package(BLAS)`.  This is standard behavior, no warning needed.
+ Try to silence a gfortran-10 warning about invalid BOZ in `mpif.h`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Ensure Appveyor builds are free of warnings.
    * [ ] ~gfortran BOZ warning eliminated~
    * [x] CMake `-Wdev` warning eliminated
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
