### PR TITLE
Provide minor environment tweaks.

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,243 @@
+# ----------------------------------
+# Options affecting listfile parsing
+#
+# https://cmake-format.readthedocs.io/en/latest/configuration.html
+# ----------------------------------
+with section("parse"):  # noqa: F821
+
+    # Specify structure for custom cmake functions
+    additional_commands = {
+
+        "add_component_library": {
+            "pargs": 1,
+            "flags": ["NOEXPORT"],
+            "kwargs": {"TARGET": '*', "LIBRARY_NAME": '*', "SOURCES": '*', "HEADERS": '*',
+                       "INCLUDE_DIRS": '*', "TARGET_DEPS": '*', "LINK_LANGUAGE": '*',
+                       "LIBRARY_TYPE": '*'}},
+
+        "add_component_executable": {
+            "kwargs": {"TARGET": '*', "LIBRARY_NAME": '*', "SOURCES": '*', "HEADERS": '*',
+                       "INCLUDE_DIRS": '*', "TARGET_DEPS": '*', "EXE_NAME": '*', "FOLDER": '*'}},
+
+        "add_scalar_tests": {
+            "kwargs": {"SOURCES": '*', "DEPS": '*', "TEST_ARGS": '*', "PASS_REGEX": '*', "LABELS":
+                       '*'}},
+
+        "add_parallel_tests": {
+            "flags": ["MPI_PLUS_OMP"],
+            "kwargs": {"SOURCES": '*', "DEPS": '*', "TEST_ARGS": '*', "PASS_REGEX": '*',
+                       "FAIL_REGEX": '*', "LABEL": '*', "PE_LIST": '*'}},
+
+        "add_app_unit_test": {
+            "kwargs": {"DRIVER": '*', "APPS": '*', "TEST_ARGS": '*', "LABELS": '*', "APP": '*',
+                       "PE_LIST": '*', "STDINFILE": '*', "GOLDFILE": '*'}},
+
+        "cmake_add_fortran_subdirectory": {
+            "pargs": 1,
+            "flags": ["VERBOSE", "NO_EXTERNAL_INSTALL"],
+            "kwargs": {"PROJECT": '*', "ARCHIVE_DIR": '*', "RUNTIME_DIR": '*', "LIBRARIES": '*',
+                       "TARGET_NAMES": '*', "DEPENDS": '*', "CMAKE_COMMAND_LINE": '*'}},
+
+    }
+
+    # Specify variable tags.
+    vartags = []
+
+    # Specify property tags.
+    proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):  # noqa: F821
+
+    # How wide to allow formatted cmake files
+    line_width = 100
+
+    # How many spaces to tab for indent
+    tab_size = 2
+
+    # If an argument group contains more than this many sub-groups (parg or kwarg groups) then force
+    # it to a vertical layout.
+    max_subgroups_hwrap = 2
+
+    # If a positional argument group contains more than this many arguments, then force it to a
+    # vertical layout.
+    max_pargs_hwrap = 6
+
+    # If a cmdline positional group consumes more than this many lines without nesting, then
+    # invalidate the layout (and nest)
+    max_rows_cmdline = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing parenthesis on its
+    # own line.
+    dangle_parens = False
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it to this reference:
+    # `prefix`: the start of the statement, `prefix-indent`: the start of the statement, plus one
+    # indentation level, `child`: align to the column of the arguments
+    dangle_align = 'prefix'
+
+    # If the statement spelling length (including space and parenthesis) is smaller than this
+    # amount, then force reject nested layouts.
+    min_prefix_chars = 4
+
+    # If the statement spelling length (including space and parenthesis) is larger than the tab
+    # width by more than this amount, then force reject un-nested layouts.
+    max_prefix_chars = 10
+
+    # If a candidate layout is wrapped horizontally but it exceeds this many lines, then reject the
+    # layout.
+    max_lines_hwrap = 2
+
+    # What style line endings to use in the output.
+    line_ending = 'unix'
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = 'canonical'
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = 'unchanged'
+
+    # A list of command names which should always be wrapped
+    always_wrap = []
+
+    # If true, the argument lists which are known to be sortable will be sorted lexicographicall
+    enable_sort = True
+
+    # If true, the parsers may infer whether or not an argument list is sortable (without
+    # annotation).
+    autosort = True
+
+    # By default, if cmake-format cannot successfully fit everything into the desired linewidth it
+    # will apply the last, most agressive attempt that it made. If this flag is True, however,
+    # cmake-format will print error, exit with non-zero status code, and write-out nothing
+    require_valid_layout = False
+
+    # A dictionary mapping layout nodes to a list of wrap decisions. See the documentation for more
+    # information.
+    layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):  # noqa: F821
+
+    # What character to use for bulleted lists
+    bullet_char = '*'
+
+    # What character to use as punctuation after numerals in an enumerated list
+    enum_char = '.'
+
+    # If comment markup is enabled, don't reflow the first comment block in each listfile. Use this
+    # to preserve formatting of your copyright/license statements.
+    first_comment_is_literal = True
+
+    # If comment markup is enabled, don't reflow any comment block which matches this (regex)
+    # pattern. Default is `None` (disabled).
+    literal_comment_pattern = None
+
+    # Regular expression to match preformat fences in comments default=
+    # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    fence_pattern = '^\\s*([`~]{3}[`~]*)(.*)$'
+
+    # Regular expression to match rulers in comments default= ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+    ruler_pattern = '^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'
+
+    # If a comment line matches starts with this pattern then it is explicitly a trailing comment
+    # for the preceeding argument. Default is '#<'
+    explicit_trailing_pattern = '#<'
+
+    # If a comment line starts with at least this many consecutive hash characters, then don't
+    # lstrip() them off. This allows for lazy hash rulers where the first hash char is not separated
+    # by space
+    hashruler_min_length = 10
+
+    # If true, then insert a space between the first hash char and remaining hash chars in a hash
+    # ruler, and normalize its length to fill the column
+    canonicalize_hashrulers = True
+
+    # enable comment markup parsing and reflow
+    enable_markup = True
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section("lint"):  # noqa: F821
+
+    # a list of lint codes to disable
+    disabled_codes = ["C0103"]
+
+    # regular expression pattern describing valid function names
+    function_pattern = '[0-9a-z_]+'
+
+    # regular expression pattern describing valid macro names
+    macro_pattern = '[0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global (cache) scope
+    global_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global scope (but
+    # internal semantic)
+    internal_var_pattern = '_[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with local scope
+    local_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for privatedirectory variables
+    private_var_pattern = '_[0-9a-z_]+'
+
+    # regular expression pattern describing valid names for public directory variables
+    public_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for function/macro arguments and loop
+    # variables.
+    argument_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for keywords used in functions or macros
+    keyword_pattern = '[A-Z][0-9A-Z_]+'
+
+    # In the heuristic for C0201, how many conditionals to match within a loop in before considering
+    # the loop a parser.
+    max_conditionals_custom_parser = 2
+
+    # Require at least this many newlines between statements
+    min_statement_spacing = 1
+
+    # Require no more than this many newlines between statements
+    max_statement_spacing = 2
+    max_returns = 6
+    max_branches = 12
+    max_arguments = 5
+    max_localvars = 15
+    max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section("encode"):  # noqa: F821
+
+    # If true, emit the unicode byte-order mark (BOM) at the start of the file
+    emit_byteorder_mark = False
+
+    # Specify the encoding of the input file. Defaults to utf-8
+    input_encoding = 'utf-8'
+
+    # Specify the encoding of the output file. Defaults to utf-8. Note that cmake only claims to
+    # support utf-8 so be careful when using anything else
+    output_encoding = 'utf-8'
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section("misc"):  # noqa: F821
+
+    # A dictionary containing any per-command configuration overrides. Currently only `command_case`
+    # is supported.
+    per_command = {}

--- a/.fprettify.rc
+++ b/.fprettify.rc
@@ -1,0 +1,12 @@
+indent = 2
+line-length = 100
+whitespace = 2
+whitespace-comma = true
+whitespace-assignment = true
+whitespace-relational = true
+whitespace-logical = false
+whitespace-plusminus = true
+whitespace-multdiv = true
+whitespace-print = true
+whitespace-type = true
+whitespace-intrinsics = true

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -171,8 +171,8 @@ if [[ ${INTERACTIVE} == true ]]; then
       # shellcheck source=/dev/null
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_rfta" ;;
 
-    # capulin, thunder, trinitite (tt-fey) | trinity (tr-fe)
-    cp-login* | th-login* |tt-fey* | tt-login* | tr-fe* | tr-login* | nid* )
+    # capulin, thunder, trinitite (tt-rfe) | trinity (tr-fe)
+    cp-rfe* | th-login* |tt-fey* | tt-rfe* | tt-login* | tr-fe* | tr-login* | nid* )
       # shellcheck source=/dev/null
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_cray" ;;
 

--- a/environment/bashrc/bash_aliases.sh
+++ b/environment/bashrc/bash_aliases.sh
@@ -44,8 +44,8 @@ alias mul='module unload'
 alias msh='module show'
 
 # machines
-alias sierra='ssh -t redcap ssh sierra.llnl.gov'
-alias rzansel='ssh -t ihpc-gate1.lanl.gov ssh rzansel.llnl.gov'
+# alias sierra='ssh -t redcap ssh sierra.llnl.gov'
+alias rzansel='ssh -t ihpc-gate.lanl.gov ssh rzansel.llnl.gov'
 
 #--------------------------------------------------------------------------------------------------#
 # Color Prompt

--- a/environment/bashrc/sample.bash_profile
+++ b/environment/bashrc/sample.bash_profile
@@ -61,7 +61,7 @@ fi
 
   # target="`uname -n | sed -e s/[.].*//`"
   # case ${target} in
-  #   tt-fey* | tt-login*)
+  #   tt-rfe* | tt-login*)
   #     module swap intel intel/15.0.3
   #     ;;
   #   *)

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -713,11 +713,10 @@ function version_gt()
 # Example:
 #
 # FILE_EXTS=".f90 .F90"
-# FILE_ENDINGS="_f.h _f77.h _f90.h"
+# FILE_ENDINGS_INCLUDE="CMakeLists.txt"
+# FILE_ENDINGS_EXCLUDE="_f.h _f77.h _f90.h"
 # for file in $modified_files; do
-#   if ! matches_extension $file; then
-#      continue;
-#   fi
+#   if ! matches_extension $file; then continue; fi
 #   <do stuff>
 # done
 #--------------------------------------------------------------------------------------------------#
@@ -728,7 +727,8 @@ matches_extension() {
   local ext
   filename=$(basename "$1")
   extension=".${filename##*.}"
-  for end in $FILE_ENDINGS; do [[ "$filename" == *"$end" ]] && return 1; done
+  for end in $FILE_ENDINGS_EXCLUDE; do [[ "$filename" == *"$end" ]] && return 1; done
+  for end in $FILE_ENDINGS_INCLUDE; do [[ "$filename" == *"$end" ]] && return 0; done
   for ext in $FILE_EXTS; do [[ "$ext" == "$extension" ]] && return 0; done
   return 1
 }

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -378,7 +378,7 @@ function npes_build
   elif [[  ${SLURM_CPUS_ON_NODE} ]]; then
     np="${SLURM_CPUS_ON_NODE}"
   elif [[ ${SLURM_TASKS_PER_NODE} ]]; then
-    np="${SLURM_TSKS_PER_NODE}"
+    np="${SLURM_TASKS_PER_NODE}"
   elif [[ ${LSB_DJOB_NUMPROC} ]]; then
     np="${LSB_DJOB_NUMPROC}"
   elif [[ -f /proc/cpuinfo ]]; then

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -423,7 +423,7 @@ function npes_test
         elif [[  ${SLURM_CPUS_ON_NODE} ]]; then
           np="${SLURM_CPUS_ON_NODE}"
         elif [[ ${SLURM_TASKS_PER_NODE} ]]; then
-          np="${SLURM_TSKS_PER_NODE}"
+          np="${SLURM_TASKS_PER_NODE}"
         elif [[ $(uname -p) == "ppc" ]]; then
           # sinfo --long --partition=pdebug (show limits)
           np=64


### PR DESCRIPTION
### Background

* Keeping up with ever changing developer environments.

### Description of changes
+ Add style configuration files for cmake-format and fprettify.  These are not yet active without extra work on the part of the developer.
+ Capture capulin, trinitite, and ihpc name changes.
+ Fix definition of bash function `matches_extension` used by our git commit hook scripts.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
