### PR TITLE
Tweak github-actions yaml files.

### DIFF
--- a/.github/workflows/ci-autodoc.yml
+++ b/.github/workflows/ci-autodoc.yml
@@ -37,8 +37,7 @@ jobs:
           # submodules: true
 
       - name: Fetch Docker image for CI
-        uses: docker://kinetictheory/draco-ci-2020nov:style-checks
-#        entrypoint: '/home/runner/work/Draco/Draco/tools/travis-run-tests.sh'
+        uses: docker://kinetictheory/draco-ci-2020nov:autodoc
 
       - name: Autodoc
         env:

--- a/.github/workflows/ci-clang-tidy.yml
+++ b/.github/workflows/ci-clang-tidy.yml
@@ -37,8 +37,7 @@ jobs:
           # submodules: true
 
       - name: Fetch Docker image for CI
-        uses: docker://kinetictheory/draco-ci-2020nov:style-checks
-#        entrypoint: '/home/runner/work/Draco/Draco/tools/travis-run-tests.sh'
+        uses: docker://kinetictheory/draco-ci-2020nov:spack-llvm
 
       - name: clang-tidy
         env:

--- a/.github/workflows/ci-gcc-mpi.yml
+++ b/.github/workflows/ci-gcc-mpi.yml
@@ -37,8 +37,7 @@ jobs:
           # submodules: true
 
       - name: Fetch Docker image for CI
-        uses: docker://kinetictheory/draco-ci-2020nov:style-checks
-#        entrypoint: '/home/runner/work/Draco/Draco/tools/travis-run-tests.sh'
+        uses: docker://kinetictheory/draco-ci-2020nov:spack-gcc
 
       - name: Gcc-mpi
         env:

--- a/.github/workflows/ci-gcc-scalar.yml
+++ b/.github/workflows/ci-gcc-scalar.yml
@@ -37,8 +37,7 @@ jobs:
           # submodules: true
 
       - name: Fetch Docker image for CI
-        uses: docker://kinetictheory/draco-ci-2020nov:style-checks
-#        entrypoint: '/home/runner/work/Draco/Draco/tools/travis-run-tests.sh'
+        uses: docker://kinetictheory/draco-ci-2020nov:spack-gcc
 
       - name: Gcc-scalar
         env:

--- a/.github/workflows/ci-llvm-mpi.yml
+++ b/.github/workflows/ci-llvm-mpi.yml
@@ -37,8 +37,7 @@ jobs:
           # submodules: true
 
       - name: Fetch Docker image for CI
-        uses: docker://kinetictheory/draco-ci-2020nov:style-checks
-#        entrypoint: '/home/runner/work/Draco/Draco/tools/travis-run-tests.sh'
+        uses: docker://kinetictheory/draco-ci-2020nov:spack-llvm
 
       - name: llvm-mpi
         env:

--- a/.github/workflows/ci-style-check.yml
+++ b/.github/workflows/ci-style-check.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Fetch Docker image for CI
         uses: docker://kinetictheory/draco-ci-2020nov:style-checks
-#        entrypoint: '/home/runner/work/Draco/Draco/tools/travis-run-tests.sh'
 
       - name: Style Checker
         env:


### PR DESCRIPTION
### Background

* I found a couple of minor issues with the new yaml files introduced in #1070.

### Description of changes

* Remove some commented out code
* Use the correct `tag` for each docker image downloaded.  Somehow, GitHub Actions did the right thing without this fix, but I want to be consistent.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
