### PR TITLE
Fix INTERNAL variable state logic.

### DIFF
--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -558,12 +558,13 @@ macro( register_parallel_test )
   if( DEFINED ENV{SLURM_CLUSTER_NAME} AND "$ENV{SLURM_CLUSTER_NAME}" STREQUAL "darwin" AND
       MPI_FLAVOR STREQUAL "openmpi" AND NOT "${MPIEXEC_EXECUTABLE}" MATCHES "smpi")
     if( NOT DEFINED orte_tmpdir_base_enum )
-      set( orte_tmpdir_base_enum 0 CACHE INTERNAL "help openmpi")
+      set( orte_tmpdir_base_enum 0 )
     else()
       math(EXPR orte_tmpdir_base_enum "${orte_tmpdir_base_enum} + 1")
     endif()
+    set( orte_tmpdir_base_enum ${orte_tmpdir_base_enum} CACHE INTERNAL "help openmpi")
     set( MPIEXEC_EXTRA_OPTS --mca orte_tmpdir_base
-      /tmp/$ENV{SLURMD_NODENAME}-$ENV{USER}-${orte_tmpdir_base_enum} ) # ${rpt_TARGET} )
+      /tmp/$ENV{SLURMD_NODENAME}-$ENV{USER}-${orte_tmpdir_base_enum} )
   endif()
 
   if( addparalleltest_MPI_PLUS_OMP )


### PR DESCRIPTION
### Background

* We are still trying to get the mpirun options correct for Darwin.  We append an index value to the `tmpdir` path for each test, but bad cmake-logic mean that the index value was always `1`.

### Description of changes

* After incrementing the cmake INTERNAL variable `orte_tmpdir_base_enum`, save the new value to `CMakeCache.txt`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
