### PR TITLE
Autopep8 py only

### DIFF
--- a/environment/git/pre-commit-autopep8
+++ b/environment/git/pre-commit-autopep8
@@ -12,7 +12,7 @@ if __name__ == '__main__':
       if 'A' in line[0:2] or 'M' in line[0:2]:
         filename = os.path.join(base_dir, line[2:].strip())
         if filename[-3:] == '.py':
-          modified_files.append(os.path.join(base_dir, line[2:].strip()))
+          modified_files.append(filename)
 
     for filename in modified_files:
         autopep8_call = ['autopep8', '--in-place', filename]

--- a/environment/git/pre-commit-autopep8
+++ b/environment/git/pre-commit-autopep8
@@ -10,7 +10,9 @@ if __name__ == '__main__':
     modified_files = []
     for line in all_files.split('\n'):
       if 'A' in line[0:2] or 'M' in line[0:2]:
-        modified_files.append(os.path.join(base_dir, line[2:].strip()))
+        filename = os.path.join(base_dir, line[2:].strip())
+        if filename[-3:] == '.py':
+          modified_files.append(os.path.join(base_dir, line[2:].strip()))
 
     for filename in modified_files:
         autopep8_call = ['autopep8', '--in-place', filename]


### PR DESCRIPTION
### Background

* The recently added `autopep8` pre-commit hook formatter was accidentally being applied to all modified files

### Purpose of Pull Request

* Fix `autopep8` pre-commit hook
* [Contributes to re-git issue #1351](https://re-git.lanl.gov/draco/draco/-/issues/1351)

### Description of changes

* Apply `autopep8` only to modified files that end in `.py` during pre-commit. 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
