### PR TITLE
Another copyright date fix.

### DIFF
--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -71,30 +71,41 @@ function rewrite_copyright_block()
   git_create_date=$(git log "${gitfile}" | grep Date | tail -n 1 | \
                       sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
 
-  debugprint "$crl"
-  debugprint "$create_date $git_last_mod_date $git_create_date"
+  debugprint "   copyright line = $crl"
+  debugprint "   create_date = $create_date, git_last_mod_date = $git_last_mod_date, git_create_date = $git_create_date"
 
   # Sanity Checks
-  [[ "${create_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line (err 1)" && exit 1
+  if [[ "${create_date}" =~ "Copyright" ]]; then
+    echo "Failed to parse copyright line (err 1)"
+    exit 1
+  fi
   # [[ "${mod_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line" && exit 1
-  [[ "${git_last_mod_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line (err 2)" &&
+  if [[ "${git_last_mod_date}" =~ "Copyright" ]]; then
+    echo "Failed to parse copyright line (err 2)"
     exit 1
-  [[ "${git_create_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line (err 3)" &&
+  fi
+  if [[ "${git_create_date}" =~ "Copyright" ]]; then
+    echo "Failed to parse copyright line (err 3)"
     exit 1
-
+  fi
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
-    echo "Existing copyright date range is corrupt. Please fix $filename manually." && exit 1
+    echo "Existing copyright date range is corrupt. Please fix $filename manually."
+    exit 1
   fi
   if [[ "${git_create_date}" -gt "${today}" ]] || [[ "${git_create_date}" -lt "1990" ]]; then
-    echo "Existing copyright date range is corrupt. Please fix $filename manually." && exit 1
+    echo "Existing copyright date range is corrupt. Please fix $filename manually."
+    exit 1
   fi
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
-    echo "Existing copyright date range is corrupt. Please fix $filename manually." && exit 1
+    echo "Existing copyright date range is corrupt. Please fix $filename manually."
+    exit 1
   fi
 
   # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
   # this case older data is lost, so just use whatever is in the file as the create date.
-  [[ "${git_create_date}" -lt "2011" ]] && git_create_date="${create_date}"
+  if [[ "${git_create_date}" -lt "2011" ]] && [[ "${create_date}" -lt "${git_create_date}" ]]; then
+    git_create_date="${create_date}"
+  fi
 
   # Expected Copyright line:
   local ecrl="Copyright (C) "
@@ -102,15 +113,18 @@ function rewrite_copyright_block()
     ecrl+="${git_create_date}-"
   fi
   ecrl+="${today} Triad National Security, LLC., All rights reserved."
+  debugprint "   expected line = $ecrl"
 
   # If existing copyright spans two lines, reduce it to one line.
   local twolines
   twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
   local twolines_closes_cpp_comment
   twolines_closes_cpp_comment=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c '[*]/')
+  debugprint "   twolines                    = $twolines"
+  debugprint "   twolines_closes_cpp_comment = $twolines_closes_cpp_comment"
   if [[ $twolines -gt 0 ]]; then
     if [[ $twolines_closes_cpp_comment -gt 0 ]]; then
-      sed -i 's%^.*All rights reserved[.]*$% */%' "${filename}"
+      sed -i 's%^.*All [Rr]ights [Rr]eserved[.]*.*[*]/$% */%' "${filename}"
     else
       sed -i '/All rights reserved/d' "${filename}"
     fi

--- a/src/ds++/Assert.cc
+++ b/src/ds++/Assert.cc
@@ -2,7 +2,7 @@
 /*!
  * \file   ds++/Assert.cc
  * \brief  Helper functions for the Assert facility.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC. All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Assert.hh"

--- a/src/ds++/Assert.hh
+++ b/src/ds++/Assert.hh
@@ -3,7 +3,8 @@
  * \file  ds++/Assert.hh
  * \brief Header file for Draco specific exception class definition (rtt_dsxx::assertion). Also
  *        define Design-by-Contract macros.
- * \note  Copyright (C) 2016-2020 Triad National Security, LLC.  All rights reserved. */
+ * \note  Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved.
+ */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef RTT_dsxx_Assert_HH

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -479,9 +479,7 @@ for file in $modifiedfiles; do
   ecrl+="${today} Triad National Security, LLC., All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
-  local twolines
   twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
-  local twolines_closes_cpp_comment
   twolines_closes_cpp_comment=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c '[*]/')
   if [[ $twolines -gt 0 ]]; then
     if [[ $twolines_closes_cpp_comment -gt 0 ]]; then

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -169,7 +169,6 @@ rm -f "${patchfile_c}"
 
 # ------------------------------------------------------------------------------------------------ #
 # Liast of modified files
-# - Used for cmake-format and Emacs F90 processing.
 # ------------------------------------------------------------------------------------------------ #
 
 # staged files
@@ -440,23 +439,37 @@ for file in $modifiedfiles; do
                             sed -e 's/.* \([0-9][0-9][0-9][0-9]\).*/\1/')
 
   # Sanity Checks
-  [[ "${create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
-  # [[ "${mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
-  [[ "${git_last_mod_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
-  [[ "${git_create_date}" =~ "Copyright" ]] && die "Failed to parse copyright line"
+  if [[ "${create_date}" =~ "Copyright" ]]; then
+    echo "Failed to parse copyright line (err 1)"
+    exit 1
+  fi
+  # [[ "${mod_date}" =~ "Copyright" ]] && echo "Failed to parse copyright line" && exit 1
+  if [[ "${git_last_mod_date}" =~ "Copyright" ]]; then
+    echo "Failed to parse copyright line (err 2)"
+    exit 1
+  fi
+  if [[ "${git_create_date}" =~ "Copyright" ]]; then
+    echo "Failed to parse copyright line (err 3)"
+    exit 1
+  fi
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
-    die "Existing copyright date range is corrupt. Please fix $file manually."
+    echo "Existing copyright date range is corrupt. Please fix $filename manually."
+    exit 1
   fi
   if [[ "${git_create_date}" -gt "${today}" ]] || [[ "${git_create_date}" -lt "1990" ]]; then
-    die "Existing copyright date range is corrupt. Please fix $file manually."
+    echo "Existing copyright date range is corrupt. Please fix $filename manually."
+    exit 1
   fi
   if [[ "${create_date}" -gt "${today}" ]] || [[ "${create_date}" -lt "1990" ]]; then
-    die "Existing copyright date range is corrupt. Please fix $file manually."
+    echo "Existing copyright date range is corrupt. Please fix $filename manually."
+    exit 1
   fi
 
   # We converted from CVS to svn in 2010. This is the oldest create date that git will report.  In
   # this case older data is lost, so just use whatever is in the file as the create date.
-  [[ "${git_create_date}" -lt "2011" ]] && git_create_date="${create_date}"
+  if [[ "${git_create_date}" -lt "2011" ]] && [[ "${create_date}" -lt "${git_create_date}" ]]; then
+    git_create_date="${create_date}"
+  fi
 
   # Expected Copyright line:
   ecrl="Copyright (C) "
@@ -466,13 +479,15 @@ for file in $modifiedfiles; do
   ecrl+="${today} Triad National Security, LLC., All rights reserved."
 
   # If existing copyright spans two lines, reduce it to one line.
-  twolines=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c reserved)
-  twolines_closes_cpp_comment=$(grep -A 1 Copyright "${tmpfile1}" | tail -n 1 | grep -c '[*]/')
+  local twolines
+  twolines=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c reserved)
+  local twolines_closes_cpp_comment
+  twolines_closes_cpp_comment=$(grep -A 1 Copyright "${filename}" | tail -n 1 | grep -c '[*]/')
   if [[ $twolines -gt 0 ]]; then
     if [[ $twolines_closes_cpp_comment -gt 0 ]]; then
-      sed -i 's%^.*All rights reserved[.]*$% */%' "${tmpfile1}"
+      sed -i 's%^.*All [Rr]ights [Rr]eserved[.]*.*[*]/$% */%' "${filename}"
     else
-      sed -i '/All rights reserved/d' "${tmpfile1}"
+      sed -i '/All rights reserved/d' "${filename}"
     fi
   fi
 


### PR DESCRIPTION
### Background

+ Alex found another bug in the script that caused the copyright line to be deleted instead of updated. This would occur if there were multiple matches for the string 'all rights reserved'.
+ Fix a problem that allowed the pre-commit hook to fail but allow the commit to go forward.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
