### PR TITLE
Tweak flags used by gcc/g++

### DIFF
--- a/config/unix-g++.cmake
+++ b/config/unix-g++.cmake
@@ -38,8 +38,8 @@ if(NOT CXX_FLAGS_INITIALIZED)
       "yes"
       CACHE INTERNAL "using draco settings.")
   string(APPEND CMAKE_C_FLAGS
-         " -g -Wall -Wextra -pedantic -Wcast-align -Wpointer-arith -Wfloat-equal -Wunused-macros"
-         " -Wshadow -Wformat=2")
+         " -g -Wall -Wextra -pedantic -Wcast-align -Wconversion -Wpointer-arith -Wfloat-equal"
+         " -Wunused-macros -Wshadow -Wformat=2")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
     string(APPEND CMAKE_C_FLAGS " -Wnull-dereference")
   endif()
@@ -92,7 +92,7 @@ if(NOT CXX_FLAGS_INITIALIZED)
   endif()
 
   string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual -Wsuggest-override")
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
   set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ include(component_macros)
 
 # Extra 'draco-only' flags
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0)
-  toggle_compiler_flag(TRUE "-Wconversion -Wdouble-promotion" "CXX" "DEBUG")
+  toggle_compiler_flag(TRUE "-Wdouble-promotion" "CXX" "DEBUG")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   string(REPLACE "/W2" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   string(REPLACE "/W2" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
### Background

* Respond to a a request for some new warning falgs.

### Purpose of Pull Request

+ Fixes #1110

### Description of changes

+ Enable `-Wconversion` for gcc/g++.
+ Enable `-Wwarn-override` for g++ Debug builds.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
