### PR TITLE
Support intel/20 on ccs-net.

### DIFF
--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -1,73 +1,77 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*---------------------------------------------#
 # file   config/unix-intel.cmake
 # author Kelly Thompson
 # date   2010 Nov 1
 # brief  Establish flags for Linux64 - Intel C++
-# note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
+# -------------------------------------------------------------------------------------------------#
 
 #
 # Compiler Flags
 #
 
-if( NOT CXX_FLAGS_INITIALIZED )
-   set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+if(NOT CXX_FLAGS_INITIALIZED)
+  set(CXX_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
 
-  # [KT 2015-07-10] I would like to turn on -w2, but this generates many
-  #    warnings from Trilinos headers that I can't suppress easily (warning 191:
-  #    type qualifier is meaningless on cast type)
-  # [KT 2015-07-10] -diag-disable 11060 -- disable warning that is issued when
-  #    '-ip' is turned on and a library has no symbols (this occurs when
-  #    capsaicin links some trilinos libraries.)
-  string( APPEND CMAKE_C_FLAGS " -w1 -vec-report0 -diag-disable=remark -shared-intel -no-ftz -fma"
-    " -diag-disable=11060" )
-  if( DBS_GENERATE_OBJECT_LIBRARIES )
-    string( APPEND CMAKE_C_FLAGS " -ipo" )
+  # * [KT 2015-07-10] I would like to turn on -w2, but this generates many warnings from Trilinos
+  #   headers that I can't suppress easily (warning 191: type qualifier is meaningless on cast type)
+  # * [KT 2015-07-10] -diag-disable 11060 -- disable warning that is issued when '-ip' is turned on
+  #   and a library has no symbols (this occurs when capsaicin links some trilinos libraries.)
+  string(APPEND CMAKE_C_FLAGS " -w1 -vec-report0 -diag-disable=remark -shared-intel -no-ftz -fma"
+         " -diag-disable=11060")
+  if(DBS_GENERATE_OBJECT_LIBRARIES)
+    string(APPEND CMAKE_C_FLAGS " -ipo")
   endif()
-  string( CONCAT CMAKE_C_FLAGS_DEBUG "-g -O0 -inline-level=0 -ftrapuv -check=uninit"
-    " -fp-model=precise -fp-speculation=safe -debug inline-debug-info -fno-omit-frame-pointer"
-    " -DDEBUG")
+  string(CONCAT CMAKE_C_FLAGS_DEBUG
+                "-g -O0 -inline-level=0 -ftrapuv -check=uninit -fp-model=precise"
+                " -fp-speculation=safe -debug inline-debug-info -fno-omit-frame-pointer -DDEBUG")
   # -qno-opt-dynamic-align fixed LAP numerical sensitivity for Hypre (Gaber, 12/01/2020).
-  string( CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -fp-speculation=fast -fp-model=precise -pthread"
-    " -qno-opt-dynamic-align -DNDEBUG" )
-  # [KT 2017-01-19] On KNL, -fp-model=fast changes behavior significantly for
-  # IMC. Revert to -fp-model=precise.
-  if( "$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl" )
-    string( REPLACE "-fp-model=fast" "-fp-model=precise" CMAKE_C_FLAGS_RELEASE
-      ${CMAKE_C_FLAGS_RELEASE} )
+  string(CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -fp-speculation=fast -fp-model=precise -pthread"
+                " -qno-opt-dynamic-align -DNDEBUG")
+  # [KT 2017-01-19] On KNL, -fp-model=fast changes behavior significantly for IMC. Revert to
+  # -fp-model=precise.
+  if("$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl")
+    string(REPLACE "-fp-model=fast" "-fp-model=precise" CMAKE_C_FLAGS_RELEASE
+                   ${CMAKE_C_FLAGS_RELEASE})
   endif()
 
-  set( CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}" )
-  string( CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-g -debug inline-debug-info -O3 -pthread"
-    " -fp-model=precise -fp-speculation=safe -fno-omit-frame-pointer" )
+  set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
+  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-g -debug inline-debug-info -O3 -pthread"
+                " -fp-model=precise -fp-speculation=safe -fno-omit-frame-pointer")
 
-  string( APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")
-  set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -early-template-check")
-  set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-  set( CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
-  set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
+  string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -early-template-check")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
-   # Use C99 standard.
-   set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  # Use C99 standard.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
 endif()
 
-find_library( INTEL_LIBM m )
-mark_as_advanced( INTEL_LIBM )
+find_library(INTEL_LIBM m)
+mark_as_advanced(INTEL_LIBM)
 
-#--------------------------------------------------------------------------------------------------#
+# -------------------------------------------------------------------------------------------------#
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_C_FLAGS)
 deduplicate_flags(CMAKE_CXX_FLAGS)
 force_compiler_flags_to_cache("C;CXX")
 
-# If this is a Cray, the compile wrappers take care of any xHost flags that are needed.
-if( NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv )
-  set( HAS_XHOST TRUE )
-  toggle_compiler_flag( HAS_XHOST "-xHost" "C;CXX" "")
+# Exceptions for -xHost
+#
+# * If this is a Cray, the compile wrappers take care of any xHost flags that are needed.
+# * On ccs-net we mix & match cpu types (vendor libs are built for sandybridge) and -xHost causes an
+#   ICE when linking libraries.
+if(NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv AND NOT IS_DIRECTORY "/ccs/opt/bin")
+  set(HAS_XHOST TRUE)
+  toggle_compiler_flag(HAS_XHOST "-xHost" "C;CXX" "")
 endif()
-toggle_compiler_flag( OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX" "" )
+toggle_compiler_flag(OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX" "")
 
-#--------------------------------------------------------------------------------------------------#
+# -------------------------------------------------------------------------------------------------#
 # End config/unix-intel.cmake
-#--------------------------------------------------------------------------------------------------#
+# -------------------------------------------------------------------------------------------------#

--- a/src/quadrature/ftest/tstquadrature_interfaces.f90
+++ b/src/quadrature/ftest/tstquadrature_interfaces.f90
@@ -1,47 +1,46 @@
-!----------------------------------*-F90-*----------------------------------
+!---------------------------------------------*-F90-*-----------------------------------------------
 !
 ! file   quadrature/ftest/tstquadrature_interfaces.f90
 ! author Allan Wollaber
 ! date   Tuesday, Jun 12, 2012, 16:03 pm
 ! brief  Test F90 quadrature_data passed into a C++ function
-! note   Copyright (c) 2016-2020 Triad National Security, LLC.
-!        All rights reserved.
-!---------------------------------------------------------------------------
+! note   Copyright (c) 2016-2021 Triad National Security, LLC., All rights reserved.
+!---------------------------------------------------------------------------------------------------
 
-!---------------------------------------------------------------------------
-! This F90 function interface allows the Fortran function
-! test_quadrature_interfaces to directly call the extern "C" function
-! rtt_test_quadrature_interfaces (from the library rtt_quadrature_test).
-!---------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------------------
+! This F90 function interface allows the Fortran function test_quadrature_interfaces to directly
+! call the extern "C" function rtt_test_quadrature_interfaces (from the library
+! rtt_quadrature_test).
+!---------------------------------------------------------------------------------------------------
 module rtt_test_quadrature_f
   implicit none
 
-  ! Now create an interface to the C routine that accepts that a user-defined
-  ! type
+  ! Now create an interface to the C routine that accepts that a user-defined type
   interface
-     subroutine rtt_test_quadrature_interfaces(quad, err_code) bind(C, &
-          & name="rtt_test_quadrature_interfaces")
-       use iso_c_binding, only : c_int
-       use quadrature_interfaces, only : quadrature_data
+     subroutine rtt_test_quadrature_interfaces(quad, err_code) &
+          bind(C, name="rtt_test_quadrature_interfaces")
+       use iso_c_binding, only: c_int
+
+       use quadrature_interfaces, only: quadrature_data
        implicit none
-       type(quadrature_data),    intent(in)  :: quad
-       integer(c_int)       ,    intent(out) :: err_code
+       type(quadrature_data), intent(in)  :: quad
+       integer(c_int), intent(out) :: err_code
      end subroutine rtt_test_quadrature_interfaces
   end interface
 
 end module rtt_test_quadrature_f
 
-!---------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------------------
 ! Test that creates / fills quadrature_data in Fortan and passes to C++
-!---------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------------------
 subroutine test_quadrature_interfaces() bind(c)
 
   use rtt_test_quadrature_f
   use quadrature_interfaces
-  use iso_c_binding, only : c_int, c_double, c_loc
+  use iso_c_binding, only: c_int, c_double, c_loc
   implicit none
 
-  !----------------------------------------------------------------------
+  !----------------------------------------------------------------------------------------------
   ! Variable declarations
   type(quadrature_data)      :: quad
   integer(c_int)             :: error_code, sn_size
@@ -50,44 +49,44 @@ subroutine test_quadrature_interfaces() bind(c)
   real(c_double), allocatable, target, dimension(:) :: q_xi
   real(c_double), allocatable, target, dimension(:) :: q_wt
 
-  !----------------------------------------------------------------------
+  !----------------------------------------------------------------------------------------------
   ! Initialization
 
   call init_quadrature(quad)
 
   ! Test a Tri Chebyshev Legendre quadrature
-  quad%dimension      = 2
-  quad%type           = 1
-  quad%order          = 4
-  quad%geometry       = 0
+  quad % dimension = 2
+  quad % type = 1
+  quad % order = 4
+  quad % geometry = 0
   ! Allocate space to fill in the data
   sn_size = 12
-  allocate(q_mu(12), q_eta(12), q_xi(12), q_wt(12))
-  quad%mu  = c_loc(q_mu)
-  quad%eta = c_loc(q_eta)
-  quad%xi  = c_loc(q_xi)
-  quad%wt  = c_loc(q_wt)
+  allocate (q_mu(12), q_eta(12), q_xi(12), q_wt(12))
+  quad % mu = c_loc(q_mu)
+  quad % eta = c_loc(q_eta)
+  quad % xi = c_loc(q_xi)
+  quad % wt = c_loc(q_wt)
 
   ! Fill in the information
   call get_quadrature(quad)
 
   error_code = -1
   print '(a)', "On the Fortran side, we have created a quadrature_data type"
-  print '(a,i1)', "The dimension is ", quad%dimension
-  print '(a,i1)', "The type is ", quad%type
-  print '(a,i2)', "The order is ", quad%order
-  print '(a,i1)', "The geometry is ", quad%geometry
+  print '(a,i1)', "The dimension is ", quad % dimension
+  print '(a,i1)', "The type is ", quad % type
+  print '(a,i2)', "The order is ", quad % order
+  print '(a,i1)', "The geometry is ", quad % geometry
   print '(a,4f7.5)', "The first ordinate is ", q_mu(1), q_eta(1), q_xi(1), q_wt(1)
   print '(a)', "Now calling C to ensure data is passed correctly"
   print '(a)'
 
-  !----------------------------------------------------------------------
+  !----------------------------------------------------------------------------------------------
   ! Call the c-function with the derived type and check the error code
   call rtt_test_quadrature_interfaces(quad, error_code)
 
-  deallocate(q_mu, q_eta, q_xi, q_wt)
+  deallocate (q_mu, q_eta, q_xi, q_wt)
 
-  if( error_code .eq. 0 )then
+  if (error_code .eq. 0) then
      print '(a)', "Test: passed"
      print '(a)', "     error code is equal to zero"
   else
@@ -97,7 +96,7 @@ subroutine test_quadrature_interfaces() bind(c)
 
   print '(a)', " "
   print '(a)', "*********************************************"
-  if(error_code .ne. 0) then
+  if (error_code .ne. 0) then
      print '(a)', "**** ftstquadrature_interface Test: FAILED."
   else
      print '(a)', "**** ftstquadrature_interface Test: PASSED."
@@ -106,6 +105,6 @@ subroutine test_quadrature_interfaces() bind(c)
 
 end subroutine test_quadrature_interfaces
 
-!---------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------------------
 ! end of tstquadrature_interfaces.f90
-!---------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Background

* A new compiler stack is now available on ccs-net machines: `draco/intel20`

### Description of changes

* This environment provides intel/20.2.1 versions of `icpc`, `icc`, and `ifort` and all of our normal TPLs.
* Draco needed a couple of tweaks to work with the new compiler version -- included in this PR.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
