### PR TITLE
Add option to generate arbitrary rectangular (prism) regions.

### DIFF
--- a/src/mesh/python/README.md
+++ b/src/mesh/python/README.md
@@ -30,6 +30,12 @@ in [0,1]x[0,2]x[0,4]:
 ./x3d_generator.py --mesh_type orth_3d_mesh --num_per_dim 4 4 4 --bnd_per_dim 0 1 0 2 0 4
 ```
 
+To create the same mesh, but with distinct upper-half and lower-half regions (lower is region id 2, upper is id 1):
+
+```bash
+./x3d_generator.py --mesh_type orth_3d_mesh --num_per_dim 4 4 4 --bnd_per_dim 0 1 0 2 0 4 --reg_ids 1 2  --reg_bnd_per_dim  0 1 0 2 2 4  0 1 0 2 0 2
+```
+
 To display a plot of the generated mesh file:
 
 ```bash

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -76,6 +76,7 @@ if (len(args.reg_ids) > 0):
     reg_dict = {reg_id: [] for reg_id in reg_ids}
     nmats = len(reg_ids)
     for cell in range(mesh.num_cells):
+        # TODO: make coordinate averaging a method for each mesh_type (permit distinct approaches)
         # -- initialize container for cell average coordinate
         coord_av = np.array([0.0, 0.0, 0.0])
         # -- average coordinates over faces first
@@ -106,9 +107,11 @@ if (len(args.reg_ids) > 0):
                 matids[cell] = reg_ids[imat]
                 reg_dict[reg_ids[imat]].append(cell + 1)
 
-    # -- remove region cells from universal region
-    for reg_id in reg_ids[1:]:
-        reg_dict[0] = [cell for cell in reg_dict[0] if cell not in reg_dict[reg_id]]
+    # -- remove region cells from universal region and lower-index regions
+    # -- this implies that this region takes precedence over regions earlier in the iteration
+    for j in range(nmats - 1):
+        for reg_id in reg_ids[j + 1:]:
+            reg_dict[j] = [cell for cell in reg_dict[j] if cell not in reg_dict[reg_id]]
 
     # -- convert dictionary of lists to dictionary of numpy arrays
     for reg_id in reg_ids:

--- a/src/mesh/python/x3d_generator.py
+++ b/src/mesh/python/x3d_generator.py
@@ -22,11 +22,15 @@ parser.add_argument('-mt', '--mesh_type', type=str, default='orth_2d_mesh',
 parser.add_argument('-nd', '--num_per_dim', type=int, nargs='+', default=[1, 1],
                     help='Number of cells per dimension.')
 parser.add_argument('-bd', '--bnd_per_dim', type=float, nargs='+', default=[0.0, 1.0, 0.0, 1.0],
-                    help='Length per dimension.')
+                    help='Bounds per dimension.')
 parser.add_argument('--name', type=str, default='mesh',
                     help='Select file name (will be prefixed with x3d. and sufficed with .in).')
 parser.add_argument('--num_cells', type=int, default=100,
                     help='Number of cells')
+# -- optional region/matid input
+parser.add_argument('--reg_ids', type=int, nargs='+', default=[], help='List of region ids.')
+parser.add_argument('--reg_bnd_per_dim', type=float, nargs='+', default=[],
+                    help='Bounds per dimension of region.')
 
 # -- parse arguments from command line
 args = parser.parse_args()
@@ -42,6 +46,10 @@ assert (ndim > 0), 'len(args.num_per_dim) <= 0'
 assert (ndim < 4), 'len(args.num_per_dim) >= 4'
 assert (len(args.bnd_per_dim) == 2 * ndim), 'len(args.bnd_per_dim) != 2 * ndim'
 
+# -- sanity check optional region input
+assert(len(args.reg_bnd_per_dim) == 2 * ndim * len(args.reg_ids)), \
+    'len(args.reg_bnd_per_dim) != 2 * ndim * len(args.reg_ids)'
+
 # -- de-serialize spatial bound list
 bnd_per_dim = [[args.bnd_per_dim[2 * i], args.bnd_per_dim[2 * i + 1]] for i in range(ndim)]
 
@@ -50,6 +58,65 @@ if args.mesh_type in ['orth_2d_mesh', 'orth_3d_mesh']:
     mesh = mesh_type_dict[args.mesh_type](bnd_per_dim, args.num_per_dim)
 elif args.mesh_type in ['vor_2d_mesh']:
     mesh = mesh_type_dict[args.mesh_type](bnd_per_dim, args.num_cells)
+
+# ------------------------------------------------------------------------------------------------ #
+# -- construct matid and region dictionary if region data arguments are available
+
+# -- set matid data (using region ids and bounds if available)
+matids = np.zeros(mesh.num_cells, dtype=int)
+reg_dict = {}
+reg_ids = []
+if (len(args.reg_ids) > 0):
+    # -- prepend reg_ids and reg_bnd_per_dim with universal region
+    reg_ids = args.reg_ids
+    reg_bnd_per_dim = args.reg_bnd_per_dim
+    reg_ids = [0] + reg_ids
+    reg_bnd_per_dim = args.bnd_per_dim + reg_bnd_per_dim
+    # -- initialize dictionary of cell lists
+    reg_dict = {reg_id: [] for reg_id in reg_ids}
+    nmats = len(reg_ids)
+    for cell in range(mesh.num_cells):
+        # -- initialize container for cell average coordinate
+        coord_av = np.array([0.0, 0.0, 0.0])
+        # -- average coordinates over faces first
+        for face in mesh.faces_per_cell[cell]:
+            # -- initialize container for face average coordinate
+            coord_face_av = np.array([0.0, 0.0, 0.0])
+            # -- get the node coordinates for this face to average
+            for node in mesh.nodes_per_face[face]:
+                for idim in range(mesh.ndim):
+                    coord_face_av[idim] += mesh.coordinates_per_node[node, idim]
+            # -- finish face average by dividing by number of nodes per face
+            coord_face_av /= mesh.num_nodes_per_face[face]
+            # -- add face average to cell average
+            coord_av += coord_face_av
+        # -- finish cell average by dividing by number of faces per cell
+        coord_av /= mesh.num_faces_per_cell[cell]
+        # -- check which region to which this cell belongs
+        for imat in range(nmats):
+            mat_has_cell = True
+            # -- check coord_av against region bounds along each dimension
+            m_off = 2 * ndim * imat
+            for idim in range(mesh.ndim):
+                mat_has_cell = mat_has_cell and \
+                    coord_av[idim] >= reg_bnd_per_dim[2 * idim + m_off] and \
+                    coord_av[idim] < reg_bnd_per_dim[2 * idim + 1 + m_off]
+            # -- set mat/reg data if the cell is in the region
+            if (mat_has_cell):
+                matids[cell] = reg_ids[imat]
+                reg_dict[reg_ids[imat]].append(cell + 1)
+
+    # -- remove region cells from universal region
+    for reg_id in reg_ids[1:]:
+        reg_dict[0] = [cell for cell in reg_dict[0] if cell not in reg_dict[reg_id]]
+
+    # -- convert dictionary of lists to dictionary of numpy arrays
+    for reg_id in reg_ids:
+        reg_dict[reg_id] = np.array(reg_dict[reg_id], dtype=int)
+
+else:
+    reg_ids = [0]
+    reg_dict[0] = np.arange(1, mesh.num_cells + 1)
 
 # ------------------------------------------------------------------------------------------------ #
 # -- write out the main mesh file in x3d format
@@ -164,12 +231,14 @@ fo.write('end_ghost_nodes\n')
 # -- space
 fo.write('\n')
 
-# -- unused data per cell
+# -- write matids per cell
 fo.write('cell_data\n')
 fo.write('matid\n')
 for cell in range(mesh.num_cells):
-    fo.write(str(cell + 1) + '         0\n')
+    fo.write('{0:10d}{1:10d}\n'.format(cell + 1, matids[cell]))
 fo.write('end_matid\n')
+
+# -- unused data (possibly supposed to be per cell)
 fo.write('partelm\n')
 fo.write('         1\n')
 fo.write('end_partelm\n')
@@ -190,7 +259,13 @@ for i in range(2 * mesh.ndim):
 # ------------------------------------------------------------------------------------------------ #
 # -- write out the mesh region files based on matid
 # -- todo: map (dictionary) matid to cell lists (this is only for X3D, so it's not a mesh task)
-np.savetxt(fname + '.Reg' + str(1) + '.in', np.arange(1, mesh.num_cells + 1), fmt='%d')
+j = 0
+for i in range(len(reg_ids)):
+    # -- only save if region has cells
+    if (np.size(reg_dict[reg_ids[i]]) > 0):
+        np.savetxt(fname + '.Reg' + str(j + 1) + '.in', reg_dict[reg_ids[i]], fmt='%d')
+        # -- incrment region counter
+        j += 1
 
 # ------------------------------------------------------------------------------------------------ #
 # end of x3d_generator.py


### PR DESCRIPTION
### Background

* It can be useful to delineate regions for an X3D mesh, where each region can have different properties ascribed to it.

### Purpose of Pull Request

* Add ability to specify any number of rectangular (prism) regions with arbitrary matids (called reg_ids on command line).
* For the changeset here, the `matid` field in the main X3D file is consistent with the region file cell partitioning (but the region file enumeration - Reg1, Reg2, etc - is not equal to the matid value per region).

### Description of changes

+ Add optional list inputs for region id and region bounds:
  * `--reg_ids` is a list of matids per region,
  * `--reg_bnd_per_dim` is a serialized list of boundaries dimensions, similar to `--bnd_per_dim` but for each value in `--reg_ids` (in the same order). 
+ Sanity check region list sizes if they have been specified.
+ Calculate a basic cell center and check if it is in the region.
+ Use region ids for matid field and create region file output.
+ Default to one universal region (matid=0) if regions unspecified.
+ Add example to README.md.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
