### PR TITLE
Cuda-11.2.0 is broken, use 11.0.2 instead.

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -45,7 +45,7 @@ else
   module use --append /usr/gapps/jayenne/Modules
   module unuse /usr/share/lmod/lmod/modulefiles/Core
   module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
-  module load draco/xl2021.03.11-cuda-11.2.0
+  module load draco/xl2021.03.11-cuda-11.0.2
 fi
 
 # Do not escape $ for bash completion


### PR DESCRIPTION
### Background

* Triage of failing tests related to cuda-11.2.0 is ongoing.  For now, revert to 11.0.2 to keep our tests passing.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
