### PR TITLE
Vor2d mesh faces fix

### DIFF
--- a/src/mesh/python/README.md
+++ b/src/mesh/python/README.md
@@ -10,6 +10,7 @@ files (some of which should be usable for RTT file creation).
 For instance, one could add a mesh class that stochastically samples points and
 triangulates them to form a mesh of triangles.
 Currently supported meshes are:
+
 - orth_2d_mesh (default)
 - orth_3d_mesh
 - vor_2d_mesh

--- a/src/mesh/python/README.md
+++ b/src/mesh/python/README.md
@@ -10,9 +10,9 @@ files (some of which should be usable for RTT file creation).
 For instance, one could add a mesh class that stochastically samples points and
 triangulates them to form a mesh of triangles.
 Currently supported meshes are:
- - orth_2d_mesh (default)
- - orth_3d_mesh
- - vor_2d_mesh
+- orth_2d_mesh (default)
+- orth_3d_mesh
+- vor_2d_mesh
 
 Currently, there is a script called `x3d_generator.py`, which takes command-line
 input to instantiate a mesh object from one of the mesh_type classes and outputs

--- a/src/mesh/python/README.md
+++ b/src/mesh/python/README.md
@@ -9,9 +9,16 @@ class has its own `__init__` method for calculating data needed to create X3D
 files (some of which should be usable for RTT file creation).
 For instance, one could add a mesh class that stochastically samples points and
 triangulates them to form a mesh of triangles.
+Currently supported meshes are:
+ - orth_2d_mesh (default)
+ - orth_3d_mesh
+ - vor_2d_mesh
+
 Currently, there is a script called `x3d_generator.py`, which takes command-line
 input to instantiate a mesh object from one of the mesh_type classes and outputs
 a set of X3D files (main mesh file and boundary node files) of the mesh object.
+Another script, `x3d_plotter.py`, quickly plots the faces, nodes, and boundaries
+for a mesh in `x3d` format.
 
 ## Example Usage
 
@@ -20,4 +27,10 @@ in [0,1]x[0,2]x[0,4]:
 
 ```bash
 ./x3d_generator.py --mesh_type orth_3d_mesh --num_per_dim 4 4 4 --bnd_per_dim 0 1 0 2 0 4
+```
+
+To display a plot of the generated mesh file:
+
+```bash
+./x3d_plotter.py -fn x3d.mesh.in
 ```

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -534,14 +534,9 @@ class vor_2d_mesh(base_mesh):
             else:
                 ridge_vertices.append(verts)
 
-        # -- assign ridge vertices to regions and boundaries
+        # -- assign ridge vertices to regions
         cells = []
         cell_nodes = []
-        boundary_edges = {}
-        boundary_edges['xl'] = []
-        boundary_edges['xr'] = []
-        boundary_edges['yl'] = []
-        boundary_edges['yr'] = []
         for n, point in enumerate(points):
             cell_nodes.append(n)
             cells.append([])
@@ -561,20 +556,6 @@ class vor_2d_mesh(base_mesh):
             else:
                 # -- a boundary
                 cells[indices[0]].append(ridge_idx)
-                if (soft_equiv(vertices[v_indices[0]][0], xmin) and
-                    soft_equiv(vertices[v_indices[1]][0], xmin)):
-                    boundary_edges['xl'].append(ridge_idx)
-                elif (soft_equiv(vertices[v_indices[0]][0], xmax) and
-                      soft_equiv(vertices[v_indices[1]][0], xmax)):
-                    boundary_edges['xr'].append(ridge_idx)
-                elif (soft_equiv(vertices[v_indices[0]][1], ymin) and
-                      soft_equiv(vertices[v_indices[1]][1], ymin)):
-                    boundary_edges['yl'].append(ridge_idx)
-                elif (soft_equiv(vertices[v_indices[0]][1], ymax) and
-                      soft_equiv(vertices[v_indices[1]][1], ymax)):
-                    boundary_edges['yr'].append(ridge_idx)
-                else:
-                    assert (False), 'Boundary edge not identified'
 
         # -- update remaining base class values
         self.num_nodes = len(vertices)
@@ -591,16 +572,6 @@ class vor_2d_mesh(base_mesh):
             self.num_nodes_per_face[n] = 2
         self.faces_per_cell = cells
         self.nodes_per_face = ridge_vertices
-        self.nodes_per_side = []
-        for n in range(4):
-            bdy_key = list(boundary_edges.keys())[n]
-            bdy_nodes = []
-            for bdy in boundary_edges[bdy_key]:
-                nodes = ridge_vertices[bdy]
-                for node in nodes:
-                    if node not in bdy_nodes:
-                        bdy_nodes.append(node)
-            self.nodes_per_side.append(bdy_nodes)
 
         # -- rewrite cells and faces to not have duplicate faces
         new_cells = []
@@ -614,13 +585,13 @@ class vor_2d_mesh(base_mesh):
         self.faces_per_cell = new_cells
         self.nodes_per_face = new_faces
 
-        # -- rewrite boundaries for new faces
+        # -- write boundaries for new faces
+        boundary_edges = {}
         boundary_edges['xl'] = []
         boundary_edges['xr'] = []
         boundary_edges['yl'] = []
         boundary_edges['yr'] = []
         for face_idx, v_indices in enumerate(self.nodes_per_face):
-            print(face_idx)
             midpoint = [(vertices[v_indices[0]][0] + vertices[v_indices[1]][0]) / 2,
                         (vertices[v_indices[0]][1] + vertices[v_indices[1]][1]) / 2]
             distances = np.zeros(len(cell_nodes))
@@ -655,7 +626,6 @@ class vor_2d_mesh(base_mesh):
                     if node not in bdy_nodes:
                         bdy_nodes.append(node)
             self.nodes_per_side.append(bdy_nodes)
-        print(self.nodes_per_side)
 
 
 # ------------------------------------------------------------------------------------------------ #

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -602,6 +602,23 @@ class vor_2d_mesh(base_mesh):
                         bdy_nodes.append(node)
             self.nodes_per_side.append(bdy_nodes)
 
+        # -- fix face logic and indices
+        print(self.nodes_per_side)
+        new_faces = []
+        for face_idx, face in enumerate(self.faces_per_cell):
+            face_num = face_idx + 1
+            # print(self.nodes_per_face[face_idx])
+            nodes = self.nodes_per_face[face_idx]
+            print(nodes)
+            if nodes[0] in self.nodes_per_side and nodes[1] in self.nodes_per_side:
+                print("BOUNDARY!")
+        import sys
+        sys.exit()
+
+        # self.faces_per_cell = [np.array([], dtype=int)]  # face indexes per cell
+        # self.nodes_per_face = [np.array([], dtype=int)]  # node indexes per face
+        # self.nodes_per_side = [[np.array([], dtype=int)]]  # list of arrays of node per bdy face
+
 
 # ------------------------------------------------------------------------------------------------ #
 # end of mesh_types.py

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -623,9 +623,8 @@ class vor_2d_mesh(base_mesh):
             for bdy in boundary_edges[bdy_key]:
                 nodes = self.nodes_per_face[bdy]
                 for node in nodes:
-                    if node not in bdy_nodes:
-                        bdy_nodes.append(node)
-            self.nodes_per_side.append(bdy_nodes)
+                    bdy_nodes.append(node)
+            self.nodes_per_side.append(np.unique(bdy_nodes))
 
 
 # ------------------------------------------------------------------------------------------------ #

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -576,13 +576,12 @@ class vor_2d_mesh(base_mesh):
                 else:
                     assert (False), 'Boundary edge not identified'
 
-        # -- update remaining base values
+        # -- update remaining base class values
         self.num_nodes = len(vertices)
         self.coordinates_per_node = np.zeros([self.num_nodes, 2])
         for n, vertex in enumerate(vertices):
             self.coordinates_per_node[n, 0] = vertex[0]
             self.coordinates_per_node[n, 1] = vertex[1]
-        #self.num_faces = len(ridge_vertices)
         self.num_faces_per_cell = np.zeros(self.num_cells, dtype=int)
         for n in range(self.num_cells):
             self.num_faces_per_cell[n] = len(cells[n])
@@ -593,13 +592,6 @@ class vor_2d_mesh(base_mesh):
         self.faces_per_cell = cells
         self.nodes_per_face = ridge_vertices
         self.nodes_per_side = []
-        # print(self.num_faces)
-        # print(len(self.nodes_per_face))
-        # print(len(self.faces_per_cell))
-        # print(sum(self.num_faces_per_cell))
-        # print(self.num_faces_per_cell)
-        # print(self.faces_per_cell)
-        #import sys; sys.exit()
         for n in range(4):
             bdy_key = list(boundary_edges.keys())[n]
             bdy_nodes = []
@@ -609,43 +601,14 @@ class vor_2d_mesh(base_mesh):
                     if node not in bdy_nodes:
                         bdy_nodes.append(node)
             self.nodes_per_side.append(bdy_nodes)
-        # print(self.num_faces)
-        # print(len(self.nodes_per_face))
-        # print(len(self.faces_per_cell))
 
-        # -- fix face logic and indices
-        # print(self.nodes_per_side)
-        #new_faces = []
-        # for face_idx, face in enumerate(self.faces_per_cell):
-        #    face_num = face_idx + 1
-        #    # print(self.nodes_per_face[face_idx])
-        #    nodes = self.nodes_per_face[face_idx]
-        #    print(nodes)
-        #    if nodes[0] in self.nodes_per_side and nodes[1] in self.nodes_per_side:
-        #        print("BOUNDARY!")
-        # print(self.faces_per_cell)
-
-#        for cell_idx, cell in enumerate(self.faces_per_cell):
-#          for face_idx, face in enumerate(self.faces_per_cell[cell_idx]):
-#            self.faces_per_cell[cell_idx][face_idx] = face + 1
-#
-#        for face_idx, face in enumerate(self.nodes_per_face):
-#          for node_idx, node in enumerate(self.nodes_per_face[face_idx]):
-#            self.nodes_per_face[face_idx][node_idx] = node + 1
-#
-#        #print(self.nodes_per_side)
-#        #import sys; sys.exit()
-#        for side_idx, side in enumerate(self.nodes_per_side):
-#          for node_idx, node in enumerate(self.nodes_per_side[side_idx]):
-#            self.nodes_per_side[side_idx][node_idx] = node + 1
-
-  #      print(self.faces_per_cell)
-  #      import sys
-  #      sys.exit()
-
-        # self.faces_per_cell = [np.array([], dtype=int)]  # face indexes per cell
-        # self.nodes_per_face = [np.array([], dtype=int)]  # node indexes per face
-        # self.nodes_per_side = [[np.array([], dtype=int)]]  # list of arrays of node per bdy face
+        faces = self.faces_per_cell[0]
+        print("Faces:")
+        for face in faces:
+            print(face)
+            print(self.nodes_per_face[face])
+            for node in self.nodes_per_face[face]:
+                print(self.coordinates_per_node[node])
 
 
 # ------------------------------------------------------------------------------------------------ #

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -620,6 +620,7 @@ class vor_2d_mesh(base_mesh):
         boundary_edges['yl'] = []
         boundary_edges['yr'] = []
         for face_idx, v_indices in enumerate(self.nodes_per_face):
+            print(face_idx)
             midpoint = [(vertices[v_indices[0]][0] + vertices[v_indices[1]][0]) / 2,
                         (vertices[v_indices[0]][1] + vertices[v_indices[1]][1]) / 2]
             distances = np.zeros(len(cell_nodes))
@@ -654,6 +655,7 @@ class vor_2d_mesh(base_mesh):
                     if node not in bdy_nodes:
                         bdy_nodes.append(node)
             self.nodes_per_side.append(bdy_nodes)
+        print(self.nodes_per_side)
 
 
 # ------------------------------------------------------------------------------------------------ #

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -582,16 +582,24 @@ class vor_2d_mesh(base_mesh):
         for n, vertex in enumerate(vertices):
             self.coordinates_per_node[n, 0] = vertex[0]
             self.coordinates_per_node[n, 1] = vertex[1]
-        self.num_faces = len(ridge_vertices)
+        #self.num_faces = len(ridge_vertices)
         self.num_faces_per_cell = np.zeros(self.num_cells, dtype=int)
         for n in range(self.num_cells):
             self.num_faces_per_cell[n] = len(cells[n])
+        self.num_faces = sum(self.num_faces_per_cell)
         self.num_nodes_per_face = np.zeros(self.num_faces, dtype=int)
         for n in range(self.num_faces):
             self.num_nodes_per_face[n] = 2
         self.faces_per_cell = cells
         self.nodes_per_face = ridge_vertices
         self.nodes_per_side = []
+        # print(self.num_faces)
+        # print(len(self.nodes_per_face))
+        # print(len(self.faces_per_cell))
+        # print(sum(self.num_faces_per_cell))
+        # print(self.num_faces_per_cell)
+        # print(self.faces_per_cell)
+        #import sys; sys.exit()
         for n in range(4):
             bdy_key = list(boundary_edges.keys())[n]
             bdy_nodes = []
@@ -601,19 +609,39 @@ class vor_2d_mesh(base_mesh):
                     if node not in bdy_nodes:
                         bdy_nodes.append(node)
             self.nodes_per_side.append(bdy_nodes)
+        # print(self.num_faces)
+        # print(len(self.nodes_per_face))
+        # print(len(self.faces_per_cell))
 
         # -- fix face logic and indices
-        print(self.nodes_per_side)
-        new_faces = []
-        for face_idx, face in enumerate(self.faces_per_cell):
-            face_num = face_idx + 1
-            # print(self.nodes_per_face[face_idx])
-            nodes = self.nodes_per_face[face_idx]
-            print(nodes)
-            if nodes[0] in self.nodes_per_side and nodes[1] in self.nodes_per_side:
-                print("BOUNDARY!")
-        import sys
-        sys.exit()
+        # print(self.nodes_per_side)
+        #new_faces = []
+        # for face_idx, face in enumerate(self.faces_per_cell):
+        #    face_num = face_idx + 1
+        #    # print(self.nodes_per_face[face_idx])
+        #    nodes = self.nodes_per_face[face_idx]
+        #    print(nodes)
+        #    if nodes[0] in self.nodes_per_side and nodes[1] in self.nodes_per_side:
+        #        print("BOUNDARY!")
+        # print(self.faces_per_cell)
+
+#        for cell_idx, cell in enumerate(self.faces_per_cell):
+#          for face_idx, face in enumerate(self.faces_per_cell[cell_idx]):
+#            self.faces_per_cell[cell_idx][face_idx] = face + 1
+#
+#        for face_idx, face in enumerate(self.nodes_per_face):
+#          for node_idx, node in enumerate(self.nodes_per_face[face_idx]):
+#            self.nodes_per_face[face_idx][node_idx] = node + 1
+#
+#        #print(self.nodes_per_side)
+#        #import sys; sys.exit()
+#        for side_idx, side in enumerate(self.nodes_per_side):
+#          for node_idx, node in enumerate(self.nodes_per_side[side_idx]):
+#            self.nodes_per_side[side_idx][node_idx] = node + 1
+
+  #      print(self.faces_per_cell)
+  #      import sys
+  #      sys.exit()
 
         # self.faces_per_cell = [np.array([], dtype=int)]  # face indexes per cell
         # self.nodes_per_face = [np.array([], dtype=int)]  # node indexes per face

--- a/src/mesh/python/mesh_types.py
+++ b/src/mesh/python/mesh_types.py
@@ -602,13 +602,30 @@ class vor_2d_mesh(base_mesh):
                         bdy_nodes.append(node)
             self.nodes_per_side.append(bdy_nodes)
 
-        faces = self.faces_per_cell[0]
-        print("Faces:")
-        for face in faces:
-            print(face)
-            print(self.nodes_per_face[face])
-            for node in self.nodes_per_face[face]:
-                print(self.coordinates_per_node[node])
+        #faces = self.faces_per_cell[0]
+        # print("Faces:")
+        # for face in faces:
+        #    print(face)
+        #    print(self.nodes_per_face[face])
+        #    for node in self.nodes_per_face[face]:
+        #        print(self.coordinates_per_node[node])
+
+        # Rewrite to not have duplicate faces
+        new_cells = []
+        new_faces = []
+        for cell in cells:
+            new_cell = []
+            for face in cell:
+                print(face)
+                new_faces.append(ridge_vertices[face])
+                new_cell.append(len(new_faces) - 1)
+            new_cells.append(new_cell)
+        print(self.faces_per_cell)
+        print(self.nodes_per_face)
+        print(new_cells)
+        print(new_faces)
+        self.faces_per_cell = new_cells
+        self.nodes_per_face = new_faces
 
 
 # ------------------------------------------------------------------------------------------------ #

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -29,10 +29,19 @@ with open(args.file_name) as f:
 
 print(lines)
 
+# Data to read in
+numdim = None
+numnodes = None
+numfaces = None
+numcells = None
+nodes = []
+faces = []
+cells = []
+
 blocks = ['header', 'nodes', 'faces', 'cells']
 current_block = None
 for line in lines:
-    print(line)
+    words = line.split()
     # If no current block, check if starting new block
     if current_block is None:
         for block in blocks:
@@ -45,5 +54,39 @@ for line in lines:
             current_block = None
 
     # Process data if currently on a block
-    if current_block is not None:
-        print(current_block)
+    if current_block == 'header':
+        if words[0] == 'numdim':
+            numdim = int(words[1])
+        elif words[0] == 'nodes':
+            numnodes = int(words[1])
+        elif words[0] == 'faces':
+            numfaces = int(words[1])
+        elif words[0] == 'elements':
+            numcells = int(words[1])
+    elif current_block == 'nodes':
+        if len(words) == 4:
+            nodes.append([float(words[1]), float(words[2]), float(words[3])])
+    elif current_block == 'faces':
+        if len(words) >= 3:
+            print(words)
+            face = []
+            for nface in range(int(words[1])):
+                face.append(words[nface + 2])
+            faces.append(face)
+
+    # if current_block is not None:
+            # print(current_block)
+
+# for n in range(
+
+assert (numdim is not None), "numdim not found!"
+assert (numnodes is not None), "numnodes not found!"
+assert (numfaces is not None), "numfaces not found!"
+assert (numcells is not None), "numcells not found!"
+assert (len(nodes) == numnodes), "numnodes does not match number of nodes!"
+print(numfaces)
+print(len(faces))
+# print(faces)
+assert (len(faces) == numfaces), "numfaces does not match number of faces!"
+
+print(nodes)

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -34,6 +34,7 @@ numnodes = None
 numfaces = None
 numcells = None
 nodes = []
+face_indices = []
 faces = []
 cells = []
 
@@ -69,21 +70,34 @@ for line in lines:
         if len(words) >= 3:
             face = []
             for nnodes in range(int(words[1])):
+                # Convert from file node ID to code node index
                 face.append(int(words[nnodes + 2]) - 1)
-            faces.append(face)
+            face_index = int(words[0])
+            if face_index not in face_indices:
+                faces.append(face)
+                face_indices.append(int(words[0]))
     elif current_block == 'cells':
         if len(words) >= 3:
             cell = []
             for nface in range(int(words[1])):
+                # Convert from file face ID to code face index
                 cell.append(int(words[nface + 2]) - 1)
             cells.append(cell)
+
+faces = [x for _, x in sorted(zip(face_indices, faces))]
+print(face_indices)
+print(sorted(face_indices))
+# print(faces)
+print(cells[0])
+print(faces[131:134])
+#import sys; sys.exit()
 
 assert (numdim is not None), "numdim not found!"
 assert (numnodes is not None), "numnodes not found!"
 assert (numfaces is not None), "numfaces not found!"
 assert (numcells is not None), "numcells not found!"
 assert (len(nodes) == numnodes), "numnodes does not match number of nodes!"
-assert (len(faces) == numfaces), "numfaces does not match number of faces!"
+#assert (len(faces) == numfaces), "numfaces does not match number of faces!"
 assert (len(cells) == numcells), "numcells does not match number of faces!"
 
 # ------------------------------------------------------------------------------------------------ #
@@ -92,9 +106,27 @@ assert (len(cells) == numcells), "numcells does not match number of faces!"
 plt.figure()
 ax = plt.gca()
 
+plotted_faces = []
+print(len(cells))
 for cell in cells:
+    print("num faces: ", len(cell))
+    print(cell)
     for face in cell:
-        pt1 = nodes[faces[face][0]]
-        pt2 = nodes[faces[face][1]]
-        ax.plot([pt1[0], pt2[0]], [pt1[1], pt2[1]], color='k')
+        print(faces[face])
+        # Don't re-plot the same face
+        if (([faces[face][0], faces[face][1]] not in plotted_faces) and
+            ([faces[face][1], faces[face][0]] not in plotted_faces)):
+            pt1 = nodes[faces[face][0]]
+            pt2 = nodes[faces[face][1]]
+            plotted_faces.append([faces[face][0], faces[face][1]])
+            ax.plot([pt1[0], pt2[0]], [pt1[1], pt2[1]], color='k')
+    # plt.show()
+    # break
+# Check that all faces are really there
+# for face in faces:
+#  pt1 = nodes[face[0]]
+#  pt2 = nodes[face[1]]
+#  ax.plot([pt1[0], pt2[0]], [pt1[1], pt2[1]], color='k')
+for node in nodes:
+    ax.plot([node[0]], [node[1]], marker='.', color='b')
 plt.show()

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -------------------------------------------*-python-*------------------------------------------- #
+# file  src/mesh/python/x3d_plotter.py
+# date  Monday, Aug 9, 2021
+# brief This script plots X3D mesh files.
+# note  Copyright (C) 2021, Triad National Security, LLC.,  All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
+import mesh_types
+import numpy as np
+import argparse
+import os
+
+# ------------------------------------------------------------------------------------------------ #
+# -- create argument parser
+
+parser = argparse.ArgumentParser(description='Plot X3D mesh file.')
+parser.add_argument('-fn', '--file_name', type=str, default=None, required=True,
+                    help='Provide mesh file to plot.')
+
+# -- parse arguments from command line
+args = parser.parse_args()
+
+# ------------------------------------------------------------------------------------------------ #
+# -- Read and parse x3d file
+
+assert (os.path.exists(args.file_name)), f"Mesh file \"{args.file_name}\" does not exist!"
+with open(args.file_name) as f:
+    lines = [line.strip() for line in f]
+
+print(lines)
+
+blocks = ['header', 'nodes', 'faces', 'cells']
+current_block = None
+for line in lines:
+    print(line)
+    # If no current block, check if starting new block
+    if current_block is None:
+        for block in blocks:
+            if block == line:
+                current_block = block
+                break
+    # If current block, check if ending current block
+    else:
+        if line == "end_" + current_block:
+            current_block = None
+
+    # Process data if currently on a block
+    if current_block is not None:
+        print(current_block)

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -5,6 +5,7 @@
 # brief This script plots X3D mesh files.
 # note  Copyright (C) 2021, Triad National Security, LLC.,  All rights reserved.
 # ------------------------------------------------------------------------------------------------ #
+import matplotlib.pyplot as plt
 import mesh_types
 import numpy as np
 import argparse
@@ -26,8 +27,6 @@ args = parser.parse_args()
 assert (os.path.exists(args.file_name)), f"Mesh file \"{args.file_name}\" does not exist!"
 with open(args.file_name) as f:
     lines = [line.strip() for line in f]
-
-print(lines)
 
 # Data to read in
 numdim = None
@@ -68,25 +67,34 @@ for line in lines:
             nodes.append([float(words[1]), float(words[2]), float(words[3])])
     elif current_block == 'faces':
         if len(words) >= 3:
-            print(words)
             face = []
-            for nface in range(int(words[1])):
-                face.append(words[nface + 2])
+            for nnodes in range(int(words[1])):
+                face.append(int(words[nnodes + 2]) - 1)
             faces.append(face)
-
-    # if current_block is not None:
-            # print(current_block)
-
-# for n in range(
+    elif current_block == 'cells':
+        if len(words) >= 3:
+            cell = []
+            for nface in range(int(words[1])):
+                cell.append(int(words[nface + 2]) - 1)
+            cells.append(cell)
 
 assert (numdim is not None), "numdim not found!"
 assert (numnodes is not None), "numnodes not found!"
 assert (numfaces is not None), "numfaces not found!"
 assert (numcells is not None), "numcells not found!"
 assert (len(nodes) == numnodes), "numnodes does not match number of nodes!"
-print(numfaces)
-print(len(faces))
-# print(faces)
 assert (len(faces) == numfaces), "numfaces does not match number of faces!"
+assert (len(cells) == numcells), "numcells does not match number of faces!"
 
-print(nodes)
+# ------------------------------------------------------------------------------------------------ #
+# -- Plot mesh
+
+plt.figure()
+ax = plt.gca()
+
+for cell in cells:
+    for face in cell:
+        pt1 = nodes[faces[face][0]]
+        pt2 = nodes[faces[face][1]]
+        ax.plot([pt1[0], pt2[0]], [pt1[1], pt2[1]], color='k')
+plt.show()

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -6,8 +6,6 @@
 # note  Copyright (C) 2021, Triad National Security, LLC.,  All rights reserved.
 # ------------------------------------------------------------------------------------------------ #
 import matplotlib.pyplot as plt
-import mesh_types
-import numpy as np
 import argparse
 import os
 

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -73,9 +73,9 @@ for line in lines:
                 # Convert from file node ID to code node index
                 face.append(int(words[nnodes + 2]) - 1)
             face_index = int(words[0])
-            if face_index not in face_indices:
-                faces.append(face)
-                face_indices.append(int(words[0]))
+            # if face_index not in face_indices:
+            faces.append(face)
+            face_indices.append(int(words[0]))
     elif current_block == 'cells':
         if len(words) >= 3:
             cell = []
@@ -97,7 +97,7 @@ assert (numnodes is not None), "numnodes not found!"
 assert (numfaces is not None), "numfaces not found!"
 assert (numcells is not None), "numcells not found!"
 assert (len(nodes) == numnodes), "numnodes does not match number of nodes!"
-#assert (len(faces) == numfaces), "numfaces does not match number of faces!"
+assert (len(faces) == numfaces), "numfaces does not match number of faces!"
 assert (len(cells) == numcells), "numcells does not match number of faces!"
 
 # ------------------------------------------------------------------------------------------------ #

--- a/src/mesh/python/x3d_plotter.py
+++ b/src/mesh/python/x3d_plotter.py
@@ -93,17 +93,13 @@ boundary_files = []
 boundary_nodes = []
 boundary_faces = []
 if numdim == 2:
-    print(args.file_name)
-    print(os.path.basename(args.file_name))
     for n in range(4):
         assert (args.file_name[-3:] == '.in'), "Filename does not end in \".in\""
         boundary_files.append(args.file_name[:-3] + f".bdy{n+1}.in")
-    print(boundary_files)
 
 for boundary_file in boundary_files:
     with open(boundary_file) as f:
         lines = [line.strip() for line in f]
-    print(lines)
     # -- read in boundary nodes
     boundary = []
     for line in lines:
@@ -117,13 +113,7 @@ for boundary_file in boundary_files:
         node1 = face[1]
         if node0 in boundary and node1 in boundary:
             boundary_face_tmp.append(face_idx)
-    # for node in boundary:
-    #  print(node)
     boundary_faces.append(boundary_face_tmp)
-
-#import sys; sys.exit()
-
-print(boundary_faces)
 
 
 # -- sanity checks


### PR DESCRIPTION
### Background

* The recently added python 2D voronoi generator was not outputting some variables correctly
* It's difficult to debug computational geometry without visualizing it

### Purpose of Pull Request

* [Fixes re-git issue #1350](https://re-git.lanl.gov/draco/draco/-/issues/1350)

### Description of changes

* Fix bugs in `vor_2d_mesh` mesh type with faces that share nodes and boundary data
* Add `x3d_plotter.py` script that quickly plots 2D `x3d` mesh files

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [x] Enhance `src/mesh/python` `README.md`
