### PR TITLE
Update environments for releases that use cuda.

### DIFF
--- a/tools/README
+++ b/tools/README
@@ -52,7 +52,7 @@ source/tools/release.sh &> logs/release-darwin-power9.log &
 
 2. x64 + Volta
 
-salloc -N 1 -p volta-x86 -C cpu_family:broadwell
+salloc -N 1 -p volta-x86 -C cpu_family:haswell
 
 3. ARM
 

--- a/tools/ats2-env.sh
+++ b/tools/ats2-env.sh
@@ -86,7 +86,7 @@ case $ddir in
       unset CPATH
       unset LD_LIBRARY_PATH
       unset LIBRARY_PATH
-      run "module load draco/xl2020.11.12-cuda-11.2.0-beta"
+      run "module load draco/xl2020.08.19-cuda-11.0.2"
       run "module list"
       export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
     }

--- a/tools/darwin-x86_64-env.sh
+++ b/tools/darwin-x86_64-env.sh
@@ -33,7 +33,7 @@ case "${ddir:=notset}" in
       run "module use --append /projects/draco/Modules"
       run "module load draco/x64-gcc930"
       if [[ ${SLURM_JOB_PARTITION} =~ "volta-" || ${SLURM_JOB_PARTITION} =~ "gpu" ]]; then
-        run "module load cuda/11.2-beta"
+        run "module load cuda/11.0"
       fi
       run "module list"
 
@@ -55,7 +55,7 @@ case "${ddir:=notset}" in
       run "module use --append /projects/draco/Modules"
       run "module load draco/x64-intel1905"
       #if [[ ${SLURM_JOB_PARTITION} =~ "volta-" || ${SLURM_JOB_PARTITION} =~ "gpu" ]]; then
-      #  run "module load cuda/11.2-beta"
+      #  run "module load cuda/11.0"
       #fi
       run "module list"
       MPIEXEC_EXECUTABLE=$(which mpirun)


### PR DESCRIPTION
### Background

* During the release of draco-7_10_0 we found issues with cuda/11.2. Backing down to 11.0.2.
* See [Redmine #2396](https://rtt.lanl.gov/redmine/issues/2396)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
