### PR TITLE
Provide git-hook that updates copyright block automagically.

### DIFF
--- a/environment/git/install-hooks.sh
+++ b/environment/git/install-hooks.sh
@@ -14,7 +14,7 @@
 # CONFIGURATION:
 # select which pre-commit hooks are going to be installed
 HOOKS="pre-commit pre-commit-clang-format pre-commit-autopep8 pre-commit-flake8 pre-commit-fprettify"
-HOOKS="$HOOKS pre-commit-cmake-format pre-commit-cmake-lint"
+HOOKS="$HOOKS pre-commit-cmake-format pre-commit-cmake-lint pre-commit-copyright"
 TOOLS="common.sh"
 ###########################################################
 # There should be no need to change anything below this line.

--- a/environment/git/pre-commit
+++ b/environment/git/pre-commit
@@ -14,7 +14,7 @@
 # pre-commit hooks to be executed. They should be in the same .git/hooks/ folder as this
 # script. Hooks should return 0 if successful and nonzero to cancel the commit. They are executed in
 # the order in which they are listed.
-HOOKS="pre-commit-clang-format"
+HOOKS="pre-commit-clang-format pre-commit-copyright"
 
 # only run autopep8 if the tool is available
 [[ $(which autopep8 2> /dev/null | wc -w) -gt 0 ]] && HOOKS+=" pre-commit-autopep8"

--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# git pre-commit hook that checks/updates the copyright block
+# Features:
+#  - Attempts to fix the copyright block in place
+#  - abort commit when commit does not comply with the style guidelines
+
+#--------------------------------------------------------------------------------------------------#
+# SETTINGS
+#
+# - none
+#--------------------------------------------------------------------------------------------------#
+
+# make tmp file readable only by owner
+umask 0077
+
+debug=off
+function debugprint()
+{
+  if [[ "$debug" == "on" ]]; then echo "==> $@"; fi
+}
+
+debugprint "running pre-commit-copyright"
+
+# remove any older patches from previous commits. Set to true or false.
+DELETE_OLD_PATCHES=true
+
+# file types to parse.
+FILE_EXTS=".c .cc .h .hh .in .f90 .F90 .f .F .py"
+#FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
+FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc"
+export FILE_EXTS FILE_ENDINGS_EXCLUDE
+
+##################################################################
+# There should be no need to change anything below this line.
+# shellcheck source=environment/git/canonicalize_filename.sh
+source "$(dirname -- "$0")/canonicalize_filename.sh"
+
+# shellcheck source=tools/common.sh
+source "$(dirname -- "$0")/common.sh"
+
+# necessary check for initial commit
+if git rev-parse --verify HEAD >/dev/null 2>&1 ; then
+  against=HEAD
+else
+  # Initial commit: diff against an empty tree object
+  against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# Arguments
+# - file
+function rewrite_copyright_block()
+{
+  local filename=$1
+  local gitfile=$2
+  local today=$(date +%Y)
+
+  # This data was found in the header comments.  It might be a single year or a range.
+  local crl=$(grep Copyright $filename)
+  local create_date=$(echo $crl | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
+
+  # These dates are reported by git
+  local git_last_mod_date=$(git log -1 $gitfile | grep Date | \
+                              sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
+  local git_create_date=$(git log $gitfile | grep Date | tail -n 1 | \
+                            sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
+
+  debugprint "$crl"
+  debugprint "$create_date $git_last_mod_date $git_create_date"
+
+  # Sanity Checks
+  [[ "${create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  # [[ "${mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  [[ "${git_last_mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  [[ "${git_create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
+    die "Existing copyright date range is corrupt. Please fix $filename manually."
+  fi
+  if [[ "${git_create_date}" -gt "${today}" ]] || [[ "${git_create_date}" -lt "1990" ]]; then
+    die "Existing copyright date range is corrupt. Please fix $filename manually."
+  fi
+  if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
+    die "Existing copyright date range is corrupt. Please fix $filename manually."
+  fi
+
+  # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
+  # this case older data is lost, so just use whatever is in the file as the create date.
+  [[ "${git_create_date}" == "2010" ]] && git_create_date="${create_date}"
+
+  # Expected Copyright line:
+  local ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "
+  ecrl+=" All rights reserved."
+  debugprint "ecrl = $ecrl"
+
+  # If existing copyright spans two lines, reduce it to one line.
+  local twolines=$(grep -A 1 Copyright $filename | tail -n 1 | grep -c reserved)
+  if [[ $twolines -gt 0 ]]; then
+    sed -i 's/All rights reserved[.]*//' ${filename}
+  fi
+
+  # Do we have terminating comement character on the 'copyright' line.  If so, keep it.
+  local ecm=""
+  if [[ $(echo $crl | grep -c "\\\*/") -gt 0 ]]; then
+    ecm=" */"
+    debugprint "ecm = $ecm"
+  fi
+
+  # Replace copyright with new one
+  debugprint "sed -i s%Copyright.*%${ecrl}${ecm}% $filename"
+  sed -i "s%Copyright.*%${ecrl}${ecm}%" $filename
+}
+
+# create a random filename to store our generated patch
+prefix="pre-commit-copyright"
+suffix="$(date +%s)"
+
+# clean up any older fprettify patches
+# $DELETE_OLD_PATCHES && rm -f /tmp/$prefix-*. &> /dev/null
+patchfile=$(mktemp "/tmp/$USER/${prefix}-${suffix}.patch.XXXXXXXX")
+
+# create one patch containing all changes to the files
+# shellcheck disable=SC2162
+git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;
+do
+  debugprint "should we process $file ?"
+
+  # only process f90 files.
+  if ! matches_extension "$file"; then continue; fi
+
+  # If file is added to commit but still has local modifications, abort
+  if [[ $(git diff "${file}" | wc -l) != 0 ]]; then
+    echo -e "\nERROR: File ${file} has local edits that are not staged. Stash modifications or add "
+    echo -e "       changes to this commit.\n\n"
+    exit 1
+  fi
+
+  debugprint "Looking at $file"
+  file_nameonly=$(basename "${file}")
+  tmpfile1="/tmp/${prefix}-$file_nameonly"
+
+  # Copy the file and attempt update it.
+  cp "${file}" "${tmpfile1}"
+  rewrite_copyright_block "$tmpfile1" "$file"
+  debugprint "  updating patchfile"
+  diff -u "${file}" "${tmpfile1}" | \
+    sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patchfile"
+  rm $tmpfile1
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if ! [[ -s "$patchfile" ]]; then
+  printf "Files in this commit comply with the expected copyright block rules.\n"
+  rm -f "$patchfile"
+  exit 0
+fi
+
+# If we get here, there are files that don't comply...
+
+# If user wants to automatically apply these changes, then do it, otherwise, print the diffs and
+# reject the commit.
+if [[ -s "$patchfile" ]]; then
+  git apply "$patchfile"
+  printf "\nFiles in this commit were updated to comply with the copyright block rules.\n"
+  printf "You must check and test these changes and then stage these updates to\n"
+  printf "be part of your current change set and retry the commit.\n\n"
+  git status
+  rm -f "$patchfile"
+  exit 1
+fi
+
+# ------------------------------------------------------------------------------------------------ #
+# End pre-commit-copyright
+# ------------------------------------------------------------------------------------------------ #

--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -17,7 +17,7 @@ umask 0077
 debug=off
 function debugprint()
 {
-  if [[ "$debug" == "on" ]]; then echo "==>" $@; fi
+  if [[ "$debug" == "on" ]]; then echo "==>" "$@"; fi
 }
 
 debugprint "running pre-commit-copyright"
@@ -26,7 +26,7 @@ debugprint "running pre-commit-copyright"
 # DELETE_OLD_PATCHES=true
 
 # file types to parse.
-FILE_EXTS=".c .cc .h .hh .in .f90 .F90 .f .F .py"
+FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt"
 #FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
 FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc"
 export FILE_EXTS FILE_ENDINGS_EXCLUDE
@@ -60,6 +60,7 @@ function rewrite_copyright_block()
   local crl
   crl=$(grep Copyright "${filename}")
   local create_date
+  # shellcheck disable=SC2001
   create_date=$(echo "${crl}" | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
 
   # These dates are reported by git
@@ -109,7 +110,7 @@ function rewrite_copyright_block()
   if [[ $(echo "${crl}" | grep -c "\\\*/") -gt 0 ]]; then ecm=" */"; fi
 
   # Replace copyright with new one
-  debugprint "sed -i s%Copyright.*%${ecrl}${ecm}% "${filename}""
+  debugprint "sed -i s%Copyright.*%${ecrl}${ecm}% ${filename}"
   sed -i "s%Copyright.*%${ecrl}${ecm}%" "${filename}"
 }
 

--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -17,13 +17,13 @@ umask 0077
 debug=off
 function debugprint()
 {
-  if [[ "$debug" == "on" ]]; then echo "==> $@"; fi
+  if [[ "$debug" == "on" ]]; then echo "==>" $@; fi
 }
 
 debugprint "running pre-commit-copyright"
 
 # remove any older patches from previous commits. Set to true or false.
-DELETE_OLD_PATCHES=true
+# DELETE_OLD_PATCHES=true
 
 # file types to parse.
 FILE_EXTS=".c .cc .h .hh .in .f90 .F90 .f .F .py"
@@ -53,17 +53,22 @@ function rewrite_copyright_block()
 {
   local filename=$1
   local gitfile=$2
-  local today=$(date +%Y)
+  local today
+  today=$(date +%Y)
 
   # This data was found in the header comments.  It might be a single year or a range.
-  local crl=$(grep Copyright $filename)
-  local create_date=$(echo $crl | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
+  local crl
+  crl=$(grep Copyright "${filename}")
+  local create_date
+  create_date=$(echo "${crl}" | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
 
   # These dates are reported by git
-  local git_last_mod_date=$(git log -1 $gitfile | grep Date | \
-                              sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
-  local git_create_date=$(git log $gitfile | grep Date | tail -n 1 | \
-                            sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
+  local git_last_mod_date
+  local git_create_date
+  git_last_mod_date=$(git log -1 "${gitfile}" | grep Date | \
+                        sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
+  git_create_date=$(git log "${gitfile}" | grep Date | tail -n 1 | \
+                      sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
 
   debugprint "$crl"
   debugprint "$create_date $git_last_mod_date $git_create_date"
@@ -93,21 +98,19 @@ function rewrite_copyright_block()
   debugprint "ecrl = $ecrl"
 
   # If existing copyright spans two lines, reduce it to one line.
-  local twolines=$(grep -A 1 Copyright $filename | tail -n 1 | grep -c reserved)
+  local twolines
+  twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
   if [[ $twolines -gt 0 ]]; then
-    sed -i 's/All rights reserved[.]*//' ${filename}
+    sed -i 's/All rights reserved[.]*//' "${filename}"
   fi
 
   # Do we have terminating comement character on the 'copyright' line.  If so, keep it.
   local ecm=""
-  if [[ $(echo $crl | grep -c "\\\*/") -gt 0 ]]; then
-    ecm=" */"
-    debugprint "ecm = $ecm"
-  fi
+  if [[ $(echo "${crl}" | grep -c "\\\*/") -gt 0 ]]; then ecm=" */"; fi
 
   # Replace copyright with new one
-  debugprint "sed -i s%Copyright.*%${ecrl}${ecm}% $filename"
-  sed -i "s%Copyright.*%${ecrl}${ecm}%" $filename
+  debugprint "sed -i s%Copyright.*%${ecrl}${ecm}% "${filename}""
+  sed -i "s%Copyright.*%${ecrl}${ecm}%" "${filename}"
 }
 
 # create a random filename to store our generated patch
@@ -144,7 +147,7 @@ do
   debugprint "  updating patchfile"
   diff -u "${file}" "${tmpfile1}" | \
     sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patchfile"
-  rm $tmpfile1
+  rm "${tmpfile1}"
 done
 
 # if no patch has been generated all is ok, clean up the file stub and exit

--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -95,7 +95,7 @@ function rewrite_copyright_block()
 
   # Expected Copyright line:
   local ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "
-  ecrl+=" All rights reserved."
+  ecrl+="All rights reserved."
   debugprint "ecrl = $ecrl"
 
   # If existing copyright spans two lines, reduce it to one line.

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -387,6 +387,118 @@ if [[ -x "$FPY" ]]; then
 
 fi
 
+# ------------------------------------------------------------------------------------------------ #
+# Check copyright block
+# ------------------------------------------------------------------------------------------------ #
+
+echo -ne "\n--------------------------------------------------------------------------------\n"
+echo -e "Checking modified code for copyright block conformance.\n"
+
+patchfile_cb=$(mktemp /tmp/copyright_block.patch.XXXXXXXX)
+
+# file types to parse.
+FILE_EXTS=".c .cc .h .hh .in .f90 .F90 .f .F .py"
+#FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
+FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc"
+export FILE_EXTS FILE_ENDINGS_EXCLUDE
+
+# Loop over all modified files.  Create one patch containing all changes to these files
+for file in $modifiedfiles; do
+
+  # ignore file if we do check for file extensions and the file does not match any of the
+  # extensions specified in $FILE_EXTS
+  if ! matches_extension "$file"; then continue; fi
+
+  file_nameonly=$(basename "${file}")
+  tmpfile1="/tmp/copyright-${file_nameonly}"
+
+  # Copy the file and attempt update it.
+  cp "${file}" "${tmpfile1}"
+
+  today=$(date +%Y)
+
+  # This data was found in the header comments.  It might be a single year or a range.
+  crl=$(grep Copyright $tmpfile1)
+  create_date=$(echo $crl | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
+
+  # These dates are reported by git
+  git_last_mod_date=$(git log -1 $file | grep Date | \
+                              sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
+  git_create_date=$(git log $file | grep Date | tail -n 1 | \
+                            sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
+
+  # Sanity Checks
+  [[ "${create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  # [[ "${mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  [[ "${git_last_mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  [[ "${git_create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
+    die "Existing copyright date range is corrupt. Please fix $file manually."
+  fi
+  if [[ "${git_create_date}" -gt "${today}" ]] || [[ "${git_create_date}" -lt "1990" ]]; then
+    die "Existing copyright date range is corrupt. Please fix $file manually."
+  fi
+  if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
+    die "Existing copyright date range is corrupt. Please fix $file manually."
+  fi
+
+  # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
+  # this case older data is lost, so just use whatever is in the file as the create date.
+  [[ "${git_create_date}" == "2010" ]] && git_create_date="${create_date}"
+
+  # Expected Copyright line:
+  ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "
+  ecrl+=" All rights reserved."
+
+  # If existing copyright spans two lines, reduce it to one line.
+  twolines=$(grep -A 1 Copyright $tmpfile1 | tail -n 1 | grep -c reserved)
+  if [[ $twolines -gt 0 ]]; then
+    sed -i 's/All rights reserved[.]*//' ${tmpfile1}
+  fi
+
+  # Do we have terminating comement character on the 'copyright' line.  If so, keep it.
+  ecm=""
+  if [[ $(echo $crl | grep -c "\\\*/") -gt 0 ]]; then
+    ecm=" */"
+  fi
+
+  # Replace copyright with new one
+  sed -i "s%Copyright.*%${ecrl}${ecm}%" $tmpfile1
+  diff -u "${file}" "${tmpfile1}" | \
+    sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patchfile_cb"
+  rm $tmpfile1
+
+  unset today
+  unset crl
+  unset create_date
+  unset git_last_mod_date
+  unset git_create_date
+  unset ecrl
+  unset twolines
+  unset ecm
+
+done
+
+# If the patch file is size 0, then no changes are needed.
+if [[ -s "$patchfile_cb" ]]; then
+  foundissues=1
+  echo -ne "FAIL: some files do not conform to this project's Copyright block requirements:\n"
+  # Modify files, if requested
+  if [[ -s "$patchfile_cb" ]]; then
+    if [[ "${fix_mode}" == 1 ]]; then
+      run "git apply $patchfile_cb"
+      echo -ne "\n      Changes have been made to your files to meet Copyright block guidelines."
+      echo -ne "\n      Please check the updated files and add them to your commit.\n"
+    else
+      echo -ne "      run ${0##*/} with option -f to automatically apply this patch.\n"
+      cat "$patchfile_cb"
+    fi
+  fi
+else
+  echo -n "PASS: Changes to sources conform to this project's Copyright block requirements."
+fi
+rm -f "${patchfile_cb}"
+
 #--------------------------------------------------------------------------------------------------#
 # Done
 #--------------------------------------------------------------------------------------------------#

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -419,6 +419,7 @@ for file in $modifiedfiles; do
 
   # This data was found in the header comments.  It might be a single year or a range.
   crl=$(grep Copyright "${tmpfile1}")
+  # shellcheck disable=SC2001
   create_date=$(echo "${crl}" | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
 
   # These dates are reported by git
@@ -453,7 +454,7 @@ for file in $modifiedfiles; do
   # If existing copyright spans two lines, reduce it to one line.
   twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)
   if [[ $twolines -gt 0 ]]; then
-    sed -i 's/All rights reserved[.]*//' ${tmpfile1}
+    sed -i 's/All rights reserved[.]*//' "${tmpfile1}"
   fi
 
   # Do we have terminating comement character on the 'copyright' line.  If so, keep it.

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -397,7 +397,7 @@ echo -e "Checking modified code for copyright block conformance.\n"
 patchfile_cb=$(mktemp /tmp/copyright_block.patch.XXXXXXXX)
 
 # file types to parse.
-FILE_EXTS=".c .cc .h .hh .in .f90 .F90 .f .F .py"
+FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt"
 #FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
 FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc"
 export FILE_EXTS FILE_ENDINGS_EXCLUDE

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -418,13 +418,13 @@ for file in $modifiedfiles; do
   today=$(date +%Y)
 
   # This data was found in the header comments.  It might be a single year or a range.
-  crl=$(grep Copyright $tmpfile1)
-  create_date=$(echo $crl | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
+  crl=$(grep Copyright "${tmpfile1}")
+  create_date=$(echo "${crl}" | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
 
   # These dates are reported by git
-  git_last_mod_date=$(git log -1 $file | grep Date | \
+  git_last_mod_date=$(git log -1 "${file}" | grep Date | \
                               sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
-  git_create_date=$(git log $file | grep Date | tail -n 1 | \
+  git_create_date=$(git log "${file}" | grep Date | tail -n 1 | \
                             sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
 
   # Sanity Checks
@@ -451,22 +451,22 @@ for file in $modifiedfiles; do
   ecrl+=" All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
-  twolines=$(grep -A 1 Copyright $tmpfile1 | tail -n 1 | grep -c reserved)
+  twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)
   if [[ $twolines -gt 0 ]]; then
     sed -i 's/All rights reserved[.]*//' ${tmpfile1}
   fi
 
   # Do we have terminating comement character on the 'copyright' line.  If so, keep it.
   ecm=""
-  if [[ $(echo $crl | grep -c "\\\*/") -gt 0 ]]; then
+  if [[ $(echo "${crl}" | grep -c "\\\*/") -gt 0 ]]; then
     ecm=" */"
   fi
 
   # Replace copyright with new one
-  sed -i "s%Copyright.*%${ecrl}${ecm}%" $tmpfile1
+  sed -i "s%Copyright.*%${ecrl}${ecm}%" "${tmpfile1}"
   diff -u "${file}" "${tmpfile1}" | \
     sed -e "1s|--- |--- a/|" -e "2s|+++ ${tmpfile1}|+++ b/${file}|" >> "$patchfile_cb"
-  rm $tmpfile1
+  rm "${tmpfile1}"
 
   unset today
   unset crl


### PR DESCRIPTION
### Background

* This feature was suggested by @brryan based on similar functionality from https://github.com/lanl/parthenon.

### Description of changes

* For modified files, ensure that the copyright dates/text are correct.
  * Inspect file types: `.c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt`
* [x] To do: Provide a sanity check in `check_style.sh` for devs who don't use our pre-commit hooks.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
