### PR TITLE
Eliminate clang-tidy warning.

### DIFF
--- a/src/cdi_eospac/Eospac.cc
+++ b/src/cdi_eospac/Eospac.cc
@@ -453,7 +453,7 @@ void Eospac::expandEosTable() const {
 
   EOS_INTEGER errorCode(0);
   Check(returnTypes.size() < INT32_MAX);
-  EOS_INTEGER nTables(static_cast<EOS_INTEGER>(returnTypes.size()));
+  auto nTables(static_cast<EOS_INTEGER>(returnTypes.size()));
   eos_CreateTables(&nTables, &returnTypes[0], &matIDs[0], &tableHandles[0], &errorCode);
 
   // Check for errors


### PR DESCRIPTION
### Background

* Missed a clang-tidy warning when #1063 was merged.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
