### PR TITLE
make origin and target write size match in the mpi_put call

### DIFF
--- a/src/kde/quick_index.cc
+++ b/src/kde/quick_index.cc
@@ -191,7 +191,7 @@ auto put_lambda = [](auto &put, auto &put_buffer, auto &put_size, auto &win) {
   // loop over all ranks we need to send this buffer too.
   for (auto &putv : put.second) {
     const int put_rank = putv[0];
-    const int put_offset = putv[2];
+    const int put_offset = putv[1];
     // This is dumb, but we need to write in chunks because MPI_Put writes
     // junk with large (>10,000) buffer sizes.
     int chunk_size = 1000;

--- a/src/kde/quick_index.cc
+++ b/src/kde/quick_index.cc
@@ -167,7 +167,7 @@ quick_index::quick_index(const size_t dim_, const std::vector<std::array<double,
               max_put_buffer_size = map.second.size();
 
             // build up map data
-            put_window_map[map.first].push_back(std::array<int, 3>{rec_proc, offset});
+            put_window_map[map.first].push_back(std::array<int, 2>{rec_proc, offset});
             offset += static_cast<int>(map.second.size());
           }
         }

--- a/src/kde/quick_index.cc
+++ b/src/kde/quick_index.cc
@@ -3,7 +3,7 @@
  * \file   kde/quick_index.cc
  * \author Mathew Cleveland
  * \brief  Explicitly defined quick_index functions.
- * \note   Copyright (C) 2021 Triad National Security, LLC., All rights reserved. 
+ * \note   Copyright (C) 2021-2021 Triad National Security, LLC., All rights reserved.
  */
 //------------------------------------------------------------------------------------------------//
 
@@ -141,11 +141,6 @@ quick_index::quick_index(const size_t dim_, const std::vector<std::array<double,
     }
     rtt_c4::global_sum(&global_need_bins_per_proc[0], nbins * nodes);
 
-    // Build a global list of buffer sizes
-    std::vector<int> proc_ghost_buffer_size(nodes, 0);
-    proc_ghost_buffer_size[node] = static_cast<int>(local_ghost_buffer_size);
-    rtt_c4::global_sum(&proc_ghost_buffer_size[0], nodes);
-
     // calculate the put map so each node knows which processor to send data
     // and where to index that data
     // PERFORMANCE NOTE: This would be more efficient to use a MPI_SCAN and
@@ -172,8 +167,7 @@ quick_index::quick_index(const size_t dim_, const std::vector<std::array<double,
               max_put_buffer_size = map.second.size();
 
             // build up map data
-            put_window_map[map.first].push_back(
-                std::array<int, 3>{rec_proc, proc_ghost_buffer_size[rec_proc], offset});
+            put_window_map[map.first].push_back(std::array<int, 3>{rec_proc, offset});
             offset += static_cast<int>(map.second.size());
           }
         }
@@ -197,7 +191,6 @@ auto put_lambda = [](auto &put, auto &put_buffer, auto &put_size, auto &win) {
   // loop over all ranks we need to send this buffer too.
   for (auto &putv : put.second) {
     const int put_rank = putv[0];
-    const int put_rank_buffer_size = putv[1];
     const int put_offset = putv[2];
     // This is dumb, but we need to write in chunks because MPI_Put writes
     // junk with large (>10,000) buffer sizes.
@@ -208,7 +201,7 @@ auto put_lambda = [](auto &put, auto &put_buffer, auto &put_size, auto &win) {
     for (int c = 0; c < nchunks; c++) {
       chunk_size = std::min(chunk_size, static_cast<int>(put_size) - nput);
       Check(chunk_size > 0);
-      MPI_Put(&put_buffer[nput], chunk_size, MPI_DOUBLE, put_rank, put_offset, put_rank_buffer_size,
+      MPI_Put(&put_buffer[nput], chunk_size, MPI_DOUBLE, put_rank, put_offset, chunk_size,
               MPI_DOUBLE, win);
       nput += chunk_size;
     }

--- a/src/kde/quick_index.hh
+++ b/src/kde/quick_index.hh
@@ -5,7 +5,7 @@
  * \brief  This class generates coarse spatial indexing to quickly access near-neighbor data. This
  *         additionally provides simple interpolation schemes to map data to simple structured
  *         meshes. 
- * \note   Copyright (C) 2021 Triad National Security, LLC., All rights reserved. 
+ * \note   Copyright (C) 2021-2021 Triad National Security, LLC., All rights reserved.
  */
 //------------------------------------------------------------------------------------------------//
 
@@ -130,7 +130,7 @@ private:
   // Map used to write local data to other processor ghost cells
   // put_window_map[global_id] = [put_rank, ghost_proc_buffer_size, ghost_proc_put_offset]
   // array is integers to accommodate mpi data types
-  std::map<size_t, std::vector<std::array<int, 3>>> put_window_map;
+  std::map<size_t, std::vector<std::array<int, 2>>> put_window_map;
   // max put buffer size;
   size_t max_put_buffer_size;
   const double pi = rtt_units::PI;


### PR DESCRIPTION
### Background

* This fixes the MPI_Put call in quick_index to specify the target buffer size equal to the origin buffer size. Originally @clevelam thought that it was supposed to be the off processor buffer size. This might also explain why we had some issues at large mpi_put writes (over 10K). For now we will leave in the chunk writing to save temporary memory space.

### Purpose of Pull Request

* [Fixes re-git issue #1355](https://re-git.lanl.gov/draco/draco/-/issues/1355)

### Description of changes

* Remove un-needed off processor buffer size
* Make target buffer size equal to the origin buffer size in the MPI_Put call used by quick_index

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
