### PR TITLE
Extend policy for CDI integrations

### DIFF
--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -51,7 +51,7 @@ CDI::~CDI() = default;
 //------------------------------------------------------------------------------------------------//
 
 std::vector<double> CDI::frequencyGroupBoundaries = std::vector<double>();
-bool CDI::extend = false;
+DLL_PUBLIC_cdi bool CDI::extend = false;
 
 //------------------------------------------------------------------------------------------------//
 // STATIC FUNCTIONS

--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -51,6 +51,7 @@ CDI::~CDI() = default;
 //------------------------------------------------------------------------------------------------//
 
 std::vector<double> CDI::frequencyGroupBoundaries = std::vector<double>();
+bool CDI::extend = false;
 
 //------------------------------------------------------------------------------------------------//
 // STATIC FUNCTIONS
@@ -221,7 +222,7 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds, double
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
-  double planck_value = integrate_planck(scaled_frequency);
+  double planck_value = extend ? 0.0 : integrate_planck(scaled_frequency);
 
   for (size_t group = 0; group < groups; ++group) {
     // Shift the data down:
@@ -237,6 +238,9 @@ void CDI::integrate_Planckian_Spectrum(std::vector<double> const &bounds, double
     planck[group] = planck_value - last_planck;
     Ensure(planck[group] >= 0.0);
     Ensure(planck[group] <= 1.0);
+  }
+  if (extend) {
+    planck[groups - 1] += 1 - planck_value;
   }
   return;
 }
@@ -264,7 +268,7 @@ std::vector<double> CDI::integrate_Planckian_Spectrum(std::vector<double> const 
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
-  double planck_value = integrate_planck(scaled_frequency);
+  double planck_value = extend ? 0.0 : integrate_planck(scaled_frequency);
 
   for (size_t group = 0; group < groups; ++group) {
     // Shift the data down:
@@ -280,6 +284,9 @@ std::vector<double> CDI::integrate_Planckian_Spectrum(std::vector<double> const 
     planck[group] = planck_value - last_planck;
     Ensure(planck[group] >= 0.0);
     Ensure(planck[group] <= 1.0);
+  }
+  if (extend) {
+    planck[groups - 1] += 1 - planck_value;
   }
   return planck;
 }
@@ -306,11 +313,16 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds, double
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
-  double exp_scaled_frequency = std::exp(-scaled_frequency);
+  double exp_scaled_frequency = extend ? 0.0 : std::exp(-scaled_frequency);
 
   double planck_value(-42.0);
   double rosseland_value(-42.0);
-  integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency, planck_value, rosseland_value);
+  if (!extend) {
+    integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency, planck_value,
+                               rosseland_value);
+  } else {
+    planck_value = rosseland_value = 0.0;
+  }
 
   for (size_t group = 0; group < groups; ++group) {
 
@@ -329,6 +341,9 @@ void CDI::integrate_Rosseland_Spectrum(std::vector<double> const &bounds, double
     rosseland[group] = rosseland_value - last_rosseland;
     Ensure(rosseland[group] >= 0.0);
     Ensure(rosseland[group] <= 1.0);
+  }
+  if (extend) {
+    rosseland[groups - 1] += 1 - rosseland_value;
   }
   return;
 }
@@ -359,11 +374,16 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(std::vector<double> const &boun
 
   // Initialize the loop:
   double scaled_frequency = bounds[0] / T;
-  double exp_scaled_frequency = std::exp(-scaled_frequency);
+  double exp_scaled_frequency = extend ? 0.0 : std::exp(-scaled_frequency);
 
   double planck_value(-42.0);
   double rosseland_value(-42.0);
-  integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency, planck_value, rosseland_value);
+  if (!extend) {
+    integrate_planck_rosseland(scaled_frequency, exp_scaled_frequency, planck_value,
+                               rosseland_value);
+  } else {
+    planck_value = rosseland_value = 0.0;
+  }
 
   for (size_t group = 0; group < groups; ++group) {
 
@@ -386,6 +406,10 @@ void CDI::integrate_Rosseland_Planckian_Spectrum(std::vector<double> const &boun
     Ensure(planck[group] <= 1.0);
     Ensure(rosseland[group] >= 0.0);
     Ensure(rosseland[group] <= 1.0);
+  }
+  if (extend) {
+    planck[groups - 1] += 1 - planck_value;
+    rosseland[groups - 1] += 1 - rosseland_value;
   }
   return;
 }

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -512,7 +512,7 @@ class CDI {
   std_string matID;
 
   //! Extend integration to place low and high tails in low and high groups?
-  static bool extend;
+  DLL_PUBLIC_cdi static bool extend;
 
   // IMPLELEMENTATION
   // ================

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -511,6 +511,9 @@ class CDI {
   //! Material ID.
   std_string matID;
 
+  //! Extend integration to place low and high tails in low and high groups?
+  static bool extend;
+
   // IMPLELEMENTATION
   // ================
 
@@ -553,6 +556,9 @@ public:
 
   //! Clear all data objects
   void reset();
+
+  //! Set extended group boundaries flag
+  static void setExtend() { extend = true; }
 
   // GETTERS
   // -------
@@ -605,6 +611,9 @@ public:
 
   //! Returns the number of frequency groups in the stored frequency vector.
   static size_t getNumberFrequencyGroups();
+
+  //! Returns the extended group boundaries flag.
+  static bool getExtend() { return extend; }
 
   // INTEGRATORS:
   // ===========

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -16,6 +16,7 @@
 #include "ds++/Soft_Equivalence.hh"
 #include <iomanip>
 #include <limits>
+#include <numeric>
 #include <sstream>
 
 using namespace std;
@@ -1154,6 +1155,41 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
 }
 
 //------------------------------------------------------------------------------------------------//
+void test_extend(rtt_dsxx::UnitTest &ut) {
+  // Test extended integration option
+
+  CDI::setExtend();
+  ut.check(CDI::getExtend(), "extend boundaries flag");
+
+  std::vector<double> planck, rosseland;
+
+  unsigned const ng = 3;
+  std::vector<double> energyBoundary(ng + 1);
+  energyBoundary[0] = 0.05;
+  energyBoundary[1] = 0.5;
+  energyBoundary[2] = 5.0;
+  energyBoundary[3] = 50.0;
+
+  CDI::integrate_Planckian_Spectrum(energyBoundary, 10.0, planck);
+  double norm = std::accumulate(planck.begin(), planck.end(), 0.0);
+  ut.check(soft_equiv(norm, 1.0), "planck extended integral, first form");
+
+  planck = CDI::integrate_Planckian_Spectrum(energyBoundary, 5.0);
+  norm = std::accumulate(planck.begin(), planck.end(), 0.0);
+  ut.check(soft_equiv(norm, 1.0), "planck extended integral, second form");
+
+  CDI::integrate_Rosseland_Spectrum(energyBoundary, 10.0, rosseland);
+  norm = std::accumulate(rosseland.begin(), rosseland.end(), 0.0);
+  ut.check(soft_equiv(norm, 1.0), "rosseland extended integral");
+
+  CDI::integrate_Rosseland_Planckian_Spectrum(energyBoundary, 5.0, planck, rosseland);
+  norm = std::accumulate(planck.begin(), planck.end(), 0.0);
+  ut.check(soft_equiv(norm, 1.0), "planck extended integral, paired");
+  norm = std::accumulate(rosseland.begin(), rosseland.end(), 0.0);
+  ut.check(soft_equiv(norm, 1.0), "rosseland extended integral, paired");
+}
+
+//------------------------------------------------------------------------------------------------//
 int main(int argc, char *argv[]) {
   rtt_dsxx::ScalarUnitTest ut(argc, argv, rtt_dsxx::release);
   try {
@@ -1161,6 +1197,7 @@ int main(int argc, char *argv[]) {
     test_planck_integration(ut);
     test_rosseland_integration(ut);
     test_mgopacity_collapse(ut);
+    test_extend(ut);
   }
   UT_EPILOG(ut);
 }


### PR DESCRIPTION
### Background

* There are situations (such as when using opacity tables or a temperature floor) where a client does not have freedom to set his group bounds structure such that it is guaranteed to take in the full Planck or Rosseland integrals. 
* For example, the lowest group bound cannot always be set to zero. This means that part of the integrals "disappears" into the gap below the lowest group bound, particularly at cold temperatures.

### Purpose of Pull Request

* Add a new policy flag to CDI, CDI::extend, that flags the code to add the lower tail to the first group and the upper tail to the last group. This guarantees that the sum of the group values equals 1, to the precision of the integration algorithm.

### Description of changes

* Add static bool CDI::extend to CDI.
* Add a setter, CDI::setExtend() that turns on this flag (which is off by default, preserving legacy behavior)
* Add a getter, CDI::getExtend(), to see if this policy has been set.
* Modify the four functions that integrate Planck or Rosseland functions over a group structure compute the extended values when the extend policy is set.

Note that this does not affect the opacity averaging routines, nor any routines that take individual group bounds rather than a complete group bound vector as their argument. In the former case, the old behavior should always be appropriate. In the latter case, the function cannot know whether it is looking at the lowest or highest group of some group structure.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
