### PR TITLE
Begin supporting nvcc+xl on darwin P9.

### DIFF
--- a/config/unix-cuda.cmake
+++ b/config/unix-cuda.cmake
@@ -57,7 +57,8 @@ if(NOT CUDA_FLAGS_INITIALIZED)
   if(CMAKE_CXX_COMPILER_ID MATCHES "XL")
     string(APPEND CMAKE_CUDA_FLAGS " -DCUB_IGNORE_DEPRECATED_CPP_DIALECT"
            " -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT")
-    string(APPEND CMAKE_CUDA_FLAGS " -ccbin ${CMAKE_CXX_COMPILER} -Xcompiler -std=c++14")
+    string(APPEND CMAKE_CUDA_FLAGS " -ccbin ${CMAKE_CXX_COMPILER} -Xcompiler -std=c++14"
+      " -Xcompiler -qxflag=disable__cplusplusOverride")
     if(EXISTS /usr/gapps)
       # ATS-2
       string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"


### PR DESCRIPTION
### Background

* While nvcc+xl works fine on ATS-2, we have struggled to get this working on Darwin.
* We were just missing one flag, added here.

### Purpose of Pull Request

* [Fixes re-git issue #1288](https://re-git.lanl.gov/draco/draco/-/issues/1288)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
