### PR TITLE
Fix overlapping theta boundary in spherical KDE reconstructions

### DIFF
--- a/src/kde/kde.cc
+++ b/src/kde/kde.cc
@@ -406,8 +406,6 @@ void kde::calc_win_min_max(const quick_index &qindex, const std::array<double, 3
   for (size_t d = 0; d < dim; d++) {
     win_min[d] = position[d] - 1.0 / one_over_bandwidth[d];
     win_max[d] = position[d] + 1.0 / one_over_bandwidth[d];
-    Ensure(win_min[d] >= local_bounding_box_min[d]);
-    Ensure(win_max[d] <= local_bounding_box_max[d]);
   }
 }
 

--- a/src/kde/kde.cc
+++ b/src/kde/kde.cc
@@ -406,6 +406,8 @@ void kde::calc_win_min_max(const quick_index &qindex, const std::array<double, 3
   for (size_t d = 0; d < dim; d++) {
     win_min[d] = position[d] - 1.0 / one_over_bandwidth[d];
     win_max[d] = position[d] + 1.0 / one_over_bandwidth[d];
+    Ensure(win_min[d] >= local_bounding_box_min[d]);
+    Ensure(win_max[d] <= local_bounding_box_max[d]);
   }
 }
 

--- a/src/kde/quick_index.cc
+++ b/src/kde/quick_index.cc
@@ -452,7 +452,6 @@ quick_index::window_coarse_index_list(const std::array<double, 3> &window_min,
       }
     }
   }
-
   // Fill in the overflow around theta=0.0
   if (spherical && (window_min[1] < 0.0 || window_max[1] > 2.0 * rtt_units::PI)) {
     // Only one bound of the window should every overshoot zero
@@ -465,13 +464,13 @@ quick_index::window_coarse_index_list(const std::array<double, 3> &window_min,
       double wmax = window_max[d];
       if (spherical && d == 1 && window_min[d] < 0.0) {
         // Capture the overshoot theta space
-        wmin = std::min(2.0 * rtt_units::PI - window_min[d], bounding_box_max[d]);
+        wmin = std::min(2.0 * rtt_units::PI + window_min[d], bounding_box_max[d]);
         wmax = 2.0 * rtt_units::PI;
       }
       if (spherical && d == 1 && window_max[d] > 2.0 * rtt_units::PI) {
         // Capture the overshoot theta space
         wmin = 0.0;
-        wmax = std::max(2.0 * rtt_units::PI - window_max[d], bounding_box_min[d]);
+        wmax = std::max(window_max[d] - 2.0 * rtt_units::PI, bounding_box_min[d]);
       }
       // Truncate based on global space
       if (spherical && d == 1 && wmin < bounding_box_min[d])


### PR DESCRIPTION
### Background

* Add some extra ensures to protect off-processor data fetching.

### Purpose of Pull Request

* Fix some sign mistakes in the overlapping theta mapping for quick_index
* [Fixes re-git issue #1358](https://re-git.lanl.gov/draco/draco/-/issues/1358)

### Description of changes

* Fix theta=0,2pi overlap boundaries

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
