### PR TITLE
Add CUDA flags to draco_info report

### DIFF
--- a/environment/git/pre-commit-copyright
+++ b/environment/git/pre-commit-copyright
@@ -28,7 +28,7 @@ debugprint "running pre-commit-copyright"
 # file types to parse.
 FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .sh .txt"
 #FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
-FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc check_style.sh imc_info.cc"
+FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc Release.hh check_style.sh info.cc"
 export FILE_EXTS FILE_ENDINGS_EXCLUDE
 
 ##################################################################

--- a/src/cdi/test/tCDI.cc
+++ b/src/cdi/test/tCDI.cc
@@ -4,7 +4,7 @@
  * \author Thomas M. Evans
  * \date   Tue Oct  9 15:52:01 2001
  * \brief  CDI test executable.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "DummyEoS.hh"
@@ -1036,10 +1036,9 @@ void test_mgopacity_collapse(rtt_dsxx::UnitTest &ut) {
     double const opacity_ross_only =
         CDI::collapseMultigroupOpacitiesRosseland(bounds, mgOpacities, rosseland_only_spectrum);
 
-    std::vector<double> emission_group_cdf_ref(bounds.size() - 1);
-    emission_group_cdf_ref[0] = 0.019244301636310527;
-    emission_group_cdf_ref[1] = 0.29196935332821244;
-    emission_group_cdf_ref[2] = 0.30090440514265909;
+    std::vector<double> emission_group_cdf_ref = {0.019244301636310527, 0.29196935332821244,
+                                                  0.30090440514265909};
+    Check(emission_group_cdf_ref.size() == 3 && bounds.size() == 4);
     double const opacity_pl_ref(0.30090440514265909);
     double const opacity_pl_recip_ref(8.80345577340399);
     double const opacity_ross_ref(0.0778314764921229);

--- a/src/cdi_ipcress/test/cdi_ipcress_test.hh
+++ b/src/cdi_ipcress/test/cdi_ipcress_test.hh
@@ -4,8 +4,7 @@
  * \author Thomas M. Evans
  * \date   Fri Oct 12 15:36:36 2001
  * \brief  cdi_ipcress test function headers.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2011-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_cdi_ipcress_test_hh
@@ -58,9 +57,8 @@ void testTemperatureGridAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType 
   // Read the temperature grid from the IPCRESS file.
   std::vector<double> temps = spOpacity->getTemperatureGrid();
 
-  // Verify that the size of the temperature grid looks right.  If it is the
-  // right size then compare the temperature grid data to the data specified
-  // when we created the IPCRESS file using TOPS.
+  // Verify that the size of the temperature grid looks right.  If it is the right size then compare
+  // the temperature grid data to the data specified when we created the IPCRESS file using TOPS.
   if (temps.size() == spOpacity->getNumTemperatures() && temps.size() == 3) {
     ostringstream message;
     message << "The number of temperature points found in the data\n\t"
@@ -69,10 +67,8 @@ void testTemperatureGridAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType 
     ut.passes(message.str());
 
     // The grid specified by TOPS has 3 temperature points.
-    std::vector<double> temps_ref(temps.size());
-    temps_ref[0] = 0.1;
-    temps_ref[1] = 1.0;
-    temps_ref[2] = 10.0;
+    std::vector<double> temps_ref = {0.1, 1.0, 10.0};
+    Check(temps.size() == 3);
 
     // Compare the grids.
     if (rtt_dsxx::soft_equiv(temps, temps_ref))
@@ -105,15 +101,12 @@ void testDensityGridAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType cons
   if (density.size() == 3 && density.size() == spOpacity->getNumDensities()) {
     ostringstream message;
     message << "The number of density points found in the data\n\t"
-            << "grid matches the number returned by the\n\t"
-            << "getNumDensities() accessor.";
+            << "grid matches the number returned by the\n\tgetNumDensities() accessor.";
     ut.passes(message.str());
 
     // The grid specified by TOPS has 3 density points
-    std::vector<double> density_ref(density.size());
-    density_ref[0] = 0.1;
-    density_ref[1] = 0.5;
-    density_ref[2] = 1.0;
+    std::vector<double> density_ref = {0.1, 0.5, 1.0};
+    Check(density.size() == 3);
 
     // Compare the grids.
     if (rtt_dsxx::soft_equiv(density, density_ref))
@@ -125,8 +118,7 @@ void testDensityGridAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType cons
     message << "The number of density points found in the data\n\t"
             << "grid does not match the number returned by the\n\t"
             << "getNumDensities() accessor. \n"
-            << "Did not test the results returned by\n\t"
-            << "getDensityGrid().";
+            << "Did not test the results returned by\n\tgetDensityGrid().";
     ut.failure(message.str());
   }
 }
@@ -139,9 +131,9 @@ void testEnergyBoundaryAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType c
   // Read the grid from the IPCRESS file.
   std::vector<double> ebounds = spOpacity->getGroupBoundaries();
 
-  // Verify that the size of the group boundary grid looks right.  If
-  // it is the right size then compare the energy groups grid data to
-  // the data specified when we created the IPCRESS file using TOPS.
+  // Verify that the size of the group boundary grid looks right.  If it is the right size then
+  // compare the energy groups grid data to the data specified when we created the IPCRESS file
+  // using TOPS.
   if (ebounds.size() == 13 && ebounds.size() == spOpacity->getNumGroupBoundaries()) {
     ostringstream message;
     message << "The number of energy boundary points found in the data\n\t"
@@ -150,20 +142,9 @@ void testEnergyBoundaryAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType c
     ut.passes(message.str());
 
     // The grid specified by TOPS has 13 energy boundaries.
-    std::vector<double> ebounds_ref(ebounds.size());
-    ebounds_ref[0] = 0.01;
-    ebounds_ref[1] = 0.03;
-    ebounds_ref[2] = 0.07;
-    ebounds_ref[3] = 0.1;
-    ebounds_ref[4] = 0.3;
-    ebounds_ref[5] = 0.7;
-    ebounds_ref[6] = 1.0;
-    ebounds_ref[7] = 3.0;
-    ebounds_ref[8] = 7.0;
-    ebounds_ref[9] = 10.0;
-    ebounds_ref[10] = 30.0;
-    ebounds_ref[11] = 70.0;
-    ebounds_ref[12] = 100.0;
+    std::vector<double> ebounds_ref = {0.01, 0.03, 0.07, 0.1,  0.3,  0.7,  1.0,
+                                       3.0,  7.0,  10.0, 30.0, 70.0, 100.0};
+    Check(ebounds.size() == 13);
 
     // Compare the grids.
     if (rtt_dsxx::soft_equiv(ebounds, ebounds_ref))
@@ -175,8 +156,7 @@ void testEnergyBoundaryAccessor(rtt_dsxx::ScalarUnitTest &ut, opacityClassType c
     message << "The number of energy boundary points found in the data\n\t"
             << "grid does not match the number returned by the\n\t"
             << "get NumGroupBoundaries() accessor. \n"
-            << "Did not test the results returned by\n\t"
-            << "getGroupBoundaries().";
+            << "Did not test the results returned by\n\tgetGroupBoundaries().";
     ut.failure(message.str());
   }
 }

--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -78,14 +78,14 @@ DracoInfo::DracoInfo()
   else if (build_type == std::string("DEBUG"))
     fc_flags += CMAKE_Fortran_FLAGS_DEBUG;
 #endif
-#if defined(__NVCC__)
-  cuda_compiler = CMAKE_CUDA_COMPILER;
-  cuda_flags = CMAKE_CUDA_FLAGS;
-  if (build_type == std::string("RELEASE"))
-    cuda_flags += CMAKE_CUDA_FLAGS_RELEASE;
-  else if (build_type == std::string("DEBUG"))
-    cuda_flags += CMAKE_CUDA_FLAGS_DEBUG;
-#endif
+  if(cuda) {
+    cuda_compiler = CMAKE_CUDA_COMPILER;
+    cuda_flags = CMAKE_CUDA_FLAGS;
+    if (build_type == std::string("RELEASE"))
+      cuda_flags += CMAKE_CUDA_FLAGS_RELEASE;
+    else if (build_type == std::string("DEBUG"))
+      cuda_flags += CMAKE_CUDA_FLAGS_DEBUG;
+  }
 }
 
 //------------------------------------------------------------------------------------------------//

--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -78,7 +78,7 @@ DracoInfo::DracoInfo()
   else if (build_type == std::string("DEBUG"))
     fc_flags += CMAKE_Fortran_FLAGS_DEBUG;
 #endif
-  if(cuda) {
+  if (cuda) {
     cuda_compiler = CMAKE_CUDA_COMPILER;
     cuda_flags = CMAKE_CUDA_FLAGS;
     if (build_type == std::string("RELEASE"))

--- a/src/diagnostics/draco_info.cc
+++ b/src/diagnostics/draco_info.cc
@@ -78,14 +78,14 @@ DracoInfo::DracoInfo()
   else if (build_type == std::string("DEBUG"))
     fc_flags += CMAKE_Fortran_FLAGS_DEBUG;
 #endif
-  if (cuda) {
-    cuda_compiler = CMAKE_CUDA_COMPILER;
-    cuda_flags = CMAKE_CUDA_FLAGS;
-    if (build_type == std::string("RELEASE"))
-      cuda_flags += CMAKE_CUDA_FLAGS_RELEASE;
-    else if (build_type == std::string("DEBUG"))
-      cuda_flags += CMAKE_CUDA_FLAGS_DEBUG;
-  }
+#ifdef CMAKE_CUDA_COMPILER
+  cuda_compiler = CMAKE_CUDA_COMPILER;
+  cuda_flags = CMAKE_CUDA_FLAGS;
+  if (build_type == std::string("RELEASE"))
+    cuda_flags += CMAKE_CUDA_FLAGS_RELEASE;
+  else if (build_type == std::string("DEBUG"))
+    cuda_flags += CMAKE_CUDA_FLAGS_DEBUG;
+#endif
 }
 
 //------------------------------------------------------------------------------------------------//

--- a/src/diagnostics/draco_info.hh
+++ b/src/diagnostics/draco_info.hh
@@ -4,7 +4,7 @@
  * \author Kelly Thompson
  * \date   Wednesday, Nov 07, 2012, 18:49 pm
  * \brief  Small executable that prints the version and copyright strings.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2014-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_diagnostics_draco_info_hh
@@ -22,17 +22,19 @@ namespace rtt_diagnostics {
  * \brief Store and present basic information about the current draco build.
  *
  * The constructed string will take this form:
+ *
  * \verbatim
-Draco-6_25_20181114, build date 2018/11/14;build type: Debug;DBC: 7; DRACO_DIAGNOSTICS: 0
+Draco-7_11_20210915, build date 2021 Sep 15, build type: Debug, DBC: 7, DRACO_DIAGNOSTICS: 0
 
-CCS-2 Draco Team: Kelly G. Thompson, Kent G. Budge, Ryan T. Wollaeger, James S. Warsa, 
-     Alex R. Long, Kendra P. Keady, Jae H. Chang, Matt A. Cleveland, Andrew T. Till, Tim Kelley, 
-     and Kris C. Garrett.
+CCS-2 Draco Team: Kelly G. Thompson, Kent G. Budge, Matt A. Cleveland, Ryan T. Wollaeger,
+     Ben R. Ryan, Alex R. Long, Kendra P. Long, James S. Warsa, Jae H. Chang, Andrew T. Till,
+     and David A. Dixon.
 
-Prior Contributers: Jeff D. Densmore, Gabriel M. Rockefeller, Allan B. Wollaber, Rob B. Lowrie, 
-     Lori A. Pritchett-Sheats, Paul W. Talbot, and Katherine J. Wang.
-
-Copyright (C) 2016-2020 Triad National Security, LLC. (LA-CC-16-016)
+Prior Contributors: Gabriel M. Rockefeller, Allan B. Wollaber, Tim Kelley, Rob B. Lowrie,
+     Paul W. Talbot, Katherine J. Wang, Seth D. Cook, Ondrej Certik, Peter Ahrens,
+     Massimiliano Rosa, Todd J. Urbatsch, Daniel Holladay, Jeff D. Densmore, Howard Pritchard,
+     Jeff Furnish, John McGhee, Kris C. Garrett, Mike Buksas, Nick Myers, Paul Henning,
+     Randy Roberts, Seth Johnson, Todd Adams, Tom Evans, and Lori Pritchett-Sheats.
 
 For information, send e-mail to draco@lanl.gov.
 
@@ -43,18 +45,18 @@ Build information:
     Site name         : ccscs3
     CUDA support      : disabled
     MPI support       : enabled
-      mpirun cmd      : /scratch/.../bin/mpiexec -n <N> -bind-to none
+      mpirun cmd      : /ccs/opt/.../bin/mpiexec -n <N> -bind-to none
     OpenMP support    : enabled
     Design-by-Contract: 7, features = Insist, Require, Check, Ensure
     Diagnostics       : 0
     Diagnostics Timing: disabled
     CXX Compiler      : /scratch/vendors/spack.20180425/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/
                         gcc-8.1.0-3c5hjkqndywdp3w2l5vts62xlllrsbtq/bin/g++
-    CXX_FLAGS         : -Wcast-align -Wpointer-arith -Wall -pedantic -Wno-expansion-to-defined 
+    CXX_FLAGS         : -Wcast-align -Wpointer-arith -Wall -pedantic -Wno-expansion-to-defined
                         -Wnarrowing -march=native -fopenmp -Werror
     C Compiler        : /scratch/vendors/spack.20180425/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/
                         gcc-8.1.0-3c5hjkqndywdp3w2l5vts62xlllrsbtq/bin/gcc
-    C_FLAGS           : -Wcast-align -Wpointer-arith -Wall -pedantic -Wno-expansion-to-defined 
+    C_FLAGS           : -Wcast-align -Wpointer-arith -Wall -pedantic -Wno-expansion-to-defined
                         -Wnarrowing -march=native -fopenmp -Werror
     Fortran Compiler  : /scratch/vendors/spack.20180425/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/
                         gcc-8.1.0-3c5hjkqndywdp3w2l5vts62xlllrsbtq/bin/gfortran
@@ -79,7 +81,7 @@ public:
    *         build parameters. */
   std::string fullReport() const;
 
-  //! Version and Copyright only
+  //! Version and (C)
   std::string briefReport() const;
 
   //! Version only
@@ -108,6 +110,8 @@ private:
   std::string cc_flags;
   std::string fc;
   std::string fc_flags;
+  std::string cuda_compiler; //! < full path to the cuda compiler (if any)
+  std::string cuda_flags;    //!< Compiler flags for cuda
 };
 
 } // end namespace rtt_diagnostics

--- a/src/ds++/Release.cc
+++ b/src/ds++/Release.cc
@@ -107,21 +107,20 @@ const std::string author_list(bool const use_doxygen_formatting) {
   current_developers.insert(fomdev(2927, "Alex R. Long"));
   current_developers.insert(fomdev(1565, "Kendra P. Long"));
   current_developers.insert(fomdev(1270, "James S. Warsa"));
-  current_developers.insert(fomdev(904, "Tim Kelley"));
   current_developers.insert(fomdev(353, "Jae H. Chang"));
   current_developers.insert(fomdev(127, "Andrew T. Till"));
-  current_developers.insert(fomdev(91, "Ondrej Certik"));
   current_developers.insert(fomdev(15, "David A. Dixon"));
-  current_developers.insert(fomdev(4, "Howard Pritchard"));
 
   mmdevs prior_developers;
 
   prior_developers.insert(fomdev(3628, "Gabriel M. Rockefeller"));
   prior_developers.insert(fomdev(1738, "Allan B. Wollaber"));
+  prior_developers.insert(fomdev(904, "Tim Kelley"));
   prior_developers.insert(fomdev(407, "Rob B. Lowrie"));
   prior_developers.insert(fomdev(282, "Paul W. Talbot"));
   prior_developers.insert(fomdev(184, "Katherine J. Wang"));
   prior_developers.insert(fomdev(98, "Seth D. Cook"));
+  prior_developers.insert(fomdev(91, "Ondrej Certik"));
   prior_developers.insert(fomdev(65, "Peter Ahrens"));
 
   // Previous authors with no current LOC attribution (less than 10):
@@ -129,6 +128,7 @@ const std::string author_list(bool const use_doxygen_formatting) {
   prior_developers.insert(fomdev(7, "Todd J. Urbatsch"));
   prior_developers.insert(fomdev(6, "Daniel Holladay"));
   prior_developers.insert(fomdev(5, "Jeff D. Densmore"));
+  prior_developers.insert(fomdev(4, "Howard Pritchard"));
   prior_developers.insert(fomdev(1, "Jeff Furnish"));
   prior_developers.insert(fomdev(1, "John McGhee"));
   prior_developers.insert(fomdev(1, "Kris C. Garrett"));

--- a/src/ds++/config.h.in
+++ b/src/ds++/config.h.in
@@ -2,7 +2,7 @@
 /*!
  * \file   config.h
  * \brief  CPP defines necessary for the ds++ package.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 /*------------------------------------------------------------------------------------------------*/
 
 #ifndef rtt_dsxx_config_h
@@ -251,6 +251,12 @@
 #cmakedefine CMAKE_Fortran_FLAGS_RELEASE   "@CMAKE_Fortran_FLAGS_RELEASE@"
 #cmakedefine CMAKE_Fortran_FLAGS_RELWITHDEBINFO "@CMAKE_Fortran_FLAGS_RELWITHDEBINFO@"
 #cmakedefine CMAKE_Fortran_FLAGS_MINSIZEREL     "@CMAKE_Fortran_FLAGS_MINSIZEREL@"
+#cmakedefine CMAKE_CUDA_COMPILER        "@CMAKE_CUDA_COMPILER@"
+#cmakedefine CMAKE_CUDA_FLAGS           "@CMAKE_CUDA_FLAGS@"
+#cmakedefine CMAKE_CUDA_FLAGS_DEBUG     "@CMAKE_CUDA_FLAGS_DEBUG@"
+#cmakedefine CMAKE_CUDA_FLAGS_RELEASE   "@CMAKE_CUDA_FLAGS_RELEASE@"
+#cmakedefine CMAKE_CUDA_FLAGS_RELWITHDEBINFO "@CMAKE_CUDA_FLAGS_RELWITHDEBINFO@"
+#cmakedefine CMAKE_CUDA_FLAGS_MINSIZEREL     "@CMAKE_CUDA_FLAGS_MINSIZEREL@"
 #cmakedefine CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
 
 #cmakedefine CMAKE_COMPILER_IS_GNUCXX         @CMAKE_COMPILER_IS_GNUCXX@

--- a/src/parser/Abstract_Class_Parser.i.hh
+++ b/src/parser/Abstract_Class_Parser.i.hh
@@ -36,7 +36,7 @@ public:
 
   // DATA
 
-  //! The tabe of raw strings
+  //! The table of raw strings
   std::vector<char *> data;
 };
 

--- a/src/parser/Contextual_Parse_Functor.hh
+++ b/src/parser/Contextual_Parse_Functor.hh
@@ -4,7 +4,7 @@
  * \author Kent Budge
  * \date   Thu Jul 17 14:08:42 2008
  * \brief  Member definitions of class Abstract_Class_Parser
- * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef parser_Contextual_Parse_Functor_hh
@@ -18,9 +18,9 @@ namespace rtt_parser {
 /*!
  * \brief Closure class for wrapping context-dependent parse functions
  *
- * This template class is used to bind a get_context() function to a parse function requiring a
+ * This template class is used to bind a \c get_context() function to a parse function requiring a
  * context argument, so that the function can be called with the usual two parameters (Token_Stream
- * and int) from an Abstract_Class_Parse_Table.
+ * and \c int) from an \c Abstract_Class_Parse_Table.
  *
  * See test/tstAbstract_Class_Contextual_Parser.cc for an example of how it is used.
  */

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -408,7 +408,7 @@ patchfile_cb=$(mktemp "/tmp/$USER/copyright_block.patch.XXXXXXXX")
 # file types to parse.
 FILE_EXTS=".c .cc .cmake .h .hh .in .f90 .F90 .f .F .py .txt"
 #FILE_ENDINGS_INCLUDE="_f.h _f77.h _f90.h"
-FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc check_style.sh"
+FILE_ENDINGS_EXCLUDE="ChangeLog Release.cc Release.hh info.cc check_style.sh"
 export FILE_EXTS FILE_ENDINGS_EXCLUDE
 
 # Loop over all modified files.  Create one patch containing all changes to these files


### PR DESCRIPTION
### Background

* Update the `draco_info` command so that information about Cuda is also printed.

### Description of changes

+ Fix a bug in the `draco_info` report that removed leading slashes for compiler paths.
+ Also wrap the fully qualified path to `mpirun`
+ Move some names to "prior contributors" section of the author list.
+ Minor clean-up in cdi files.

### Example output

![draco-info-out](https://user-images.githubusercontent.com/17579601/133514570-19d61213-8018-41eb-8e7e-8122b0974b09.jpg)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease (new, cuda-specific, code can't be covered by CI).
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
