### PR TITLE
Update draco environment scripts for ccscs[45].

### DIFF
--- a/config/windows-msvc.cmake
+++ b/config/windows-msvc.cmake
@@ -62,6 +62,8 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # - /wd 5105 After upgrading to VS2019 version 16.8.0 preview 3, warning C5105 is issued from many
   #            system headers like stdio.h. Suppress for now.
   # - /arch:[SSE|SSE2|AVX|AVX2|IA32]
+  # - /fsanitize=address
+  # - /RTC1 - check for unitialized variables.
 
   string( APPEND CMAKE_C_FLAGS " /nologo /Gy /fp:precise /DWIN32 /D_WINDOWS /MP /wd4251" )
   if(HAVE_HARDWARE_AVX2)

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -187,13 +187,7 @@ if [[ ${INTERACTIVE} == true ]]; then
       # shellcheck source=/dev/null
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_vm" ;;
 
-    # CCS-NET machines (insufficient space on ccscs5 for vendor+data).
-    ccscs5*)
-      echo "Draco developer environment not provided on this machine"
-      echo "(${target}) due to insufficient /scratch storage."
-      export NoModules=1
-      ;;
-    ccscs[1-4]* | ccscs[6-9]*)
+    ccscs[1-9]* | ccsnet[1-9]*)
       # shellcheck source=/dev/null
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_ccsnet" ;;
 

--- a/environment/bashrc/.bashrc_ccsnet
+++ b/environment/bashrc/.bashrc_ccsnet
@@ -16,7 +16,14 @@ if [[ -n "$verbose" ]]; then echo "In draco/environment/bashrc/.bashrc_ccsnet"; 
 
 target=`uname -n`
 case $target in
-  ccscs[1-9]*)
+  ccscs[45]*)
+    [[ -z "${MODULEPATH}" ]] && export MODULEPATH=/ccs/opt/modulefiles
+    module unuse /usr/share/Modules/modulefiles /usr/local/lmod/lmod/modulefiles/Core
+    module load user_contrib/2021.03
+    module use --append /ccs/codes/radtran/Modules
+    module load draco/gcc1020
+    ;;
+  ccscs[1236789]*)
     [[ -z "${MODULEPATH}" ]] && export MODULEPATH=/ccs/opt/modulefiles
     module load user_contrib/2020.04
     module use --append /ccs/codes/radtran/Modules

--- a/src/mesh/Draco_Mesh_Builder.t.hh
+++ b/src/mesh/Draco_Mesh_Builder.t.hh
@@ -158,9 +158,7 @@ Draco_Mesh_Builder<FRT>::build_mesh(rtt_mesh_element::Geometry geometry) {
                std::minmax_element(cell_to_node_linkage.begin(), cell_to_node_linkage.end()));
   Remember(auto sn_minmax =
                std::minmax_element(side_to_node_linkage.begin(), side_to_node_linkage.end()));
-  Ensure(*cn_minmax.first >= 0);
   Ensure(*cn_minmax.second < num_nodes);
-  Ensure(side_to_node_linkage.size() > 0 ? *sn_minmax.first >= 0 : true);
   Ensure(side_to_node_linkage.size() > 0 ? *sn_minmax.second < num_nodes : true);
 
   // >>> CONSTRUCT THE MESH


### PR DESCRIPTION
### Background

* Much of draco development is one on ccs-net.  Updated systems require a new environment.

### Description of changes

+ New OS is RHEL8.
+ New spack build.  Probably some issues remain but most tools are in place.
+ Remove `Ensure` statements that caused build warnings issued by gcc@10.2.0.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
