### PR TITLE
Bump ats-2 default env to newer tools.

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -45,7 +45,7 @@ else
   module use --append /usr/gapps/jayenne/Modules
   module unuse /usr/share/lmod/lmod/modulefiles/Core
   module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
-  module load draco/xl2020.08.19-cuda-11.0.2
+  module load draco/xl2021.03.11-cuda-11.2.0
 fi
 
 # Do not escape $ for bash completion


### PR DESCRIPTION
### Background

* Bump default developer environment for ATS-2 to `xl/2021.03.11` and `cuda-11.2.0`.

### Purpose of Pull Request

* [Fixes Redmine Issue #2395](https://rtt.lanl.gov/redmine/issues/2395)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
