### PR TITLE
Add LAP SE 1.8 as a release build env

### DIFF
--- a/tools/ats1-env.sh
+++ b/tools/ats1-env.sh
@@ -24,7 +24,7 @@ else
 fi
 
 # The following toolchains will be used when releasing code
-environments="cce11env intel1904env intel1904env-knl"
+environments="cce11env lapse18intelenv lapse18intelenv-knl"
 
 # Extra cmake options
 export CONFIG_BASE+=" -DCMAKE_VERBOSE_MAKEFILE=ON"
@@ -70,7 +70,7 @@ case "$ddir" in
       export CC CXX FC
     }
 
-    function intel1904env()
+    function lapse18intelenv()
     {
       unset partition
       unset jobnameext
@@ -78,19 +78,19 @@ case "$ddir" in
       sysname=$(/usr/projects/hpcsoft/utilities/bin/sys_name)
       module use --append "/usr/projects/draco/Modules/${sysname}"
 
-      run "module unload draco"
-      run "module unload PrgEnv-cray"
+      run "module unload draco lapse"
+      run "module unload PrgEnv-intel PrgEnv-cray PrgEnv-gnu"
       run "module load PrgEnv-intel"
-      run "module load draco/intel19"
+      run "module load lapse/1.8-intel"
       run "module list"
       CC=$(which cc)
       CXX=$(which CC)
       FC=$(which ftn)
-      # export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH":"$LD_LIBRARY_PATH"
+      export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH":"$LD_LIBRARY_PATH"
       export CC CXX FC
     }
 
-    function intel1904env-knl()
+    function lapse18intelenv-knl()
     {
       export partition="-p knl --exclude=nid00192"
       export jobnameext="-knl"
@@ -98,13 +98,13 @@ case "$ddir" in
       sysname=$(/usr/projects/hpcsoft/utilities/bin/sys_name)
       module use --append "/usr/projects/draco/Modules/${sysname}"
 
-      run "module unload draco"
-      run "module unload PrgEnv-cray"
+      run "module unload draco lapse"
+      run "module unload PrgEnv-intel PrgEnv-cray PrgEnv-gnu"
       run "module load PrgEnv-intel"
-      run "module load draco/intel19"
-      if ! [[ "${CRAY_CPU_TARGET}" == mic-knl ]]; then
-        run "module swap craype-haswell craype-mic-knl"
-      fi
+      run "module load lapse/1.8-intel"
+      # Be explicit about unloading haswell / loading the knl module!
+      run "module unload craype-haswell"
+      run "module load craype-mic-knl"
       run "module list"
       CC=$(which cc)
       CXX=$(which CC)

--- a/tools/cts1-env.sh
+++ b/tools/cts1-env.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # The following toolchains will be used when releasing code
-environments="intel1904env gcc930env"
+environments="intel1904env gcc930env lapse18intelenv"
 
 # Extra cmake options
 export CONFIG_BASE+=" -DCMAKE_VERBOSE_MAKEFILE=ON"
@@ -57,6 +57,13 @@ case "${ddir}" in
       run "module purge"
       run "module use --append /usr/projects/draco/Modules/cts1"
       run "module load draco/gcc9"
+      run "module list"
+    }
+    function lapse18intelenv()
+    {
+      run "module purge"
+      run "module use --append /usr/projects/draco/Modules/cts1"
+      run "module load lapse/1.8-intel"
       run "module list"
     }
     ;;


### PR DESCRIPTION
### Background

* Codifying changes made during draco-7_12 release process :)

### Purpose of Pull Request

* Add LAP SE1.8 environments as release builds for CTS/ATS-1
* (This seems useful given that LAP is now the default draco env on those machines.)
* [Fixes re-git issue #1363](https://re-git.lanl.gov/draco/draco/-/issues/1363)

### Description of changes

* Add functions to bash scripts to load LAP SE environments
* Small changes have already been made to corresponding draco module files to ensure the correct mpich is loaded.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
