### PR TITLE
Replace use of WIN32 CPP macro with _MSC_VER

### DIFF
--- a/src/c4/C4_MPI.cc
+++ b/src/c4/C4_MPI.cc
@@ -4,7 +4,7 @@
  * \author Thomas M. Evans
  * \date   Thu Mar 21 16:56:17 2002
  * \brief  C4 MPI implementation.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "c4/config.h"
@@ -118,7 +118,7 @@ double wall_clock_time() { return MPI_Wtime(); }
 // overloaded function (provide POSIX timer information).
 double wall_clock_time(DRACO_TIME_TYPE &now) {
 // obtain POSIX timer information and return it to the user via the reference value argument "now".
-#ifdef WIN32
+#ifdef _MSC_VER
   now = std::chrono::high_resolution_clock::now();
 #else
   times(&now);

--- a/src/c4/C4_Serial.cc
+++ b/src/c4/C4_Serial.cc
@@ -4,7 +4,7 @@
  * \author Thomas M. Evans
  * \date   Mon Mar 25 17:06:25 2002
  * \brief  Implementation of C4 serial option.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "C4_Functions.hh"
@@ -66,7 +66,7 @@ void global_barrier() { /* empty */
 // TIMING FUNCTIONS
 //------------------------------------------------------------------------------------------------//
 
-#if defined(WIN32)
+#if defined(_MSC_VER)
 double wall_clock_time(DRACO_TIME_TYPE &now) {
   using namespace std::chrono;
   now = high_resolution_clock::now();

--- a/src/c4/C4_sys_times.h
+++ b/src/c4/C4_sys_times.h
@@ -4,7 +4,7 @@
  * \author Kelly Thompson
  * \date   Mon Sep 20 21:54:18 2010
  * \brief  Encapsulate system headers for timing information.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef c4_C4_sys_times_h
@@ -12,7 +12,7 @@
 
 #include "ds++/config.h"
 
-#if defined(WIN32) || defined(MINGW)
+#if defined(_MSC_VER) || defined(MINGW)
 #include <chrono>
 #include <ctime>
 #else
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #endif
 
-#if defined(WIN32)
+#if defined(_MSC_VER)
 // Consider using GetProcessTimes instead of this as a higher resolution timer.
 #define DRACO_TIME_TYPE std::chrono::high_resolution_clock::time_point
 #define DRACO_CLOCKS_PER_SEC CLOCKS_PER_SEC

--- a/src/c4/Timer.cc
+++ b/src/c4/Timer.cc
@@ -3,7 +3,7 @@
  * \file   c4/Timer.cc
  * \author Thomas M. Evans
  * \date   Mon Mar 25 17:56:11 2002
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Timer.hh"
@@ -41,7 +41,7 @@ Timer::Timer()
     : tms_begin(DRACO_TIME_TYPE()), tms_end(DRACO_TIME_TYPE()),
       posix_clock_ticks_per_second(static_cast<int>(DRACO_CLOCKS_PER_SEC)),
       isMPIWtimeAvailable(setIsMPIWtimeAvailable()) {
-#if defined(WIN32)
+#if defined(_MSC_VER)
   static_assert(DRACO_CLOCKS_PER_SEC < INT32_MAX, "!(DRACO_CLOCKS_PER_SEC < INT32_MAX)");
 #else
   Check(DRACO_CLOCKS_PER_SEC < INT32_MAX);

--- a/src/c4/Timer.hh
+++ b/src/c4/Timer.hh
@@ -4,7 +4,7 @@
  * \author Thomas M. Evans
  * \date   Mon Mar 25 17:35:07 2002
  * \brief  Define class Timer, a POSIX standard timer.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_c4_Timer_hh
@@ -322,7 +322,7 @@ double Timer::wall_clock() const {
 //! Return the system cpu time in seconds, for the last interval.
 double Timer::system_cpu() const {
   Require(!timer_on);
-#if defined(WIN32)
+#if defined(_MSC_VER)
   return 0.0; // difftime( tms_end, tms_begin );
 #else
   return static_cast<double>(tms_end.tms_stime - tms_begin.tms_stime) /
@@ -334,7 +334,7 @@ double Timer::system_cpu() const {
 //! Return the user cpu time in seconds, for the last interval.
 double Timer::user_cpu() const {
   Require(!timer_on);
-#if defined(WIN32)
+#if defined(_MSC_VER)
   using namespace std::chrono;
   duration<double> diff = tms_end - tms_begin;
   return duration_cast<nanoseconds>(diff).count() / 1.0e9;

--- a/src/c4/test/tstTime.cc
+++ b/src/c4/test/tstTime.cc
@@ -4,8 +4,7 @@
  * \author Thomas M. Evans
  * \date   Mon Mar 25 17:19:16 2002
  * \brief  Test timing functions in C4.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "c4/Global_Timer.hh"
@@ -63,7 +62,7 @@ void wall_clock_test(rtt_dsxx::UnitTest &ut) {
 
   Timer t;
 
-#ifdef WIN32
+#ifdef _MSC_VER
   // KT: I'm not sure why I'm having so much trouble on Win32 for the timing
   // precision check.  I may need to use a different mechanism for timing
   // values.  Right now the ngihtly tests fail about 1 out of 20 times.
@@ -271,8 +270,7 @@ void test_pause(rtt_dsxx::UnitTest &ut) {
 
   double end(rtt_c4::wall_clock_time());
 
-  if (end - begin < pauseTime)
-    ITFAILS;
+  FAIL_IF(end - begin < pauseTime);
 
   std::cout << "Starting tstTime::test_pause tests...done\n" << std::endl;
 

--- a/src/c4/xthi_cpuset.hh
+++ b/src/c4/xthi_cpuset.hh
@@ -4,7 +4,7 @@
  * \author Mike Berry <mrberry@lanl.gov>, Kelly Thompson <kgt@lanl.gov>
  * \date   Wednesday, Aug 09, 2017, 11:45 am
  * \brief  Helper functions to generate string for core affinity.
- * \note   Copyright (C) 2017-2020 Triad National Security, LLC., All rights reserved.
+ * \note   Copyright (C) 2019-2021 Triad National Security, LLC., All rights reserved.
  *
  * These functions are needed by c4's xthi and ythi programs to report human readable thread
  * bindings.  It is also used by the unit test for libquo.
@@ -20,7 +20,7 @@
 #include <bitset>
 #include <sstream>
 
-#ifdef WIN32
+#ifdef _MSC_VER
 #include <processthreadsapi.h> // requries SystemCall.hh to be loaded first.
 #endif
 
@@ -102,7 +102,7 @@ inline int sched_getaffinity(pid_t /*pid*/, size_t /*cpu_size*/, cpu_set_t *cpu_
 
 #endif
 
-#ifdef WIN32
+#ifdef _MSC_VER
 
 //! \param[in] num_cpu Number of CPU's per node.
 inline std::string cpuset_to_string(unsigned const num_cpu) {

--- a/src/ds++/DracoMath.hh
+++ b/src/ds++/DracoMath.hh
@@ -4,7 +4,7 @@
  * \author Kent G. Budge
  * \date   Wed Jan 22 15:18:23 MST 2003
  * \brief  New or overloaded cmath or cmath-like functions.
- * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2013-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_DracoMath_hh
@@ -27,7 +27,7 @@ namespace rtt_dsxx {
 // namespace.  The problem here is that PGI/13.7 does not have these language features.  However,
 // PGI does provide the C99 _macros_ of the same name (w/o namespace qualifier).
 //------------------------------------------------------------------------------------------------//
-#if defined _WIN32 || defined __CYGWIN__
+#if defined _MSC_VER || defined __CYGWIN__
 
 template <typename T> bool isNan(T a) { return _isnan(a); }
 template <typename T> bool isInf(T a) { return !_finite(a); }

--- a/src/ds++/DracoStrings.cc
+++ b/src/ds++/DracoStrings.cc
@@ -1,10 +1,10 @@
 //--------------------------------------------*-C++-*---------------------------------------------//
 /*!
  * \file   ds++/DracoStrings.cc
- * \author Kelly G. Thompson <kgt@lanl.gov
+ * \author Kelly G. Thompson <kgt@lanl.gov>
  * \date   Wednesday, Aug 23, 2017, 12:48 pm
  * \brief  Encapsulates common string manipulations (implementation).
- * \note   Copyright (C) 2017-2020 Triad National Security, LLC.  All rights reserved. */
+ * \note   Copyright (C) 2017-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "DracoStrings.hh"
@@ -53,7 +53,7 @@ template <> auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t
 }
 
 // See notes in DracoStrings.hh about this CPP block
-#if defined(WIN32) || defined(APPLE)
+#if defined(_MSC_VER) || defined(APPLE)
 
 template <> auto parse_number_impl<long>(std::string const &str) -> long {
   return std::stol(str); // use stoull or stul?

--- a/src/ds++/DracoStrings.hh
+++ b/src/ds++/DracoStrings.hh
@@ -4,8 +4,7 @@
  * \author Kelly G. Thompson <kgt@lanl.gov
  * \date   Wednesday, Aug 23, 2017, 12:48 pm
  * \brief  Encapsulates common string manipulations.
- * \note   Copyright (C) 2017-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2017-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_DracoStrings_hh
@@ -114,7 +113,7 @@ template <> auto parse_number_impl<uint64_t>(std::string const &str) -> uint64_t
 // If we are using Visual Studio, we need these definitions. I expect that they will be needed for
 // 32-bit Linux as well, but I can't test that.  Might need to add "|| (defined(__GNUC__) &&
 // __WORDSIZE != 64)"
-#if defined(WIN32) || defined(APPLE)
+#if defined(_MSC_VER) || defined(APPLE)
 
 template <> auto parse_number_impl<long>(std::string const &str) -> long;
 template <> auto parse_number_impl<unsigned long>(std::string const &str) -> unsigned long;
@@ -126,8 +125,7 @@ template <> auto parse_number_impl<double>(std::string const &str) -> double;
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Convert a string into a floating-point type or an integral type with
- *        error checking.
+ * \brief Convert a string into a floating-point type or an integral type with error checking.
  *
  * \param[in] str The string that contains a number.
  * \param[in] verbose Should the function print conversion message warnings (default: true).
@@ -140,7 +138,7 @@ template <> auto parse_number_impl<double>(std::string const &str) -> double;
  * appropriate.
  *
  * Consider catching thrown conversion errors using code similar to this:
-
+ *
  * \code
  try {
     parse_number<T>(str);

--- a/src/ds++/StackTrace.cc
+++ b/src/ds++/StackTrace.cc
@@ -4,7 +4,7 @@
  * \author Kelly Thompson
  * \date   Friday, Dec 20, 2013, 10:15 am
  * \brief  Linux/X86 implementation of stack trace functions.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2014-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "StackTrace.hh"
@@ -156,7 +156,7 @@ std::string rtt_dsxx::print_stacktrace(std::string const &error_message) {
 //------------------------------------------------------------------------------------------------//
 // Stack trace feature is also available on Win32-based systems when compiled with Visual Studio.
 // ------------------------------------------------------------------------------------------------//
-#ifdef WIN32
+#ifdef _MSC_VER
 
 //------------------------------------------------------------------------------------------------//
 // Print a demangled stack backtrace of the caller function.
@@ -184,7 +184,7 @@ std::string rtt_dsxx::print_stacktrace(std::string const &error_message) {
   return msg.str();
 }
 
-#endif // WIN32
+#endif // _MSC_VER
 
 //------------------------------------------------------------------------------------------------//
 // end of ds++/StackTrace.cc

--- a/src/ds++/SystemCall.hh
+++ b/src/ds++/SystemCall.hh
@@ -1,8 +1,8 @@
 //--------------------------------------------*-C++-*---------------------------------------------//
 /*!
- * \file   ds++/SystemCall.hh
+ * \file  ds++/SystemCall.hh
  * \brief Wrapper for system calls. Hide differences between Unix/Windows system calls.
- * \note Copyright (C) 2016-2021 Triad National Security, LLC.  All rights reserved. */
+ * \note  Copyright (C) 2012-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_dsxx_SystemCall_hh
@@ -16,7 +16,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
-#ifdef WIN32
+#ifdef _MSC_VER
 #define _WINSOCKAPI_
 #include <WinSock2.h>
 #include <Windows.h>
@@ -54,7 +54,7 @@ std::string draco_getcwd();
 class draco_getstat {
 private:
   int stat_return_code;
-#ifdef WIN32
+#ifdef _MSC_VER
   struct _stat buf;
   bool filefound;
   WIN32_FIND_DATA FileInformation; // Additional file information

--- a/src/ds++/path.hh
+++ b/src/ds++/path.hh
@@ -2,7 +2,7 @@
 /*!
  * \file   ds++/path.hh
  * \brief  Encapsulate path information (path separator, etc.)
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved.
  *
  * \bug Consider replacing path.cc and path.hh with C++17 filesystem */
 //------------------------------------------------------------------------------------------------//
@@ -99,9 +99,9 @@ void draco_walk_directory_tree(std::string const &dirname, T const &myOperator) 
     return;
   }
 
-#ifdef WIN32
+#ifdef _MSC_VER
   /*! \note If path contains the location of a directory, it cannot contain a trailing backslash. If
-     * it does, -1 will be returned and errno will be set to ENOENT. */
+   * it does, -1 will be returned and errno will be set to ENOENT. */
   std::string d_name;
   if (dirname[dirname.size() - 1] == rtt_dsxx::WinDirSep ||
       dirname[dirname.size() - 1] == rtt_dsxx::UnixDirSep)

--- a/src/ds++/path_getFilenameComponent.cc
+++ b/src/ds++/path_getFilenameComponent.cc
@@ -2,7 +2,7 @@
 /*!
  * \file   ds++/path_getFilenameComponent.cc
  * \brief  Encapsulate path information (path separator, etc.)
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2014-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "path.hh"
@@ -111,7 +111,7 @@ std::string getFilenameComponent(std::string const &fqName, FilenameComponent fc
   }
 
   // Always convert paths to use native format.
-#ifdef WIN32
+#ifdef _MSC_VER
   std::replace(retVal.begin(), retVal.end(), UnixDirSep, dirSep);
 #else
   std::replace(retVal.begin(), retVal.end(), WinDirSep, dirSep);

--- a/src/ds++/test/tstPath.cc
+++ b/src/ds++/test/tstPath.cc
@@ -4,8 +4,7 @@
  * \author Kelly Thompson
  * \date   Tue Jul 12 16:00:59 2011
  * \brief  Test functions found in ds++/path.hh and path.cc
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2011-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -140,7 +139,7 @@ void test_getFilenameComponent(ScalarUnitTest &ut, string const &fqp) {
   // ------------------------------------------------------------
   string realpath = getFilenameComponent(fqp, rtt_dsxx::FC_REALPATH);
 
-#if defined(WIN32)
+#if defined(_MSC_VER)
   { // The binary should exist.  Windows does not provide an execute bit.
 
     if (realpath.size() > 0)

--- a/src/ds++/test/tstdbc.cc
+++ b/src/ds++/test/tstdbc.cc
@@ -3,7 +3,7 @@
  * \file   ds++/test/tstdbc.cc
  * \author Kent G. Budge
  * \date   Feb 18 2003
- * \brief  Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \brief  Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/DracoMath.hh"
@@ -55,8 +55,8 @@ void dbc_test(UnitTest &ut) {
   else
     PASSMSG("is_monotonic_increasing function template ok");
 
-  // Ensure that the is_monotonic_increasing() function will return true if
-  // there is only one data point.
+  // Ensure that the is_monotonic_increasing() function will return true if there is only one data
+  // point.
 
   if (!is_monotonic_increasing(sum_test_array.begin(), sum_test_array.begin() + 1))
     FAILMSG(string("is_monotonic_increasing function template ") +
@@ -71,8 +71,8 @@ void dbc_test(UnitTest &ut) {
   else
     PASSMSG("is_strict_monotonic_increasing function template ok");
 
-  // Ensure that the is_strict_monotonic_increasing() function will return true
-  // if there is only one data point.
+  // Ensure that the is_strict_monotonic_increasing() function will return true if there is only one
+  // data point.
 
   if (is_strict_monotonic_increasing(sum_test_array.begin(), sum_test_array.begin() + 1))
     PASSMSG(string("is_strict_monotonic_increasing function template worked ") +
@@ -87,8 +87,8 @@ void dbc_test(UnitTest &ut) {
   else
     FAILMSG("is_strict_monotonic_decreasing function template FAILED");
 
-  // Ensure that the is_strict_monotonic_decreasing() function will return
-  // true if there is only one data point.
+  // Ensure that the is_strict_monotonic_decreasing() function will return true if there is only one
+  // data point.
 
   if (is_strict_monotonic_decreasing(sum_test_array.begin(), sum_test_array.begin() + 1))
     PASSMSG(string("is_strict_monotonic_decreasing function template ") +
@@ -103,13 +103,12 @@ void dbc_test(UnitTest &ut) {
   else
     PASSMSG("std::bind2nd or std::greater function templates ok");
 
-// The preceeding tests whether binders are present in the C++
-// implementation. The binders in <functional> supercede the old
-// rtt_utils::exceeds predicate.
+// The preceeding tests whether binders are present in the C++ implementation. The binders in
+// <functional> supercede the old rtt_utils::exceeds predicate.
 
 // Test badly formed numbers.
 // Note: VS2013 with Nov 2013 CTP will not compile an explicit division by zero.
-#ifndef WIN32
+#ifndef _MSC_VER
   if (!ut.fpe_trap_active) {
     double const Zero = 0.0;
     double const Infinity = 1.0 / Zero;

--- a/src/parser/test/tstToken.cc
+++ b/src/parser/test/tstToken.cc
@@ -4,18 +4,14 @@
  * \author Kent G. Budge
  * \date   Feb 18 2003
  * \brief  Unit test for the class rtt_parser::Token.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved.
- */
-//------------------------------------------------------------------------------------------------//
-
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
 #include "parser/Token.hh"
 
-#ifdef WIN32
+#ifdef _MSC_VER
 #undef ERROR
 #endif
 


### PR DESCRIPTION
### Background

+ This is generally a more standardized syntax.  Also, `WIN32` might be defined for non-MSVC environments on Windows platforms like MinGW or MSYS.

### Purpose of Pull Request

* fixes #500

### Description of changes

+ `WIN32` is the correct variable to check within CMake files.
+ Fix copyright blocks based on pre-commit-hook.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
