### PR TITLE
Use '--exclusive' srun option on all Cray machines.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -44,6 +44,9 @@ jobs:
       ##########################
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
 
       ################################
       # Run Linter against code base #

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -187,8 +187,7 @@ macro( add_component_executable )
   # Create the library and set the properties
   #
 
-  # Set the component name: If registered from a test directory, extract
-  # the parent's name.
+  # Set the component name: If registered from a test directory, extract the parent's name.
   get_filename_component( ldir ${CMAKE_CURRENT_SOURCE_DIR} NAME )
   if( ${ldir} STREQUAL "test")
     get_filename_component( comp_target ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY )

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -331,10 +331,7 @@ macro( setupCrayMPI )
   #           they will stomp on the same cores.
 
   set(preflags " ") # -N 1 --cpu_bind=verbose,cores
-  string(APPEND preflags " --gres=craynetwork:0") # --exclusive
-  if( SITENAME_FAMILY STREQUAL "IC-ARM")
-    string(APPEND preflags " --exclusive")
-  endif()
+  string(APPEND preflags " --gres=craynetwork:0 --exclusive")
   set( MPIEXEC_PREFLAGS ${preflags} CACHE STRING "extra mpirun flags (list)." FORCE)
   # consider adding '-m=cyclic'
   set( MPIEXEC_PREFLAGS_PERFBENCH ${preflags} CACHE STRING "extra mpirun flags (list)." FORCE)

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -27,9 +27,7 @@
 case ${-} in
   *i*)
     export INTERACTIVE=true
-    if [[ "${verbose:=false}" == "true" ]]; then
-      echo "in draco/environment/bashrc/.bashrc";
-    fi
+    [[ "${verbose:=false}" == "true" ]] && echo "in draco/environment/bashrc/.bashrc"
 
     # Shell options
     shopt -s checkwinsize # autocorrect window size
@@ -60,7 +58,8 @@ case ${-} in
       export DRACO_SRC_DIR
       export DRACO_ENV_DIR="${DRACO_SRC_DIR}/environment"
     fi
-    [[ -z $DRACO_ENV_DIR ]]; echo "DRACO_ENV_DIR not set, some draco env will be disabled."
+    [[ "${DRACO_ENV_DIR:-notset}" == "notset" ]] && \
+      echo "DRACO_ENV_DIR not set, some draco env will be disabled."
 
     #----------------------------------------------------------------------------------------------#
     # Common aliases

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -10,7 +10,7 @@
 
 #verbose=true
 
-[[ -n "$verbose" ]] && echo "In draco/environment/bashrc/.bashrc_cray"
+[[ "${verbose:=false}" == "true" ]] && echo "In draco/environment/bashrc/.bashrc_cray"
 
 #--------------------------------------------------------------------------------------------------#
 # ENVIRONMENTS

--- a/environment/bashrc/bashrc_slurm
+++ b/environment/bashrc/bashrc_slurm
@@ -88,7 +88,7 @@ case ${-} in
      # shellcheck disable=SC2086
      if ! [[ $(squeue ${squeue_args} -h -t R | wc -l) == 0 ]]; then
        echo -e "\n${boldface}RUNNING${normalface}":
-       echo " squeue ${squeue_args} -o \"%.7i %.10u %.10a %.8q %.9P %.16j %.6D %.6C %.12L %S\" -S \"L\" -t R"
+       # echo " squeue ${squeue_args} -o \"%.7i %.10u %.10a %.8q %.9P %.16j %.6D %.6C %.12L %S\" -S \"L\" -t R"
        # shellcheck disable=SC2086
        squeue ${squeue_args} -o "%.7i %.10u %.10a %.8q %.9P %.16j %.6D %.6C %.12L %S" -S "L" -t R | grep --color -E ".*${hluser}.*|$"
      fi

--- a/src/diagnostics/qt/CMakeLists.txt
+++ b/src/diagnostics/qt/CMakeLists.txt
@@ -3,8 +3,7 @@
 # author Kelly Thompson <kgt@lanl.gov>
 # date   2015 June 26
 # brief  Generate build project files for diagnostics/qt
-# note   Copyright (C) 2016-2020, Triad National Security, LLC.
-#        All rights reserved.
+# note   Copyright (C) 2016-2020, Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 cmake_minimum_required( VERSION 3.17.0 )
 project( diagnostics_qt CXX )
@@ -13,8 +12,7 @@ project( diagnostics_qt CXX )
 # Special options for Qt applications
 #--------------------------------------------------------------------------------------------------#
 
-# Instruct CMake to run MOC automatically when needed (only for subdirectories
-# that need Qt)
+# Instruct CMake to run MOC automatically when needed (only for subdirectories that need Qt)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
@@ -23,18 +21,17 @@ set(CMAKE_AUTORCC ON)
 # Source files
 #--------------------------------------------------------------------------------------------------#
 
-file( GLOB sources   main.cc mainwindow.cc diWidget.cc)
-file( GLOB headers   mainwindow.hh diWidget.hh)
-file( GLOB ui_files  mainwindow.ui )
+set(sources  main.cc mainwindow.cc diWidget.cc)
+set(headers  mainwindow.hh diWidget.hh)
+set(ui_files mainwindow.ui )
 # file( GLOB resources *.qrc )
 
 #--------------------------------------------------------------------------------------------------#
 # Build package library
 #--------------------------------------------------------------------------------------------------#
 
-# List Qt5::Widgets as a dependencies but not a VENDOR_LIB to prevent DBS from
-# listing this library as a DRACO_TPL_LIBRARY.  It is not intended for export
-# into other projects.
+# List Qt5::Widgets as a dependencies but not a VENDOR_LIB to prevent DBS from listing this library
+# as a DRACO_TPL_LIBRARY.  It is not intended for export into other projects.
 add_component_executable(
   TARGET      Exe_draco_info_gui
   TARGET_DEPS "Lib_diagnostics;Qt5::Widgets"
@@ -42,12 +39,10 @@ add_component_executable(
   FOLDER       diagnostics
   NOCOMMANDWINDOW )
 
-# Disable IPO for applications that link to Qt SDK, as this causes compile
-# warnings for the Intel compiler (and it refuses to run IPO for this
-# application anyway).
+# Disable IPO for applications that link to Qt SDK, as this causes compile warnings for the Intel
+# compiler (and it refuses to run IPO for this application anyway).
 if( CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-  set_target_properties( Exe_draco_info_gui PROPERTIES
-    INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF )
+  set_target_properties( Exe_draco_info_gui PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF )
 endif()
 
 # Copy necessary dll files to build directory
@@ -57,8 +52,7 @@ if (WIN32)
             $<TARGET_FILE_DIR:Exe_draco_info_gui>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Lib_c4>
             $<TARGET_FILE_DIR:Exe_draco_info_gui>
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:Lib_diagnostics>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Lib_diagnostics>
             $<TARGET_FILE_DIR:Exe_draco_info_gui> )
 endif()
 


### PR DESCRIPTION
### Background

* Archive minor updates from my sandbox that were created while porting Draco to run on Cray ARM machines.

### Purpose of Pull Request

* [Related to Redmine Issue #2344](https://rtt.lanl.gov/redmine/issues/2344)

### Description of changes

+ New recommendation from LANL is to use `--exclusive` for all of our regression tests when targeting Cray systems.  `setupMPI.cmake` modified accordingly.
+ Update comments to use 100 column format.
+ Fix some debug print statements.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
