### PR TITLE
Fix a bad merge that reverted draco's published version number.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ string(CONCAT ddesc "An object-oriented component library supporting radiation t
 project(
   Draco
   DESCRIPTION ${ddesc}
-  VERSION 7.9
+  VERSION 7.10
   LANGUAGES CXX C)
 
 # Export compile commands for compiler tools

--- a/config/platform_checks.cmake
+++ b/config/platform_checks.cmake
@@ -25,7 +25,10 @@ function(dbs_set_sitename)
   if(${SITENAME} MATCHES "ba")
     set(SITENAME "Badger")
     set(SITENAME_FAMILY "CTS-1")
-  elseif(${SITENAME} MATCHES "cp-rfe" OR ${SITENAME} MATCHES "cp-login")
+  elseif(
+    ${SITENAME} MATCHES "cp-rfe"
+    OR ${SITENAME} MATCHES "cp-login"
+    OR ${SITENAME} MATCHES "cp-rlogin")
     set(SITENAME "Capulin")
     set(SITENAME_FAMILY "IC-ARM")
   elseif(${SITENAME} MATCHES "ccscs[0-9]+")

--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -58,11 +58,10 @@ if(NOT CXX_FLAGS_INITIALIZED)
     string(
       CONCAT CMAKE_CXX_COMPILER_CONFIG_FILE
              "/projects/opt/ppc64le/ibm/xlc-${xlc_version}/xlC/${xlc_version_3}/etc/xlc.cfg.rhel."
-             "${redhat_version}.gcc.${gcc_version}.cuda.${cuda_version}"
-             CACHE
-             FILEPATH
-             "XL config file"
-             FORCE)
+             "${redhat_version}.gcc.${gcc_version}.cuda.${cuda_version}")
+    set(CMAKE_CXX_COMPILER_CONFIG_FILE
+        ${CMAKE_CXX_COMPILER_CONFIG_FILE}
+        CACHE FILEPATH "XL config file" FORCE)
     if(EXISTS ${CMAKE_CXX_COMPILER_CONFIG_FILE})
       string(APPEND CMAKE_C_FLAGS " -F${CMAKE_CXX_COMPILER_CONFIG_FILE}")
     else()

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -172,7 +172,7 @@ if [[ ${INTERACTIVE} == true ]]; then
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_rfta" ;;
 
     # capulin, thunder, trinitite (tt-rfe) | trinity (tr-fe)
-    cp-rfe* | th-login* |tt-fey* | tt-rfe* | tt-login* | tr-fe* | tr-login* | nid* )
+    cp-rfe* | cp-rlogin* | th-login* |tt-fey* | tt-rfe* | tt-login* | tr-fe* | tr-login* | nid* )
       # shellcheck source=/dev/null
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_cray" ;;
 

--- a/src/c4/ftest/CMakeLists.txt
+++ b/src/c4/ftest/CMakeLists.txt
@@ -19,13 +19,13 @@ if(NOT TARGET Lib_dsxx)
 
   # CAFS setup unique to this directory.
   #
-  # 1. create import targets that we will link against.
+  # Create import targets that we will link against.
   if(NOT fc4_BINARY_DIR)
     set(fc4_BINARY_DIR "${draco_BINARY_DIR}/src/c4/fc4")
   endif()
   cafs_create_imported_targets(Lib_c4_fc4 "librtt_fc4" "${fc4_BINARY_DIR}" CXX)
 
-  # 1. Vendor discovery is not needed for this package
+  # Vendor discovery is not needed for this package
   #
   # setupVendorLibraries()
 endif()


### PR DESCRIPTION
### Background

* Sometimes git is confused.  The feature branches I was working from predated the release of draco-7.10.0.  Somehow the old version number was preserved instead of the new number during a merge from `develop`.

### Description of changes

+ Draco version number was accidentally overwritten.
+ Fix some machine name issues related to capulin.
+ Fix comment block formatting issue.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
