### PR TITLE
Hack to work around OpenMPI error 'mkdir unable to create dir".

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -556,7 +556,7 @@ macro( register_parallel_test )
   unset( RUN_CMD )
 
   # Attempt of fix issues on Darwin related to /tmp permission errors, #2359.
-  if( DEFINED ENV{SLURM_CLUSTER_NAME} AND $ENV{SLURM_CLUSTER_NAME} STREQUAL "darwin" AND
+  if( DEFINED ENV{SLURM_CLUSTER_NAME} AND "$ENV{SLURM_CLUSTER_NAME}" STREQUAL "darwin" AND
       MPI_FLAVOR STREQUAL "openmpi" AND NOT "${MPIEXEC_EXECUTABLE}" MATCHES "smpi")
     set( MPIEXEC_EXTRA_OPTS --mca orte_tmpdir_base
       /tmp/$ENV{SLURMD_NODENAME}-$ENV{USER}-${rpt_TARGET} )

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -3,13 +3,12 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2016 Sep 22
 # brief  Setup MPI Vendors
-# note   Copyright (C) 2016-2020 Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
 #
 # Try to find MPI in the default locations (look for mpic++ in PATH)
 #
-# See cmake --help-module FindMPI for details on variables set and published
-# targets. Additionally, this module will set the following variables:
+# See cmake --help-module FindMPI for details on variables set and published targets. Additionally,
+# this module will set the following variables:
 #
 # DRACO_C4   MPI|SCALAR
 # C4_SCALAR  BOOL
@@ -252,9 +251,11 @@ macro( setupOpenMPI )
   # - Adding '--debug-daemons' is often requested by the OpenMPI dev team in conjunction with
   #   'export OMPI_MCA_btl_base_verbose=100' to obtain debug traces from openmpi.
   set(MPIEXEC_PREFLAGS_PERFBENCH "${MPIEXEC_PREFLAGS} --map-by socket:SPAN")
-  string(APPEND MPIEXEC_PREFLAGS " -bind-to none")
+  if( NOT MPIEXEC_PREFLAGS MATCHES " -bind-to none")
+    string(APPEND MPIEXEC_PREFLAGS " -bind-to none")
+  endif()
   # Setup for OMP plus MPI
-  if( NOT APPLE )
+  if( NOT APPLE AND NOT MPIEXEC_OMP_PREFLAGS MATCHES "--map-by ppr")
     # -bind-to fails on OSX, See #691
     set(MPIEXEC_OMP_PREFLAGS
       "${MPIEXEC_PREFLAGS} --map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings" )
@@ -263,7 +264,7 @@ macro( setupOpenMPI )
   # Spectrum-MPI on darwin
   # Limit communication to on-node via '-intra sm' or 'intra vader'
   # https://www.ibm.com/support/knowledgecenter/SSZTET_EOS/eos/guide_101.pdf
-  if( "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" )
+  if( "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" AND NOT MPIEXEC_PREFLAGS MATCHES "-intra sm")
     string(REPLACE "-bind-to none" "-bind-to core" MPIEXEC_PREFLAGS ${MPIEXEC_PREFLAGS})
     # string(REPLACE "-bind-to none" "-bind-to core" MPIEXEC_OMP_PREFLAGS ${MPIEXEC_OMP_PREFLAGS})
     set(smpi-sm-only "-intra sm -aff off --report-bindings")


### PR DESCRIPTION
### Background

+ This hack adds an extra command to mpirun for darwin: `--mca orte_tmpdir_base <dir>`
+ `<dir>` will be a unique string based on node name, user name, and ctest name.

### Purpose of Pull Request

* [Fixes Redmine Issue #2359](https://rtt.lanl.gov/redmine/issues/2359)
* Related to https://github.com/open-mpi/ompi/issues/8510.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
