### PR TITLE
Fix broken Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
   #   . numdiff is in the 'bin' directory,
   #   . The vs2019-toolchain.cmake file used by this script.
   - cd \projects
-  - curl -L -o win32-vs16-tools.zip https://github.com/KineticTheory/ci-demo/releases/download/vendors-201809/win32-vs16-tools.zip
+  - curl -L -o win32-vs16-tools.zip https://github.com/lanl/Draco/wiki/win32-vs16-tools.zip
   - dir win32-vs16-tools.zip
   - 7z.exe -y x win32-vs16-tools.zip
   - xcopy %VENDOR_DIR%\ports\* %VCPKGDIR%\ports /E /Y /I /Q


### PR DESCRIPTION
### Background

+ The repository that hosted the tools provided by `win32-vs16-tools.zip` was deleted.
+ I have added this file to the Draco/wiki repository so that we maintain full control over it.

### Description of changes

+ The `appveyor.yml` file was updated to download the zip file from the new location.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
