### PR TITLE
Here is another try at providing a mca orte_tmpdir_base hack

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -558,8 +558,13 @@ macro( register_parallel_test )
   # Attempt of fix issues on Darwin related to /tmp permission errors, #2359.
   if( DEFINED ENV{SLURM_CLUSTER_NAME} AND "$ENV{SLURM_CLUSTER_NAME}" STREQUAL "darwin" AND
       MPI_FLAVOR STREQUAL "openmpi" AND NOT "${MPIEXEC_EXECUTABLE}" MATCHES "smpi")
+    if( NOT DEFINED orte_tmpdir_base_enum )
+      set( orte_tmpdir_base_enum 0 CACHE INTERNAL "help openmpi")
+    else()
+      math(EXPR orte_tmpdir_base_enum "${orte_tmpdir_base_enum} + 1")
+    endif()
     set( MPIEXEC_EXTRA_OPTS --mca orte_tmpdir_base
-      /tmp/$ENV{SLURMD_NODENAME}-$ENV{USER}-${rpt_TARGET} )
+      /tmp/$ENV{SLURMD_NODENAME}-$ENV{USER}-${orte_tmpdir_base_enum} ) # ${rpt_TARGET} )
   endif()
 
   if( addparalleltest_MPI_PLUS_OMP )


### PR DESCRIPTION
### Background

+ The previous try used the test name as a unique identifier, but this created stings that were too long to be used as Unix domain sockets (error reported by OpenMPI).
+ Instead of using the test name, use an integer that is incremented for each registered test.

### Purpose of Pull Request

* [Fixes Redmine Issue #2359](https://rtt.lanl.gov/redmine/issues/2359)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
