### PR TITLE
Suppress a gcc warning related to -O3 -g

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -51,7 +51,8 @@ if(NOT CXX_FLAGS_INITIALIZED)
     CONCAT CMAKE_C_FLAGS_DEBUG "-fno-inline -fno-eliminate-unused-debug-types -O0"
            " -Wundef -Wunreachable-code -fsanitize=bounds-strict -fdiagnostics-color=auto -DDEBUG")
   # GCC_COLORS="error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
-  string(CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -funroll-loops -D_FORTIFY_SOURCE=2 -DNDEBUG")
+  string(CONCAT CMAKE_C_FLAGS_RELEASE "-O3 -funroll-loops -D_FORTIFY_SOURCE=2"
+                " -fno-var-tracking-assignments -DNDEBUG")
   set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
   string(CONCAT CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -fno-eliminate-unused-debug-types"
                 " -funroll-loops")


### PR DESCRIPTION
### Background

* We recently added `-g` to all builds.  We have some source code that generates warnings for `-g -O3` related code complexity that we want to silence.

### Description of changes

* Add option `-fno-var-tracking-assignments` for Release GNU builds.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
