### PR TITLE
Enable -g for all builds, including Release.

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -1,98 +1,106 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-clang.cmake
 # brief  Establish flags for Unix clang
-# note   Copyright (C) 2010-2020 Triad National Security, LLC., All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
 include_guard(GLOBAL)
 
 # Note: In config/compilerEnv.cmake, the build system sets flags for
-# 1) the language standard (C++14, C99, etc)
-# 2) interprocedural optimization.
+#
+# 1. the language standard (C++14, C99, etc)
+# 2. interprocedural optimization.
 
 # Suggested flags:
-# ---------------
-# - http://clang.llvm.org/docs/UsersManual.html#options-to-control-error-and-warning-messages
-#    -fdiagnostics-show-hotness
-# - https://lefticus.gitbooks.io/cpp-best-practices/content/02-Use_the_Tools_Available.html
 #
-# valgrind like options - https://clang.llvm.org/docs/AddressSanitizer.html
-#      '-g -fsanitize=address -fno-omit-frame-pointer'
-#      must use clang++ for linking
-#      suppressions: LSAN_OPTIONS=suppressions=MyLSan.supp
-#      human readable: ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer ./a.out
+# * http://clang.llvm.org/docs/UsersManual.html#options-to-control-error-and-warning-messages
+#   -fdiagnostics-show-hotness
+# * https://lefticus.gitbooks.io/cpp-best-practices/content/02-Use_the_Tools_Available.html
+#
+# valgrind like options, https://clang.llvm.org/docs/AddressSanitizer.html
+#
+# * '-g -fsanitize=address -fno-omit-frame-pointer'
+# * must use clang++ for linking
+# * suppressions: LSAN_OPTIONS=suppressions=MyLSan.supp
+# * human readable: ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer ./a.out
 
-if( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0 AND NOT MSVC )
-  message( FATAL_ERROR "Draco requires LLVM clang version >= 6.0." )
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0 AND NOT MSVC)
+  message(FATAL_ERROR "Draco requires LLVM clang version >= 6.0.")
 endif()
 
 #
 # Compiler Flags
 #
-if( NOT CXX_FLAGS_INITIALIZED )
-  set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+if(NOT CXX_FLAGS_INITIALIZED)
+  set(CXX_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
 
-  string( APPEND CMAKE_C_FLAGS " -Weverything")
+  string(APPEND CMAKE_C_FLAGS " -g -Weverything")
   # now turn off some flags that produce too many warnings (we should work on these eventually!)
-  string( APPEND CMAKE_C_FLAGS " -Wno-c++98-compat -Wno-c++98-compat-pedantic"
-    " -Wno-documentation-unknown-command -Wno-exit-time-destructors -Wno-global-constructors"
-    " -Wno-weak-vtables -Wno-old-style-cast -Wno-sign-conversion -Wno-padded -Wno-extra-semi-stmt"
-    " -Wno-unreachable-code-break -Wno-unreachable-code-return"
-    " -Wno-missing-prototypes -Wno-disabled-macro-expansion -Wno-switch-enum"
-    " -Wno-deprecated-declarations -Wno-missing-noreturn -Wno-unreachable-code"
+  string(
+    APPEND
+    CMAKE_C_FLAGS
+    " -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation-unknown-command"
+    " -Wno-exit-time-destructors -Wno-global-constructors -Wno-weak-vtables -Wno-old-style-cast"
+    " -Wno-sign-conversion -Wno-padded -Wno-extra-semi-stmt -Wno-unreachable-code-break"
+    " -Wno-unreachable-code-return -Wno-missing-prototypes -Wno-disabled-macro-expansion"
+    " -Wno-switch-enum -Wno-deprecated-declarations -Wno-missing-noreturn -Wno-unreachable-code"
     " -Wno-documentation-deprecated-sync -Wno-documentation -Wno-undefined-func-template"
     " -Wno-weak-template-vtables -Wno-comma")
 
-  if( (NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv) AND
-      (NOT ${CMAKE_GENERATOR} MATCHES Xcode) AND HAS_MARCH_NATIVE)
-    string( APPEND CMAKE_C_FLAGS " -march=native" )
+  if((NOT CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv)
+     AND (NOT ${CMAKE_GENERATOR} MATCHES Xcode)
+     AND HAS_MARCH_NATIVE)
+    string(APPEND CMAKE_C_FLAGS " -march=native")
   endif()
 
-  set( CMAKE_C_FLAGS_DEBUG          "-g -fno-inline -O0 -DDEBUG")
-  set( CMAKE_C_FLAGS_RELEASE        "-O3 -funroll-loops -DNDEBUG" )
-  set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
-  set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -funroll-loops" )
+  set(CMAKE_C_FLAGS_DEBUG "-fno-inline -O0 -DDEBUG")
+  set(CMAKE_C_FLAGS_RELEASE "-O3 -funroll-loops -DNDEBUG")
+  set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -funroll-loops")
 
   # Suppress warnings about typeid() called with function as an argument. In this case, the function
   # might not be called if the type can be deduced.
-  string( APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS} -Wno-undefined-var-template"
-    " -Wno-potentially-evaluated-expression" )
+  string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS} -Wno-undefined-var-template"
+         " -Wno-potentially-evaluated-expression")
 
-  if( DEFINED CMAKE_CXX_COMPILER_WRAPPER AND "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv" )
+  if(DEFINED CMAKE_CXX_COMPILER_WRAPPER AND "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv")
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libstdc++")
     # Work around for broken ftn + CC linking (Redmine #1323) that results in
-    # > ld.lld: error: corrupt input file: version definition index 0 for symbol mpiprivc_ is out
-    # > of bounds
+    #
+    # ld.lld: error: corrupt input file: version definition index 0 for symbol mpiprivc_ is out of
+    # bounds
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=bfd")
   else()
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libc++")
   endif()
 
-  set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
   # Tried to use -fsanitize=safe-stack but this caused build issues.
-  set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
-  set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
-  set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Toggle for OpenMP support
-if( OpenMP_C_FLAGS )
-  toggle_compiler_flag( OPENMP_FOUND "${OpenMP_C_FLAGS}" "C" "" )
+if(OpenMP_C_FLAGS)
+  toggle_compiler_flag(OPENMP_FOUND "${OpenMP_C_FLAGS}" "C" "")
 endif()
-if( OpenMP_CXX_FLAGS )
-  toggle_compiler_flag( OPENMP_FOUND "${OpenMP_CXX_FLAGS}" "CXX" "" )
+if(OpenMP_CXX_FLAGS)
+  toggle_compiler_flag(OPENMP_FOUND "${OpenMP_CXX_FLAGS}" "CXX" "")
 endif()
 # Note: adding openmp option to EXE_LINKER will break MPI detection for gfortran when running with
-#       clang++/clang/gfortran.
+# clang++/clang/gfortran.
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_C_FLAGS)
 deduplicate_flags(CMAKE_CXX_FLAGS)
 force_compiler_flags_to_cache("C;CXX;EXE_LINKER")
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-clang.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #

--- a/config/unix-crayCC.cmake
+++ b/config/unix-crayCC.cmake
@@ -1,18 +1,18 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-crayCC.cmake
 # author Kelly Thompson
 # date   2010 Nov 1
 # brief  Establish flags for Linux64 - Cray C/C++
-# note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
 include_guard(GLOBAL)
 
 #
 # Compiler flag checks
 #
-if( CMAKE_CXX_COMPILER_VERSION LESS "8.4" )
-  message( FATAL_ERROR "Cray C++ prior to 8.4 does not support C++11.")
+if(CMAKE_CXX_COMPILER_VERSION LESS "8.4")
+  message(FATAL_ERROR "Cray C++ prior to 8.4 does not support C++11.")
 endif()
 
 #
@@ -20,39 +20,39 @@ endif()
 #
 
 # As of cmake-3.12.1, the cray flags for C++14 were not available in cmake.
-if( NOT DEFINED CMAKE_CXX14_STANDARD_COMPILE_OPTION )
-  set( CMAKE_CXX14_STANDARD_COMPILE_OPTION "-hstd=c++14" CACHE STRING "internal" FORCE)
+if(NOT DEFINED CMAKE_CXX14_STANDARD_COMPILE_OPTION)
+  set(CMAKE_CXX14_STANDARD_COMPILE_OPTION
+      "-hstd=c++14"
+      CACHE STRING "internal" FORCE)
 endif()
 
-if( NOT CXX_FLAGS_INITIALIZED )
-  set( CXX_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+if(NOT CXX_FLAGS_INITIALIZED)
+  set(CXX_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
 
-  string( APPEND CMAKE_C_FLAGS " -DR123_USE_GNU_UINT128=0" )
-  set( CMAKE_C_FLAGS_DEBUG          "-g -O0 -DDEBUG")
-  #if( HAVE_MIC )
-  #  # For floating point consistency with Xeon when using Intel 15.0.090 + Intel MPI 5.0.2
-  #  set( CMAKE_C_FLAGS_DEBUG       "${CMAKE_C_FLAGS_DEBUG} -fp-model precise -fp-speculation safe")
-  #endif()
-  set( CMAKE_C_FLAGS_RELEASE        "-O3 -DNDEBUG" )
-  set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
-  set( CMAKE_C_FLAGS_RELWITHDEBINFO "-g -O3 -DNDEBUG" )
+  string(APPEND CMAKE_C_FLAGS " -g -DR123_USE_GNU_UINT128=0")
+  set(CMAKE_C_FLAGS_DEBUG "-O0 -DDEBUG")
+  set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+  set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -DNDEBUG")
 
-  string( APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")
-  set( CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG}")
-  set( CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE}")
-  set( CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_RELEASE}")
-  set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
+  string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_C_FLAGS)
 deduplicate_flags(CMAKE_CXX_FLAGS)
 force_compiler_flags_to_cache("C;CXX")
 
-toggle_compiler_flag( OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX" "" )
+toggle_compiler_flag(OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX" "")
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-crayCC.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #

--- a/config/unix-crayftn.cmake
+++ b/config/unix-crayftn.cmake
@@ -1,44 +1,48 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-crayftn.cmake
 # author Kelly Thompson
 # date   2008 May 30
 # brief  Establish flags for Unix - Cray Fortran
-# note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
 include_guard(GLOBAL)
 
 #
 # Compiler flags:
 #
-if( NOT Fortran_FLAGS_INITIALIZED )
-  set( Fortran_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+if(NOT Fortran_FLAGS_INITIALIZED)
+  set(Fortran_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
 
   # Find and cache the compiler version (2015-09-28 CMake-3.3.1 misses this).
-  execute_process( COMMAND ${CMAKE_Fortran_COMPILER} -V
+  execute_process(
+    COMMAND ${CMAKE_Fortran_COMPILER} -V
     ERROR_VARIABLE ftn_version_output
-    OUTPUT_STRIP_TRAILING_WHITESPACE )
-  string( REGEX REPLACE ".*Version ([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\1.\\2"
-    CMAKE_Fortran_COMPILER_VERSION "${ftn_version_output}" )
-  set( CMAKE_Fortran_COMPILER_VERSION ${CMAKE_Fortran_COMPILER_VERSION} CACHE STRING
-    "Fortran compiler version string" FORCE )
-  mark_as_advanced( CMAKE_Fortran_COMPILER_VERSION )
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX REPLACE ".*Version ([0-9]+)[.]([0-9]+)[.]([0-9]+).*" "\\1.\\2"
+                       CMAKE_Fortran_COMPILER_VERSION "${ftn_version_output}")
+  set(CMAKE_Fortran_COMPILER_VERSION
+      ${CMAKE_Fortran_COMPILER_VERSION}
+      CACHE STRING "Fortran compiler version string" FORCE)
+  mark_as_advanced(CMAKE_Fortran_COMPILER_VERSION)
 
-  # string( APPEND CMAKE_Fortran_FLAGS "" )
-  set( CMAKE_Fortran_FLAGS_DEBUG          "-g -O0 -DDEBUG" )
-  set( CMAKE_Fortran_FLAGS_RELEASE        "-O3 -DNDEBUG" )
-  set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_RELEASE}" )
-  set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -O3 -DDEBUG" )
+  string(APPEND CMAKE_Fortran_FLAGS " -g")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -DDEBUG")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG")
+  set(CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O3 -DDEBUG")
 
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_Fortran_FLAGS)
 force_compiler_flags_to_cache("Fortran")
 
-toggle_compiler_flag( OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "" )
+toggle_compiler_flag(OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "")
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-crayftn.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #

--- a/config/unix-cuda.cmake
+++ b/config/unix-cuda.cmake
@@ -1,9 +1,8 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-cuda.cmake
 # brief  Establish flags for Unix/Linux - Cuda
-# note   Copyright (C) 2020 Triad National Security, LLC.
-#        All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2020-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
 include_guard(GLOBAL)
 
@@ -11,35 +10,35 @@ if(NOT CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA)
   message(FATAL_ERROR "Draco only supports the Nvidia cuda compiler.")
 endif()
 
-# Note: In config/component_macros.cmake, the build system sets flags for
-# 1) the language standard (C++14, C99, etc)
-# 2) interprocedural optimization.
-
 # Notes:
-# ----------------------------------------
+#
 # Useful options that could be added to aid debugging
-# - https://devblogs.nvidia.com/tag/cuda/
-# - https://devblogs.nvidia.com/building-cuda-applications-cmake/
+#
+# * https://devblogs.nvidia.com/tag/cuda/
+# * https://devblogs.nvidia.com/building-cuda-applications-cmake/
 
 # Discover CUDA compute capabilities.
-if( NOT DEFINED CUDA_ARCHITECTURES )
-  if( NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/config )
-    file(MAKE_DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/config )
+if(NOT DEFINED CUDA_ARCHITECTURES)
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/config)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/config)
   endif()
   set(OUTPUTFILE ${CMAKE_CURRENT_BINARY_DIR}/config/cuda_script)
   set(CUDAFILE ${CMAKE_CURRENT_SOURCE_DIR}/config/query_gpu.cu)
-  execute_process( COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CUDAFILE} -o ${OUTPUTFILE} )
-  execute_process( COMMAND ${OUTPUTFILE}
+  execute_process(COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
+  execute_process(
+    COMMAND ${OUTPUTFILE}
     RESULT_VARIABLE CUDA_RETURN_CODE
-    OUTPUT_VARIABLE CUDA_ARCHITECTURES )
-  if( NOT ${CUDA_RETURN_CODE} EQUAL 0 )
-    message( FATAL_ERROR "Unable to determine target Cuda arch." )
+    OUTPUT_VARIABLE CUDA_ARCHITECTURES)
+  if(NOT ${CUDA_RETURN_CODE} EQUAL 0)
+    message(FATAL_ERROR "Unable to determine target Cuda arch.")
   endif()
   unset(OUTPUTFILE)
   unset(CUDAFILE)
   unset(CUDA_RETURN_CODE)
   # This value is automatically added to all CUDA targets. See cmake/component_macros.cmake
-  set(CUDA_ARCHITECTURES ${CUDA_ARCHITECTURES} CACHE STRING "target architecture for gpu code.")
+  set(CUDA_ARCHITECTURES
+      ${CUDA_ARCHITECTURES}
+      CACHE STRING "target architecture for gpu code.")
 endif()
 
 #
@@ -47,38 +46,40 @@ endif()
 #
 # -Xcudafe --diag_suppress=1427: suppress "warning: offsetof applied to non-POD"
 
-if( NOT CUDA_FLAGS_INITIALIZED )
+if(NOT CUDA_FLAGS_INITIALIZED)
 
-  set( CUDA_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+  set(CUDA_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
 
-  string(APPEND CMAKE_CUDA_FLAGS " --expt-relaxed-constexpr")
+  string(APPEND CMAKE_CUDA_FLAGS " -G --expt-relaxed-constexpr")
   string(APPEND CMAKE_CUDA_FLAGS " --expt-extended-lambda")
-  if( CMAKE_CXX_COMPILER_ID MATCHES "XL")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "XL")
     string(APPEND CMAKE_CUDA_FLAGS " -DCUB_IGNORE_DEPRECATED_CPP_DIALECT"
-      " -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT")
+           " -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT")
     string(APPEND CMAKE_CUDA_FLAGS " -ccbin ${CMAKE_CXX_COMPILER} -Xcompiler -std=c++14")
-    if( EXISTS /usr/gapps )
+    if(EXISTS /usr/gapps)
       # ATS-2
       string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
-        " -Xcompiler -qxflag=disable__cplusplusOverride")
-    elseif( EXISTS ${CMAKE_CXX_COMPILER_CONFIG_FILE} )
+             " -Xcompiler -qxflag=disable__cplusplusOverride")
+    elseif(EXISTS ${CMAKE_CXX_COMPILER_CONFIG_FILE})
       # Darwin
       string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler -F${CMAKE_CXX_COMPILER_CONFIG_FILE}")
     endif()
   endif()
-  string(CONCAT CMAKE_CUDA_FLAGS_DEBUG "-G -O0 -Xcudafe --display_error_number"
-    " -Xcudafe --diag_suppress=1427")
-  set( CMAKE_CUDA_FLAGS_RELEASE        "-O2") # -dipo
-  set( CMAKE_CUDA_FLAGS_MINSIZEREL     "-O2")
-  set( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-O2 --generate-line-info")
+  string(CONCAT CMAKE_CUDA_FLAGS_DEBUG " -O0 -Xcudafe --display_error_number"
+                " -Xcudafe --diag_suppress=1427")
+  set(CMAKE_CUDA_FLAGS_RELEASE "-O2") # -dipo
+  set(CMAKE_CUDA_FLAGS_MINSIZEREL "-O2")
+  set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-O2 --generate-line-info")
 
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_CUDA_FLAGS)
 force_compiler_flags_to_cache("CUDA")
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-cuda.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #

--- a/config/unix-flang.cmake
+++ b/config/unix-flang.cmake
@@ -1,41 +1,40 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-flang.cmake
 # author Kelly Thompson
 # date   Sunday, Apr 29, 2018, 19:56 pm
 # brief  Establish flags for Unix/Linux - Gnu Fortran
-# note   Copyright (C) 2018-2020 Triad National Security, LLC.
-#        All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2018-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
-if( NOT Fortran_FLAGS_INITIALIZED )
-  mark_as_advanced( CMAKE_Fortran_COMPILER_VERSION )
+if(NOT Fortran_FLAGS_INITIALIZED)
+  mark_as_advanced(CMAKE_Fortran_COMPILER_VERSION)
 endif()
 
-#
 # Compiler Flags
-#
 
-if( NOT Fortran_FLAGS_INITIALIZED )
-   set( Fortran_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
+if(NOT Fortran_FLAGS_INITIALIZED)
+  set(Fortran_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
 
-   string(APPEND CMAKE_Fortran_FLAGS " -cpp" )
-   set( CMAKE_Fortran_FLAGS_DEBUG "-g -gdwarf-3 -DDEBUG" )
-   set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG" )
-   set( CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}" )
-   set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -gdwarf-3 ${CMAKE_Fortran_FLAGS_RELEASE}")
+  string(APPEND CMAKE_Fortran_FLAGS " -g -cpp")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-gdwarf-3 -DDEBUG")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG")
+  set(CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-gdwarf-3 ${CMAKE_Fortran_FLAGS_RELEASE}")
 
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_Fortran_FLAGS)
 force_compiler_flags_to_cache("Fortran")
 
 # Toggle compiler flags for optional features
-if( OpenMP_Fortran_FLAGS )
-  toggle_compiler_flag( OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "" )
+if(OpenMP_Fortran_FLAGS)
+  toggle_compiler_flag(OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "")
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-flang.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #

--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -37,8 +37,9 @@ if(NOT CXX_FLAGS_INITIALIZED)
   set(CXX_FLAGS_INITIALIZED
       "yes"
       CACHE INTERNAL "using draco settings.")
-  string(APPEND CMAKE_C_FLAGS " -Wall -Wextra -pedantic -Wcast-align -Wpointer-arith -Wfloat-equal"
-         " -Wunused-macros -Wshadow -Wformat=2")
+  string(APPEND CMAKE_C_FLAGS
+         " -g -Wall -Wextra -pedantic -Wcast-align -Wpointer-arith -Wfloat-equal -Wunused-macros"
+         " -Wshadow -Wformat=2")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
     string(APPEND CMAKE_C_FLAGS " -Wnull-dereference")
   endif()
@@ -47,12 +48,12 @@ if(NOT CXX_FLAGS_INITIALIZED)
     string(APPEND CMAKE_C_FLAGS " -Wno-expansion-to-defined")
   endif()
   string(
-    CONCAT CMAKE_C_FLAGS_DEBUG "-g -fno-inline -fno-eliminate-unused-debug-types -O0"
+    CONCAT CMAKE_C_FLAGS_DEBUG "-fno-inline -fno-eliminate-unused-debug-types -O0"
            " -Wundef -Wunreachable-code -fsanitize=bounds-strict -fdiagnostics-color=auto -DDEBUG")
   # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
   string(CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -funroll-loops -D_FORTIFY_SOURCE=2 -DNDEBUG")
   set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
-  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -fno-eliminate-unused-debug-types"
+  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -fno-eliminate-unused-debug-types"
                 " -funroll-loops")
 
   if(NOT DEFINED ENV{TRAVIS})

--- a/config/unix-gfortran.cmake
+++ b/config/unix-gfortran.cmake
@@ -17,12 +17,12 @@ if(NOT Fortran_FLAGS_INITIALIZED)
       "yes"
       CACHE INTERNAL "using draco settings.")
 
-  string(APPEND CMAKE_Fortran_FLAGS " -ffree-line-length-none -cpp")
-  string(CONCAT CMAKE_Fortran_FLAGS_DEBUG "-g -fbounds-check -frange-check"
+  string(APPEND CMAKE_Fortran_FLAGS " -g -ffree-line-length-none -cpp")
+  string(CONCAT CMAKE_Fortran_FLAGS_DEBUG "-fbounds-check -frange-check"
                 " -ffpe-trap=invalid,zero,overflow -fbacktrace -finit-character=127 -DDEBUG")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -mtune=native -ftree-vectorize -funroll-loops -DNDEBUG")
   set(CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}")
-  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g ${CMAKE_Fortran_FLAGS_RELEASE}")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELEASE}")
 
   # Only add '-march=native' if -march and -mtune are not already requested. Spack will add -march=
   # options if spacific target is requested (ie. target Haswell CPU when building on Skylake).

--- a/config/unix-ifort.cmake
+++ b/config/unix-ifort.cmake
@@ -1,52 +1,55 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# --------------------------------------------*-cmake-*------------------------------------------- #
 # file   config/unix-ifort.cmake
 # author Kelly Thompson
 # date   2008 May 30
 # brief  Establish flags for Unix - Intel Fortran
-# note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
 #
 # Compiler flags:
 #
-if( NOT Fortran_FLAGS_INITIALIZED )
-  set( Fortran_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
-  set( CMAKE_Fortran_COMPILER_VERSION ${CMAKE_Fortran_COMPILER_VERSION} CACHE
-    STRING "Fortran compiler version string" FORCE )
-  mark_as_advanced( CMAKE_Fortran_COMPILER_VERSION )
+if(NOT Fortran_FLAGS_INITIALIZED)
+  set(Fortran_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
+  set(CMAKE_Fortran_COMPILER_VERSION
+      ${CMAKE_Fortran_COMPILER_VERSION}
+      CACHE STRING "Fortran compiler version string" FORCE)
+  mark_as_advanced(CMAKE_Fortran_COMPILER_VERSION)
 
-  # [KT 2015-07-10] -diag-disable 11060 -- disable warning that is issued when '-ip' is turned on
-  #    and a library has no symbols (this occurs when a client links some trilinos libraries.)
-  # [KT 2016-11-16] -diag-disable 11021 -- disable warning that is issued when '-ip' is turned on
-  #    and a library has unresolved symbols (this occurs when a client links to openmpi/1.10.3 on
-  #    snow/fire/ice).  Ref: https://github.com/open-mpi/ompi/issues/251
-  # [KT 2018-03-14] '-assume nostd_mod_proc_name' -- discussion with G.  Rockefeller and S. Nolen
-  #    aobut ifort's non-standard name mangling for module procedures. Not sure if we need this yet.
+  # * [KT 2015-07-10] -diag-disable 11060 -- disable warning that is issued when '-ip' is turned on
+  #   and a library has no symbols (this occurs when a client links some trilinos libraries.)
+  # * [KT 2016-11-16] -diag-disable 11021 -- disable warning that is issued when '-ip' is turned on
+  #   and a  library has unresolved symbols (this occurs when a client links to openmpi/1.10.3 on
+  #   snow/fire/ice).  Ref: https://github.com/open-mpi/ompi/issues/251
+  # * [KT 2018-03-14] '-assume nostd_mod_proc_name' -- discussion with G.  Rockefeller and S. Nolen
+  #   aobut ifort's non-standard  name mangling for module procedures. Not sure if we need this yet.
 
-  string( APPEND CMAKE_Fortran_FLAGS " -warn -fpp -implicitnone -diag-disable=11060" )
-  string( CONCAT CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -ftrapuv -check -fno-omit-frame-pointer -DDEBUG")
-  if( NOT DEFINED CMAKE_CXX_COMPILER_WRAPPER AND
-      NOT "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv" )
-    string( APPEND CMAKE_Fortran_FLAGS_DEBUG " -traceback")
+  string(APPEND CMAKE_Fortran_FLAGS " -g -warn -fpp -implicitnone -diag-disable=11060")
+  string(CONCAT CMAKE_Fortran_FLAGS_DEBUG "-O0 -ftrapuv -check -fno-omit-frame-pointer -DDEBUG")
+  if(NOT DEFINED CMAKE_CXX_COMPILER_WRAPPER AND NOT "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL
+                                                "CrayPrgEnv")
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -traceback")
   endif()
-  string( CONCAT CMAKE_Fortran_FLAGS_RELEASE "-O2 -inline-level=2 -fp-speculation fast"
-    " -fp-model=fast -align array32byte -funroll-loops -diag-disable=11021 -DNDEBUG" )
-  set( CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}" )
-  set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -O2 -inline-level=2 -funroll-loops -DDEBUG" )
+  string(CONCAT CMAKE_Fortran_FLAGS_RELEASE "-O2 -inline-level=2 -fp-speculation fast"
+                " -fp-model=fast -align array32byte -funroll-loops -diag-disable=11021 -DNDEBUG")
+  set(CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -inline-level=2 -funroll-loops -DDEBUG")
 
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_Fortran_FLAGS)
 force_compiler_flags_to_cache("Fortran")
 
 # Optional compiler flags
-if( NOT ${SITENAME} STREQUAL "Trinitite" )
-  toggle_compiler_flag( ENABLE_SSE  "-mia32 -axSSSE3" "Fortran" "") #sse3, ssse3
+if(NOT ${SITENAME} STREQUAL "Trinitite")
+  toggle_compiler_flag(ENABLE_SSE "-mia32 -axSSSE3" "Fortran" "") # sse3, ssse3
 endif()
-toggle_compiler_flag( OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "" )
+toggle_compiler_flag(OPENMP_FOUND ${OpenMP_Fortran_FLAGS} "Fortran" "")
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-ifort.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #

--- a/config/unix-ifx.cmake
+++ b/config/unix-ifx.cmake
@@ -18,15 +18,15 @@ if(NOT Fortran_FLAGS_INITIALIZED)
       CACHE STRING "Fortran compiler version string" FORCE)
   mark_as_advanced(CMAKE_Fortran_COMPILER_VERSION)
 
-  string(APPEND CMAKE_Fortran_FLAGS " ")
-  string(CONCAT CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -DDEBUG")
+  string(APPEND CMAKE_Fortran_FLAGS " -g")
+  string(CONCAT CMAKE_Fortran_FLAGS_DEBUG "-O0 -DDEBUG")
   if(NOT DEFINED CMAKE_CXX_COMPILER_WRAPPER AND NOT "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL
                                                 "CrayPrgEnv")
     string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -traceback")
   endif()
   string(CONCAT CMAKE_Fortran_FLAGS_RELEASE "-O2 -DNDEBUG")
   set(CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}")
-  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -O2 -DDEBUG")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -DDEBUG")
 
 endif()
 

--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -1,14 +1,12 @@
-# -------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-intel.cmake
 # author Kelly Thompson
 # date   2010 Nov 1
 # brief  Establish flags for Linux64 - Intel C++
 # note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
-# -------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 
-#
 # Compiler Flags
-#
 
 if(NOT CXX_FLAGS_INITIALIZED)
   set(CXX_FLAGS_INITIALIZED
@@ -19,26 +17,26 @@ if(NOT CXX_FLAGS_INITIALIZED)
   #   headers that I can't suppress easily (warning 191: type qualifier is meaningless on cast type)
   # * [KT 2015-07-10] -diag-disable 11060 -- disable warning that is issued when '-ip' is turned on
   #   and a library has no symbols (this occurs when capsaicin links some trilinos libraries.)
-  string(APPEND CMAKE_C_FLAGS " -w1 -vec-report0 -diag-disable=remark -shared-intel -no-ftz -fma"
+  string(APPEND CMAKE_C_FLAGS
+         " -g -w1 -vec-report0 -diag-disable=remark -shared-intel -no-ftz -fma"
          " -diag-disable=11060")
   if(DBS_GENERATE_OBJECT_LIBRARIES)
     string(APPEND CMAKE_C_FLAGS " -ipo")
   endif()
-  string(CONCAT CMAKE_C_FLAGS_DEBUG
-                "-g -O0 -inline-level=0 -ftrapuv -check=uninit -fp-model=precise"
+  string(CONCAT CMAKE_C_FLAGS_DEBUG "-O0 -inline-level=0 -ftrapuv -check=uninit -fp-model=precise"
                 " -fp-speculation=safe -debug inline-debug-info -fno-omit-frame-pointer -DDEBUG")
   # -qno-opt-dynamic-align fixed LAP numerical sensitivity for Hypre (Gaber, 12/01/2020).
   string(CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -fp-speculation=fast -fp-model=precise -pthread"
                 " -qno-opt-dynamic-align -DNDEBUG")
-  # [KT 2017-01-19] On KNL, -fp-model=fast changes behavior significantly for IMC. Revert to
-  # -fp-model=precise.
+  # * [KT 2017-01-19] On KNL, -fp-model=fast changes behavior significantly for IMC. Revert to
+  #   -fp-model=precise.
   if("$ENV{CRAY_CPU_TARGET}" STREQUAL "mic-knl")
     string(REPLACE "-fp-model=fast" "-fp-model=precise" CMAKE_C_FLAGS_RELEASE
                    ${CMAKE_C_FLAGS_RELEASE})
   endif()
 
   set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
-  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-g -debug inline-debug-info -O3 -pthread"
+  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-debug inline-debug-info -O3 -pthread"
                 " -fp-model=precise -fp-speculation=safe -fno-omit-frame-pointer")
 
   string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")

--- a/config/unix-intelllvm.cmake
+++ b/config/unix-intelllvm.cmake
@@ -15,14 +15,14 @@ if(NOT CXX_FLAGS_INITIALIZED)
       "yes"
       CACHE INTERNAL "using draco settings.")
 
-  string(APPEND CMAKE_C_FLAGS " ")
+  string(APPEND CMAKE_C_FLAGS " -g")
   if(DBS_GENERATE_OBJECT_LIBRARIES)
     string(APPEND CMAKE_C_FLAGS " -ipo")
   endif()
-  string(CONCAT CMAKE_C_FLAGS_DEBUG "-g -O0 -DDEBUG -Wno-potentially-evaluated-expression")
+  string(CONCAT CMAKE_C_FLAGS_DEBUG "-O0 -DDEBUG -Wno-potentially-evaluated-expression")
   string(CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
   set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
-  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-g -O3 ")
+  string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 ")
 
   string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")

--- a/config/unix-xl.cmake
+++ b/config/unix-xl.cmake
@@ -25,7 +25,7 @@ if(NOT CXX_FLAGS_INITIALIZED)
       "yes"
       CACHE INTERNAL "using draco settings.")
 
-  string(APPEND CMAKE_C_FLAGS "-qflttrap -qmaxmem=-1")
+  string(APPEND CMAKE_C_FLAGS " -g -qflttrap -qmaxmem=-1")
   if(EXISTS /usr/gapps)
     # ATS-2
     string(APPEND CMAKE_C_FLAGS " --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1")
@@ -73,8 +73,8 @@ if(NOT CXX_FLAGS_INITIALIZED)
     unset(config_file)
   endif()
 
-  set(CMAKE_C_FLAGS_DEBUG "-g -O0 -qsmp=omp:noopt -qfullpath -DDEBUG")
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-g -O2 -qsmp=omp -qstrict=nans:operationprecision")
+  set(CMAKE_C_FLAGS_DEBUG "-O0 -qsmp=omp:noopt -qfullpath -DDEBUG")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -qsmp=omp -qstrict=nans:operationprecision")
   set(CMAKE_C_FLAGS_RELEASE "-O2 -qsmp=omp -qstrict=nans:operationprecision -DNDEBUG")
   set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
 

--- a/config/unix-xlf.cmake
+++ b/config/unix-xlf.cmake
@@ -1,38 +1,41 @@
-#--------------------------------------------*-cmake-*---------------------------------------------#
+# -------------------------------------------*-cmake-*-------------------------------------------- #
 # file   config/unix-xlf.cmake
 # author Gabriel Rockefeller, Kelly Thompson <kgt@lanl.gov>
 # date   2012 Nov 1
 # brief  Establish flags for Unix - IBM XL Fortran
-# note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
-#--------------------------------------------------------------------------------------------------#
+# note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
 
 include_guard(GLOBAL)
 
 # Let anyone who is interested in which FORTRAN compiler we're using switch on this macro.
-set( CMAKE_Fortran_COMPILER_FLAVOR "XL" )
+set(CMAKE_Fortran_COMPILER_FLAVOR "XL")
 
 # -qsuppress=
-#   1501-210 (W) command option t contains an incorrect subargument
-#            This is related to '-pthread' showing up in the flags (a cmake bug)
+#
+# * 1501-210 (W) command option t contains an incorrect subargument This is related to '-pthread'
+#   showing up in the flags (a cmake bug)
 
-if( NOT Fortran_FLAGS_INITIALIZED )
-   set( Fortran_FLAGS_INITIALIZED "yes" CACHE INTERNAL "using draco settings." )
-   string(APPEND CMAKE_Fortran_FLAGS " -qlanglvl=2008std -qflag=i:w -qsuppress=1501-210" )
-   if( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
-     string( APPEND CMAKE_Fortran_FLAGS " -qarch=pwr9 -qtune=pwr9" )
-   endif()
+if(NOT Fortran_FLAGS_INITIALIZED)
+  set(Fortran_FLAGS_INITIALIZED
+      "yes"
+      CACHE INTERNAL "using draco settings.")
+  string(APPEND CMAKE_Fortran_FLAGS " -g -qlanglvl=2008std -qflag=i:w -qsuppress=1501-210")
+  if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
+    string(APPEND CMAKE_Fortran_FLAGS " -qarch=pwr9 -qtune=pwr9")
+  endif()
 
-   set( CMAKE_Fortran_FLAGS_DEBUG "-O0" )
-   set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O3 -qstrict=nans:operationprecision" )
-   set( CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}" )
-   set( CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}" )
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O3 -qstrict=nans:operationprecision")
+  set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}")
+  set(CMAKE_Fortran_FLAGS_MINSIZEREL "${CMAKE_Fortran_FLAGS_RELEASE}")
 endif()
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Ensure cache values always match current selection
 deduplicate_flags(CMAKE_Fortran_FLAGS)
 force_compiler_flags_to_cache("Fortran")
 
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # End config/unix-xlf.cmake
-#--------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #


### PR DESCRIPTION
### Background

* During a planning meeting several developers and stakeholders requested that `-g` be enabled for all builds.

### Description of changes

* This change was made for all Linux builds.  
* Touched cmake files were reformatted with `cmake-format`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
