### PR TITLE
Add autopep8 git hook

### DIFF
--- a/environment/git/install-hooks.sh
+++ b/environment/git/install-hooks.sh
@@ -13,7 +13,7 @@
 ###########################################################
 # CONFIGURATION:
 # select which pre-commit hooks are going to be installed
-HOOKS="pre-commit pre-commit-clang-format pre-commit-flake8 pre-commit-fprettify"
+HOOKS="pre-commit pre-commit-clang-format pre-commit-autopep8 pre-commit-flake8 pre-commit-fprettify"
 HOOKS="$HOOKS pre-commit-cmake-format pre-commit-cmake-lint"
 TOOLS="common.sh"
 ###########################################################

--- a/environment/git/pre-commit
+++ b/environment/git/pre-commit
@@ -16,6 +16,8 @@
 # the order in which they are listed.
 HOOKS="pre-commit-clang-format"
 
+# only run autopep8 if the tool is available
+[[ $(which autopep8 2> /dev/null | wc -w) -gt 0 ]] && HOOKS+=" pre-commit-autopep8"
 # only run flake8 if the tool is available.
 [[ $(which flake8 2> /dev/null | wc -w) -gt 0 ]] && HOOKS+=" pre-commit-flake8"
 # only run cmake-format if the tool is available.

--- a/environment/git/pre-commit-autopep8
+++ b/environment/git/pre-commit-autopep8
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+
+if __name__ == '__main__':
+    output = subprocess.run(['git', 'rev-parse', '--show-toplevel'], capture_output=True)
+    base_dir = output.stdout.decode('utf-8').strip()
+    output = subprocess.run(['git', 'status', '--porcelain'], capture_output=True)
+    all_files = output.stdout.decode('utf-8')
+    modified_files = []
+    for line in all_files.split('\n'):
+      if 'A' in line[0:2] or 'M' in line[0:2]:
+        modified_files.append(os.path.join(base_dir, line[2:].strip()))
+
+    for filename in modified_files:
+        autopep8_call = ['autopep8', '--in-place', filename]
+        subprocess.call(autopep8_call)
+        subprocess.call(['git', 'add', filename])

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -24,6 +24,7 @@ parser.add_argument('-mt',
 
 
 
+
 '--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -16,7 +16,15 @@ mesh_type_dict = {'orth_2d_mesh': mesh_types.orth_2d_mesh, 'orth_3d_mesh': mesh_
 # -- create argument parser
 
 parser = argparse.ArgumentParser(description='Generate X3D mesh file.')
-parser.add_argument('-mt', '--mesh_type', type=str, default='orth_2d_mesh',
+parser.add_argument('-mt',
+
+
+
+
+
+
+
+'--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -16,7 +16,7 @@ mesh_type_dict = {'orth_2d_mesh': mesh_types.orth_2d_mesh, 'orth_3d_mesh': mesh_
 # -- create argument parser
 
 parser = argparse.ArgumentParser(description='Generate X3D mesh file.')
-parser.add_argument('-mt',    '--mesh_type', type=str, default='orth_2d_mesh',
+parser.add_argument('-mt', '--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -16,8 +16,7 @@ mesh_type_dict = {'orth_2d_mesh': mesh_types.orth_2d_mesh, 'orth_3d_mesh': mesh_
 # -- create argument parser
 
 parser = argparse.ArgumentParser(description='Generate X3D mesh file.')
-parser.add_argument('-mt',
-                    '--mesh_type', type=str, default='orth_2d_mesh',
+parser.add_argument('-mt',    '--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -16,7 +16,8 @@ mesh_type_dict = {'orth_2d_mesh': mesh_types.orth_2d_mesh, 'orth_3d_mesh': mesh_
 # -- create argument parser
 
 parser = argparse.ArgumentParser(description='Generate X3D mesh file.')
-parser.add_argument('-mt', '--mesh_type', type=str, default='orth_2d_mesh',
+parser.add_argument('-mt',
+ '--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -17,7 +17,7 @@ mesh_type_dict = {'orth_2d_mesh': mesh_types.orth_2d_mesh, 'orth_3d_mesh': mesh_
 
 parser = argparse.ArgumentParser(description='Generate X3D mesh file.')
 parser.add_argument('-mt',
- '--mesh_type', type=str, default='orth_2d_mesh',
+                    '--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -16,16 +16,7 @@ mesh_type_dict = {'orth_2d_mesh': mesh_types.orth_2d_mesh, 'orth_3d_mesh': mesh_
 # -- create argument parser
 
 parser = argparse.ArgumentParser(description='Generate X3D mesh file.')
-parser.add_argument('-mt',
-
-
-
-
-
-
-
-
-'--mesh_type', type=str, default='orth_2d_mesh',
+parser.add_argument('-mt', '--mesh_type', type=str, default='orth_2d_mesh',
                     help='Select mesh type.')
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')


### PR DESCRIPTION
### Background

* `flake8` is effective for enforcing python syntax, but it doesn't apply inline updates. 
* `autopep8` does provide inline fixes as an option

### Purpose of Pull Request

* Add `autopep8` git hook to apply inline formatting fixes to modified python code prior to calling `flake8`. 
* [Fixes re-git issue #18](https://re-git.lanl.gov/draco/devops/-/issues/18)

### Description of changes

* Add `pre-commit-autopep8` script and update `pre-commit` and `install-hooks.sh` to `Draco/environment/git`. 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
