### PR TITLE
WIP: Only append -bind-to none if it is not already present in MPIEXEC_PRE…

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -252,7 +252,9 @@ macro( setupOpenMPI )
   # - Adding '--debug-daemons' is often requested by the OpenMPI dev team in conjunction with
   #   'export OMPI_MCA_btl_base_verbose=100' to obtain debug traces from openmpi.
   set(MPIEXEC_PREFLAGS_PERFBENCH "${MPIEXEC_PREFLAGS} --map-by socket:SPAN")
-  string(APPEND MPIEXEC_PREFLAGS " -bind-to none")
+  if(NOT MPIEXEC_PREFLAGS MATCHES " -bind-to none")
+    string(APPEND MPIEXEC_PREFLAGS " -bind-to none")
+  endif()
   # Setup for OMP plus MPI
   if( NOT APPLE )
     # -bind-to fails on OSX, See #691


### PR DESCRIPTION
…FLAGS

### Background

* Running cmake . without blowing away causes "-bind-to none" to be appended to MPIEXEC_PREFLAGS over and over again (I was up to 8 repeats in my local build before I noticed!)
* I don't know if this is the "right" solution, but it seems to work.

### Purpose of Pull Request

* detail 1, refs #2 (github number)
* detail 2
* [Fixes Redmine Issue #3](https://rtt.lanl.gov/redmine/issues/3)

### Description of changes

* item

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
