### PR TITLE
Provide basic environment for ATS-4.

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -71,7 +71,12 @@ if(NOT CXX_FLAGS_INITIALIZED)
     #
     # ld.lld: error: corrupt input file: version definition index 0 for symbol mpiprivc_ is out of
     # bounds
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=bfd")
+    #
+    # As of 2021-08-10, this is required on Capulin/Thunder when using cce@11, but must be ommitted
+    # on rznevada when using cce@12.
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0.0)
+      string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=bfd")
+    endif()
   else()
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libc++")
   endif()

--- a/environment/bashrc/.bashrc_ats4
+++ b/environment/bashrc/.bashrc_ats4
@@ -30,23 +30,27 @@ export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
 #
 
 # 1. Determine if the module command is available
-# modcmd=`declare -f module`
-# # If not found, look for it in /usr/share/Modules
-# if [[ ! ${modcmd} ]]; then
-#   source /usr/share/lmod/lmod/init/bash || die \
-#     "ERROR: The module command was not found. No modules will be loaded (ats-2 e01)."
-# fi
-# modcmd=`declare -f module`
+modcmd=`declare -f module`
+# If not found, look for it in /usr/share/Modules
+if [[ ! ${modcmd} ]]; then
+  source /usr/share/lmod/lmod/init/bash || die \
+    "ERROR: The module command was not found. No modules will be loaded (ats-4 e01)."
+fi
+modcmd=`declare -f module`
 
 # 2. Use modules found in the draco directory
-# if [[ ! ${modcmd} ]]; then
-#   echo "ERROR: The module command was not found. No modules will be loaded (ats-2, e02)."
-# else
-#  module use --append /usr/gapps/jayenne/Modules
-#  module unuse /usr/share/lmod/lmod/modulefiles/Core
-#  module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
-#  module load draco/xl2021.03.11-cuda-11.0.2
-#fi
+if [[ ! ${modcmd} ]]; then
+  echo "ERROR: The module command was not found. No modules will be loaded (ats-4 e02)."
+else
+  module use --append /usr/gapps/jayenne/Modules/rznevada
+  module unuse /opt/cray/pe/lmod/modulefiles/compiler/crayclang/10.0
+  module unuse /opt/cray/pe/lmod/modulefiles/perftools/21.05.0
+  module unuse /opt/cray/pe/lmod/modulefiles/cpu/x86-rome/1.0
+  module unuse /usr/apps/modulefiles
+  module unuse /usr/share/lmod/lmod/modulefiles/Core
+# module unuse /collab/usr/global/tools/modulefiles/blueos_3_ppc64le_ib_p9/Core
+ module load draco/cce1201.lua
+fi
 
 # Do not escape $ for bash completion
 shopt -s direxpand


### PR DESCRIPTION
### Background

* We are starting to port our codes to rzNevada.  This update provides a very basic developer environment.

### Description of changes

* Provides a basic set of modules that load third-party libraries needed by Draco.
```shell
rznevada % module list

Currently Loaded Modules:
  1) craype-x86-rome          6) cray-libsci/21.06.1.1      11) cray-mpich/8.1.7  16) gsl/2.6              21) csk/0.5.0
  2) craype-network-ofi       7) PrgEnv-cray/8.1.0          12) numdiff/5.9.0     17) metis/5.1.0          22) ack/2.22
  3) libfabric/1.10.2pre1     8) rocm/4.2.0                 13) random123/1.13.2  18) netlib-lapack/3.8.0  23) git/2.31.1
  4) perftools-base/21.05.0   9) StdEnv                (S)  14) cmake/3.20.2      19) parmetis/4.0.3       24) htop/2.2.0
  5) craype/2.7.8            10) cce/12.0.1                 15) eospac/6.4.2beta  20) libquo/1.3.1         25) draco/cce1201
```

* Currently, I am unable to build superlu-dist (and thus trilinos) or caliper with `%cce@12.0.1`.
* Draco will configure, but the build fails due to a link error when mixing Fortran and C++.
* See https://re-git.lanl.gov/draco/devops/-/issues/21 for additional details.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
