### PR TITLE
Tweak some slurm alias commands.

### DIFF
--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -321,7 +321,7 @@ function qrm ()
     fi
 
     # Identify the scratch system
-    trashdir="${fqd//${USER}*/${USER}\/trash}"
+    trashdir="${fqd//${USER}*/${USER}/trash}"
 
     # ensure trash folder exists.
     if ! [[ -d "$trashdir" ]]; then mkdir -p "$trashdir"; fi

--- a/environment/bashrc/bashrc_slurm
+++ b/environment/bashrc/bashrc_slurm
@@ -90,15 +90,15 @@ case ${-} in
        echo -e "\n${boldface}RUNNING${normalface}":
        # echo " squeue ${squeue_args} -o \"%.7i %.10u %.10a %.8q %.9P %.16j %.6D %.6C %.12L %S\" -S \"L\" -t R"
        # shellcheck disable=SC2086
-       squeue ${squeue_args} -o "%.7i %.10u %.10a %.8q %.9P %.16j %.6D %.6C %.12L %S" -S "L" -t R | grep --color -E ".*${hluser}.*|$"
+       squeue ${squeue_args} -o "%.7i %.8u %.8a %.8q %.9P %.24j %.6D %.6C %.12L %S" -S "L" -t R | grep --color -E ".*${hluser}.*|$"
      fi
      # shellcheck disable=SC2086
      if ! [[ $(squeue ${squeue_args} -h -t PD | wc -l) == 0 ]]; then
        echo -e "\n${boldface}PENDING:${normalface}"
        # shellcheck disable=SC2086
-       squeue ${squeue_args} -o "%.7i %.8Q %.10u %.10a %.8q %.9P %.16j %.6C %.16S %.10L %.r" -t PD --sort=S,-p | grep -v "N/A" | grep --color -E ".*${hluser}.*|$"
+       squeue ${squeue_args} -o "%.7i %.8u %.8a %.8q %.9P %.24j %.6C %.16S %.10L %.8Q %.r" -t PD --sort=S,-p | grep -v "N/A" | grep --color -E ".*${hluser}.*|$"
        # shellcheck disable=SC2086
-       squeue ${squeue_args} -o "%.7i %.8Q %.10u %.10a %.8q %.9P %.16j %.6C %.16S %.10L %.r" -t PD --sort=S,-p | grep --color=never "N/A" | grep --color -E ".*${hluser}.*|$"
+       squeue ${squeue_args} -o "%.7i %.8u %.8a %.8q %.9P %.24j %.6C %.16S %.10L %.8Q %.r" -t PD --sort=S,-p | grep --color=never "N/A" | grep --color -E ".*${hluser}.*|$"
      fi
 #     if ! [[ `squeue ${squeue_args} -h -t S,CG,CF,F,TO,PR,NF | wc -l` == 0 ]]; then
 #       echo -e "\n${boldface}OTHER:${normalface}"


### PR DESCRIPTION
### Background

* Tweak the `sq` and `sqshowme` bash function to have a more useful and consistent format.  These bash functions print information about SLURM status.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
