### PR TITLE
Disable -traceback for CrayPrgEnv to eliminate link warning.

### DIFF
--- a/config/unix-ifort.cmake
+++ b/config/unix-ifort.cmake
@@ -24,8 +24,11 @@ if( NOT Fortran_FLAGS_INITIALIZED )
   #    aobut ifort's non-standard name mangling for module procedures. Not sure if we need this yet.
 
   string( APPEND CMAKE_Fortran_FLAGS " -warn -fpp -implicitnone -diag-disable=11060" )
-  string( CONCAT CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -traceback -ftrapuv -check"
-    " -fno-omit-frame-pointer -DDEBUG" )
+  string( CONCAT CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -ftrapuv -check -fno-omit-frame-pointer -DDEBUG")
+  if( NOT DEFINED CMAKE_CXX_COMPILER_WRAPPER AND
+      NOT "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv" )
+    string( APPEND CMAKE_Fortran_FLAGS_DEBUG " -traceback")
+  endif()
   string( CONCAT CMAKE_Fortran_FLAGS_RELEASE "-O2 -inline-level=2 -fp-speculation fast"
     " -fp-model=fast -align array32byte -funroll-loops -diag-disable=11021 -DNDEBUG" )
   set( CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}" )


### PR DESCRIPTION
### Background

* After recent updates to machines running Cray CE, dynamic linking starting issuing warnings like this:
```
ld: myq.o: warning: relocation against `qi._' in read-only section `.trace'
ld: warning: creating DT_TEXTREL in a shared object
```

### Purpose of Pull Request

* [Fixes Redmine Issue #2351](https://rtt.lanl.gov/redmine/issues/2351)

### Description of changes

* Disabling compiler flag `-traceback` seems to silence the warning.
* Cray was notified of the issue.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
