### PR TITLE
Adopt LAP SE 1.8 for default develop env on CTS-1 and ATS-1

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -60,10 +60,23 @@ if(NOT CXX_FLAGS_INITIALIZED)
   set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE}")
   set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -funroll-loops")
 
+  # OneAPI on trinitite reports itself as "LLVM" and parses this file.  The Intel optimizer needs
+  # these options to maintain IEEE 754 compliance.
+  if(CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv)
+    string(APPEND CMAKE_C_FLAGS_RELEASE " -fp-model=precise")
+    string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -fp-model=precise")
+  endif()
+
   # Suppress warnings about typeid() called with function as an argument. In this case, the function
   # might not be called if the type can be deduced.
   string(APPEND CMAKE_CXX_FLAGS " ${CMAKE_C_FLAGS} -Wno-undefined-var-template"
          " -Wno-potentially-evaluated-expression")
+
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
+  # Tried to use -fsanitize=safe-stack but this caused build issues.
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
   if(DEFINED CMAKE_CXX_COMPILER_WRAPPER AND "${CMAKE_CXX_COMPILER_WRAPPER}" STREQUAL "CrayPrgEnv")
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libstdc++")
@@ -80,12 +93,6 @@ if(NOT CXX_FLAGS_INITIALIZED)
   else()
     string(APPEND CMAKE_CXX_FLAGS " -stdlib=libc++")
   endif()
-
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Woverloaded-virtual")
-  # Tried to use -fsanitize=safe-stack but this caused build issues.
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-  set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_RELEASE}")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
 endif()
 

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -3,7 +3,7 @@
 # File  : environment/bashrc/.bashrc_cray
 # Date  : Tuesday, May 31, 2016, 14:48 pm
 # Author: Kelly Thompson
-# Note  : Copyright (C) 2016-2020, Triad National Security, LLC., All rights are reserved.
+# Note  : Copyright (C) 2016-2021, Triad National Security, LLC., All rights are reserved.
 #
 # Bash configuration file for Cray HPC machines.
 #--------------------------------------------------------------------------------------------------#
@@ -72,6 +72,7 @@ arch=`uname -m`
 # Use modules found in the draco directory
 sysname=`/usr/projects/hpcsoft/utilities/bin/sys_name`
 module use --append /usr/projects/draco/Modules/$sysname
+module unload draco lapse
 case $sysname in
   capulin)
     module unuse /usr/share/modules
@@ -80,7 +81,7 @@ case $sysname in
     module load draco
     ;;
   trinitite | trinity )
-    module load draco/intel19
+    module load lapse/1.8-intel
     if [[ ${SLURM_JOB_PARTITION} =~ "knl" ]]; then
       module swap craype-haswell craype-mic-knl
     fi

--- a/environment/bashrc/.bashrc_cts1
+++ b/environment/bashrc/.bashrc_cts1
@@ -55,7 +55,8 @@ else
 
   if [[ -d /usr/projects/draco/Modules/cts1 ]]; then
     module use --append /usr/projects/draco/Modules/cts1
-    module load draco/intel19
+    module unload draco lapse
+    module load lapse/1.8-intel
   fi
 
 fi

--- a/src/ds++/StackTrace.hh
+++ b/src/ds++/StackTrace.hh
@@ -19,8 +19,7 @@ namespace rtt_dsxx {
 /*!
  * \brief print_stacktrace
  *
- * \param error_name A string that identifies why the stack trace is
- *                   requested.
+ * \param error_name A string that identifies why the stack trace is requested.
  * \return A multi-line message including the error_name and the stack trace.
  *
  * A stack trace will look something like this:


### PR DESCRIPTION
### Background

* When possible, we are adopting the LAP SE environments.  This reduces devops maintenance costs on the TRT teams by offloading the work to LAP.  The older environments are still available and can be loaded manually.
* For ATS-1, we are now using LAP SE 1.8 for intel-19 environments.   CCE and OneAPI environments are still provided by the TRT team.
* For CTS-1, we are now using LAP SE 1.8 for intel-19 and gcc-9 environments.  The intel/19.1.3 environment is still provided by the TRT team.

### Description of changes

+ The `draco/intel19` are still available and can be loaded manually.
+ Also update compiler flags for Intel OneAPI to fix 4 failing tests.
  - One test is still failing and triage continues.
+ Related to
  - https://re-git.lanl.gov/draco/draco/-/issues/1243
  - https://re-git.lanl.gov/draco/devops/-/issues/41

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
