### PR TITLE
Help CMake differentiate bewteen Clang, IntelLLVM and CCELLVM.

### DIFF
--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -62,7 +62,7 @@ if(NOT CXX_FLAGS_INITIALIZED)
 
   # OneAPI on trinitite reports itself as "LLVM" and parses this file.  The Intel optimizer needs
   # these options to maintain IEEE 754 compliance.
-  if(CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv)
+  if(CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv AND INTEL_COMPILER_TYPE STREQUAL "ONEAPI")
     string(APPEND CMAKE_C_FLAGS_RELEASE " -fp-model=precise")
     string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -fp-model=precise")
   endif()


### PR DESCRIPTION
### Background

* CMake is confused about LLVM Clang vs. LLVM Intel vs. LLVM CCE.  Provide some help. 

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
