### PR TITLE
Use FMA in Planck integration

### DIFF
--- a/src/cdi/CDI.cc
+++ b/src/cdi/CDI.cc
@@ -533,7 +533,7 @@ double CDI::collapseMultigroupOpacitiesPlanck(std::vector<double> const &groupBo
   for (size_t g = 1; g < groupBounds.size(); ++g) {
     Check(planckSpectrum[g - 1] >= 0.0);
     Check(opacity[g - 1] >= 0.0);
-    sig_planck_sum += planckSpectrum[g - 1] * opacity[g - 1];
+    sig_planck_sum = FMA(planckSpectrum[g - 1], opacity[g - 1], sig_planck_sum);
     // Also collect some CDF data.
     emission_group_cdf[g - 1] = sig_planck_sum;
   }
@@ -597,7 +597,7 @@ double CDI::collapseMultigroupOpacitiesPlanck(std::vector<double> const &groupBo
   for (size_t g = 1; g < groupBounds.size(); ++g) {
     Check(planckSpectrum[g - 1] >= 0.0);
     Check(opacity[g - 1] >= 0.0);
-    sig_planck_sum += planckSpectrum[g - 1] * opacity[g - 1];
+    sig_planck_sum = FMA(planckSpectrum[g - 1], opacity[g - 1], sig_planck_sum);
   }
 
   //                         int_{\nu_0}^{\nu_G}{d\nu sigma(\nu,T) * B(\nu,T)}

--- a/src/cdi/CDI.hh
+++ b/src/cdi/CDI.hh
@@ -16,6 +16,7 @@
 #include "GrayOpacity.hh"
 #include "MultigroupOpacity.hh"
 #include "ds++/Constexpr_Functions.hh"
+#include "ds++/FMA.hh"
 #include "ds++/Soft_Equivalence.hh"
 #include <algorithm>
 #include <array>
@@ -80,36 +81,16 @@ static inline double taylor_series_planck(double x) {
 
   double const xsqrd = x * x;
 
-  double taylor(coeff_21 * xsqrd);
-
-  taylor += coeff_19;
-  taylor *= xsqrd;
-
-  taylor += coeff_17;
-  taylor *= xsqrd;
-
-  taylor += coeff_15;
-  taylor *= xsqrd;
-
-  taylor += coeff_13;
-  taylor *= xsqrd;
-
-  taylor += coeff_11;
-  taylor *= xsqrd;
-
-  taylor += coeff_9;
-  taylor *= xsqrd;
-
-  taylor += coeff_7;
-  taylor *= xsqrd;
-
-  taylor += coeff_5;
-  taylor *= x;
-
-  taylor += coeff_4;
-  taylor *= x;
-
-  taylor += coeff_3;
+  double taylor = FMA(xsqrd, coeff_21, coeff_19);
+  taylor = FMA(taylor, xsqrd, coeff_17);
+  taylor = FMA(taylor, xsqrd, coeff_15);
+  taylor = FMA(taylor, xsqrd, coeff_13);
+  taylor = FMA(taylor, xsqrd, coeff_11);
+  taylor = FMA(taylor, xsqrd, coeff_9);
+  taylor = FMA(taylor, xsqrd, coeff_7);
+  taylor = FMA(taylor, xsqrd, coeff_5);
+  taylor = FMA(taylor, x, coeff_4);
+  taylor = FMA(taylor, x, coeff_3);
   taylor *= x * xsqrd * coeff;
 
   Ensure(taylor >= 0.0);


### PR DESCRIPTION
### Background

* I was trying to track down a difference between release and debug builds in a recent Jayenne PR and I tracked down the difference to the values of the Planckian integral between release and debug optimization levels. This PR changes the planck integration routines to use FMAs in the Taylor series integral and uses an FMA in collapsing the integral values to form the CDF used by Jayenne.

* This only changes one gold in Jayenne as far as I can tell. It may introduce more diffs in Intel builds. I'm working with KT to look into that. I'll try to coordinate with the other transporter teams before merging this.

### Purpose of Pull Request

* Reduce numerical differences between Release and Debug builds

### Description of changes

* Use FMA operation in the taylor series expansion planck intergral
* Use FMA operation in the summation when collapsing plank integral

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
