### PR TITLE
Add region output, with all the cells, to x3d_generator.py.

### DIFF
--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -188,5 +188,10 @@ for i in range(2 * mesh.ndim):
                np.unique(np.array(mesh.nodes_per_side[i]) + 1), fmt='%d')
 
 # ------------------------------------------------------------------------------------------------ #
+# -- write out the mesh region files based on matid
+# -- todo: map (dictionary) matid to cell lists (this is only for X3D, so it's not a mesh task)
+np.savetxt(fname + '.Reg' + str(1) + '.in', np.arange(1, mesh.num_cells + 1), fmt='%d')
+
+# ------------------------------------------------------------------------------------------------ #
 # end of x3d_generator.py
 # ------------------------------------------------------------------------------------------------ #


### PR DESCRIPTION
Note: it is planned to eventually permit multiple regions/matids.

### Background

* Some dependent packages may need to parse region files corresponding to the matid field in X3D.
* Eventually, `x3d_generator.py` should support multiple simple regions (i.e. matids), but the intent here is to merely ensure compatibility with parsers.

### Purpose of Pull Request

* Add region output, with all the cells, to x3d_generator.py for parsers requiring X3D region files.

### Description of changes

* Add region output, with all the cells, to x3d_generator.py.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
