### PR TITLE
Add error message when CSK data file is not found

### DIFF
--- a/src/compton_tools/Compton_Native.cc
+++ b/src/compton_tools/Compton_Native.cc
@@ -197,6 +197,7 @@ int Compton_Native::read_binary(const std::string &filename) {
   try {
     fin.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   } catch (std::fstream::failure & /*error*/) {
+    std::cout << "Error: Compton data file '" << filename << "' not found!\n";
     return 1;
   }
 


### PR DESCRIPTION
### Description of changes

* Add error message (printed by rank 0) when Compton is requested but the file cannot be found

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
