### PR TITLE
Cleanup in Abstract_Class_Parser

### DIFF
--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -14,9 +14,9 @@ Compiler Setup...
 ")
 endif()
 
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # PAPI
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 if(DEFINED ENV{PAPI_HOME})
   set(HAVE_PAPI
       1
@@ -43,12 +43,12 @@ if(HAVE_PAPI)
   add_feature_info(HAVE_PAPI HAVE_PAPI "Provide PAPI hardware counters if available.")
 endif()
 
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Query OpenMP availability
 #
 # This feature is usually compiler specific and a compile flag must be added. For this to work the
 # <platform>-<compiler>.cmake files (e.g.:  unix-g++.cmake) call this macro.
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 macro(query_openmp_availability)
   if(NOT PLATFORM_CHECK_OPENMP_DONE)
     set(PLATFORM_CHECK_OPENMP_DONE
@@ -77,9 +77,9 @@ macro(query_openmp_availability)
   endif()
 endmacro()
 
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Force save compiler flags to CMakeCache.txt
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 function(force_compiler_flags_to_cache lang_list)
   if("${lang_list}x" STREQUAL "x")
     message(FATAL_ERROR "argument lang_list is required. eg. \"C;CXX\"")
@@ -96,14 +96,15 @@ function(force_compiler_flags_to_cache lang_list)
       CACHE STRING "link flags" FORCE)
 endfunction()
 
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # De-duplicate compiler flags
 #
 # example: deduplicate_flags(CMAKE_C_FLAGS)
 #
 # * ${FLAGS} evaluates to a string like "CMAKE_C_FLAGS"
 # * ${${FLAGS}} evaluates to a list of compiler options like "-Werror -O2"
-# --------------------------------------------------------------------------------------------------#
+#
+# ------------------------------------------------------------------------------------------------ #
 function(deduplicate_flags FLAGS)
   set(flag_list ${${FLAGS}}) # ${FLAGS} is CMAKE_C_FLAGS, double ${${FLAGS}} is the string of flags.
   separate_arguments(flag_list)
@@ -115,9 +116,9 @@ function(deduplicate_flags FLAGS)
       PARENT_SCOPE)
 endfunction()
 
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 # Setup compilers
-# --------------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------------ #
 macro(dbsSetupCompilers)
 
   if(NOT dbsSetupCompilers_done)
@@ -344,7 +345,8 @@ macro(dbsSetupCxx)
     include(unix-g++)
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     include(windows-cl)
-  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "XLClang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "XLCLang")
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "XLClang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL
+                                                          "XLCLang")
     include(unix-xl)
   else()
     # missing CMAKE_CXX_COMPILER_ID? - try to match the compiler path+name to a string.

--- a/config/doxygen_config.in
+++ b/config/doxygen_config.in
@@ -1091,7 +1091,7 @@ ALPHABETICAL_INDEX     = YES
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-COLS_IN_ALPHA_INDEX    = 5
+# COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag

--- a/src/parser/Abstract_Class_Parser.cc
+++ b/src/parser/Abstract_Class_Parser.cc
@@ -3,8 +3,7 @@
  * \file   parser/Abstract_Class_Parser.cc
  * \author Kent Budge
  * \brief  Define destructor for Abstract_Class_Parser_Base
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2020 Triad National Security, LLC..All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Abstract_Class_Parser.hh"
@@ -14,16 +13,8 @@
 
 namespace rtt_parser {
 
+// Create global static variable on the stack.
 c_string_vector abstract_class_parser_keys;
-
-//------------------------------------------------------------------------------------------------//
-c_string_vector::~c_string_vector() {
-  Check(data.size() < UINT_MAX);
-  auto const n = static_cast<unsigned>(data.size());
-  for (unsigned i = 0; i < n; ++i) {
-    delete[] data[i];
-  }
-}
 
 } // end namespace rtt_parser
 

--- a/src/parser/Abstract_Class_Parser.hh
+++ b/src/parser/Abstract_Class_Parser.hh
@@ -3,14 +3,14 @@
  * \file   parser/Abstract_Class_Parser.hh
  * \author Kent Budge
  * \brief  Define class Abstract_Class_Parser
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef parser_Abstract_Class_Parser_hh
 #define parser_Abstract_Class_Parser_hh
 
-#include "Parse_Table.hh"
+#include "parser/Contextual_Parse_Functor.hh"
+#include "parser/Parse_Table.hh"
 #include <functional>
 #include <iostream>
 
@@ -18,52 +18,24 @@ namespace rtt_parser {
 
 //================================================================================================//
 /*!
- * \brief Closure class for wrapping context-dependent parse functions
- *
- * This template class is used to bind a get_context() function to a parse
- * function requiring a context argument, so that the function can be called
- * with the usual two parameters (Token_Stream and int) from an
- * Abstract_Class_Parse_Table.
- *
- * See test/tstAbstract_Class_Contextual_Parser.cc for an example of how it is
- * used.
- */
-//================================================================================================//
-template <typename Abstract_Class, typename Context, Context const &get_context()>
-class Contextual_Parse_Functor {
-public:
-  Contextual_Parse_Functor(std::shared_ptr<Abstract_Class> parse_function(Token_Stream &,
-                                                                          Context const &));
-
-  std::shared_ptr<Abstract_Class> operator()(Token_Stream &) const;
-
-private:
-  std::shared_ptr<Abstract_Class> (*f_)(Token_Stream &, Context const &);
-};
-
-//================================================================================================//
-/*!
  * \class Abstract_Class_Parser
  * \brief Template for parser that produces a class object.
  *
- * This template is meant to be specialized for parse tables that select one
- * of a set of child classes of a single abstract class. It simplifies and
- * regularizes the task of allowing additional child classes to be added to
- * the table by a local developer working on his own version of one of the
- * Capsaicin drivers.
+ * This template is meant to be specialized for parse tables that select one of a set of child
+ * classes of a single abstract class. It simplifies and regularizes the task of allowing additional
+ * child classes to be added to the table by a local developer working on his own version of one of
+ * the Capsaicin drivers.
  *
- * \arg \a Abstract_Class The abstract class whose children are to be parsed.
+ * - \a Abstract_Class The abstract class whose children are to be parsed.
+ * - \a get_parse_table A function that returns a reference to the parse table for the abstract
+ *   class.
+ * - \a get_parsed_object A function that returns a reference to a storage location for a pointer
+ *   to the abstract class.
  *
- * \arg \a get_parse_table A function that returns a reference to the parse
- * table for the abstract class.
- *
- * \arg \a get_parsed_object A function that returns a reference to a storage
- * location for a pointer to the abstract class.
- *
- * The key to this class is the register_child function, which is called for
- * each child class prior to attempting any parsing. It specifies a keyword for
- * selecting each child class and a function that does the actual parsing of the
- * class specification. This assumes an input grammar of the form
+ * The key to this class is the register_child function, which is called for each child class prior
+ * to attempting any parsing. It specifies a keyword for selecting each child class and a function
+ * that does the actual parsing of the class specification. This assumes an input grammar of the
+ * form
  *
  * \code
  * abstract class keyword
@@ -73,15 +45,14 @@ private:
  * end
  * \endcode
  *
- * Note that Abstract_Class_Parser does not actually do any parsing itself. It
- * is simply a repository for keyword-parser combinations that is typically used
- * by the Class_Parser for the abstract class.
+ * Note that Abstract_Class_Parser does not actually do any parsing itself. It is simply a
+ * repository for keyword-parser combinations that is typically used by the Class_Parser for the
+ * abstract class.
  *
  * See test/tstAbstract_Class_Parser.cc for an example of its use.
  *
- * This template has proven useful but does not provide a fully satisfactory
- * solution to the problem of abstract class keywords other than those
- * specifying a child class.
+ * This template has proven useful but does not provide a fully satisfactory solution to the problem
+ * of abstract class keywords other than those specifying a child class.
  */
 //================================================================================================//
 template <typename Abstract_Class, Parse_Table &get_parse_table(),
@@ -89,10 +60,6 @@ template <typename Abstract_Class, Parse_Table &get_parse_table(),
           typename Parse_Function = std::function<std::shared_ptr<Abstract_Class>(Token_Stream &)>>
 class Abstract_Class_Parser {
 public:
-  // TYPES
-
-  // STATIC members
-
   //! Register children of the abstract class
   static void register_child(std::string const &keyword, Parse_Function parse_function);
 
@@ -115,6 +82,7 @@ private:
   static std::vector<Parse_Function> map_;
 };
 
+// Implementation
 #include "Abstract_Class_Parser.i.hh"
 
 } // end namespace rtt_parser

--- a/src/parser/Abstract_Class_Parser.i.hh
+++ b/src/parser/Abstract_Class_Parser.i.hh
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Thu Jul 17 14:08:42 2008
  * \brief  Member definitions of class Abstract_Class_Parser
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef utils_Abstract_Class_Parser_i_hh
@@ -13,36 +13,39 @@
 //! \bug This file needs to be cleaned up for doxygen parsing.
 //! \cond doxygen_ignore_block
 
-//------------------------------------------------------------------------------------------------//
-template <typename Abstract_Class, typename Context, Context const &get_context()>
-Contextual_Parse_Functor<Abstract_Class, Context, get_context>::Contextual_Parse_Functor(
-    std::shared_ptr<Abstract_Class> parse_function(Token_Stream &, Context const &))
-    : f_(parse_function) {}
-
-template <typename Abstract_Class, typename Context, Context const &get_context()>
-std::shared_ptr<Abstract_Class> Contextual_Parse_Functor<Abstract_Class, Context, get_context>::
-operator()(Token_Stream &tokens) const {
-  return f_(tokens, get_context());
-}
-
 //================================================================================================//
 /*!
- * Helper class defining a table of raw strings created by strdup that will be
- * properly deallocated using free on program termination.
+ * \class c_string_vector
+ * \brief Helper class defining a table of raw strings created by strdup that will be properly
+ *        deallocated using \c delete[] on program termination.
  */
 class c_string_vector {
 public:
-  ~c_string_vector();
-  c_string_vector() : data(0) { /* empty */
+  //! destructor
+  ~c_string_vector() {
+    for (auto &d : data)
+      delete[] d;
   }
+  //! constructor
+  c_string_vector() : data(0) {}
+  // Disallow copy/move/assignment/move-assignment operators.
+  c_string_vector(const c_string_vector &) = delete;
+  c_string_vector(const c_string_vector &&) = delete;
+  c_string_vector operator=(const c_string_vector &) = delete;
+  c_string_vector operator=(const c_string_vector &&) = delete;
+
+  // DATA
+
+  //! The tabe of raw strings
   std::vector<char *> data;
 };
+
+//! Keep this data as a global static variable.
 DLL_PUBLIC_parser extern c_string_vector abstract_class_parser_keys;
 
 //================================================================================================//
 /*
- * The following rather lengthy and clumsy declaration declares storage for the
- * parse functions.
+ * The following rather lengthy and clumsy declaration declares storage for the parse functions.
  *
  * Remember:
  * \code
@@ -56,13 +59,12 @@ std::vector<Parse_Function>
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function allows a host code to register children of the abstract class
- * with the parser. This helps support extensions by local developers.
+ * \brief This function allows a host code to register children of the abstract class with the
+ *        parser. This helps support extensions by local developers.
  *
- * \param keyword Keyword associated with the child class
- *
- * \param parsefunction Parse function that reads a specification from a
- *           Token_Stream and returns a corresponding object of the child class.
+ * \param[in] keyword Keyword associated with the child class
+ * \param parsefunction Parse function that reads a specification from a Token_Stream and returns a
+ *               corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
@@ -88,13 +90,12 @@ void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function allows a host code to register children of the abstract class
- * with the parser. This helps support extensions by local developers.
+ * This function allows a host code to register children of the abstract class with the parser. This
+ * helps support extensions by local developers.
  *
- * \param keyword Keyword associated with the child class
- *
- * \param parsefunction Parse function that reads a specification from a
- *           Token_Stream and returns a corresponding object of the child class.
+ * \param[in] keyword Keyword associated with the child class
+ * \param parsefunction Parse function that reads a specification from a Token_Stream and returns a
+ *           corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>
@@ -122,8 +123,8 @@ void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object,
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This is the generic parse function associated with all child keywords. It
- * makes use of the Parse_Function associated with each child keyword.
+ * This is the generic parse function associated with all child keywords. It makes use of the
+ * Parse_Function associated with each child keyword.
  */
 template <typename Class, Parse_Table &get_parse_table(),
           std::shared_ptr<Class> &get_parsed_object(), typename Parse_Function>

--- a/src/parser/Contextual_Parse_Functor.hh
+++ b/src/parser/Contextual_Parse_Functor.hh
@@ -1,0 +1,51 @@
+//--------------------------------------------*-C++-*---------------------------------------------//
+/*!
+ * \file   parser/Contextual_Parse_Functor.hh
+ * \author Kent Budge
+ * \date   Thu Jul 17 14:08:42 2008
+ * \brief  Member definitions of class Abstract_Class_Parser
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
+//------------------------------------------------------------------------------------------------//
+
+#ifndef parser_Contextual_Parse_Functor_hh
+#define parser_Contextual_Parse_Functor_hh
+
+#include "parser/Parse_Table.hh"
+
+namespace rtt_parser {
+
+//================================================================================================//
+/*!
+ * \brief Closure class for wrapping context-dependent parse functions
+ *
+ * This template class is used to bind a get_context() function to a parse function requiring a
+ * context argument, so that the function can be called with the usual two parameters (Token_Stream
+ * and int) from an Abstract_Class_Parse_Table.
+ *
+ * See test/tstAbstract_Class_Contextual_Parser.cc for an example of how it is used.
+ */
+//================================================================================================//
+template <typename Abstract_Class, typename Context, Context const &get_context()>
+class Contextual_Parse_Functor {
+public:
+  //! Primary constructor
+  Contextual_Parse_Functor(std::shared_ptr<Abstract_Class> parse_function(Token_Stream &,
+                                                                          Context const &))
+      : f_(parse_function) {}
+
+  //! Return handle to the parse function.
+  std::shared_ptr<Abstract_Class> operator()(Token_Stream &tokens) const {
+    return f_(tokens, get_context());
+  }
+
+private:
+  std::shared_ptr<Abstract_Class> (*f_)(Token_Stream &, Context const &);
+};
+
+} // end namespace rtt_parser
+
+#endif // parser_Contextual_Parse_Functor_hh
+
+//------------------------------------------------------------------------------------------------//
+// end of parser/Contextual_Parse_Functor.hh
+//------------------------------------------------------------------------------------------------//


### PR DESCRIPTION
### Background

* Before working on #525, I wanted to do a little cleanup in these files.
* <s>This clean-up includes the removal of class `Contextual_Parse_Functor`, since it doesn't appear to be used.  I'm not sure if this change is safe, but downstream testing will be required to know if this is the case.</s> This class is needed by a client.

### Description of changes

+ For class `c_string_vector`, move member fuction definitions into the `.i.hh` file. This allows the entire helper class to be defined in a single place.  Also disable copy/move constructors and assignment/move-assignment operations.
+ Re-wrap comment blocks to 100 columns.
+ For class `Contextual_Parse_Functor`, move member function definitions to the `.hh` file. This allows the entire helper class to be defined in a single place.
+ Remove doxygen config option that is deprecated by newer versions of doxygen.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
