### PR TITLE
Fix warnings issued by Intel OneAPI 2021.4.0

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -513,6 +513,7 @@ macro(setupMPILibrariesUnix)
     setmpiflavorver()
 
     # Set additional flags, environments that are MPI vendor specific.
+    message("==> MPI_FLAVOR = ${MPI_FLAVOR}")
     if("${MPI_FLAVOR}" MATCHES "openmpi")
       setupopenmpi()
     elseif("${MPI_FLAVOR}" MATCHES "mpich")

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -513,7 +513,6 @@ macro(setupMPILibrariesUnix)
     setmpiflavorver()
 
     # Set additional flags, environments that are MPI vendor specific.
-    message("==> MPI_FLAVOR = ${MPI_FLAVOR}")
     if("${MPI_FLAVOR}" MATCHES "openmpi")
       setupopenmpi()
     elseif("${MPI_FLAVOR}" MATCHES "mpich")

--- a/config/unix-clang.cmake
+++ b/config/unix-clang.cmake
@@ -62,10 +62,11 @@ if(NOT CXX_FLAGS_INITIALIZED)
 
   # OneAPI on trinitite reports itself as "LLVM" and parses this file.  The Intel optimizer needs
   # these options to maintain IEEE 754 compliance.
-  if(DEFINED CMAKE_CXX_COMPILER_WRAPPER AND CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv AND
-      DEFINED ENV{INTEL_COMPILER_TYPE} AND "$ENV{INTEL_COMPILER_TYPE}" STREQUAL "ONEAPI")
-    string(APPEND CMAKE_C_FLAGS_RELEASE " -fp-model=precise")
-    string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -fp-model=precise")
+  if(DEFINED CMAKE_CXX_COMPILER_WRAPPER
+     AND CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv
+     AND DEFINED ENV{INTEL_COMPILER_TYPE}
+     AND "$ENV{INTEL_COMPILER_TYPE}" STREQUAL "ONEAPI")
+    string(APPEND CMAKE_C_FLAGS " -fp-model=precise")
   endif()
 
   # Suppress warnings about typeid() called with function as an argument. In this case, the function

--- a/src/RTT_Format_Reader/CellDefs.hh
+++ b/src/RTT_Format_Reader/CellDefs.hh
@@ -4,7 +4,7 @@
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for CellDefs library.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_RTT_Format_Reader_CellDefs_hh
@@ -57,6 +57,12 @@ public:
   }
 
   ~CellDef() = default;
+
+  //! Copy constructor
+  CellDef(CellDef const &rhs)
+      : cellDefs(rhs.cellDefs), name(rhs.name), nnodes(rhs.nnodes), nsides(rhs.nsides),
+        side_types(rhs.side_types), sides(rhs.sides), ordered_sides(rhs.ordered_sides),
+        node_map(rhs.node_map) {}
 
   void readDef(ifstream &meshfile);
   void redefineCellDef(vector_uint const &new_side_types_,

--- a/src/RTT_Format_Reader/CellDefs.hh
+++ b/src/RTT_Format_Reader/CellDefs.hh
@@ -4,7 +4,7 @@
  * \author B.T. Adams
  * \date   Wed Jun 7 10:33:26 2000
  * \brief  Header file for CellDefs library.
- * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_RTT_Format_Reader_CellDefs_hh
@@ -59,10 +59,13 @@ public:
   ~CellDef() = default;
 
   //! Copy constructor
-  CellDef(CellDef const &rhs)
-      : cellDefs(rhs.cellDefs), name(rhs.name), nnodes(rhs.nnodes), nsides(rhs.nsides),
-        side_types(rhs.side_types), sides(rhs.sides), ordered_sides(rhs.ordered_sides),
-        node_map(rhs.node_map) {}
+  CellDef(CellDef const &rhs) = default;
+  CellDef(CellDef &&rhs) = default;
+
+  // Assignment operator - "explicitly defaulted assignment op is implicitly deleted because
+  // CellsDefs is of reference type.
+  // CellDef & operator=(CellDef const & rhs) = default;
+  // CellDef & operator=(CellDef && rhs) = default;
 
   void readDef(ifstream &meshfile);
   void redefineCellDef(vector_uint const &new_side_types_,
@@ -101,7 +104,7 @@ public:
   /*!
    * \brief Returns the side definition of the specified side index of this cell definition with the
    *        returned cell-node indexes in sorted order.
-   * \param s Side index number.
+   * \param[in] s Side index number.
    * \return The side definition (i.e., the cell-node indexes that comprise the side).
    */
   vector_uint const &get_side(size_t s) const { return sides[s]; }
@@ -110,7 +113,7 @@ public:
    * \brief Returns the side definition of the specified side index of this cell definition with the
    *        returned cell-node indexes ordered to preserve the right hand rule for the
    *        outward-directed normal.
-   * \param s Side index number.
+   * \param[in] s Side index number.
    * \return The side definition (i.e., the cell-node indexes that comprise the side).
    */
   vector_uint const &get_ordered_side(size_t s) const { return ordered_sides[s]; }
@@ -162,7 +165,7 @@ private:
 public:
   /*!
    * \brief Returns the name of the specified cell definition.
-   * \param i Cell definition index number.
+   * \param[in] i Cell definition index number.
    * \return The cell definition name.
    */
   string get_name(size_t i) const {
@@ -172,7 +175,7 @@ public:
 
   /*!
    * \brief Returns the specified cell definition.
-   * \param i Cell definition index number.
+   * \param[in] i Cell definition index number.
    * \return The cell definition.
    */
   const CellDef &get_cell_def(size_t i) const { return *(defs[i]); }
@@ -180,14 +183,14 @@ public:
 
   /*!
    * \brief Returns the number of nodes associated with the specified cell definition.
-  * \param i Cell definition index number.
+   * \param[in] i Cell definition index number.
    * \return The number of nodes comprising the cell definition.
    */
   size_t get_nnodes(size_t i) const { return defs[i]->get_nnodes(); }
 
   /*!
    * \brief Returns the number of sides associated with the specified cell definition.
-   * \param i Cell definition index number.
+   * \param[in] i Cell definition index number.
    * \return The number of sides comprising the cell definition.
    */
   size_t get_nsides(size_t i) const { return defs[i]->get_nsides(); }
@@ -195,8 +198,8 @@ public:
   /*!
    * \brief Returns the side type number associated with the specified side index and cell
    *        definition.
-   * \param i Cell definition index number.
-   * \param s Side index number.
+   * \param[in] i Cell definition index number.
+   * \param[in] s Side index number.
    * \return The side type number.
    */
   int get_side_types(size_t i, size_t s) const { return defs[i]->get_side_types(s); }
@@ -204,8 +207,8 @@ public:
   /*!
    * \brief Returns the side definition associated with the specified cell definition and side index
    *        with the returned cell-node indexes in sorted order.
-   * \param i Cell definition index number.
-   * \param s Side index number.
+   * \param[in] i Cell definition index number.
+   * \param[in] s Side index number.
    * \return The side definition (i.e., the cell-node indexes that comprise the side).
    */
   vector_uint const &get_side(size_t i, size_t s) const { return defs[i]->get_side(s); }
@@ -214,8 +217,8 @@ public:
    * \brief Returns the side definition associated with the specified cell definition and side index
    *        with the returned cell-node indexes ordered to preserve the right hand rule for the
    *        outward-directed normal.
-   * \param i Cell definition index number.
-   * \param s Side index number.
+   * \param[in] i Cell definition index number.
+   * \param[in] s Side index number.
    * \return The side definition (i.e., the cell-node indexes that comprise the side).
    */
   vector_uint const &get_ordered_side(size_t i, size_t s) const {
@@ -231,7 +234,7 @@ public:
   /*!
    * \brief Returns the new node map for the specified cell definition when redefinition has been
    *        performed.
-   * \param cell_def Cell definition index.
+   * \param[in] cell_def Cell definition index.
    * \return New cell definition node map.
    */
   const vector_uint &get_node_map(int cell_def) const { return defs[cell_def]->get_node_map(); }

--- a/src/c4/C4_Datatype.hh
+++ b/src/c4/C4_Datatype.hh
@@ -1,9 +1,8 @@
 //--------------------------------------------*-C++-*---------------------------------------------//
 /*!
- * \file   c4/C4_Datatype.hh
- * \author Kent G. Budge
- * \brief  C4_Datatype class definition.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \file  c4/C4_Datatype.hh
+ * \brief Kent G. Budge
+ * \note  Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef c4_C4_Datatype_hh

--- a/src/c4/C4_Functions.hh
+++ b/src/c4/C4_Functions.hh
@@ -4,7 +4,7 @@
  * \author Thomas M. Evans
  * \date   Thu Mar 21 11:42:03 2002
  * \brief  C4 Communication Functions.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved.
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved.
  *
  * This file contains the declarations for communication functions provided by C4. This file allows
  * the client to include the message passing services provided by C4.  The function declarations and

--- a/src/c4/fc4/Draco_MPI.F90
+++ b/src/c4/fc4/Draco_MPI.F90
@@ -3,7 +3,7 @@
 ! \author Allan Wollaber
 ! \date   Mon Jul 30 07:06:24 MDT 2012
 ! \brief  Helper functions to support scalar vs. distributed MPI tests.
-! \note   Copyright (c) 2016-2020 Triad National Security, LLC., All rights reserved.
+! \note   Copyright (c) 2016-2021 Triad National Security, LLC., All rights reserved.
 !--------------------------------------------------------------------------------------------------!
 
 module draco_mpi

--- a/src/c4/test/tstTime.cc
+++ b/src/c4/test/tstTime.cc
@@ -96,11 +96,9 @@ void wall_clock_test(rtt_dsxx::UnitTest &ut) {
     std::cout << "\nDoing some work..." << std::endl;
   size_t len(10000000);
   std::vector<double> foo(len);
-  //double sum(0);
   for (size_t i = 0; i < len; ++i) {
     auto const d(static_cast<double>(i + 1));
     foo[i] = std::sqrt(std::log(d * 3.14) * std::fabs(std::cos(d / 3.14)));
-    // sum += foo[i];
   }
 
   double end = rtt_c4::wall_clock_time();

--- a/src/c4/test/tstTime.cc
+++ b/src/c4/test/tstTime.cc
@@ -96,11 +96,11 @@ void wall_clock_test(rtt_dsxx::UnitTest &ut) {
     std::cout << "\nDoing some work..." << std::endl;
   size_t len(10000000);
   std::vector<double> foo(len);
-  double sum(0);
+  //double sum(0);
   for (size_t i = 0; i < len; ++i) {
     auto const d(static_cast<double>(i + 1));
     foo[i] = std::sqrt(std::log(d * 3.14) * std::fabs(std::cos(d / 3.14)));
-    sum += foo[i];
+    // sum += foo[i];
   }
 
   double end = rtt_c4::wall_clock_time();

--- a/src/c4/xthi_cpuset.hh
+++ b/src/c4/xthi_cpuset.hh
@@ -17,6 +17,7 @@
 #include "c4_omp.h"
 #include "ds++/Assert.hh"
 #include "ds++/SystemCall.hh"
+
 #include <bitset>
 #include <sstream>
 
@@ -140,6 +141,11 @@ inline std::string cpuset_to_string(unsigned const num_cpu) {
 
 #else
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
 inline std::string cpuset_to_string(unsigned const /*num_cpu*/) {
 
   // return value;
@@ -170,6 +176,10 @@ inline std::string cpuset_to_string(unsigned const /*num_cpu*/) {
   }
   return cpuset.str().substr(0, cpuset.str().length() - entry_made);
 }
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
+#endif
 
 #endif
 

--- a/src/cdi_eospac/EospacException.hh
+++ b/src/cdi_eospac/EospacException.hh
@@ -64,7 +64,7 @@ public:
    *
    * Do not allow destructor to throw.
    */
-  ~EospacException() noexcept override = default;
+  // ~EospacException() noexcept override = default;
 };
 
 //------------------------------------------------------------------------------------------------//
@@ -73,7 +73,7 @@ public:
   explicit EospacUnknownDataType(std::string const &msg) noexcept
       : EospacException(msg) { /* empty */
   }
-  ~EospacUnknownDataType() noexcept override = default;
+  // ~EospacUnknownDataType() noexcept override = default;
 };
 
 } // end namespace rtt_cdi_eospac

--- a/src/ds++/Index_Converter.hh
+++ b/src/ds++/Index_Converter.hh
@@ -4,7 +4,7 @@
  * \author Mike Buksas
  * \date   Fri Jan 20 14:51:51 2006
  * \brief  Decleration and Definition of Index_Converter
- * \note   Copyright 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef dsxx_Index_Converter_hh
@@ -39,6 +39,10 @@ public:
 
   //! Construct a with all dimensions equal
   Index_Converter(const unsigned dimension) { set_size(dimension); }
+
+  //! Copy constructor
+  Index_Converter(Index_Converter const &rhs)
+      : Index_Set<D, OFFSET>(rhs), sub_sizes(rhs.sub_sizes) {}
 
   //! Destructor
   ~Index_Converter() override = default;

--- a/src/ds++/Index_Counter.hh
+++ b/src/ds++/Index_Counter.hh
@@ -38,6 +38,10 @@ public:
   //! Default constructors.
   explicit Index_Counter(const Index_Set<D, OFFSET> &index_set);
 
+  //! Copy constructor
+  Index_Counter(Index_Counter const &rhs)
+      : index_set(rhs.index_set), indices(rhs.indices), index(rhs.index), in_range(rhs.in_range) {}
+
   //! Destructor.
   ~Index_Counter() = default;
 

--- a/src/ds++/Index_Set.hh
+++ b/src/ds++/Index_Set.hh
@@ -38,6 +38,10 @@ public:
   //! Construct with all dimensions equal
   explicit Index_Set(const unsigned dimension) { set_size(dimension); }
 
+  //! Copy constructor
+  Index_Set(Index_Set const &rhs)
+      : m_array_size(rhs.m_array_size), m_dimensions(rhs.m_dimensions) {}
+
   //! Destructor
   virtual ~Index_Set() = default;
 

--- a/src/ds++/test/tstIndex_Converter.cc
+++ b/src/ds++/test/tstIndex_Converter.cc
@@ -3,8 +3,7 @@
  * \file   ds++/test/tstIndex_Converter.cc
  * \author Mike Buksas
  * \date   Fri Jan 20 15:53:51 2006
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Index_Converter.hh"

--- a/src/experimental/mdspan
+++ b/src/experimental/mdspan
@@ -65,6 +65,11 @@
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
 #include "__p0009_bits/accessor_basic.hpp"
 #include "__p0009_bits/all_type.hpp"
 #include "__p0009_bits/array_workaround.hpp"
@@ -78,6 +83,10 @@
 #include "__p0009_bits/macros.hpp"
 #include "__p0009_bits/mixed_size_storage.hpp"
 #include "__p0009_bits/subspan.hpp"
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
+#endif
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop

--- a/src/kde/quick_index.cc
+++ b/src/kde/quick_index.cc
@@ -3,8 +3,7 @@
  * \file   kde/quick_index.cc
  * \author Mathew Cleveland
  * \brief  Explicitly defined quick_index functions.
- * \note   Copyright (C) 2021-2021 Triad National Security, LLC., All rights reserved.
- */
+ * \note   Copyright (C) 2021-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "quick_index.hh"
@@ -16,7 +15,7 @@ namespace rtt_kde {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief quick_index constructor. 
+ * \brief quick_index constructor.
  *
  * This function builds up a global indexing table to quickly access data that is spatial located
  * near each other. It breaks up the data into equally spaced bins in each dimension. For domain
@@ -25,7 +24,7 @@ namespace rtt_kde {
  * size such that any cell on the local domain will have access to all points that should fall into
  * the spatial window centered on any given local point.
  *
- * \param[in] dim_ specifying the data dimensionality 
+ * \param[in] dim_ specifying the data dimensionality
  * \param[in] locations_ data locations.
  * \param[in] max_window_size_ maximum supported window size
  * \param[in] bins_per_dimension_ number of bins in each dimension
@@ -230,14 +229,14 @@ auto put_lambda = [](auto &put, auto &put_buffer, auto &put_size, auto &win) {
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Collect ghost data for a vector<std::array<double, 3>>
- * 
+ *
  * Collect ghost data for vector of 3 dimensional arrays. This function uses RMA and the local
  * put_window_map to allow each rank to independently fill in its data to ghost cells of other
  * ranks.
  *
  * \param[in] local_data the local 3 dimensional data that is required to be available as ghost cell
  * data on other processors.
- * \param[in] local_ghost_data the resulting 3 dimensional ghost data data. 
+ * \param[in] local_ghost_data the resulting 3 dimensional ghost data data.
  */
 void quick_index::collect_ghost_data(const std::vector<std::array<double, 3>> &local_data,
                                      std::vector<std::array<double, 3>> &local_ghost_data) const {
@@ -286,8 +285,8 @@ void quick_index::collect_ghost_data(const std::vector<std::array<double, 3>> &l
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Collect ghost data for a vector<vector<double>> 
- * 
+ * \brief Collect ghost data for a vector<vector<double>>
+ *
  * Collect ghost data for vector<vector<double>> arrays. This function uses RMA and the local
  * put_window_map to allow each rank to independently fill in its data to ghost cells of other
  * ranks.
@@ -350,7 +349,7 @@ void quick_index::collect_ghost_data(const std::vector<std::vector<double>> &loc
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Collect ghost data for a vector<double>
- * 
+ *
  * Collect ghost data for a single vector. This function uses RMA and the local put_window_map to
  * allow each rank to independently fill in its data to ghost cells of other ranks.
  *
@@ -395,7 +394,7 @@ void quick_index::collect_ghost_data(const std::vector<double> &local_data,
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Generate a coarse index list for a window.
- * 
+ *
  *  Provides a list of global indices that are required by any given window range.
  *
  * \param[in] window_min the smallest corner point for every dimension
@@ -456,7 +455,7 @@ quick_index::window_coarse_index_list(const std::array<double, 3> &window_min,
   if (spherical && (window_min[1] < 0.0 || window_max[1] > 2.0 * rtt_units::PI)) {
     // Only one bound of the window should every overshoot zero
     Check(!(window_min[1] < 0.0 && window_max[1] > 2.0 * rtt_units::PI));
-    size_t overlap_nbins = 1;
+    // size_t overlap_nbins = 1;
     for (size_t d = 0; d < dim; d++) {
       // because local bounds can extend beyond the mesh we need to force a
       // positive index if necessary
@@ -487,8 +486,8 @@ quick_index::window_coarse_index_list(const std::array<double, 3> &window_min,
       index_max[d] = std::min(index_max[d], coarse_bin_resolution - 1);
 
       // Use multiplicity to accumulate total bins;
-      if ((index_max[d] - index_min[d]) > 0)
-        overlap_nbins *= index_max[d] - index_min[d] + 1;
+      // if ((index_max[d] - index_min[d]) > 0)
+      //   overlap_nbins *= index_max[d] - index_min[d] + 1;
     }
     for (size_t k = index_min[2]; k <= index_max[2]; k++) {
       for (size_t j = index_min[1]; j <= index_max[1]; j++) {
@@ -592,10 +591,10 @@ auto map_data = [](auto &bias_cell_count, auto &data_count, auto &grid_data, aut
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Map data to a grid window for vector<double> data
- * 
+ *
  * Maps local+ghost data to a fixed mesh grid based on a specified weighting type. This data can
  * additionally be normalized and positively biased on the grid.
- * 
+ *
  *
  * \param[in] local_data the local data on the processor to be mapped to the window
  * \param[in] ghost_data the ghost data on the processor to be mapped to the window
@@ -818,10 +817,10 @@ auto map_vector_data = [](auto &bias_cell_count, auto &data_count, auto &grid_da
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Map data to a grid window for vector<vector<double>>
- * 
+ *
  * Maps multiple local+ghost data vectors to a fixed mesh grid based on a specified weighting type.
  * This data can additionally be normalized and positively biased on the grid.
- * 
+ *
  *
  * \param[in] local_data the local data on the processor to be mapped to the window
  * \param[in] ghost_data the ghost data on the processor to be mapped to the window
@@ -1021,10 +1020,10 @@ void quick_index::map_data_to_grid_window(const std::vector<std::vector<double>>
 //------------------------------------------------------------------------------------------------//
 /*!
  * \brief Calculate the orthogonal distance between two points
- * 
+ *
  * Maps multiple local+ghost data vectors to a fixed mesh grid based on a specified weighting type.
  * This data can additionally be normalized and positively biased on the grid.
- * 
+ *
  *
  * \param[in] r0 initial position
  * \param[in] r final position

--- a/src/mesh_element/Element_Definition.hh
+++ b/src/mesh_element/Element_Definition.hh
@@ -258,6 +258,12 @@ public:
    */
   virtual ~Element_Definition() = default;
 
+  //! Copy constructor
+  Element_Definition(Element_Definition const &rhs)
+      : name(rhs.name), type(rhs.type), dimension(rhs.dimension),
+        number_of_nodes(rhs.number_of_nodes), number_of_sides(rhs.number_of_sides),
+        elem_defs(rhs.elem_defs), side_type(rhs.side_type), side_nodes(rhs.side_nodes) {}
+
   // ACCESSORS
 
   /*!

--- a/src/mesh_element/Element_Definition.hh
+++ b/src/mesh_element/Element_Definition.hh
@@ -4,7 +4,7 @@
  * \author John McGhee
  * \date   Fri Feb 25 10:03:18 2000
  * \brief  Header file for the RTT Element_Definition class.
- * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_mesh_element_Element_Definition_hh
@@ -253,6 +253,11 @@ public:
 
   //! Copy constructor
   Element_Definition(Element_Definition const &rhs) = default;
+  Element_Definition(Element_Definition &&rhs) = default;
+
+  //! Assignment operator
+  Element_Definition &operator=(Element_Definition const &rhs) = default;
+  Element_Definition &operator=(Element_Definition &&rhs) = default;
 
   // ACCESSORS
 

--- a/src/mesh_element/Element_Definition.hh
+++ b/src/mesh_element/Element_Definition.hh
@@ -4,7 +4,7 @@
  * \author John McGhee
  * \date   Fri Feb 25 10:03:18 2000
  * \brief  Header file for the RTT Element_Definition class.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_mesh_element_Element_Definition_hh
@@ -183,27 +183,23 @@ public:
    *
    * \param name_ The name of the element.
    *
-   * \param dimension_ The dimension of the element. i.e. nodes return 0, lines
-   *        return 1, quads return 2, hexahedra return 3.
+   * \param dimension_ The dimension of the element. i.e. nodes return 0, lines return 1, quads
+   *        return 2, hexahedra return 3.
    *
    * \param number_of_nodes_ Total number of nodes in the element
    *
-   * \param number_of_sides_ The number of n-1 dimensional entities that compose
-   *        an n dimensional element. i.e. nodes return 0, lines return 2, quads
-   *        return 4, hexahedra return 6.
+   * \param number_of_sides_ The number of n-1 dimensional entities that compose an n dimensional
+   *        element. i.e. nodes return 0, lines return 2, quads return 4, hexahedra return 6.
    *
-   * \param elem_defs_ Element definitions that describe element sides.  There
-   *        need be only one such definition for each type of side present in
-   *        the element.  For example, a QUAD_4 element would need only one side
-   *        element definition, for BAR_2.
+   * \param elem_defs_ Element definitions that describe element sides.  There need be only one such
+   *        definition for each type of side present in the element.  For example, a QUAD_4 element
+   *        would need only one side element definition, for BAR_2.
    *
-   * \param side_type_ Index into \c elem_defs_ of the element definition
-   *        appropriate for each side.
+   * \param side_type_ Index into \c elem_defs_ of the element definition appropriate for each side.
    *
-   * \param side_nodes_ A vector of vectors specifying the nodes associated with
-   *        each side. For example, <code>side_nodes_[2]</code> is a vector
-   *        specifying the nodes associated with the third side of the element.
-   *        Note that the node numbering is 0 based.
+   * \param side_nodes_ A vector of vectors specifying the nodes associated with each side. For
+   *        example, <code>side_nodes_[2]</code> is a vector specifying the nodes associated with
+   *        the third side of the element.  Note that the node numbering is 0 based.
    *
    * \pre <code>dimension_>=0</code>
    *
@@ -222,12 +218,10 @@ public:
    * \pre <code>side_nodes_.size()==number_of_sides_</code>
    *
    * \pre All elements of \c side_nodes_ must satisfy
-   *        <code>side_nodes_[i].size() ==
-   *        elem_defs_[side_type_[i]].get_number_of_nodes() </code>
+   *        <code>side_nodes_[i].size() == elem_defs_[side_type_[i]].get_number_of_nodes() </code>
    *
    * \pre All elements of \c side_nodes_ must satisfy
-   *        <code>static_cast<unsigned>(side_nodes_[i][j])<number_of_nodes_
-   *        </code>
+   *        <code>static_cast<unsigned>(side_nodes_[i][j])<number_of_nodes_</code>
    *
    * \post <code> get_type()==Element_Definition::POLYGON </code>
    *
@@ -253,16 +247,12 @@ public:
   /*!
    * \brief Destructor for the Element_Definition class.
    *
-   * This destructor is virtual, implying that Element_Definition is extensible
-   * by inheritance.
+   * This destructor is virtual, implying that Element_Definition is extensible by inheritance.
    */
   virtual ~Element_Definition() = default;
 
   //! Copy constructor
-  Element_Definition(Element_Definition const &rhs)
-      : name(rhs.name), type(rhs.type), dimension(rhs.dimension),
-        number_of_nodes(rhs.number_of_nodes), number_of_sides(rhs.number_of_sides),
-        elem_defs(rhs.elem_defs), side_type(rhs.side_type), side_nodes(rhs.side_nodes) {}
+  Element_Definition(Element_Definition const &rhs) = default;
 
   // ACCESSORS
 
@@ -284,8 +274,8 @@ public:
    */
   unsigned get_number_of_nodes() const { return number_of_nodes; }
   /*!
-   * \brief Returns the dimension of an element. i.e. nodes return 0, lines
-   *        return 1, quads return 2, hexahedra return 3.
+   * \brief Returns the dimension of an element. i.e. nodes return 0, lines return 1, quads return
+   *        2, hexahedra return 3.
    *
    * \return The element dimension (0, 1, 2, or 3).
    */
@@ -293,25 +283,22 @@ public:
   /*!
    * \brief Returns the number of sides on an element.
    *
-   * \return The number of n-1 dimensional entities that compose an n
-   *         dimensional element. i.e. nodes return 0, lines return 2, quads
-   *         return 4, hexahedra return 6.
+   * \return The number of n-1 dimensional entities that compose an n dimensional
+   *         element. i.e. nodes return 0, lines return 2, quads return 4, hexahedra return 6.
    */
   unsigned get_number_of_sides() const { return number_of_sides; }
 
   /*!
    * \brief Returns the type (i.e. quad, tri, etc.) of a specified element side.
    *
-   * \return Returns a valid element definition that describes a element
-   *         side. Can be queried using any of the accessors provided in the
-   *         Element_Definition class.
+   * \return Returns a valid element definition that describes a element side. Can be queried using
+   *         any of the accessors provided in the Element_Definition class.
 
    * \param side_number Side number for which a type is desired.  Side numbers
    *        are in the range [0:number_of_sides).
    *
-   * Note that there is no valid side number for a "NODE" element.  "Side" in
-   * the context of this method means the (n-1) dimensional element that
-   * composes a n dimensional element.
+   * Note that there is no valid side number for a "NODE" element.  "Side" in the context of this
+   * method means the (n-1) dimensional element that composes a n dimensional element.
    */
   Element_Definition get_side_type(unsigned const side_number) const {
     Insist(side_number < side_type.size(), "Side index out of range!");
@@ -319,34 +306,29 @@ public:
   }
 
   /*!
-   * \brief Returns a vector of node numbers that are associated with a
-   *        particular element side.
+   * \brief Returns a vector of node numbers that are associated with a particular element side.
    *
-   * \param side_number The number of the element side for which the nodes are
-   *        desired. Side numbers are in the range [0:number_of_sides)
+   * \param side_number The number of the element side for which the nodes are desired. Side numbers
+   *        are in the range [0:number_of_sides)
    *
-   * \return A vector of the nodes associated with the side. Note that the node
-   *         numbering is 0 based.
+   * \return A vector of the nodes associated with the side. Note that the node numbering is 0
+   *         based.
    *
-   * "Side" in the context of this method means the (n-1) dimensional element
-   * that composes a (n) dimensional element. For example, on a hexahedra, a
-   * side is a quadrilateral, whereas, on a quadrilateral a side is a line
-   * element.  The returned order of the side nodes is significant. The
-   * side-node numbers are returned in the following order based on node
-   * location: (corners, edges, faces, cells). For sides which are faces of 3D
-   * elements, the vector cross product of the vector from (side-node1 to
-   * side-node2) with the vector from (side-node1 to side- node3) results in a
-   * vector that is oriented outward from the parent element.  Equivalently, the
-   * side corner-nodes are listed sequentially in a counter-clockwise direction
-   * when viewed from outside the element. Both corner and edge nodes are
-   * returned in a sequential order as one progresses around a side. Moreover,
-   * the corner and edge nodes are returned so that edge-node1 lies between
-   * corner-node1 and corner-node2, etc., etc.
+   * "Side" in the context of this method means the (n-1) dimensional element that composes a (n)
+   * dimensional element. For example, on a hexahedra, a side is a quadrilateral, whereas, on a
+   * quadrilateral a side is a line element.  The returned order of the side nodes is
+   * significant. The side-node numbers are returned in the following order based on node location:
+   * (corners, edges, faces, cells). For sides which are faces of 3D elements, the vector cross
+   * product of the vector from (side-node1 to side-node2) with the vector from (side-node1 to side-
+   * node3) results in a vector that is oriented outward from the parent element.  Equivalently, the
+   * side corner-nodes are listed sequentially in a counter-clockwise direction when viewed from
+   * outside the element. Both corner and edge nodes are returned in a sequential order as one
+   * progresses around a side. Moreover, the corner and edge nodes are returned so that edge-node1
+   * lies between corner-node1 and corner-node2, etc., etc.
    *
-   * For sides which are edges of 2D elements, the vector cross product of the
-   * vector from (side-node1 to side-node2) with a vector pointing towards the
-   * observer results in a vector that is oriented outward from the parent
-   * element.
+   * For sides which are edges of 2D elements, the vector cross product of the vector from
+   * (side-node1 to side-node2) with a vector pointing towards the observer results in a vector that
+   * is oriented outward from the parent element.
    *
    * Note that there is no valid side number for a "NODE" element.
    */
@@ -378,9 +360,8 @@ public:
   }
 
   /*!
-   * \brief Performs some simple sanity checks on the private data of the
-   *        Element_Description class. Note that this only works with DBC turned
-   *        on.
+   * \brief Performs some simple sanity checks on the private data of the Element_Description
+   *        class. Note that this only works with DBC turned on.
    */
   bool invariant_satisfied() const;
 

--- a/src/min/test/tstmrqmin.cc
+++ b/src/min/test/tstmrqmin.cc
@@ -69,7 +69,9 @@ void tstmrqmin(UnitTest &ut) {
   ifstream data(filename.c_str());
   vector<double> x, y, sig;
   for (;;) {
-    double y2sum = 0, ysum = 0, ymin = 1e100;
+    // double y2sum = 0;
+    // double ysum = 0;
+    double ymin = 1e100;
     for (unsigned i = 0; i < 3; ++i) {
       double s, n, c, a, t;
       data >> s >> n >> c >> a >> t;
@@ -83,8 +85,8 @@ void tstmrqmin(UnitTest &ut) {
         x.push_back(a);
         //                y.push_back(t);
       }
-      y2sum += t * t;
-      ysum += t;
+      // y2sum += t * t;
+      // ysum += t;
       ymin = min(t, ymin);
     }
     if (!data) {

--- a/src/min/test/tstmrqmin.cc
+++ b/src/min/test/tstmrqmin.cc
@@ -3,7 +3,7 @@
  * \file   min/test/tstmrqmin.cc
  * \author Kent Budge
  * \date   Mon Aug  9 13:39:20 2004
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
@@ -69,8 +69,6 @@ void tstmrqmin(UnitTest &ut) {
   ifstream data(filename.c_str());
   vector<double> x, y, sig;
   for (;;) {
-    // double y2sum = 0;
-    // double ysum = 0;
     double ymin = 1e100;
     for (unsigned i = 0; i < 3; ++i) {
       double s, n, c, a, t;
@@ -83,23 +81,15 @@ void tstmrqmin(UnitTest &ut) {
         x.push_back(n);
         x.push_back(c);
         x.push_back(a);
-        //                y.push_back(t);
       }
-      // y2sum += t * t;
-      // ysum += t;
       ymin = min(t, ymin);
     }
     if (!data) {
       break;
     }
-    //        for (unsigned i=0; i<3; ++i)
     {
-      //            double const ymean = ysum/3;
       y.push_back(ymin);
       sig.push_back(ymin);
-      //            sig.push_back(sqrt(0.5*(y2sum - 2*ysum*ymean + 3*ymean*ymean)));
-      //            sig.push_back(ymean);
-      //            sig.push_back(1.0);
     }
   }
 

--- a/src/norms/Norms_Base.hh
+++ b/src/norms/Norms_Base.hh
@@ -4,7 +4,7 @@
   \author Rob Lowrie
   \date   Fri Jan 14 13:01:19 2005
   \brief  Header file for Norms_Base.
-  \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
+  \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_norms_Norms_Base_hh
@@ -52,20 +52,12 @@ public:
   virtual ~Norms_Base() = default;
 
   //! Copy assignment
-  Norms_Base operator=(Norms_Base const &rhs) {
-    if (this != &rhs) {
-      d_sum_L1 = rhs.d_sum_L1;
-      d_sum_L2 = rhs.d_sum_L2;
-      d_Linf = rhs.d_Linf;
-      d_sum_weights = rhs.d_sum_weights;
-    }
-    return *this;
-  }
+  Norms_Base &operator=(Norms_Base const &rhs) = default;
+  Norms_Base &operator=(Norms_Base &&rhs) = default;
 
   //! Copy constructor
-  Norms_Base(Norms_Base const &rhs)
-      : d_sum_L1(rhs.d_sum_L1), d_sum_L2(rhs.d_sum_L2), d_Linf(rhs.d_Linf),
-        d_sum_weights(rhs.d_sum_weights) {}
+  Norms_Base(Norms_Base const &rhs) = default;
+  Norms_Base(Norms_Base &&rhs) = default;
 
   // MANIPULATORS
 

--- a/src/norms/Norms_Base.hh
+++ b/src/norms/Norms_Base.hh
@@ -4,8 +4,7 @@
   \author Rob Lowrie
   \date   Fri Jan 14 13:01:19 2005
   \brief  Header file for Norms_Base.
-  \note   Copyright (C) 2016-2020 Triad National Security, LLC.
-          All rights reserved. */
+  \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_norms_Norms_Base_hh
@@ -22,8 +21,8 @@ namespace rtt_norms {
 
   \brief Base class for all (template) Norms classes.
 
-  This class is not intended to be used by clients.  It allows non-template
-  dependent functionality of Norms to be compiled in a single place.
+  This class is not intended to be used by clients.  It allows non-template dependent functionality
+  of Norms to be compiled in a single place.
 */
 //================================================================================================//
 class Norms_Base {
@@ -51,6 +50,22 @@ public:
 
   /// Destructor for Norms_Base.
   virtual ~Norms_Base() = default;
+
+  //! Copy assignment
+  Norms_Base operator=(Norms_Base const &rhs) {
+    if (this != &rhs) {
+      d_sum_L1 = rhs.d_sum_L1;
+      d_sum_L2 = rhs.d_sum_L2;
+      d_Linf = rhs.d_Linf;
+      d_sum_weights = rhs.d_sum_weights;
+    }
+    return *this;
+  }
+
+  //! Copy constructor
+  Norms_Base(Norms_Base const &rhs)
+      : d_sum_L1(rhs.d_sum_L1), d_sum_L2(rhs.d_sum_L2), d_Linf(rhs.d_Linf),
+        d_sum_weights(rhs.d_sum_weights) {}
 
   // MANIPULATORS
 

--- a/src/parser/Text_Token_Stream.cc
+++ b/src/parser/Text_Token_Stream.cc
@@ -3,8 +3,7 @@
  * \file   parser/Text_Token_Stream.cc
  * \author Kent G. Budge
  * \brief  Contains definitions of all Text_Token_Stream member functions.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "Text_Token_Stream.hh"
@@ -21,8 +20,7 @@ namespace rtt_parser {
 using namespace std;
 
 //------------------------------------------------------------------------------------------------//
-// Helper function to allow a string && argument to take over storage of a
-// string.
+// Helper function to allow a string && argument to take over storage of a string.
 static string give(string &source) {
   string Result;
   Result.swap(source);
@@ -34,35 +32,28 @@ set<char> const Text_Token_Stream::default_whitespace = {'=', ':', ';', ','};
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructs a Text_Token_Stream with the specified set of breaking
- * whitespace characters.
+ * \brief Constructs a Text_Token_Stream with the specified set of breaking whitespace characters.
  *
- * \param ws String containing the user-defined whitespace characters for this
- * Text_Token_Stream.
+ * \param ws String containing the user-defined whitespace characters for this Text_Token_Stream.
  *
- * \param no_nonbreaking_ws If true, treat spaces and tabs as breaking
- * whitespace. This has the effect of forcing all keywords to consist of a
- * single identifier.
+ * \param no_nonbreaking_ws If true, treat spaces and tabs as breaking whitespace. This has the
+ * effect of forcing all keywords to consist of a single identifier.
  *
- * Whitespace characters are classified as breaking or nonbreaking whitespace.
- * Nonbreaking whitespace separates non-keyword tokens and identifiers within a
- * keyword but has no other significance. Breaking whitespace is similar to
- * nonbreaking whitespace except that it always separates tokens; thus, two
- * identifiers separated by breaking whitespace are considered to belong to
- * separate keywords.
+ * Whitespace characters are classified as breaking or nonbreaking whitespace.  Nonbreaking
+ * whitespace separates non-keyword tokens and identifiers within a keyword but has no other
+ * significance. Breaking whitespace is similar to nonbreaking whitespace except that it always
+ * separates tokens; thus, two identifiers separated by breaking whitespace are considered to belong
+ * to separate keywords.
  *
- * Nonbreaking whitespace characters are the space and horizontal tab
- * characters.
+ * Nonbreaking whitespace characters are the space and horizontal tab characters.
  *
- * Breaking whitespace characters include all other characters for which the
- * standard C library function <CODE>isspace(char)</CODE> returns a nonzero
- * value, plus additional characters defined as nonbreaking whitespace by the
- * client of the Token_Stream. In particular, a newline character is always
- * breaking whitespace.
+ * Breaking whitespace characters include all other characters for which the standard C library
+ * function <CODE>isspace(char)</CODE> returns a nonzero value, plus additional characters defined
+ * as nonbreaking whitespace by the client of the Token_Stream. In particular, a newline character
+ * is always breaking whitespace.
  *
- * Whitespace is stripped from the beginning and end of every token, and the
- * nonbreaking whitespace separating each identifier within a keyword is
- * replaced by a single space character.
+ * Whitespace is stripped from the beginning and end of every token, and the nonbreaking whitespace
+ * separating each identifier within a keyword is replaced by a single space character.
  */
 Text_Token_Stream::Text_Token_Stream(set<char> const &ws, bool const no_nonbreaking_ws)
     : buffer_(), whitespace_(ws), no_nonbreaking_ws_(no_nonbreaking_ws) {
@@ -74,9 +65,8 @@ Text_Token_Stream::Text_Token_Stream(set<char> const &ws, bool const no_nonbreak
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Constructs a Text_Token_Stream with the default set of breaking
- * whitespace characters. See the previous constructor documentation for a
- * discussion of how whitespace is defined and handled.
+ * \brief Constructs a Text_Token_Stream with the default set of breaking whitespace characters. See
+ * the previous constructor documentation for a discussion of how whitespace is defined and handled.
  *
  * The default whitespace characters are contained in the set
  * \c Text_Token_Stream::default_whitespace.
@@ -90,9 +80,8 @@ Text_Token_Stream::Text_Token_Stream() : buffer_(), whitespace_(default_whitespa
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief Scan the next token from the character stream. The character stream
- * is accessed via the fill_character_buffer, error, and end functions, which
- * are pure virtual functions.
+ * \brief Scan the next token from the character stream. The character stream is accessed via the
+ * fill_character_buffer, error, and end functions, which are pure virtual functions.
  */
 Token Text_Token_Stream::fill_() {
   eat_whitespace_();
@@ -126,10 +115,9 @@ Token Text_Token_Stream::fill_() {
       Ensure(check_class_invariants());
       return Result;
     } else if (isdigit(c) || c == '.') {
-      // A number of some kind.  Note that an initial sign ('+' or '-')
-      // is tokenized independently, because it could be interpreted as
-      // a binary operator in arithmetic expressions.  It is up to the
-      // parser to decide if this is the correct interpretation.
+      // A number of some kind.  Note that an initial sign ('+' or '-') is tokenized independently,
+      // because it could be interpreted as a binary operator in arithmetic expressions.  It is up
+      // to the parser to decide if this is the correct interpretation.
       unsigned const float_length = scan_floating_literal_();
       unsigned const int_length = scan_integer_literal_();
       string text;
@@ -246,13 +234,12 @@ Token Text_Token_Stream::fill_() {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief This function searches for the argument character in its internal
- *        list of whitespace characters.
+ * \brief This function searches for the argument character in its internal list of whitespace
+ *        characters.
  *
  * \param c Character to be checked against the whitespace list.
  *
- * \return \c true if and only if the character is found in the internal
- *         whitespace list.
+ * \return \c true if and only if the character is found in the internal whitespace list.
  */
 bool Text_Token_Stream::is_whitespace(char const c) const {
   return isspace(c) || whitespace_.count(c);
@@ -260,14 +247,13 @@ bool Text_Token_Stream::is_whitespace(char const c) const {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \brief This function searches for the argument character in the
- * Token_Stream's internal list of nonbreaking whitespace characters.
+ * \brief This function searches for the argument character in the Token_Stream's internal list of
+ * nonbreaking whitespace characters.
  *
  * \param c Character to be checked against the nonbreaking whitespace list.
  *
- * \return \c true if and only if the character is found in the internal
- * nonbreaking whitespace list, and is \e not found in the breaking whitespace
- * list..
+ * \return \c true if and only if the character is found in the internal nonbreaking whitespace
+ * list, and is \e not found in the breaking whitespace list..
  */
 bool Text_Token_Stream::is_nb_whitespace(char const c) const {
   return !whitespace_.count(c) && (c == ' ' || c == '\t');
@@ -275,12 +261,11 @@ bool Text_Token_Stream::is_nb_whitespace(char const c) const {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * An internal buffer is used to implement unlimited lookahead, necessary for
- * scanning numbers (which have a quite complex regular expression.)  This
- * function pops a character off the top of the internal buffer, using
- * fill_character_buffer() if necessary to ensure that there is at least one
- * character in the buffer.  If the next character is a carriage return, the
- * line count is incremented.
+ * An internal buffer is used to implement unlimited lookahead, necessary for scanning numbers
+ * (which have a quite complex regular expression.)  This function pops a character off the top of
+ * the internal buffer, using fill_character_buffer() if necessary to ensure that there is at least
+ * one character in the buffer.  If the next character is a carriage return, the line count is
+ * incremented.
  *
  * \return The next character in the buffer.
  */
@@ -460,11 +445,10 @@ unsigned Text_Token_Stream::scan_octal_literal_(unsigned &pos) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * An internal buffer is used to implement unlimited lookahead, necessary for
- * scanning numbers (which have a quite complex regular expression.)  This
- * function peeks ahead the specified number of places in the buffer, using
- * fill_character_buffer() if necessary to ensure that there is a sufficient
- * number of characters in the buffer.
+ * An internal buffer is used to implement unlimited lookahead, necessary for scanning numbers
+ * (which have a quite complex regular expression.)  This function peeks ahead the specified number
+ * of places in the buffer, using fill_character_buffer() if necessary to ensure that there is a
+ * sufficient number of characters in the buffer.
  *
  * \param pos Position at which to peek.
  *
@@ -481,9 +465,9 @@ char Text_Token_Stream::peek_(unsigned const pos) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function flushes the Text_Token_Stream's internal buffers, so that
- * scanning resumes at the beginning of the file stream.  It is normally called
- * by its overriding version in children of Text_Token_Stream.
+ * This function flushes the Text_Token_Stream's internal buffers, so that scanning resumes at the
+ * beginning of the file stream.  It is normally called by its overriding version in children of
+ * Text_Token_Stream.
  */
 void Text_Token_Stream::rewind() {
   while (!buffers_.empty())
@@ -504,9 +488,8 @@ bool Text_Token_Stream::check_class_invariants() const { return line_ > 0; }
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function skips past any whitespace present at the cursor position,
- * leaving the cursor at the first non-whitespace character following the
- * initial cursor position.
+ * This function skips past any whitespace present at the cursor position, leaving the cursor at the
+ * first non-whitespace character following the initial cursor position.
  */
 
 /* private */
@@ -550,37 +533,33 @@ void Text_Token_Stream::eat_whitespace_() {
  * \param c Character to be pushed onto the back of the character queue.
  */
 void Text_Token_Stream::character_push_back_(char const c) {
-  Remember(auto const old_buffer__size = static_cast<unsigned>(buffer_.size()));
+  Remember(auto const old_buffer_size = static_cast<unsigned>(buffer_.size()));
   buffer_.push_back(c);
   Ensure(check_class_invariants());
-  Ensure(buffer_.size() == old_buffer__size + 1);
+  Ensure(buffer_.size() == old_buffer_size + 1);
   Ensure(buffer_.back() == c);
 }
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * \param file_name Name of file to be included at this point. On
- * return, replaced with an absolute path based on DRACO_INCLUDE_PATH if the
- * relative path did not exist.
+ * \param file_name Name of file to be included at this point. On return, replaced with an absolute
+ * path based on DRACO_INCLUDE_PATH if the relative path did not exist.
  *
- * Child classes must set a policy on how to include a file. For example, a
- * File_Token_Stream can be expected to read the included file in serial; a
- * Parallel_File_Token_Stream can be expected to read the included file in
- * parallel; and a Console_Token_Stream or String_Token_Stream presently do
- * not provide this capability and will treat a include directive as an
- * error.
+ * Child classes must set a policy on how to include a file. For example, a File_Token_Stream can be
+ * expected to read the included file in serial; a Parallel_File_Token_Stream can be expected to
+ * read the included file in parallel; and a Console_Token_Stream or String_Token_Stream presently
+ * do not provide this capability and will treat a include directive as an error.
  *
- * This function is pure virtual with an implementation. This means that every
- * child class must implement this function, but part of its implementation
- * must be to include
+ * This function is pure virtual with an implementation. This means that every child class must
+ * implement this function, but part of its implementation must be to include
  *
  * \code
  *    Text_Token_Stream::push_include(include_file_name);
  * \endcode
  *
- * as the first line in its implementation of this function. This call stashes
- * the line and character buffer of the underlying Text_Token_Stream and also
- * finds the absolute path of the file name.
+ * as the first line in its implementation of this function. This call stashes the line and
+ * character buffer of the underlying Text_Token_Stream and also finds the absolute path of the file
+ * name.
  */
 void Text_Token_Stream::push_include(std::string &file_name) {
   lines_.push(line_);
@@ -591,11 +570,11 @@ void Text_Token_Stream::push_include(std::string &file_name) {
   // Now find the absolute path of the file name.
 
   if (!rtt_dsxx::fileExists(file_name)) {
-    // File name as given does not resolve to an existing file. Assume this
-    // is a relative path and look for the file in DRACO_INCLUDE_PATH.
+    // File name as given does not resolve to an existing file. Assume this is a relative path and
+    // look for the file in DRACO_INCLUDE_PATH.
 
-    // At present, DRACO_INCLUDE_PATH can contain only a single path.
-    // Multiple search options may be implemented in the future.
+    // At present, DRACO_INCLUDE_PATH can contain only a single path.  Multiple search options may
+    // be implemented in the future.
     auto path = getenv("DRACO_INCLUDE_PATH");
     if (path != nullptr) {
       // For now, the only other possibility:
@@ -612,10 +591,9 @@ void Text_Token_Stream::push_include(std::string &file_name) {
 
 //------------------------------------------------------------------------------------------------//
 /*!
- * This function is pure virtual with an implementation. This means that every
- * child class must implement this function, but part of its implementation
- * must be to reset the line number by directly calling the base version. That
- * is, every child class must include
+ * This function is pure virtual with an implementation. This means that every child class must
+ * implement this function, but part of its implementation must be to reset the line number by
+ * directly calling the base version. That is, every child class must include
  *
  * \code
  *    Text_Token_Stream::pop_include(include_file_name);
@@ -651,9 +629,8 @@ Token Text_Token_Stream::scan_keyword() {
       c = peek_(ci);
     }
     if (!no_nonbreaking_ws_) {
-      // Replace any nonbreaking whitespace after the identifier with a
-      // single space, but ONLY if the identifier is followed by another
-      // identifer.
+      // Replace any nonbreaking whitespace after the identifier with a single space, but ONLY if
+      // the identifier is followed by another identifer.
       while (is_nb_whitespace(c)) {
         ci++;
         c = peek_(ci);
@@ -676,9 +653,8 @@ Token Text_Token_Stream::scan_keyword() {
       c = peek_();
     }
     if (!no_nonbreaking_ws_) {
-      // Replace any nonbreaking whitespace after the identifier with a
-      // single space, but ONLY if the identifier is followed by another
-      // identifer.
+      // Replace any nonbreaking whitespace after the identifier with a single space, but ONLY if
+      // the identifier is followed by another identifer.
       while (is_nb_whitespace(c)) {
         pop_char_();
         c = peek_();

--- a/src/parser/Token_Stream.hh
+++ b/src/parser/Token_Stream.hh
@@ -3,8 +3,7 @@
  * \file   Token_Stream.hh
  * \author Kent G. Budge
  * \brief  Definition of class Token_Stream.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_Token_Stream_HH
@@ -32,59 +31,49 @@ public:
 /*!
  * \brief Abstract token stream for simple parsers
  *
- * Modern simulation codes require detailed problem specifications, which
- * typically take the form of a human-readable ASCII text input file.  The
- * problem specification language used in such input files has some similarities
- * to a programming language, though it is typically simpler than a high-level
- * language like C++ or Java. The problem specification expressed in this
- * problem specification language must be scanned and parsed by the simulation
- * code in order to load the data structures and control parameters required to
- * run the simulation.
+ * Modern simulation codes require detailed problem specifications, which typically take the form of
+ * a human-readable ASCII text input file.  The problem specification language used in such input
+ * files has some similarities to a programming language, though it is typically simpler than a
+ * high-level language like C++ or Java. The problem specification expressed in this problem
+ * specification language must be scanned and parsed by the simulation code in order to load the
+ * data structures and control parameters required to run the simulation.
  *
  * For example, if a fragment of a problem specification text takes the form
  *
  * <code>   boundary 1 gray source 1.0 keV  </code>
  *
- * then the simulation code must be able to recognize keywords like "boundary"
- * or "gray source", numerical values like "1" or "1.0", and expressions like
- * "keV". It must also understand the syntax of the problem specification
- * language, which requires an integer value after a "boundary" keyword,
- * followed by a keyword identifying the kind of boundary ("gray source"), and
- * so on.
+ * then the simulation code must be able to recognize keywords like "boundary" or "gray source",
+ * numerical values like "1" or "1.0", and expressions like "keV". It must also understand the
+ * syntax of the problem specification language, which requires an integer value after a "boundary"
+ * keyword, followed by a keyword identifying the kind of boundary ("gray source"), and so on.
  *
- * Modern input readers split the task of reading a problem specification text
- * into scanning and parsing. Scanning is the task of converting the raw text
- * into a sequence of \b tokens, which represent the keywords, numerical or
- * string values, and other lowest-level constructs in the problem specification
- * language. This sequence or stream of tokens is then analyzed by a parser that
- * understands the syntax of the problem specification language and can extract
- * the semantic meaning of each part of the problem specification.
+ * Modern input readers split the task of reading a problem specification text into scanning and
+ * parsing. Scanning is the task of converting the raw text into a sequence of \b tokens, which
+ * represent the keywords, numerical or string values, and other lowest-level constructs in the
+ * problem specification language. This sequence or stream of tokens is then analyzed by a parser
+ * that understands the syntax of the problem specification language and can extract the semantic
+ * meaning of each part of the problem specification.
  *
- * A Token_Stream is an abstract representation of a stream of tokens that can
- * be presented to a Parse_Table or other parsing client. Each token is
- * represented as a Token struct.  There is unlimited lookahead and pushback
- * capability, but no backtracking is implemented in this release.  In other
- * words, the client may look as many tokens to the right of the cursor as he
- * desires, and he may push any number of tokens onto the stream at the cursor
- * position; but when the cursor advances (via the Shift method) the token it
- * advances over is discarded forever.
+ * A Token_Stream is an abstract representation of a stream of tokens that can be presented to a
+ * Parse_Table or other parsing client. Each token is represented as a Token struct.  There is
+ * unlimited lookahead and pushback capability, but no backtracking is implemented in this release.
+ * In other words, the client may look as many tokens to the right of the cursor as he desires, and
+ * he may push any number of tokens onto the stream at the cursor position; but when the cursor
+ * advances (via the Shift method) the token it advances over is discarded forever.
  *
- * The actual scanner that does the conversion of raw text to tokens is provided
- * by an implementation of the \c fill function in a child class. This is
- * usually the \c Text_Token_Stream class, whose implementation of the \c fill
- * function converts a stream of ASCII characters to a stream of tokens, but one
- * can imagine unconventional sources of tokens such as an HTML form on a web
- * interface.
+ * The actual scanner that does the conversion of raw text to tokens is provided by an
+ * implementation of the \c fill function in a child class. This is usually the \c Text_Token_Stream
+ * class, whose implementation of the \c fill function converts a stream of ASCII characters to a
+ * stream of tokens, but one can imagine unconventional sources of tokens such as an HTML form on a
+ * web interface.
  *
- * Because the token stream object is specific to a particular kind of user
- * interface, we find it convenient to allow the parser to report any syntax or
- * semantic errors it discovers in the problem specification to the token
- * stream, which "knows" the best way to convey these to the human client
- * running the program. This style of error reporting also permits the token
- * stream to add additional information to the error message, indicating to the
- * human client where the error occurred. For example, a \c File_Token_Stream
- * can tell the human client the line in the input file where the error was
- * detected.
+ * Because the token stream object is specific to a particular kind of user interface, we find it
+ * convenient to allow the parser to report any syntax or semantic errors it discovers in the
+ * problem specification to the token stream, which "knows" the best way to convey these to the
+ * human client running the program. This style of error reporting also permits the token stream to
+ * add additional information to the error message, indicating to the human client where the error
+ * occurred. For example, a \c File_Token_Stream can tell the human client the line in the input
+ * file where the error was detected.
  */
 
 class Token_Stream {
@@ -92,6 +81,18 @@ public:
   // CREATORS
 
   virtual ~Token_Stream() = default;
+
+  //! Copy constructor
+  Token_Stream(Token_Stream const &rhs) : error_count_(rhs.error_count_), deq(rhs.deq) {}
+
+  //! Copy assignment
+  Token_Stream &operator=(Token_Stream const &rhs) {
+    if (this != &rhs) {
+      error_count_ = rhs.error_count_;
+      deq = rhs.deq;
+    }
+    return *this;
+  }
 
   // MANIPULATORS
 
@@ -101,8 +102,7 @@ public:
   /*!
    * \brief Look ahead at tokens.
    *
-   * Lookahead references should remain valid until the referenced token is
-   * shifted.
+   * Lookahead references should remain valid until the referenced token is shifted.
    */
   Token const &lookahead(unsigned pos = 0);
 
@@ -149,8 +149,8 @@ public:
   /*!
    * \brief Report an error to the user.
    *
-   * This function sends a message to the user in a stream-specific manner. This
-   * variant assumes that the cursor gives the correct location of the error.
+   * This function sends a message to the user in a stream-specific manner. This variant assumes
+   * that the cursor gives the correct location of the error.
    *
    * \param message
    * Message to be passed to the user.
@@ -161,11 +161,10 @@ public:
   /*!
    * \brief Send a comment, without location information, to the user.
    *
-   * This function sends a message to the user in a stream-specific manner. This
-   * differs from the report() functions chiefly in that the message is not
-   * preceded by any location information. This is useful for extended comments,
-   * e.g., listing available keywords when the stream contains an unrecognized
-   * keyword.
+   * This function sends a message to the user in a stream-specific manner. This differs from the
+   * report() functions chiefly in that the message is not preceded by any location
+   * information. This is useful for extended comments, e.g., listing available keywords when the
+   * stream contains an unrecognized keyword.
    *
    * \param message
    * Message to be passed to the user.
@@ -175,13 +174,12 @@ public:
   //------------------------------------------------------------------------------------------------//
   /*! Check a syntax condition.
    *
-   * By putting the check branch here, we improve coverage statistics for branch
-   * coverage. Making the function inline keeps the cost of doing so negligible.
+   * By putting the check branch here, we improve coverage statistics for branch coverage. Making
+   * the function inline keeps the cost of doing so negligible.
    *
-   * \param condition
-   * Condition to be checked. If false, the message is delivered in a
-   * stream-dependent manner, the stream's error counter is incremented, and a
-   * syntax exception is thrown.
+   * \param condition Condition to be checked. If false, the message is delivered in a
+   * stream-dependent manner, the stream's error counter is incremented, and a syntax exception is
+   * thrown.
    *
    * \param message
    * Diagnostic message to be delivered if condition tests as false.
@@ -194,14 +192,13 @@ public:
   //------------------------------------------------------------------------------------------------//
   /*! Check a semantic condition.
    *
-   * By putting the check branch here, we improve coverage statistics for branch
-   * coverage. Making the function inline keeps the cost of doing so negligible.
+   * By putting the check branch here, we improve coverage statistics for branch coverage. Making
+   * the function inline keeps the cost of doing so negligible.
    *
-   * \param condition Condition to be checked. If false, the message is
-   * delivered and the stream's error counter is incremented.
+   * \param condition Condition to be checked. If false, the message is delivered and the stream's
+   * error counter is incremented.
    *
-   * \param message Diagnostic message to be delivered if condition tests as
-   * false.
+   * \param message Diagnostic message to be delivered if condition tests as false.
    */
   void check_semantics(bool const condition, char const *const message) {
     if (!condition)
@@ -210,8 +207,7 @@ public:
 
   // ACCESSORS
 
-  //! Return the number of errors reported to the stream since it was last
-  //! constructed or rewound.
+  //! Return the number of errors reported to the stream since it was last constructed or rewound.
   unsigned error_count() const noexcept { return error_count_; }
 
   //! Check that all class invariants are satisfied.
@@ -229,12 +225,11 @@ protected:
   /*!
    * \brief Add one or more tokens to the end of the lookahead buffer.
    *
-   * This function is used by \c shift and \c lookahead to keep the token stream
-   * filled.
+   * This function is used by \c shift and \c lookahead to keep the token stream filled.
    *
-   * Each call to the function scans the next token from the ultimate token
-   * source (such as a text file or GUI) and returns it to the client. If no
-   * more tokens are available, the function must return an EXIT token.
+   * Each call to the function scans the next token from the ultimate token source (such as a text
+   * file or GUI) and returns it to the client. If no more tokens are available, the function must
+   * return an EXIT token.
    *
    * \return Next token to put on the token buffer.
    */
@@ -243,8 +238,7 @@ protected:
 private:
   // DATA
 
-  //! Number of errors reported to the stream since it was constructed or last
-  //! rewound.
+  //! Number of errors reported to the stream since it was constructed or last rewound.
   unsigned error_count_ = {0};
 
 private:

--- a/src/parser/Token_Stream.hh
+++ b/src/parser/Token_Stream.hh
@@ -3,7 +3,7 @@
  * \file   Token_Stream.hh
  * \author Kent G. Budge
  * \brief  Definition of class Token_Stream.
- * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
+ * \note   Copyright (C) 2010-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #ifndef rtt_Token_Stream_HH
@@ -83,16 +83,12 @@ public:
   virtual ~Token_Stream() = default;
 
   //! Copy constructor
-  Token_Stream(Token_Stream const &rhs) : error_count_(rhs.error_count_), deq(rhs.deq) {}
+  Token_Stream(Token_Stream const &rhs) = default;
+  Token_Stream(Token_Stream &&rhs) = default;
 
   //! Copy assignment
-  Token_Stream &operator=(Token_Stream const &rhs) {
-    if (this != &rhs) {
-      error_count_ = rhs.error_count_;
-      deq = rhs.deq;
-    }
-    return *this;
-  }
+  Token_Stream &operator=(Token_Stream const &rhs) = default;
+  Token_Stream &operator=(Token_Stream &&rhs) = default;
 
   // MANIPULATORS
 

--- a/src/parser/test/tstString_Token_Stream.cc
+++ b/src/parser/test/tstString_Token_Stream.cc
@@ -4,8 +4,7 @@
  * \author Kent G. Budge
  * \date   Feb 18 2003
  * \brief  Unit tests for String_Token_Stream class.
- * \note   Copyright (C) 2016-2020 Triad National Security, LLC.
- *         All rights reserved. */
+ * \note   Copyright (C) 2016-2021 Triad National Security, LLC., All rights reserved. */
 //------------------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"

--- a/src/rng/Counter_RNG.hh
+++ b/src/rng/Counter_RNG.hh
@@ -51,8 +51,17 @@
 #pragma clang diagnostic ignored "-Wextra-semi"
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
 #include "Random123/threefry.h"
 #include "uniform.hpp"
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
+#endif
 
 #if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.

--- a/src/rng/test/kat_cpp.cpp
+++ b/src/rng/test/kat_cpp.cpp
@@ -70,6 +70,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wshadow"
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
 #include <Random123/MicroURNG.hpp>
 #include <Random123/conventional/Engine.hpp>
 #include <cstring>
@@ -242,6 +247,10 @@ void host_execute_tests(kat_instance *tests, unsigned ntests) {
 
   dev_execute_tests(tests, ntests);
 }
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
+#endif
 
 #ifdef __clang__
 // Restore clang diagnostics to previous state.

--- a/src/rng/test/ut_M128.cpp
+++ b/src/rng/test/ut_M128.cpp
@@ -54,6 +54,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
 #include <Random123/features/compilerfeatures.h>
 #if !R123_USE_SSE
 #include <stdio.h>
@@ -187,6 +192,10 @@ int main(int, char **) {
   return 0;
 }
 
+#endif
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/src/rng/test/ut_carray.cpp
+++ b/src/rng/test/ut_carray.cpp
@@ -55,6 +55,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
 #include "ut_carray.hh"
 
 #include "util_demangle.hpp"
@@ -354,6 +360,10 @@ int main(int, char **) {
   cout << "ut_carray: all OK" << endl;
   return 0;
 }
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
+#endif
 
 #if defined(__clang__) && !defined(__ibmxl__)
 #pragma clang diagnostic pop

--- a/src/rng/test/ut_uniform.cpp
+++ b/src/rng/test/ut_uniform.cpp
@@ -87,6 +87,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
 #include "uniform.hpp"
 #include <Random123/threefry.h>
 #include <map>
@@ -201,6 +206,10 @@ int main(int argc, char **argv) {
 
   return !!nfail;
 }
+
+#if defined(__INTEL_LLVM_COMPILER)
+#pragma clang diagnostic pop
+#endif
 
 #if defined(__clang__) && !defined(__ibmxl__)
 // Restore clang diagnostics to previous state.


### PR DESCRIPTION
### Background

* We are adding support for Intel OneAPI compilers for Crossroads.  This change-set eliminates build warnings for `Release` builds. 
* These changes seem to also eliminate all build warnings for `Debug` flavor.

### Purpose of Pull Request

* [Fixes re-git issue #56](https://re-git.lanl.gov/draco/devops/-/issues/56)

### Description of changes

* Always build with `-fp-model=precise`
* Provide copy constructors and copy assignment operators for classes that have explicit destructors.
* Remove variables that are defined and set, but not read.
* Add `pragmas` to quiet warnings for vendor code.

### Status

* Reference:
  * [Pre-Merge Code Review](https://github.com/lanl/Draco/wiki/Style-Guide)
  * [CDash Status](https://rtt.lanl.gov/cdash3/index.php?project=Draco&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=-pr)
* Checks
  * [x] Travis/Appveyor CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Toss3 checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/cdash3/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
