### PR TITLE
Fix a bug in pre-commit-copyright and other shell script fixes.

### DIFF
--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -304,7 +304,7 @@ function rdp()
     echo "FATAL ERROR: expecting a machine name as an argument.  Example: 'rdp centipede'."
     exit 1
   fi
-  xfreerdp /sec:rdp +clipboard /dynamic-resolution /size:90% /v:$1
+  xfreerdp /sec:rdp +clipboard /dynamic-resolution /size:90% "/v:$1"
 }
 export -f rdp
 

--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -1,42 +1,46 @@
 #!/bin/bash
-## -*- Mode: bash -*-
-##-----------------------------------------------------------------------------------------------##
-## File  : environment/bashrc/bash_functions.sh
-## Date  : Tuesday, May 31, 2016, 14:48 pm
-## Author: Kelly Thompson
-## Note  : Copyright (C) 2016-2020, Triad National Security, LLC., All rights are reserved.
-##-----------------------------------------------------------------------------------------------##
-##
-## Summary: Misc bash functions useful during development of code.
-##
-## Functions
-## ---------
-##
-## whichall <string> - show path of all commands in path that match <string>
-##
-## cleanemacs        - recursively remove ~ files, .flc files and .rel files.
-##
-## findsymbol <sym>  - search all libraries (.so and .a files) in the current directory for symbol
-##                     <sym>.
-##
-## npwd              - function used to set the prompt under bash.
-##
-## xfstatus          - report status of transfer.lanl.gov
-##
-## rm_from_path      - remove a directory from $PATH
-##
-## add_to_path       - add a directory to $PATH
-##
-## proxy             - (un)set http_proxy variables
-##
-## fn_exists         - test if a bash function is defined
-##
-## run               - echo then evaluate a bash command
-##
-## rdde              - reload the default draco environment
-##
-## qrm               - quick remove (for lustre filesystems).
-##-----------------------------------------------------------------------------------------------##
+# -*- Mode: bash -*-
+# ------------------------------------------------------------------------------------------------ #
+# File  : environment/bashrc/bash_functions.sh
+# Date  : Tuesday, May 31, 2016, 14:48 pm
+# Author: Kelly Thompson
+# Note  : Copyright (C) 2019-2021 Triad National Security, LLC., All rights reserved.
+# ------------------------------------------------------------------------------------------------ #
+
+#
+# Summary: Misc bash functions useful during development of code.
+#
+# Functions
+# ---------
+#
+# add_to_path       - add a directory to $PATH
+#
+# cleanemacs        - recursively remove ~ files, .flc files and .rel files.
+#
+# findsymbol <sym>  - search all libraries (.so and .a files) in the current directory for symbol
+#                     <sym>.
+#
+# fn_exists         - test if a bash function is defined
+#
+# npwd              - function used to set the prompt under bash.
+#
+# proxy             - (un)set http_proxy variables
+#
+# qrm               - quick remove (for lustre filesystems).
+#
+# rdde              - reload the default draco environment
+#
+# rdp               - start an xfree rdp session (Cortez)
+#
+# rm_from_path      - remove a directory from $PATH
+#
+# run               - echo then evaluate a bash command
+#
+# whichall <string> - show path of all commands in path that match <string>
+#
+# xfstatus          - report status of transfer.lanl.gov
+# ------------------------------------------------------------------------------------------------ #
+
 
 # pragma once
 if [[ $(type dbf_pragma_once 2>&1 | grep -c "bash: type: ") != 0 ]]; then
@@ -48,9 +52,9 @@ if [[ "${verbose:=false}" ==  "true" ]]; then
   echo "in draco/environment/bashrc/bash_functions.sh";
 fi
 
-##-----------------------------------------------------------------------------------------------##
-## Find all matches in PATH (not just the first one)
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Find all matches in PATH (not just the first one)
+#-----------------------------------------------------------------------------------------------#
 
 function whichall ()
 {
@@ -60,9 +64,9 @@ function whichall ()
 }
 export -f whichall
 
-##-----------------------------------------------------------------------------------------------##
-## Recursively delete all ~ files.
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Recursively delete all ~ files.
+#-----------------------------------------------------------------------------------------------#
 
 function cleanemacs
 {
@@ -79,12 +83,12 @@ function cleanemacs
 }
 export -f cleanemacs
 
-##-----------------------------------------------------------------------------------------------##
-## Used for formatting PROMPT.
-## $HOME            -> ~
-## ...scratch...    -> #
-## .../projects/... -> @
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Used for formatting PROMPT.
+# $HOME            -> ~
+# ...scratch...    -> #
+# .../projects/... -> @
+#-----------------------------------------------------------------------------------------------#
 parse_git_branch() {
   git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
 }
@@ -151,14 +155,14 @@ export -f npwd_alt
 # PROMPT_COMMAND='DIR=`pwd|sed -e "s!$HOME!~!"`; if [ ${#DIR} -gt 30 ]; then CurDir=${DIR:0:12}...${DIR:${#DIR}-15}; else CurDir=$DIR; fi'
 # PS1="[\$CurDir] \$ "
 
-##-----------------------------------------------------------------------------------------------##
-## Usage:
-##    findsymbol <symbol>
-##
-## Searches all .a and .so files in local directory for symbol
-## <symbol>.  If found, the script provides the name of the library
-## that contains the symbol.
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Usage:
+#    findsymbol <symbol>
+#
+# Searches all .a and .so files in local directory for symbol
+# <symbol>.  If found, the script provides the name of the library
+# that contains the symbol.
+#-----------------------------------------------------------------------------------------------#
 
 function findsymbol()
 {
@@ -181,15 +185,15 @@ function findsymbol()
 }
 export -f findsymbol
 
-##-----------------------------------------------------------------------------------------------##
-## Transfer 2.0 (Mercury replacement)
-## Ref: http://transfer.lanl.gov
-##
-## Examples:
-##   xfpush foo.txt
-##   xfstatus
-##   xfpull foo.txt
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Transfer 2.0 (Mercury replacement)
+# Ref: http://transfer.lanl.gov
+#
+# Examples:
+#   xfpush foo.txt
+#   xfstatus
+#   xfpull foo.txt
+#-----------------------------------------------------------------------------------------------#
 
 function xfstatus()
 {
@@ -197,21 +201,21 @@ function xfstatus()
 }
 export -f xfstatus
 
-##-----------------------------------------------------------------------------------------------##
-## If string is found in PATH, remove it.
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# If string is found in PATH, remove it.
+#-----------------------------------------------------------------------------------------------#
 function rm_from_path ()
 {
   export PATH="${PATH//${1}/}"
 }
 export -f rm_from_path
 
-##-----------------------------------------------------------------------------------------------##
-## If path is a directory add it to PATH (if not already in PATH)
-##
-## Use:
-##   add_to_path <path> TEXINPUTS|BSTINPUTS|BIBINPUTS|PATH
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# If path is a directory add it to PATH (if not already in PATH)
+#
+# Use:
+#   add_to_path <path> TEXINPUTS|BSTINPUTS|BIBINPUTS|PATH
+#-----------------------------------------------------------------------------------------------#
 function add_to_path ()
 {
   case $2 in
@@ -231,10 +235,10 @@ function add_to_path ()
 }
 export -f add_to_path
 
-##-----------------------------------------------------------------------------------------------##
-## Toggle LANL proxies on/off
-## https://wiki.archlinux.org/index.php/proxy_settings
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Toggle LANL proxies on/off
+# https://wiki.archlinux.org/index.php/proxy_settings
+#-----------------------------------------------------------------------------------------------#
 function proxy()
 {
   if [[ ! ${http_proxy} ]]; then
@@ -259,9 +263,9 @@ function proxy()
 }
 export -f proxy
 
-##-----------------------------------------------------------------------------------------------##
-## Test to determine if named bash function exists in the current environment.
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Test to determine if named bash function exists in the current environment.
+#-----------------------------------------------------------------------------------------------#
 function fn_exists()
 {
   type "$1" 2>/dev/null | grep -q 'is a function'
@@ -271,18 +275,18 @@ function fn_exists()
 }
 export -f fn_exists
 
-##-----------------------------------------------------------------------------------------------##
-## Echo commands before execution (used in scripts)
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Echo commands before execution (used in scripts)
+#-----------------------------------------------------------------------------------------------#
 function run () {
   echo "$1"
   if [[ "${dry_run:-notset}" != "notset" ]]; then eval "$1"; fi
 }
 export -f run
 
-##-----------------------------------------------------------------------------------------------##
-## Reset the draco developer environment
-##-----------------------------------------------------------------------------------------------##
+#-----------------------------------------------------------------------------------------------#
+# Reset the draco developer environment
+#-----------------------------------------------------------------------------------------------#
 function rdde ()
 {
   unset DRACO_BASHRC_DONE
@@ -290,6 +294,19 @@ function rdde ()
   source "${DRACO_ENV_DIR}/bashrc/.bashrc"
 }
 export -f rdde
+
+# ------------------------------------------------------------------------------------------------ #
+# Start a Remote Desktop Session: `rdp mymachine`
+# ------------------------------------------------------------------------------------------------ #
+function rdp()
+{
+  if [[ $1 == "" ]]; then
+    echo "FATAL ERROR: expecting a machine name as an argument.  Example: 'rdp centipede'."
+    exit 1
+  fi
+  xfreerdp /sec:rdp +clipboard /dynamic-resolution /size:90% /v:$1
+}
+export -f rdp
 
 #--------------------------------------------------------------------------------------------------#
 # Quick remove: instead of 'rm -rf', mv the directory to .../trash/tmpname

--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -26,9 +26,9 @@ debugprint "running pre-commit-copyright"
 # DELETE_OLD_PATCHES=true
 
 # file types to parse.
-FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt"
+FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .sh .txt"
 #FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
-FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc"
+FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc check_style.sh"
 export FILE_EXTS FILE_ENDINGS_EXCLUDE
 
 ##################################################################
@@ -58,7 +58,7 @@ function rewrite_copyright_block()
 
   # This data was found in the header comments.  It might be a single year or a range.
   local crl
-  crl=$(grep Copyright "${filename}")
+  crl=$(grep Copyright "${filename}" | head -n 1)
   local create_date
   # shellcheck disable=SC2001
   create_date=$(echo "${crl}" | sed -e 's/.* \([0-9][0-9]*\).*/\1/')
@@ -75,10 +75,10 @@ function rewrite_copyright_block()
   debugprint "$create_date $git_last_mod_date $git_create_date"
 
   # Sanity Checks
-  [[ "${create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  [[ "${create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line (err 1)"
   # [[ "${mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
-  [[ "${git_last_mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
-  [[ "${git_create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  [[ "${git_last_mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line (err 2)"
+  [[ "${git_create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line (err 3)"
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
     die "Existing copyright date range is corrupt. Please fix $filename manually."
   fi
@@ -119,7 +119,8 @@ prefix="pre-commit-copyright"
 suffix="$(date +%s)"
 
 # clean up any older fprettify patches
-# $DELETE_OLD_PATCHES && rm -f /tmp/$prefix-*. &> /dev/null
+# $DELETE_OLD_PATCHES && rm -f /tmp/$USER/$prefix-*. &> /dev/null
+mkdir -p "/tmp/$USER" || die "Could not create /tmp/$USER"
 patchfile=$(mktemp "/tmp/$USER/${prefix}-${suffix}.patch.XXXXXXXX")
 
 # create one patch containing all changes to the files
@@ -140,7 +141,7 @@ do
 
   debugprint "Looking at $file"
   file_nameonly=$(basename "${file}")
-  tmpfile1="/tmp/${prefix}-$file_nameonly"
+  tmpfile1="/tmp/$USER/${prefix}-$file_nameonly"
 
   # Copy the file and attempt update it.
   cp "${file}" "${tmpfile1}"

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -130,7 +130,7 @@ echo -ne "\n--------------------------------------------------------------------
 echo -ne "Checking modified C/C++ code for style conformance...\n\n"
 
 mkdir -p "/tmp/$USER" || die "Could not create /tmp/$USER"
-patchfile_c=$(mktemp /tmp/$USER/gcf.patch.XXXXXXXX)
+patchfile_c=$(mktemp "/tmp/$USER/gcf.patch.XXXXXXXX")
 
 # don't actually modify the files (originally we compared to branch 'develop', but let's try
 # ORIG_HEAD or maybe use CI variables like TRAVIS_BRANCH or CI_MERGE_REQUEST_TARGET_BRANCH_NAME).
@@ -205,7 +205,7 @@ if [[ -x "${CMF}" ]]; then
   echo -ne "\n--------------------------------------------------------------------------------\n"
   echo -ne "Checking modified CMake code for style conformance...\n\n"
 
-  patchfile_cmf=$(mktemp /tmp/$USER/cmf.patch.XXXXXXXX)
+  patchfile_cmf=$(mktemp "/tmp/$USER/cmf.patch.XXXXXXXX")
 
   # file types to parse.
   FILE_EXTS=".cmake"
@@ -334,8 +334,8 @@ if [[ -x "$FPY" ]]; then
   echo -ne "\n--------------------------------------------------------------------------------\n"
   echo -e "Checking modified F90 code for style conformance.\n"
 
-  patchfile_f90=$(mktemp /tmp/$USER/fpy.patch.XXXXXXXX)
-  lintfile_f90=$(mktemp /tmp/$USER/fpy.lint.XXXXXXXX)
+  patchfile_f90=$(mktemp "/tmp/$USER/fpy.patch.XXXXXXXX")
+  lintfile_f90=$(mktemp "/tmp/$USER/fpy.lint.XXXXXXXX")
 
   # file types to parse.
   FILE_EXTS=".f90 .F90 .f .F"
@@ -403,7 +403,7 @@ fi
 echo -ne "\n--------------------------------------------------------------------------------\n"
 echo -e "Checking modified code for copyright block conformance.\n"
 
-patchfile_cb=$(mktemp /tmp/$USER/copyright_block.patch.XXXXXXXX)
+patchfile_cb=$(mktemp "/tmp/$USER/copyright_block.patch.XXXXXXXX")
 
 # file types to parse.
 FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt"

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -119,6 +119,9 @@ t) fix_mode=0 ;;
 esac
 done
 
+# The copyright block check needs the full history
+run "git fetch --depth=1000000"
+
 #--------------------------------------------------------------------------------------------------#
 # Test C++ code with git-clang-format
 #--------------------------------------------------------------------------------------------------#
@@ -126,7 +129,8 @@ done
 echo -ne "\n--------------------------------------------------------------------------------\n"
 echo -ne "Checking modified C/C++ code for style conformance...\n\n"
 
-patchfile_c=$(mktemp /tmp/gcf.patch.XXXXXXXX)
+mkdir -p "/tmp/$USER" || die "Could not create /tmp/$USER"
+patchfile_c=$(mktemp /tmp/$USER/gcf.patch.XXXXXXXX)
 
 # don't actually modify the files (originally we compared to branch 'develop', but let's try
 # ORIG_HEAD or maybe use CI variables like TRAVIS_BRANCH or CI_MERGE_REQUEST_TARGET_BRANCH_NAME).
@@ -157,7 +161,7 @@ else
     cat "${patchfile_c}"
   else
     echo -ne "      run clang-formt -i < file> to fix files, or"
-    echo -e  " run ${0##*/} with option -f to automatically apply this patch.\n"
+    echo -e  "      run ${0##*/} with option -f to automatically apply this patch.\n"
     cat "${patchfile_c}"
   fi
 fi
@@ -187,18 +191,21 @@ if [[ $CMF ]]; then
     echo "         partially disabled (cmake-format, cmake-lint)"
     unset CMF
   fi
-  if ! [[ -f "${rscriptdir}/../.cmake-format.py" ]]; then unset CMF; fi
+  if ! [[ -f "${rscriptdir}/../../.cmake-format.py" ]]; then
+    unset CMF;
+    echo "WARNING: Missing .cmake-format.py configuration file, skipping cmake-format checks."
+  fi
 fi
 
 DIFFVER=$(diff --version | head -n 1 | sed -e 's/.*[ ]\([0-9.]\)/\1/')
 [[ $(version_gt "3.4" "${DIFFVER}") ]] && DIFFCOLOR="--color"
 
-if [[ -x $CMF ]]; then
+if [[ -x "${CMF}" ]]; then
 
   echo -ne "\n--------------------------------------------------------------------------------\n"
   echo -ne "Checking modified CMake code for style conformance...\n\n"
 
-  patchfile_cmf=$(mktemp /tmp/cmf.patch.XXXXXXXX)
+  patchfile_cmf=$(mktemp /tmp/$USER/cmf.patch.XXXXXXXX)
 
   # file types to parse.
   FILE_EXTS=".cmake"
@@ -213,7 +220,8 @@ if [[ -x $CMF ]]; then
     if ! matches_extension "$file"; then continue; fi
 
     file_nameonly=$(basename "${file}")
-    tmpfile1="/tmp/cmf-${file_nameonly}"
+    tmpfile1="/tmp/$USER/cmf-${file_nameonly}"
+    echo "==> cmake-format ${file}"
     cp -f "${file}" "${tmpfile1}"
     $CMF -c "${rscriptdir}/../.cmake-format.py" -i "${tmpfile1}" &> /dev/null
     # color output is possible if diff -version >= 3.4 with option `--color`
@@ -274,6 +282,7 @@ if [[ -x $CML ]]; then
   FILE_EXTS=".cmake"
   FILE_ENDINGS_INCLUDE="CMakeLists.txt"
   # FILE_ENDINGS_EXLCUDE=".cmake.in"
+  export FILE_EXTS FILE_ENDINGS_INCLUDE
 
   cml_issues=0
   # Loop over all modified cmake files.  Create one patch containing all changes to these files
@@ -325,8 +334,8 @@ if [[ -x "$FPY" ]]; then
   echo -ne "\n--------------------------------------------------------------------------------\n"
   echo -e "Checking modified F90 code for style conformance.\n"
 
-  patchfile_f90=$(mktemp /tmp/fpy.patch.XXXXXXXX)
-  lintfile_f90=$(mktemp /tmp/fpy.lint.XXXXXXXX)
+  patchfile_f90=$(mktemp /tmp/$USER/fpy.patch.XXXXXXXX)
+  lintfile_f90=$(mktemp /tmp/$USER/fpy.lint.XXXXXXXX)
 
   # file types to parse.
   FILE_EXTS=".f90 .F90 .f .F"
@@ -342,7 +351,7 @@ if [[ -x "$FPY" ]]; then
     if ! matches_extension "$file"; then continue; fi
 
     file_nameonly=$(basename "${file}")
-    tmpfile1="/tmp/f90-format-${file_nameonly}"
+    tmpfile1="/tmp/$USER/f90-format-${file_nameonly}"
 
     # 1. These issues can be fixed automatically.
     "$FPY" -sS "${file}" &> "${tmpfile1}"
@@ -394,12 +403,12 @@ fi
 echo -ne "\n--------------------------------------------------------------------------------\n"
 echo -e "Checking modified code for copyright block conformance.\n"
 
-patchfile_cb=$(mktemp /tmp/copyright_block.patch.XXXXXXXX)
+patchfile_cb=$(mktemp /tmp/$USER/copyright_block.patch.XXXXXXXX)
 
 # file types to parse.
 FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt"
 #FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
-FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc"
+FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc check_style.sh"
 export FILE_EXTS FILE_ENDINGS_EXCLUDE
 
 # Loop over all modified files.  Create one patch containing all changes to these files
@@ -410,7 +419,7 @@ for file in $modifiedfiles; do
   if ! matches_extension "$file"; then continue; fi
 
   file_nameonly=$(basename "${file}")
-  tmpfile1="/tmp/copyright-${file_nameonly}"
+  tmpfile1="/tmp/$USER/copyright-${file_nameonly}"
 
   # Copy the file and attempt update it.
   cp "${file}" "${tmpfile1}"
@@ -449,7 +458,7 @@ for file in $modifiedfiles; do
 
   # Expected Copyright line:
   ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "
-  ecrl+=" All rights reserved."
+  ecrl+="All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
   twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)


### PR DESCRIPTION
### Background

* @along reported that the `pre-commit-copyright` script fails when `/tmp/$USER` doesn't exist.
* Also provide a couple of small changes to environments/shell scripts.

### Description of changes

+ Pre-commit hooks and `check_style.sh` expect the path `/tmp/$USER` to exist.  Create this path if it doesn't already exist.
+ For the copyright block check, also check shell scripts (extension `.sh`), but exclude `check_style.sh` as the script logic gets confused for this file (too many `Copyright` strings).
+ Add bash function `rdp` (runs `xfreerdp`).  This is useful for running desktop-on-demand Win10 sessions from the Cortez network.  Also, cleanup comment formatting in `bash_functions.sh`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
