### PR TITLE
Remove code to set TF_ variables in draco environments

### DIFF
--- a/environment/bashrc/.bashrc_ats2
+++ b/environment/bashrc/.bashrc_ats2
@@ -19,12 +19,6 @@ export PATH=${VENDOR_DIR:=/usr/gapps/jayenne/vendors}/bin:$PATH
 export VENDOR_DIR
 export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
 
-# Support building cassio with ccsrad shared deployment repository.
-if [[ -d /usr/workspace/dacodes/eap/users/ccsrad/Cassio.deployment ]]; then
-  export TF_DEPLOYMENT_CLONES=/usr/workspace/dacodes/eap/users/ccsrad/eap.deployment
-  export TF_SPACK_INSTANCES=/usr/workspace/dacodes/eap/users/ccsrad/spack_instances
-fi
-
 #
 # MODULES
 #

--- a/environment/bashrc/.bashrc_ats4
+++ b/environment/bashrc/.bashrc_ats4
@@ -19,12 +19,6 @@ export PATH=${VENDOR_DIR:=/usr/gapps/jayenne/vendors}/bin:$PATH
 export VENDOR_DIR
 export JSM_JSRUN_NO_WARN_OVERSUBSCRIBE=1
 
-# Support building cassio with ccsrad shared deployment repository.
-# if [[ -d /usr/workspace/dacodes/eap/users/ccsrad/Cassio.deployment ]]; then
-#   export TF_DEPLOYMENT_CLONES=/usr/workspace/dacodes/eap/users/ccsrad/eap.deployment
-#   export TF_SPACK_INSTANCES=/usr/workspace/dacodes/eap/users/ccsrad/spack_instances
-# fi
-
 #
 # MODULES
 #

--- a/environment/bashrc/.bashrc_cray
+++ b/environment/bashrc/.bashrc_cray
@@ -56,10 +56,6 @@ if [[ -d /usr/projects/eap/users ]]; then
 elif [[ -d /usr/projects/crestone/users ]]; then
   export UPE=/usr/projects/crestone
 fi
-if [[ -d ${UPE}/users/ccsrad/Cassio.deployment ]]; then
-  export TF_DEPLOYMENT_CLONES=${UPE}/users/ccsrad/Cassio.deployment
-  export TF_SPACK_INSTANCES=${UPE}/users/ccsrad/spack_instances
-fi
 add_to_path ${UPE}/tools
 
 #

--- a/environment/bashrc/.bashrc_cts1
+++ b/environment/bashrc/.bashrc_cts1
@@ -24,10 +24,6 @@ if [[ -d /usr/projects/eap/users ]]; then
 elif [[ -d /usr/projects/crestone/users ]]; then
   export UPE=/usr/projects/crestone
 fi
-if [[ -d ${UPE}/users/ccsrad/Cassio.deployment ]]; then
-  export TF_DEPLOYMENT_CLONES="${UPE}/users/ccsrad/Cassio.deployment"
-  export TF_SPACK_INSTANCES="${UPE}/users/ccsrad/spack_instances"
-fi
 add_to_path "${UPE}/tools"
 
 # shell options


### PR DESCRIPTION
### Background

* We have decided to discontinue use of our shared spack instance in favor of individual developer instances (where needed)

### Purpose of Pull Request

* remove code that sets env variables TF_SPACK_INSTANCES and TF_DEPLOYMENT_CLONES for various draco environments

### Description of changes

* (see above)

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [ ] Travis/Appveyor CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
