### PR TITLE
Fix NDI DEDX error in density spacing tolerance

### DIFF
--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -202,20 +202,25 @@ void NDI_CP_Eloss::load_ndi() {
   max_temperature = exp(min_log_temperature + d_log_temperature * n_temperature);
 
   stopping_data_1d.resize(n_energy * n_density * n_temperature);
-  ndi_error = NDI2_get_float64_vec_x(
-      dataset_handle, NDI_TARGET_DEDX, std::to_string(target.get_zaid()).c_str(),
-      stopping_data_1d.data(), static_cast<int>(stopping_data_1d.size()));
+  if (target.get_zaid() == -1) {
+    ndi_error = NDI2_get_float64_vec(dataset_handle, NDI_DEDX, stopping_data_1d.data(),
+      static_cast<int>(stopping_data_1d.size()));
+  } else {
+    ndi_error = NDI2_get_float64_vec_x(
+        dataset_handle, NDI_TARGET_DEDX, std::to_string(target.get_zaid()).c_str(),
+        stopping_data_1d.data(), static_cast<int>(stopping_data_1d.size()));
+  }
   Require(ndi_error == 0);
 
   // Check for uniform log spacing
   for (uint32_t n = 1; n < n_energy; n++) {
-    Require(rtt_dsxx::soft_equiv(d_log_energy, energies[n] - energies[n - 1], 1.e-5));
+    Require(rtt_dsxx::soft_equiv(d_log_energy, energies[n] - energies[n - 1], 1.e-4));
   }
   for (uint32_t n = 1; n < n_density; n++) {
-    Require(rtt_dsxx::soft_equiv(d_log_density, densities[n] - densities[n - 1], 1.e-5));
+    Require(rtt_dsxx::soft_equiv(d_log_density, densities[n] - densities[n - 1], 1.e-4));
   }
   for (uint32_t n = 1; n < n_temperature; n++) {
-    Require(rtt_dsxx::soft_equiv(d_log_temperature, temperatures[n] - temperatures[n - 1], 1.e-5));
+    Require(rtt_dsxx::soft_equiv(d_log_temperature, temperatures[n] - temperatures[n - 1], 1.e-4));
   }
 
   // Convert units on table to match those of getEloss:

--- a/src/cdi_ndi/NDI_CP_Eloss.cc
+++ b/src/cdi_ndi/NDI_CP_Eloss.cc
@@ -204,7 +204,7 @@ void NDI_CP_Eloss::load_ndi() {
   stopping_data_1d.resize(n_energy * n_density * n_temperature);
   if (target.get_zaid() == -1) {
     ndi_error = NDI2_get_float64_vec(dataset_handle, NDI_DEDX, stopping_data_1d.data(),
-      static_cast<int>(stopping_data_1d.size()));
+                                     static_cast<int>(stopping_data_1d.size()));
   } else {
     ndi_error = NDI2_get_float64_vec_x(
         dataset_handle, NDI_TARGET_DEDX, std::to_string(target.get_zaid()).c_str(),
@@ -241,6 +241,10 @@ void NDI_CP_Eloss::load_ndi() {
   for (auto &temperature : temperatures) {
     temperature = exp(temperature);
   }
+
+  //! Close datafile
+  ndi_error = NDI2_close_gendir(gendir_handle);
+  Require(ndi_error == 0);
 #else
   Insist(0,
          "NDI version " + std::string(NDI_VERSION_STRING) + " does not support stopping powers!");


### PR DESCRIPTION
### Background

* The NDI DEDX wrapper was reporting failures in the check for a uniformly spaced logarithmic grid of density support points. 
* h/t @david8dixon for reporting this issue

### Purpose of Pull Request

* The tolerance for logarithmic spacing of density support points exceeded the accuracy provided by NDI
* It turns out we also weren't requesting electron stopping powers correctly
* [Fixes Redmine Issue #2342](https://rtt.lanl.gov/redmine/issues/2342)

### Description of changes

* Reduce the tolerance for density support point spacing (and the temperature and particle energy grids) by a factor of 10
* Request electron stopping powers the right way
* `NDI_CP_Eloss` also wasn't closing the gendir file it read from, which can cause other NDI calls to fail

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
