### PR TITLE
Remove constexpr square root call in CDI

### DIFF
--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -124,7 +124,7 @@ static inline double taylor_series_planck(double x) {
  */
 static double polylog_series_minus_one_planck(double const x, double const eix) {
   Require(x >= 0.0);
-  Require(x < rtt_dsxx::ce_sqrt(std::numeric_limits<double>::max()));
+  Require(x < 1.0e154); // value will be squared, make sure it's less than sqrt of max double
   Require(rtt_dsxx::soft_equiv(std::exp(-x), eix));
 
   double const xsqrd = x * x;


### PR DESCRIPTION
### Background

* I used `constexpr` square root in a `Require` function to make sure overflow would not result when an input value was squared. I thought this was a good idea because the `sqrt(std::numeric_limits<double>::max)` was previously being computed every time through this loop. Unfortunately, it seems that debug code versions were not evaluating this expression at compile time and it was causing very slow runtimes and even more problems under profiling (the `ce_sqrt` is not an efficient version of `sqrt` it's just one that can be marked `constexpr`!). This PR removes the ce_sqrt call and replaces it with the sqrt of the max double. There is a comment explaining the magic number.

### Purpose of Pull Request

* Fix slow runtimes and profiling times in debug mode

### Description of changes

* Replace constexpr squar root call with a numeric value

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
