### PR TITLE
Improve compiler flag logic for Cuda and GNU.

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -117,7 +117,7 @@ macro(dbsSetupCompilers)
     #    - EXE_LINKER_FLAGS
     # 2. Provide these as arguments to cmake as -DC_FLAGS="whatever".
     #----------------------------------------------------------------------------------------------#
-    foreach( lang C CXX Fortran EXE_LINKER SHARED_LINKER)
+    foreach( lang C CXX Fortran EXE_LINKER SHARED_LINKER CUDA)
       if( DEFINED ENV{${lang}_FLAGS} )
         string(REPLACE "\"" "" tmp "$ENV{${lang}_FLAGS}" )
         string( APPEND ${lang}_FLAGS " ${tmp}")

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -1,7 +1,7 @@
 #--------------------------------------------*-cmake-*---------------------------------------------#
 # file   config/compilerEnv.cmake
 # brief  Default CMake build parameters
-# note   Copyright (C) 2019-2020 Triad National Security, LLC., All rights reserved.
+# note   Copyright (C) 2019-2021 Triad National Security, LLC., All rights reserved.
 #--------------------------------------------------------------------------------------------------#
 
 include_guard(GLOBAL)
@@ -848,12 +848,13 @@ macro( toggle_compiler_flag switch compiler_flag compiler_flag_var_names build_m
     if( NOT ${comp} STREQUAL "C" AND
         NOT ${comp} STREQUAL "CXX" AND
         NOT ${comp} STREQUAL "Fortran" AND
+        NOT ${comp} STREQUAL "CUDA" AND
         NOT ${comp} STREQUAL "EXE_LINKER" AND
         NOT ${comp} STREQUAL "SHARED_LINKER")
       message(FATAL_ERROR "When calling "
 "toggle_compiler_flag(switch, compiler_flag, compiler_flag_var_names), "
 "compiler_flag_var_names must be set to one or more of these valid "
-"names: C;CXX;Fortran;EXE_LINKER;SHARED_LINKER.")
+"names: C;CXX;Fortran;CUDA;EXE_LINKER;SHARED_LINKER.")
     endif()
 
     string( REPLACE "+" "x" safe_CMAKE_${comp}_FLAGS "${CMAKE_${comp}_FLAGS}" )

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -71,12 +71,15 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # Systems running CrayPE use compile wrappers to specify this option.
   site_name( sitename )
   string( REGEX REPLACE "([A-z0-9]+).*" "\\1" sitename ${sitename} )
-  if (HAS_MARCH_NATIVE AND
-      NOT APPLE AND
-      NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
-    string( APPEND CMAKE_C_FLAGS " -march=native" )
-  elseif( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
-    string( APPEND CMAKE_C_FLAGS " -mcpu=powerpc64le -mtune=powerpc64le" )
+  # Only add '-march=native' if -march and -mtune are not already requested. Spack will add -march=
+  # options if spacific target is requested (ie. target Haswell CPU when building on Skylake).
+  if( NOT ("${CC}" MATCHES "-mtune" OR "${CC}" MATCHES "-march" OR
+        "${CMAKE_C_FLAGS}" MATCHES "-mtune" OR "${CMAKE_C_FLAGS}" MATCHES "-march" ))
+    if (HAS_MARCH_NATIVE AND NOT APPLE AND NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
+      string( APPEND CMAKE_C_FLAGS " -march=native" )
+    elseif( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
+      string( APPEND CMAKE_C_FLAGS " -mcpu=powerpc64le -mtune=powerpc64le" )
+    endif()
   endif()
 
   string( APPEND CMAKE_CXX_FLAGS      " ${CMAKE_C_FLAGS}")

--- a/config/unix-gfortran.cmake
+++ b/config/unix-gfortran.cmake
@@ -22,9 +22,14 @@ if( NOT Fortran_FLAGS_INITIALIZED )
    set( CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}" )
    set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g ${CMAKE_Fortran_FLAGS_RELEASE}")
 
-   if (NOT APPLE AND HAS_MARCH_NATIVE)
+   # Only add '-march=native' if -march and -mtune are not already requested. Spack will add -march=
+  # options if spacific target is requested (ie. target Haswell CPU when building on Skylake).
+  if( NOT ("${FC}" MATCHES "-mtune" OR "${FC}" MATCHES "-march" OR
+        "${CMAKE_Fortran_FLAGS}" MATCHES "-mtune" OR "${CMAKE_Fortran_FLAGS}" MATCHES "-march" ))
+    if (NOT APPLE AND HAS_MARCH_NATIVE)
       set( CMAKE_Fortran_FLAGS    "${CMAKE_Fortran_FLAGS} -march=native" )
-   endif()
+    endif()
+  endif()
 endif()
 
 #--------------------------------------------------------------------------------------------------#

--- a/environment/bashrc/.bashrc_ccsnet
+++ b/environment/bashrc/.bashrc_ccsnet
@@ -22,14 +22,12 @@ case $target in
     module use --append /ccs/codes/radtran/Modules
     module load draco/gcc1020-ompi4
     ;;
-  ccsnet[23]*|rtt*)
-    module load user_contrib/2020.04
-    module use --append /ccs/codes/radtran/Modules
-    ;;
-  *)
-    die "I don't know how to setup modules for $target"
-    ;;
+  ccsnet[23]*|rtt*) module use --append /ccs/codes/radtran/Modules ;;
+  *) die "I don't know how to setup modules for $target" ;;
 esac
+
+# Enable auto-completion for <TAB> for git commands
+[[ -f /ccs/opt/bin/git-completion.bash ]] && source /ccs/opt/bin/git-completion.bash
 
 #--------------------------------------------------------------------------------------------------#
 # end of .bashrc_ccsnet

--- a/tools/travis-run-tests.sh
+++ b/tools/travis-run-tests.sh
@@ -108,6 +108,7 @@ elif [[ "${COMPILER:=GCC}" == "GCC" ]]; then
     for i in C CXX Fortran; do
       eval export ${i}_FLAGS+=\" -Werror\"
     done
+    eval export CUDA_FLAGS+=\" -Werror all-warnings\"
   fi
   if [[ ${COVERAGE:-OFF} == "ON" ]]; then
     CMAKE_OPTS="-DCODE_COVERAGE=ON"
@@ -184,6 +185,7 @@ elif [[ "${COMPILER}" == "LLVM" ]]; then
     for i in C CXX Fortran; do
       eval export ${i}_FLAGS+=\" -Werror\"
     done
+    eval export CUDA_FLAGS+=\" -Werror all-warnings\"
   fi
 
   echo -e "\n========== printenv =========="


### PR DESCRIPTION
### Background

* Compile warnings from `nvcc` where not treated as errors in our CI.
* When using spack to build Draco, specifying a target caused a build failure because two `-march=` commands were listed in the compiler flags.

### Purpose of Pull Request

* [Fixes Redmine Issue #2384](https://rtt.lanl.gov/redmine/issues/2384)

### Description of changes

+ If provided, use `CUDA_FLAGS` provided by the environment or on the cmake configure line.  This will allows `-Werror` set by the CI system to be used correctly by the build system.
+ Disable `-march=native` if `-march` options are provided by the environment or on the cmake configure line.  This will allow `spack` to target an alternate architecture (eg. broadwell vs. haswell).
+ Sneak in a small change to the ccs-net `.bashrc` that enables tab-completion of git branch names.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
