### PR TITLE
Adopt LAP SE 1.7 environments on rzansel.

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -45,7 +45,7 @@ else
   module use --append /usr/gapps/jayenne/Modules
   module unuse /usr/share/lmod/lmod/modulefiles/Core
   module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
-  module load draco/xl2021.03.11-cuda-11.0.2
+  module load draco/lapse-xl-gpu-1.7.0
 fi
 
 # Do not escape $ for bash completion

--- a/src/cdi_eospac/test/CMakeLists.txt
+++ b/src/cdi_eospac/test/CMakeLists.txt
@@ -15,8 +15,10 @@ set(test_sources ${PROJECT_SOURCE_DIR}/tEospac.cc ${PROJECT_SOURCE_DIR}/tEospacW
 # ------------------------------------------------------------------------------------------------ #
 # Build Unit tests
 # ------------------------------------------------------------------------------------------------ #
-if((DEFINED ENV{SESAMEPATH} AND EXISTS "$ENV{SESAMEPATH}") OR (DEFINED ENV{SESPATHU}
-                                                               AND EXISTS "$ENV{SESPATHU}"))
+if((DEFINED ENV{SESAMEPATH} AND EXISTS "$ENV{SESAMEPATH}")
+   OR (DEFINED ENV{SESPATHU} AND EXISTS "$ENV{SESPATHU}")
+   OR IS_DIRECTORY "/usr/gapps/lanl-data/eos"
+   OR IS_DIRECTORY "/usr/projects/data/eos")
 
   # These tests require a datafile to be defined in the environment.
 


### PR DESCRIPTION
### Background

* We are trying to reduce the number of environments that TRT must support by using another team's TPLs.

### Description of changes

+ Register cdi_eospac tests if default locations are available -- even when `SESAMEPATH` isn't set.
* EOSPAC always looks at `$CWD` and specific common data locations.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
