### PR TITLE
Expand scope of proxy-on/off.

### DIFF
--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -128,8 +128,16 @@ if [[ ${INTERACTIVE} == true ]]; then
     export https_proxy=$http_proxy
     export HTTP_PROXY=$http_proxy
     export HTTPS_PROXY=$http_proxy
-    export no_proxy=".lanl.gov,127.0.0.1,localhost"
-    export NO_PROXY=$no_proxy
+    export proxy_rsync=$http_proxy
+    export RSYNC_PROXY=$http_proxy
+    export proxy_http=$http_proxy
+    export proxy_skip=$http_proxy
+    export proxy_https=$http_proxy
+    export proxy_ftp=$http_proxy
+    if ! [[ "${nodename}" =~ "-rfe" ]]; then
+      export no_proxy=".lanl.gov,127.0.0.1,localhost"
+      export NO_PROXY=$no_proxy
+    fi
   fi
 
   # cd paths - disable here, let user choose in ~/.bashrc

--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -253,7 +253,7 @@ function proxy()
     export proxy_skip=$http_proxy
     export proxy_https=$http_proxy
     export proxy_ftp=$http_proxy
-    if ! [[ "${nodename}" =~ "-rfe" ]]; then
+    if ! [[ "$(uname -n)" =~ "-rfe" ]]; then
       export no_proxy="localhost,127.0.0.1,.lanl.gov"
       export NO_PROXY=$no_proxy
     fi

--- a/environment/bashrc/bash_functions.sh
+++ b/environment/bashrc/bash_functions.sh
@@ -247,16 +247,28 @@ function proxy()
     export https_proxy=$http_proxy
     export HTTP_PROXY=$http_proxy
     export HTTPS_PROXY=$http_proxy
-    # export http_no_proxy="*.lanl.gov"
-    export no_proxy="localhost,127.0.0.1,.lanl.gov"
-    export NO_PROXY=$no_proxy
+    export proxy_rsync=$http_proxy
+    export RSYNC_PROXY=$http_proxy
+    export proxy_http=$http_proxy
+    export proxy_skip=$http_proxy
+    export proxy_https=$http_proxy
+    export proxy_ftp=$http_proxy
+    if ! [[ "${nodename}" =~ "-rfe" ]]; then
+      export no_proxy="localhost,127.0.0.1,.lanl.gov"
+      export NO_PROXY=$no_proxy
+    fi
   else
     # proxies are set, kill them
     unset http_proxy
     unset https_proxy
     unset HTTP_PROXY
     unset HTTPS_PROXY
-    #unset http_no_proxy
+    unset proxy_rsync
+    unset RSYNC_PROXY
+    unset proxy_http
+    unset proxy_skip
+    unset proxy_https
+    unset proxy_ftp
     unset no_proxy
     unset NO_PROXY
   fi


### PR DESCRIPTION
### Background

* After debugging a recent proxy issue, it was determined that our automation/environments need to be expanded.

### Description of changes

* LANL `*-rfe` machines need different settings than their predecessors.
* Also set proxy variables for `rsync*` and `proxy*`.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
