### PR TITLE
Another fix for the copyright pre-commit-hook

### DIFF
--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -75,18 +75,21 @@ function rewrite_copyright_block()
   debugprint "$create_date $git_last_mod_date $git_create_date"
 
   # Sanity Checks
-  [[ "${create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line (err 1)"
-  # [[ "${mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
-  [[ "${git_last_mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line (err 2)"
-  [[ "${git_create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line (err 3)"
+  [[ "${create_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line (err 1)" && exit 1
+  # [[ "${mod_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line" && exit 1
+  [[ "${git_last_mod_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line (err 2)" &&
+    exit 1
+  [[ "${git_create_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line (err 3)" &&
+    exit 1
+
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
-    die "Existing copyright date range is corrupt. Please fix $filename manually."
+    echo "Existing copyright date range is corrupt. Please fix $filename manually." && exit 1
   fi
   if [[ "${git_create_date}" -gt "${today}" ]] || [[ "${git_create_date}" -lt "1990" ]]; then
-    die "Existing copyright date range is corrupt. Please fix $filename manually."
+    echo "Existing copyright date range is corrupt. Please fix $filename manually." && exit 1
   fi
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
-    die "Existing copyright date range is corrupt. Please fix $filename manually."
+    echo "Existing copyright date range is corrupt. Please fix $filename manually." && exit 1
   fi
 
   # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
@@ -94,9 +97,11 @@ function rewrite_copyright_block()
   [[ "${git_create_date}" -lt "2011" ]] && git_create_date="${create_date}"
 
   # Expected Copyright line:
-  local ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "
-  ecrl+="All rights reserved."
-  debugprint "ecrl = $ecrl"
+  local ecrl="Copyright (C) "
+  if [[ "${git_create_date}" != "${today}" ]]; then
+    ecrl+="${git_create_date}-"
+  fi
+  ecrl+="${today} Triad National Security, LLC., All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
   local twolines
@@ -126,7 +131,7 @@ suffix="$(date +%s)"
 
 # clean up any older fprettify patches
 # $DELETE_OLD_PATCHES && rm -f /tmp/$USER/$prefix-*. &> /dev/null
-mkdir -p "/tmp/$USER" || die "Could not create /tmp/$USER"
+mkdir -p "/tmp/$USER" || ( echo "Could not create /tmp/$USER" && exit 1 )
 patchfile=$(mktemp "/tmp/$USER/${prefix}-${suffix}.patch.XXXXXXXX")
 
 # create one patch containing all changes to the files

--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -101,8 +101,14 @@ function rewrite_copyright_block()
   # If existing copyright spans two lines, reduce it to one line.
   local twolines
   twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
+  local twolines_closes_cpp_comment
+  twolines_closes_cpp_comment=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c '[*]/')
   if [[ $twolines -gt 0 ]]; then
-    sed -i 's/All rights reserved[.]*//' "${filename}"
+    if [[ $twolines_closes_cpp_comment -gt 0 ]]; then
+      sed -i 's%^.*All rights reserved[.]*$% */%' "${filename}"
+    else
+      sed -i '/All rights reserved/d' "${filename}"
+    fi
   fi
 
   # Do we have terminating comement character on the 'copyright' line.  If so, keep it.

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -461,13 +461,13 @@ for file in $modifiedfiles; do
   ecrl+="All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
-  twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
-  twolines_closes_cpp_comment=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c '[*]/')
+  twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)
+  twolines_closes_cpp_comment=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c '[*]/')
   if [[ $twolines -gt 0 ]]; then
     if [[ $twolines_closes_cpp_comment -gt 0 ]]; then
-      sed -i 's%^.*All rights reserved[.]*$% */%' "${filename}"
+      sed -i 's%^.*All rights reserved[.]*$% */%' "${tmpfile1}"
     else
-      sed -i '/All rights reserved/d' "${filename}"
+      sed -i '/All rights reserved/d' "${tmpfile1}"
     fi
   fi
 

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -457,8 +457,11 @@ for file in $modifiedfiles; do
   [[ "${git_create_date}" -lt "2011" ]] && git_create_date="${create_date}"
 
   # Expected Copyright line:
-  ecrl="Copyright (C) ${git_create_date}-${today} Triad National Security, LLC., "
-  ecrl+="All rights reserved."
+  ecrl="Copyright (C) "
+  if [[ "${git_create_date}" != "${today}" ]]; then
+    ecrl+="${git_create_date}-"
+  fi
+  ecrl+="${today} Triad National Security, LLC., All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
   twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -417,6 +417,8 @@ for file in $modifiedfiles; do
   # ignore file if we do check for file extensions and the file does not match any of the
   # extensions specified in $FILE_EXTS
   if ! matches_extension "$file"; then continue; fi
+  # If this PR deletes a file, skip it
+  if ! [[ -f "${file}" ]]; then continue; fi
 
   file_nameonly=$(basename "${file}")
   tmpfile1="/tmp/$USER/copyright-${file_nameonly}"

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -461,9 +461,14 @@ for file in $modifiedfiles; do
   ecrl+="All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
-  twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)
+  twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
+  twolines_closes_cpp_comment=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c '[*]/')
   if [[ $twolines -gt 0 ]]; then
-    sed -i 's/All rights reserved[.]*//' "${tmpfile1}"
+    if [[ $twolines_closes_cpp_comment -gt 0 ]]; then
+      sed -i 's%^.*All rights reserved[.]*$% */%' "${filename}"
+    else
+      sed -i '/All rights reserved/d' "${filename}"
+    fi
   fi
 
   # Do we have terminating comement character on the 'copyright' line.  If so, keep it.
@@ -485,6 +490,7 @@ for file in $modifiedfiles; do
   unset git_create_date
   unset ecrl
   unset twolines
+  unset twolines_closes_cpp_comment
   unset ecm
 
 done


### PR DESCRIPTION
### Background

+ For new files, the script was setting a date range like `2021-2021`.  Catch this special case and just insert a single date.
+ Also, `pre-commit-copyright` wasn't aborting the commit process when `die` was called.  Replace `die` with `echo && exit 1`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
