### PR TITLE
Use softer adjustment for start date for Copyright block.

### DIFF
--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -91,7 +91,7 @@ function rewrite_copyright_block()
 
   # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
   # this case older data is lost, so just use whatever is in the file as the create date.
-  [[ "${git_create_date}" == "2010" ]] && git_create_date="${create_date}"
+  [[ "${git_create_date}" -lt "2011" ]] && git_create_date="${create_date}"
 
   # Expected Copyright line:
   local ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -445,7 +445,7 @@ for file in $modifiedfiles; do
 
   # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
   # this case older data is lost, so just use whatever is in the file as the create date.
-  [[ "${git_create_date}" == "2010" ]] && git_create_date="${create_date}"
+  [[ "${git_create_date}" -lt "2011" ]] && git_create_date="${create_date}"
 
   # Expected Copyright line:
   ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "


### PR DESCRIPTION
### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
