### PR TITLE
Use -g instead of -G in standard CUDA flags

### DIFF
--- a/config/unix-cuda.cmake
+++ b/config/unix-cuda.cmake
@@ -52,7 +52,7 @@ if(NOT CUDA_FLAGS_INITIALIZED)
       "yes"
       CACHE INTERNAL "using draco settings.")
 
-  string(APPEND CMAKE_CUDA_FLAGS " -G --expt-relaxed-constexpr")
+  string(APPEND CMAKE_CUDA_FLAGS " -g --expt-relaxed-constexpr")
   string(APPEND CMAKE_CUDA_FLAGS " --expt-extended-lambda")
   if(CMAKE_CXX_COMPILER_ID MATCHES "XL")
     string(APPEND CMAKE_CUDA_FLAGS " -DCUB_IGNORE_DEPRECATED_CPP_DIALECT"


### PR DESCRIPTION
### Background

* I was seeing a mysterious slowdown of the Jayenne CUDA code. After a PR that add a flag to include debug symbols in all builds the CUDA flag `-G` was moved from Debug into the standard set of flags. `-G` disables all optimization in device code, whereas `-g` just includes the debug symbols. The `-G` flag may still be useful in debug builds but we can revisit that later.

### Purpose of Pull Request

* Fix slow GPU code in release builds

### Description of changes

* Change `-G` to `-g` in CUDA builds.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
