### PR TITLE
Minor cleanup in shell scripts

### DIFF
--- a/environment/git/pre-commit-cmake-format
+++ b/environment/git/pre-commit-cmake-format
@@ -113,6 +113,7 @@ do
   cp -f "${file}" "${tmpfile1}"
   debugprint "$CMF -i ${tmpfile1}"
   $CMF -c "${SCRIPTPATH}/../../.cmake-format.py" -i "${tmpfile1}" &> /dev/null
+  printf "==> cmake-format -c .cmake-format.py -i %s\n" "$file_nameonly"
   diff -u "${file}" "${tmpfile1}" | \
     sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patch"
   debugprint "rm $tmpfile1"

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -l
 # -*- Mode: sh -*-
 #--------------------------------------------------------------------------------------------------#
-# File  : regression/sripts/common.sh
+# File  : tools/common.sh
 # Date  : Tuesday, May 31, 2016, 14:48 pm
 # Author: Kelly Thompson
-# Note  : Copyright (C) 2016-2020, Triad National Security, LLC., All rights are reserved.
+# Note  : Copyright (C) 2016-2021, Triad National Security, LLC., All rights are reserved.
 #
 # Summary: Misc bash functions useful during development of code.
 #--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Background

+ Fix comments, headers, quotes
+ Only run F90 line length checks on F90 sources.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
