### PR TITLE
Fix gcc-based build on ATS-2 and add preliminary env for new machine.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -66,6 +66,9 @@ function(setMPIflavorVer)
   elseif(DEFINED ENV{LMOD_MPI_VERSION})
     # Toss3 with srun
     string(REGEX REPLACE "-[a-z0-9]+" "" MPI_VERSION "$ENV{LMOD_MPI_VERSION}")
+  elseif(DEFINED ENV{LMOD_FAMILY_MPI_VERSION})
+    # ATS-2 with lrun
+    string(REGEX REPLACE "-[a-z0-9]+" "" MPI_VERSION "$ENV{LMOD_FAMILY_MPI_VERSION}")
   else()
     execute_process(
       COMMAND ${MPIEXEC_EXECUTABLE} --version
@@ -74,7 +77,6 @@ function(setMPIflavorVer)
     set(DBS_MPI_VER "${DBS_MPI_VER_OUT}${DBS_MPI_VER_ERR}")
     string(REPLACE "\n" ";" TEMP ${DBS_MPI_VER})
     foreach(line ${TEMP})
-
       # extract the version...
       if(${line} MATCHES "Version"
          OR ${line} MATCHES "OpenRTE"

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -177,9 +177,14 @@ if [[ ${INTERACTIVE} == true ]]; then
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_cray" ;;
 
     # LLNL ATS-2
-    rzmanta* | rzansel* | sierra* )
+    rzmanta* | rzansel* | sierra*)
       # shellcheck source=/dev/null
       source "${DRACO_ENV_DIR}/bashrc/.bashrc_ats2" ;;
+
+    # LLNL ATS-4
+    rznevada*)
+      # shellcheck source=/dev/null
+      source "${DRACO_ENV_DIR}/bashrc/.bashrc_ats4" ;;
 
     # LAP Virtual Machine
     vc*)

--- a/environment/bashrc/.bashrc_ats4
+++ b/environment/bashrc/.bashrc_ats4
@@ -1,0 +1,56 @@
+##-*- Mode: sh -*-
+# ------------------------------------------------------------------------------------------------ #
+#  .bashrc_ats4 - my bash configuration file upon bash login
+# ------------------------------------------------------------------------------------------------ #
+
+if test -n "$verbose"; then
+   echo "In draco/environment/bashrc/.bashrc_ats4"
+fi
+
+# ------------------------------------------------------------------------------------------------ #
+# ENVIRONMENTS
+# ------------------------------------------------------------------------------------------------ #
+
+# unlimit stack and core dump sizes.
+ulimit -s unlimited
+
+# Where is the vendor directory
+export PATH=${VENDOR_DIR:=/usr/gapps/jayenne/vendors}/bin:$PATH
+export VENDOR_DIR
+export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
+
+# Support building cassio with ccsrad shared deployment repository.
+# if [[ -d /usr/workspace/dacodes/eap/users/ccsrad/Cassio.deployment ]]; then
+#   export TF_DEPLOYMENT_CLONES=/usr/workspace/dacodes/eap/users/ccsrad/eap.deployment
+#   export TF_SPACK_INSTANCES=/usr/workspace/dacodes/eap/users/ccsrad/spack_instances
+# fi
+
+#
+# MODULES
+#
+
+# 1. Determine if the module command is available
+# modcmd=`declare -f module`
+# # If not found, look for it in /usr/share/Modules
+# if [[ ! ${modcmd} ]]; then
+#   source /usr/share/lmod/lmod/init/bash || die \
+#     "ERROR: The module command was not found. No modules will be loaded (ats-2 e01)."
+# fi
+# modcmd=`declare -f module`
+
+# 2. Use modules found in the draco directory
+# if [[ ! ${modcmd} ]]; then
+#   echo "ERROR: The module command was not found. No modules will be loaded (ats-2, e02)."
+# else
+#  module use --append /usr/gapps/jayenne/Modules
+#  module unuse /usr/share/lmod/lmod/modulefiles/Core
+#  module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
+#  module load draco/xl2021.03.11-cuda-11.0.2
+#fi
+
+# Do not escape $ for bash completion
+shopt -s direxpand
+
+# ------------------------------------------------------------------------------------------------ #
+# End
+# ------------------------------------------------------------------------------------------------ #


### PR DESCRIPTION
### Background

+ PR #1073 fixed an issue related to the new `srun` environments on Toss3 machines but it also introduced a configure error for gcc-based builds on ATS-2.

### Purpose of Pull Request

* [Fixes re-git Issue #1](https://re-git.lanl.gov/draco/draco/-/issues/1)
* [Related to Redmine Issue #2361](https://rtt.lanl.gov/redmine/issues/2361)

### Description of changes

+ Update logic in `setupMPI.cmake` to account for more ways of discovering the MPI vendor version.
+ Also, introduce very preliminary environment support for rzNevada.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
