### PR TITLE
Fix static builds after PR1051 was merged

### DIFF
--- a/src/kde/kde.i.hh
+++ b/src/kde/kde.i.hh
@@ -72,20 +72,20 @@ inline double kde::log_inv_transform(const double log_value, const double bias) 
 }
 
 //! Lambda to calculate a vector
-auto calc_vec = [](const auto &v1, const auto &v2) {
+const auto calc_vec = [](const auto &v1, const auto &v2) {
   Require(v1.size() == 3);
   Require(v2.size() == 3);
   return std::array<double, 3>{v2[0] - v1[0], v2[1] - v1[1], v2[2] - v1[2]};
 };
 
 //! Lambda to calculate vector magnitude
-auto calc_mag = [](const auto &v) {
+const auto calc_mag = [](const auto &v) {
   Require(v.size() == 3);
   return sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
 };
 
 //! Lambda to calculate unit vector
-auto calc_unit_vec = [](const auto &v) {
+const auto calc_unit_vec = [](const auto &v) {
   Require(v.size() == 3);
   const double mag = calc_mag(v);
   return std::array<double, 3>{v[0] / mag, v[1] / mag, v[2] / mag};


### PR DESCRIPTION
### Background

* Static builds were picking up duplicate definitions associated with the new lambda functions in the KDE class. Marking those function as const seems to fix this issue (my guess is this allows the compiler to recognize them as inline functions). 

### Purpose of Pull Request

*  fixes https://re-git.lanl.gov/draco/draco/-/issues/1356

### Description of changes

* add const the three helper lambdas in the KDE class

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
